### PR TITLE
Making Text Bold in the Security Policy

### DIFF
--- a/community.md
+++ b/community.md
@@ -54,7 +54,7 @@ Hit a bump on the road? Report an issue in the relevant repo out of the GitHub r
    - Compiler, runtime, standard library, or tooling: <a href="https://github.com/ballerina-platform/ballerina-lang/issues">ballerina-lang</a> repo
    - Language specification: <a href="https://github.com/ballerina-platform/ballerina-spec/issues">ballerina-spec</a> repo
    - Website: <a href="https://github.com/ballerina-platform/ballerina-dev-website/issues">ballerina-dev-website</a> repo
-   - Security flaw: send an email to security@ballerina.io. For details, see the <a href="https://ballerina.io/security/">security policy</a>.
+   - Security flaw: send an email to security@ballerina.io. For details, see the <a href="/security">security policy</a>.
 
 ## Help us grow 
 

--- a/security.md
+++ b/security.md
@@ -15,9 +15,9 @@ Ballerina project maintainers take security issues very seriously and all the vu
 
 Ensure you are using the latest Ballerina version before you run an automated security scan or perform a penetration test against it.
 
-Based on the ethics of responsible disclosure, you must only use the **[security@ballerina.io](mailto:security@ballerina.io)** mailing list to report security vulnerabilities and any other concerns regarding the security aspects of the source code or any other resource in this repo.
+Based on the ethics of responsible disclosure, you must **only use the [security@ballerina.io](mailto:security@ballerina.io) mailing list** to report security vulnerabilities and any other concerns regarding the security aspects of the source code or any other resource in this repo.
 
-**Warning:** To protect the end-user security, please do not use any other medium to report security vulnerabilities. Also, kindly refrain from disclosing the vulnerability details you come across with other individuals, in any forums, sites, or other groups - public or private before it’s mitigation actions and disclosure process are completed.
+> **WARNING:** To protect the end-user security, **please do not use any other medium to report security vulnerabilities**. Also, kindly refrain from disclosing the vulnerability details you come across with other individuals, in any forums, sites, or other groups - public or private before it’s mitigation actions and disclosure process are completed.
 
 Use the following key to send secure messages to security@ballerina.io:
 
@@ -25,11 +25,11 @@ Use the following key to send secure messages to security@ballerina.io:
 
 Also, use the following template when reporting vulnerabilities so that it contains all the required information and helps expedite the analysis and mitigation process.
 
-- Vulnerable Ballerina artifact(s) and version(s)
-- Overview: High-level overview of the issue and self-assessed severity
-- Description: Include the steps to reproduce
-- Impact: Self-assessed impact
-- Solution: Any proposed solution
+- **Vulnerable Ballerina artifact(s) and version(s):** list of the Ballerina artifacts/versions that are considered as vulnerable
+- **Overview:** high-level overview of the issue and self-assessed severity
+- **Description:** include the steps to reproduce
+- **Impact:** self-assessed impact
+- **Solution:** any proposed solution
 
 We will keep you informed of the progress towards a fix and disclosure of the vulnerability if the reported issue is identified as a true positive. 
 


### PR DESCRIPTION
## Purpose
 This is to make some important text bold in the security policy.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
