### PR TITLE
Change "Plugin" to "Extension" in VSCode Docs

### DIFF
--- a/learn/tools-ides/vscode-plugin.md
+++ b/learn/tools-ides/vscode-plugin.md
@@ -1,43 +1,43 @@
 ---
 layout: ballerina-inner-page
-title: The Visual Studio Code Plugin
+title: The Visual Studio Code Extension
 permalink: /learn/tools-ides/vscode-plugin/
 ---
 
-# The Visual Studio Code Plugin
+# The Visual Studio Code Extension
 
-The VS Code Ballerina plugin provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code plugin.
+The VS Code Ballerina extension provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code extension.
 
 - [Downloading VS Code](#downloading-vs-code)
-- [Installing the plugin](#installing-the-plugin)
-- [Using the plugin](#using-the-plugin)
+- [Installing the extension](#installing-the-extension)
+- [Using the extension](#using-the-extension)
 
 ## Downloading VS Code 
 
 Download the [Visual Studio Code editor](https://code.visualstudio.com/download).
 
 
-## Installing the plugin
+## Installing the extension
 
-Use either of the below approaches to install the VS Code Ballerina plugin.
+Use either of the below approaches to install the VS Code Ballerina extension.
 
 - [Installing via the VS Code editor](#installing-via-the-vs-code-editor)
-- [Installing by downloading the plugin](#installing-by-downloading-the-plugin)
+- [Installing by downloading the extension](#installing-by-downloading-the-extension)
 
 ### Installing via the VS Code editor
 
-Click **Extensions** on the left-most menu of the editor, search for the Ballerina plugin, and click **Install**.
+Click **Extensions** on the left-most menu of the editor, search for the Ballerina extension, and click **Install**.
 
 > **Tip**: Click **Reload** to reload the editor to apply the change.
 
-![Install the plugin via VS Code](/learn/images/install-via-editor.gif)
+![Install the extension via VS Code](/learn/images/install-via-editor.gif)
 
-This downloads the plugin and installs it.
+This downloads the extension and installs it.
 
-### Installing by downloading the plugin
+### Installing by downloading the extension
 
-1. Download the [Visual Studio Code Ballerina plugin](https://marketplace.visualstudio.com/items?itemName=ballerina.ballerina).
-2. Follow either of the below approaches to install the plugin.
+1. Download the [Visual Studio Code Ballerina extension](https://marketplace.visualstudio.com/items?itemName=ballerina.ballerina).
+2. Follow either of the below approaches to install the extension.
     - [Using the VS Code editor](#using-the-vs-code-editor)
     - [Using the Command Line](#using-the-command-line)
 
@@ -45,24 +45,24 @@ This downloads the plugin and installs it.
 
 1. Click **View** in the top menu of the editor and click **Command Palette**.
 2. In the search bar, type "vsix" and click **Extensions: Install from VSIX...**.
-3. Browse and select the VSIX file of the plugin you downloaded.
+3. Browse and select the VSIX file of the extension you downloaded.
 
 ![Install using the Command Palette of the editor.](/learn/images/install-via-palette.gif)
 
 #### Using the Command Line
 In a new Command Line tab, execute the below command.
 ```bash
-$ code --install-extension <BALLERINA-PLUGIN-DIRECTORY>
+$ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 ```
-> **Tip**: In the above command, `<BALLERINA_PLUGIN-DIRECTORY>` refers to the path of the Ballerina plugin directory (i.e., the VSIX file) you downloaded.
+> **Tip**: In the above command, `<BALLERINA_EXTENSION-DIRECTORY>` refers to the path of the Ballerina extension directory (i.e., the VSIX file) you downloaded.
 
-## Using the plugin
+## Using the extension
 
-> **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VSCode Plugin, enable the Allow Experimental option in user settings.
+> **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VSCode Extension, enable the Allow Experimental option in user settings.
 
 > **Troubleshooting**: If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
 
-The below sections include information on the various capabilities that are facilitated by the VS Code Ballerina plugin for the development process.
+The below sections include information on the various capabilities that are facilitated by the VS Code Ballerina extension for the development process.
 
 - [Language intelligence](/learn/tools-ides/vscode-plugin/language-intelligence)
 - [Run and debug](/learn/tools-ides/vscode-plugin/run-and-debug)

--- a/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -5,7 +5,7 @@ title: Documentation Viewer
 
 # Documentation Viewer
 
-The VS Code Ballerina plugin is shipped with a Documentation Viewer. You can add documentation for the functions and other public entities in your module for the reference of other users of it. 
+The VS Code Ballerina extension is shipped with a Documentation Viewer. You can add documentation for the functions and other public entities in your module for the reference of other users of it. 
 
 The Documentation Viewer represents the documented entities in a file in an organized manner. Follow the steps below to launch the Documentation Viewer.
 

--- a/learn/tools-ides/vscode-plugin/graphical-editor.md
+++ b/learn/tools-ides/vscode-plugin/graphical-editor.md
@@ -7,7 +7,7 @@ title: Graphical View
 
 A rich set of Visualization tools will immensely enhance your development experience especially in the integration space. 
 
-The Graphical Editor of the VS Code Ballerina plugin allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. 
+The Graphical Editor of the VS Code Ballerina extension allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. 
 
 The bellow sections discuss how to use the Graphical Editor and explore its capabilities.
 
@@ -16,7 +16,7 @@ The bellow sections discuss how to use the Graphical Editor and explore its capa
 
 ## Launching the Graphical View
 
-The below are the two types of Graphical Views you can find in the VSCode plugin.
+The below are the two types of Graphical Views you can find in the VSCode extension.
 
 1.Project Overview
 
@@ -55,6 +55,6 @@ You can expand the Diagram View to show not only the control flow but also to sh
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina plugin, see [Documentation Viewer](/learn/tools-ides/vscode-plugin/documentation-viewer).
- - For information on the VS Code Ballerina plugin, see [The Visual Studio Code Plugin](/learn/tools-ides/vscode-plugin).
- - For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](/learn/tools-ides).
+ - For information on the next capability of the VS Code Ballerina extension, see [Documentation Viewer](/learn/tools-ides/vscode-plugin/documentation-viewer).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/tools-ides/vscode-plugin).
+ - For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](/learn/tools-ides).

--- a/learn/tools-ides/vscode-plugin/language-intelligence.md
+++ b/learn/tools-ides/vscode-plugin/language-intelligence.md
@@ -5,9 +5,9 @@ title: Language intelligence
 
 # Language intelligence
 
-The VS Code Ballerina plugin brings in language intelligence to enhance the development experience and increase its efficiency.
+The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency.
 
-Language intelligence is built in to the plugin via a Language Server implementation, which consists of the below language intelligence options.
+Language intelligence is built in to the extension via a Language Server implementation, which consists of the below language intelligence options.
 
 - [Semantic and syntactic diagnostics](#semantic-and-syntactic-diagnostics)
 - [Suggestions and auto completion](#suggestions-and-auto-completion)
@@ -24,7 +24,7 @@ When there are syntax or semantic errors in your code, you will be notified with
 
 ## Suggestions and auto completion
 
-The plugin provides you with suggestions on keywords, variables, and code snippets of language constructs (such as functions, services, and iterable constructs etc.).
+The extension provides you with suggestions on keywords, variables, and code snippets of language constructs (such as functions, services, and iterable constructs etc.).
 
 ![Suggestions and auto completion](/learn/images/suggestions.gif)
 
@@ -54,10 +54,10 @@ For example, you can add documentation for a function as shown below.
  
  > **Tip**: Likewise, if you hover over an entity name of an object or a record, you can view the description of the object/record as well as descriptions of its fields.
 
-Above are the language intelligence features that are currently available in the Ballerina VS Code Plugin.
+Above are the language intelligence features that are currently available in the Ballerina VS Code Extension.
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina plugin, see [Run and Debug](/learn/tools-ides/vscode-plugin/run-and-debug).
- - For information on the VS Code Ballerina plugin, see [The Visual Studio Code Ballerina Plugin](/learn/tools-ides/vscode-plugin).
- - For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](/learn/tools-ides).
+ - For information on the next capability of the VS Code Ballerina extension, see [Run and Debug](/learn/tools-ides/vscode-plugin/run-and-debug).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/tools-ides/vscode-plugin).
+ - For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](/learn/tools-ides).

--- a/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -14,6 +14,6 @@ This option allows you to run all the tests that belong to multiple modules of y
 
 ## What's next?
 
-- For information on the next capability of the VS Code Ballerina plugin, see [Graphical Editor](graphical-editor.md).
-- For information on the VS Code Ballerina plugin, see [The Visual Studio Code Plugin](../vscode-plugin.md).
-- For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](../../tools-ides.md).
+- For information on the next capability of the VS Code Ballerina extension, see [Graphical Editor](graphical-editor.md).
+- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](../vscode-plugin.md).
+- For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](../../tools-ides.md).

--- a/learn/tools-ides/vscode-plugin/run-and-debug.md
+++ b/learn/tools-ides/vscode-plugin/run-and-debug.md
@@ -5,9 +5,9 @@ title: Run and debug
 
 # Run and debug
 
-The VS Code Ballerina plugin gives you the  same debugging experience as the conventional VS Code Debugger.
+The VS Code Ballerina extension gives you the  same debugging experience as the conventional VS Code Debugger.
 
-Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina plugin by launching its debugger. 
+Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
 
 Follow the steps below to start a 
 debug session. 
@@ -33,7 +33,7 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina plugin, see [Graphical View](/learn/tools-ides//vscode-plugin/graphical-editor).
- - For information on the VS Code Ballerina plugin, see [The Visual Studio Code Plugin](/learn/tools-ides/vscode-plugin).
- - For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](/learn/tools-ides).
+ - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/learn/tools-ides//vscode-plugin/graphical-editor).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/tools-ides/vscode-plugin).
+ - For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](/learn/tools-ides).
 

--- a/v1-0/learn/tools-ides/vscode-plugin.md
+++ b/v1-0/learn/tools-ides/vscode-plugin.md
@@ -1,43 +1,43 @@
 ---
 layout: ballerina-inner-page
-title: The Visual Studio Code Plugin
+title: The Visual Studio Code Extension
 permalink: /learn/tools-ides/vscode-plugin/
 ---
 
-# The Visual Studio Code Plugin
+# The Visual Studio Code Extension
 
-The VS Code Ballerina plugin provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code plugin.
+The VS Code Ballerina extension provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code extension.
 
 - [Downloading VS Code](#downloading-vs-code)
-- [Installing the plugin](#installing-the-plugin)
-- [Using the plugin](#using-the-plugin)
+- [Installing the extension](#installing-the-extension)
+- [Using the extension](#using-the-extension)
 
 ## Downloading VS Code 
 
 Download the [Visual Studio Code editor](https://code.visualstudio.com/download).
 
 
-## Installing the plugin
+## Installing the extension
 
-Use either of the below approaches to install the VS Code Ballerina plugin.
+Use either of the below approaches to install the VS Code Ballerina extension.
 
 - [Installing via the VS Code editor](#installing-via-the-vs-code-editor)
-- [Installing by downloading the plugin](#installing-by-downloading-the-plugin)
+- [Installing by downloading the extension](#installing-by-downloading-the-extension)
 
 ### Installing via the VS Code editor
 
-Click **Extensions** on the left-most menu of the editor, search for the Ballerina plugin, and click **Install**.
+Click **Extensions** on the left-most menu of the editor, search for the Ballerina extension, and click **Install**.
 
 > **Tip**: Click **Reload** to reload the editor to apply the change.
 
-![Install the plugin via VS Code](/learn/images/install-via-editor.gif)
+![Install the extension via VS Code](/learn/images/install-via-editor.gif)
 
-This downloads the plugin and installs it.
+This downloads the extension and installs it.
 
-### Installing by downloading the plugin
+### Installing by downloading the extension
 
-1. Download the [Visual Studio Code Ballerina plugin](https://marketplace.visualstudio.com/items?itemName=ballerina.ballerina).
-2. Follow either of the below approaches to install the plugin.
+1. Download the [Visual Studio Code Ballerina extension](https://marketplace.visualstudio.com/items?itemName=ballerina.ballerina).
+2. Follow either of the below approaches to install the extension.
     - [Using the VS Code editor](#using-the-vs-code-editor)
     - [Using the Command Line](#using-the-command-line)
 
@@ -45,24 +45,24 @@ This downloads the plugin and installs it.
 
 1. Click **View** in the top menu of the editor and click **Command Palette**.
 2. In the search bar, type "vsix" and click **Extensions: Install from VSIX...**.
-3. Browse and select the VSIX file of the plugin you downloaded.
+3. Browse and select the VSIX file of the extension you downloaded.
 
 ![Install using the Command Palette of the editor.](/learn/images/install-via-palette.gif)
 
 #### Using the Command Line
 In a new Command Line tab, execute the below command.
 ```bash
-$ code --install-extension <BALLERINA-PLUGIN-DIRECTORY>
+$ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 ```
-> **Tip**: In the above command, `<BALLERINA_PLUGIN-DIRECTORY>` refers to the path of the Ballerina plugin directory (i.e., the VSIX file) you downloaded.
+> **Tip**: In the above command, `<BALLERINA_EXTENSION-DIRECTORY>` refers to the path of the Ballerina extension directory (i.e., the VSIX file) you downloaded.
 
-## Using the plugin
+## Using the extension
 
-> **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VSCode Plugin, enable the Allow Experimental option in user settings.
+> **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VSCode Extension, enable the Allow Experimental option in user settings.
 
 > **Troubleshooting**: If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
 
-The below sections include information on the various capabilities that are facilitated by the VS Code Ballerina plugin for the development process.
+The below sections include information on the various capabilities that are facilitated by the VS Code Ballerina extension for the development process.
 
 - [Language intelligence](/learn/tools-ides/vscode-plugin/language-intelligence)
 - [Run and debug](/learn/tools-ides/vscode-plugin/run-and-debug)

--- a/v1-0/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/v1-0/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -5,7 +5,7 @@ title: Documentation Viewer
 
 # Documentation Viewer
 
-The VS Code Ballerina plugin is shipped with a Documentation Viewer. You can add documentation for the functions and other public entities in your module for the reference of other users of it. 
+The VS Code Ballerina extension is shipped with a Documentation Viewer. You can add documentation for the functions and other public entities in your module for the reference of other users of it. 
 
 The Documentation Viewer represents the documented entities in a file in an organized manner. Follow the steps below to launch the Documentation Viewer.
 

--- a/v1-0/learn/tools-ides/vscode-plugin/graphical-editor.md
+++ b/v1-0/learn/tools-ides/vscode-plugin/graphical-editor.md
@@ -7,7 +7,7 @@ title: Graphical View
 
 A rich set of Visualization tools will immensely enhance your development experience especially in the integration space. 
 
-The Graphical Editor of the VS Code Ballerina plugin allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. 
+The Graphical Editor of the VS Code Ballerina extension allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. 
 
 The bellow sections discuss how to use the Graphical Editor and explore its capabilities.
 
@@ -16,7 +16,7 @@ The bellow sections discuss how to use the Graphical Editor and explore its capa
 
 ## Launching the Graphical View
 
-The below are the two types of Graphical Views you can find in the VSCode plugin.
+The below are the two types of Graphical Views you can find in the VSCode extension.
 
 1.Project Overview
 
@@ -55,6 +55,6 @@ You can expand the Diagram View to show not only the control flow but also to sh
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina plugin, see [Documentation Viewer](/learn/tools-ides/vscode-plugin/documentation-viewer).
- - For information on the VS Code Ballerina plugin, see [The Visual Studio Code Plugin](/learn/tools-ides/vscode-plugin).
- - For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](/learn/tools-ides).
+ - For information on the next capability of the VS Code Ballerina extension, see [Documentation Viewer](/learn/tools-ides/vscode-plugin/documentation-viewer).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/tools-ides/vscode-plugin).
+ - For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](/learn/tools-ides).

--- a/v1-0/learn/tools-ides/vscode-plugin/language-intelligence.md
+++ b/v1-0/learn/tools-ides/vscode-plugin/language-intelligence.md
@@ -5,9 +5,9 @@ title: Language intelligence
 
 # Language intelligence
 
-The VS Code Ballerina plugin brings in language intelligence to enhance the development experience and increase its efficiency.
+The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency.
 
-Language intelligence is built in to the plugin via a Language Server implementation, which consists of the below language intelligence options.
+Language intelligence is built in to the extension via a Language Server implementation, which consists of the below language intelligence options.
 
 - [Semantic and syntactic diagnostics](#semantic-and-syntactic-diagnostics)
 - [Suggestions and auto completion](#suggestions-and-auto-completion)
@@ -24,7 +24,7 @@ When there are syntax or semantic errors in your code, you will be notified with
 
 ## Suggestions and auto completion
 
-The plugin provides you with suggestions on keywords, variables, and code snippets of language constructs (such as functions, services, and iterable constructs etc.).
+The extension provides you with suggestions on keywords, variables, and code snippets of language constructs (such as functions, services, and iterable constructs etc.).
 
 ![Suggestions and auto completion](/learn/images/suggestions.gif)
 
@@ -54,10 +54,10 @@ For example, you can add documentation for a function as shown below.
  
  > **Tip**: Likewise, if you hover over an entity name of an object or a record, you can view the description of the object/record as well as descriptions of its fields.
 
-Above are the language intelligence features that are currently available in the Ballerina VS Code Plugin.
+Above are the language intelligence features that are currently available in the Ballerina VS Code Extension.
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina plugin, see [Run and Debug](/learn/tools-ides/vscode-plugin/run-and-debug).
- - For information on the VS Code Ballerina plugin, see [The Visual Studio Code Ballerina Plugin](/learn/tools-ides/vscode-plugin).
- - For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](/learn/tools-ides).
+ - For information on the next capability of the VS Code Ballerina extension, see [Run and Debug](/learn/tools-ides/vscode-plugin/run-and-debug).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/tools-ides/vscode-plugin).
+ - For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](/learn/tools-ides).

--- a/v1-0/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/v1-0/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -14,6 +14,6 @@ This option allows you to run all the tests that belong to multiple modules of y
 
 ## What's next?
 
-- For information on the next capability of the VS Code Ballerina plugin, see [Graphical Editor](graphical-editor.md).
-- For information on the VS Code Ballerina plugin, see [The Visual Studio Code Plugin](../vscode-plugin.md).
-- For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](../../tools-ides.md).
+- For information on the next capability of the VS Code Ballerina extension, see [Graphical Editor](graphical-editor.md).
+- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](../vscode-plugin.md).
+- For information on the tools and IDEs that are supported by the VS Code Ballerina Extension, see [Tools and IDEs](../../tools-ides.md).

--- a/v1-0/learn/tools-ides/vscode-plugin/run-and-debug.md
+++ b/v1-0/learn/tools-ides/vscode-plugin/run-and-debug.md
@@ -5,9 +5,9 @@ title: Run and debug
 
 # Run and debug
 
-The VS Code Ballerina plugin gives you the  same debugging experience as the conventional VS Code Debugger.
+The VS Code Ballerina extension gives you the  same debugging experience as the conventional VS Code Debugger.
 
-Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina plugin by launching its debugger. 
+Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
 
 Follow the steps below to start a 
 debug session. 
@@ -33,7 +33,7 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina plugin, see [Graphical View](/learn/tools-ides//vscode-plugin/graphical-editor).
- - For information on the VS Code Ballerina plugin, see [The Visual Studio Code Plugin](/learn/tools-ides/vscode-plugin).
- - For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](/learn/tools-ides).
+ - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/learn/tools-ides//vscode-plugin/graphical-editor).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/tools-ides/vscode-plugin).
+ - For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](/learn/tools-ides).
 

--- a/v1-1/learn/tools-ides/vscode-plugin.md
+++ b/v1-1/learn/tools-ides/vscode-plugin.md
@@ -1,43 +1,43 @@
 ---
 layout: ballerina-inner-page
-title: The Visual Studio Code Plugin
+title: The Visual Studio Code Extension
 permalink: /v1-1/learn/tools-ides/vscode-plugin/
 ---
 
-# The Visual Studio Code Plugin
+# The Visual Studio Code Extension
 
-The VS Code Ballerina plugin provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code plugin.
+The VS Code Ballerina extension provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code extension.
 
 - [Downloading VS Code](#downloading-vs-code)
-- [Installing the plugin](#installing-the-plugin)
-- [Using the plugin](#using-the-plugin)
+- [Installing the extension](#installing-the-extension)
+- [Using the extension](#using-the-extension)
 
 ## Downloading VS Code 
 
 Download the [Visual Studio Code editor](https://code.visualstudio.com/download).
 
 
-## Installing the plugin
+## Installing the extension
 
-Use either of the below approaches to install the VS Code Ballerina plugin.
+Use either of the below approaches to install the VS Code Ballerina extension.
 
 - [Installing via the VS Code editor](#installing-via-the-vs-code-editor)
-- [Installing by downloading the plugin](#installing-by-downloading-the-plugin)
+- [Installing by downloading the extension](#installing-by-downloading-the-extension)
 
 ### Installing via the VS Code editor
 
-Click **Extensions** on the left-most menu of the editor, search for the Ballerina plugin, and click **Install**.
+Click **Extensions** on the left-most menu of the editor, search for the Ballerina extension, and click **Install**.
 
 > **Tip**: Click **Reload** to reload the editor to apply the change.
 
-![Install the plugin via VS Code](/v1-1/learn/images/install-via-editor.gif)
+![Install the extension via VS Code](/v1-1/learn/images/install-via-editor.gif)
 
-This downloads the plugin and installs it.
+This downloads the extension and installs it.
 
-### Installing by downloading the plugin
+### Installing by downloading the extension
 
-1. Download the [Visual Studio Code Ballerina plugin](https://marketplace.visualstudio.com/items?itemName=ballerina.ballerina).
-2. Follow either of the below approaches to install the plugin.
+1. Download the [Visual Studio Code Ballerina Extension](https://marketplace.visualstudio.com/items?itemName=ballerina.ballerina).
+2. Follow either of the below approaches to install the extension.
     - [Using the VS Code editor](#using-the-vs-code-editor)
     - [Using the Command Line](#using-the-command-line)
 
@@ -45,24 +45,24 @@ This downloads the plugin and installs it.
 
 1. Click **View** in the top menu of the editor and click **Command Palette**.
 2. In the search bar, type "vsix" and click **Extensions: Install from VSIX...**.
-3. Browse and select the VSIX file of the plugin you downloaded.
+3. Browse and select the VSIX file of the extension you downloaded.
 
 ![Install using the Command Palette of the editor.](/v1-1/learn/images/install-via-palette.gif)
 
 #### Using the Command Line
 In a new Command Line tab, execute the below command.
 ```bash
-$ code --install-extension <BALLERINA-PLUGIN-DIRECTORY>
+$ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 ```
-> **Tip**: In the above command, `<BALLERINA_PLUGIN-DIRECTORY>` refers to the path of the Ballerina plugin directory (i.e., the VSIX file) you downloaded.
+> **Tip**: In the above command, `<BALLERINA_EXTENSION-DIRECTORY>` refers to the path of the Ballerina extension directory (i.e., the VSIX file) you downloaded.
 
-## Using the plugin
+## Using the extension
 
-> **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VSCode Plugin, enable the Allow Experimental option in user settings.
+> **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VSCode Extension, enable the Allow Experimental option in user settings.
 
 > **Troubleshooting**: If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
 
-The below sections include information on the various capabilities that are facilitated by the VS Code Ballerina plugin for the development process.
+The below sections include information on the various capabilities that are facilitated by the VS Code Ballerina Extension for the development process.
 
 - [Language intelligence](/v1-1/learn/tools-ides/vscode-plugin/language-intelligence)
 - [Run and debug](/v1-1/learn/tools-ides/vscode-plugin/run-and-debug)

--- a/v1-1/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/v1-1/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -5,7 +5,7 @@ title: Documentation Viewer
 
 # Documentation Viewer
 
-The VS Code Ballerina plugin is shipped with a Documentation Viewer. You can add documentation for the functions and other public entities in your module for the reference of other users of it. 
+The VS Code Ballerina extension is shipped with a Documentation Viewer. You can add documentation for the functions and other public entities in your module for the reference of other users of it. 
 
 The Documentation Viewer represents the documented entities in a file in an organized manner. Follow the steps below to launch the Documentation Viewer.
 

--- a/v1-1/learn/tools-ides/vscode-plugin/graphical-editor.md
+++ b/v1-1/learn/tools-ides/vscode-plugin/graphical-editor.md
@@ -7,7 +7,7 @@ title: Graphical View
 
 A rich set of Visualization tools will immensely enhance your development experience especially in the integration space. 
 
-The Graphical Editor of the VS Code Ballerina plugin allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. 
+The Graphical Editor of the VS Code Ballerina extension allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. 
 
 The bellow sections discuss how to use the Graphical Editor and explore its capabilities.
 
@@ -16,7 +16,7 @@ The bellow sections discuss how to use the Graphical Editor and explore its capa
 
 ## Launching the Graphical View
 
-The below are the two types of Graphical Views you can find in the VSCode plugin.
+The below are the two types of Graphical Views you can find in the VSCode extension.
 
 1.Project Overview
 
@@ -55,6 +55,6 @@ You can expand the Diagram View to show not only the control flow but also to sh
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina plugin, see [Documentation Viewer](/v1-1/learn/tools-ides/vscode-plugin/documentation-viewer).
- - For information on the VS Code Ballerina plugin, see [The Visual Studio Code Plugin](/v1-1/learn/tools-ides/vscode-plugin).
- - For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](/v1-1/learn/tools-ides).
+ - For information on the next capability of the VS Code Ballerina extension, see [Documentation Viewer](/v1-1/learn/tools-ides/vscode-plugin/documentation-viewer).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/v1-1/learn/tools-ides/vscode-plugin).
+ - For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](/v1-1/learn/tools-ides).

--- a/v1-1/learn/tools-ides/vscode-plugin/language-intelligence.md
+++ b/v1-1/learn/tools-ides/vscode-plugin/language-intelligence.md
@@ -5,9 +5,9 @@ title: Language intelligence
 
 # Language intelligence
 
-The VS Code Ballerina plugin brings in language intelligence to enhance the development experience and increase its efficiency.
+The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency.
 
-Language intelligence is built in to the plugin via a Language Server implementation, which consists of the below language intelligence options.
+Language intelligence is built in to the extension via a Language Server implementation, which consists of the below language intelligence options.
 
 - [Semantic and syntactic diagnostics](#semantic-and-syntactic-diagnostics)
 - [Suggestions and auto completion](#suggestions-and-auto-completion)
@@ -24,7 +24,7 @@ When there are syntax or semantic errors in your code, you will be notified with
 
 ## Suggestions and auto completion
 
-The plugin provides you with suggestions on keywords, variables, and code snippets of language constructs (such as functions, services, and iterable constructs etc.).
+The extension provides you with suggestions on keywords, variables, and code snippets of language constructs (such as functions, services, and iterable constructs etc.).
 
 ![Suggestions and auto completion](/v1-1/learn/images/suggestions.gif)
 
@@ -54,10 +54,10 @@ For example, you can add documentation for a function as shown below.
  
  > **Tip**: Likewise, if you hover over an entity name of an object or a record, you can view the description of the object/record as well as descriptions of its fields.
 
-Above are the language intelligence features that are currently available in the Ballerina VS Code Plugin.
+Above are the language intelligence features that are currently available in the Ballerina VS Code Extension.
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina plugin, see [Run and Debug](/v1-1/learn/tools-ides/vscode-plugin/run-and-debug).
- - For information on the VS Code Ballerina plugin, see [The Visual Studio Code Ballerina Plugin](/v1-1/learn/tools-ides/vscode-plugin).
- - For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](/v1-1/learn/tools-ides).
+ - For information on the next capability of the VS Code Ballerina extension, see [Run and Debug](/v1-1/learn/tools-ides/vscode-plugin/run-and-debug).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/v1-1/learn/tools-ides/vscode-plugin).
+ - For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](/v1-1/learn/tools-ides).

--- a/v1-1/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/v1-1/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -14,6 +14,6 @@ This option allows you to run all the tests that belong to multiple modules of y
 
 ## What's next?
 
-- For information on the next capability of the VS Code Ballerina plugin, see [Graphical Editor](graphical-editor.md).
-- For information on the VS Code Ballerina plugin, see [The Visual Studio Code Plugin](../vscode-plugin.md).
-- For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](../../tools-ides.md).
+- For information on the next capability of the VS Code Ballerina extension, see [Graphical Editor](graphical-editor.md).
+- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](../vscode-plugin.md).
+- For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](../../tools-ides.md).

--- a/v1-1/learn/tools-ides/vscode-plugin/run-and-debug.md
+++ b/v1-1/learn/tools-ides/vscode-plugin/run-and-debug.md
@@ -5,9 +5,9 @@ title: Run and debug
 
 # Run and debug
 
-The VS Code Ballerina plugin gives you the  same debugging experience as the conventional VS Code Debugger.
+The VS Code Ballerina extension gives you the  same debugging experience as the conventional VS Code Debugger.
 
-Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina plugin by launching its debugger. 
+Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
 
 Follow the steps below to start a 
 debug session. 
@@ -33,7 +33,7 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina plugin, see [Graphical View](/v1-1/learn/tools-ides//vscode-plugin/graphical-editor).
- - For information on the VS Code Ballerina plugin, see [The Visual Studio Code Plugin](/v1-1/learn/tools-ides/vscode-plugin).
- - For information on the tools and IDEs that are supported by the VS Code Ballerina plugin, see [Tools and IDEs](/v1-1/learn/tools-ides).
+ - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/v1-1/learn/tools-ides//vscode-plugin/graphical-editor).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/v1-1/learn/tools-ides/vscode-plugin).
+ - For information on the tools and IDEs that are supported by the VS Code Ballerina extension, see [Tools and IDEs](/v1-1/learn/tools-ides).
 


### PR DESCRIPTION
## Purpose
We need to change the word "plugin" to "extension" in all occurrences of VSCode docs in the below website versions.

no-version
v1-1
v1-0
v0-991
> Fixes #186

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
