### PR TITLE
Update Code Snippets of the Service Skeleton Start/Stop Utility Example

### DIFF
--- a/learn/how-to-test-ballerina-code.md
+++ b/learn/how-to-test-ballerina-code.md
@@ -368,7 +368,6 @@ test:stopServiceSkeleton(“petstore.service.skeleton”);
 The following sample explains how you can start and stop a skeleton service based on an OpenAPI definition.
 
 ```ballerina
-import ballerina/config;
 import ballerina/http;
 import ballerina/test;
 
@@ -395,7 +394,7 @@ function testService() {
     test:assertTrue(isServiceSkeletonStarted, msg = "Service skeleton failed to start");
 
     // Send a GET request to the specified endpoint
-    var response = httpEndpoint->get("/pets");
+    var response = clientEndpoint->get("/pets");
     if (response is http:Response) {
          var strRes = response.getTextPayload();
          string expected = "Sample listPets Response";


### PR DESCRIPTION
## Purpose
Below code snippets need to be updated in the Service Skeleton Start/Stop Utility example code in Ballerina Test documentation. https://ballerina.io/learn/how-to-test-ballerina-code/`

In line 1 import ballerina/config; should removed
In line 31 httpEndpoint should changed as clientEndpoint
> Fixes https://github.com/ballerina-platform/ballerina-dev-website/issues/151

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
