### PR TITLE
Fix the Broken Links After Removing Tools & IDEs Page

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -6,6 +6,7 @@ keywords: Ballerina, ballerinalang
 permalink: /learn/
 redirect_from:
   - /learn/tools-ides
+  - /learn/tools-ides/
 ---
 
 <meta http-equiv="refresh" content="0; url=/v1-1/learn">

--- a/v0-991/learn.md
+++ b/v0-991/learn.md
@@ -3,7 +3,7 @@ layout: ballerina-inner-page
 permalink: /v0-991/learn/
 redirect_from:
   - /v0-991/learn/tools-ides
-  - /v0-991/learn/tools-ides
+  - /v0-991/learn/tools-ides/
 ---
 
 # Learn Ballerina

--- a/v0-991/learn.md
+++ b/v0-991/learn.md
@@ -3,6 +3,7 @@ layout: ballerina-inner-page
 permalink: /v0-991/learn/
 redirect_from:
   - /v0-991/learn/tools-ides
+  - /v0-991/learn/tools-ides
 ---
 
 # Learn Ballerina

--- a/v0-991/learn.md
+++ b/v0-991/learn.md
@@ -32,7 +32,7 @@ The [Quick Tour](/v0-991/learn/quick-tour/) is the fastest way to try Ballerina.
 
 ### Tools and IDEs
 
-The [Tools and IDEs](/v0-991/learn/tools-ides/) section introduces the language servers, editors, IDEs, and graphical visualization tools that are supported by Ballerina.
+The [VS Code](/v0-991/learn/vscode-plugin) and [IntelliJ IDEA](/v0-991/learn/intellij-plugin) extesnions are the Tools & IDEs that are currently supported by Ballerina.
 
 ### How to Structure Ballerina Code
 

--- a/v1-0/learn.md
+++ b/v1-0/learn.md
@@ -6,6 +6,7 @@ keywords: Ballerina, ballerinalang
 permalink: /v1-0/learn/
 redirect_from:
   - /v1-0/learn/tools-ides
+  - /v1-0/learn/tools-ides/
 ---
 
 <h1>Let’s learn Ballerina!</h1>

--- a/v1-1/learn.md
+++ b/v1-1/learn.md
@@ -6,6 +6,7 @@ keywords: Ballerina, ballerinalang
 permalink: /v1-1/learn/
 redirect_from:
   - /v1-1/learn/tools-ides
+  - /v1-1/learn/tools-ides/
 ---
 
 <h1>Let’s learn Ballerina!</h1>


### PR DESCRIPTION
## Purpose
This is to fix the broken links after the change that was done in https://github.com/ballerina-platform/ballerina-dev-website/pull/182/.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
