### PR TITLE
Add Installing from Source Instructions  to B.io

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-inner-page
 title: The Ballerina Code of Conduct
-permalink: /code-of-conduct/
+permalink: /code-of-conduct
 ---
 
 # Contributor Covenant Code of Conduct

--- a/community.md
+++ b/community.md
@@ -78,8 +78,7 @@ We run an announcement-only, no-marketing-spam mailing list that we will use to 
 
 ## Contribute to Ballerina
 
-Join us and contribute to the source code to make Ballerina better! To be aware of the ground rules as you start, see the <a href="https://ballerina.io/contribution-guide">Contribution Guide</a>. Happy contributing! 
-
+Join us and contribute to the source code to make Ballerina better! To be aware of the ground rules as you start, see the <a href="/contribution-guide">Contribution Guide</a>. Happy contributing! 
 
 <style>
 .nav > li.cVersionItem {

--- a/contribution-guide.md
+++ b/contribution-guide.md
@@ -67,7 +67,7 @@ We appreciate your help!
 
 ## Build the source code 
 
-For instructions, see [Installing from source](https://ballerina.io/v1-1/learn/installing-ballerina/installing-from-source).
+For instructions, see [Installing from source](https://ballerina.io/learn/installing-ballerina/installing-from-source).
 
 ## Set up the development environment
 

--- a/contribution-guide.md
+++ b/contribution-guide.md
@@ -64,37 +64,10 @@ We appreciate your help!
 ## Set up the prerequisites
 1. Download [Ballerina](https://ballerina.io) and go through the [learning resources](https://ballerina.io/learn).
 2. Read the [Ballerina Code of Conduct](https://ballerina.io/code-of-conduct).
-3. Download the Java SE Development Kit (JDK) version 8 from one of the following locations and install it.
-    - [Oracle](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
-    - [OpenJDK](http://openjdk.java.net/install/index.html) 
->**Note:** Set the `JAVA_HOME` environment variable to the path name of the directory into which you installed JDK.
-4. Download [Node.js](https://nodejs.org/en/download/) (version 8.9.x or the latest LTS release) and install it.
-5. Download [npm](https://www.npmjs.com/get-npm) (version 5.6.0 or later) and install it.
 
-## Obtain the source code 
+## Build the source code 
 
-1. Execute the below command to clone the ballerina-lang Git repo.
-```bash 
-git clone --recursive https://github.com/ballerina-platform/ballerina-lang.git
-```
->**Tip:** If you have already forked the repository to your GitHub account, then execute the below command replacing `<YOUR-GITHUB-USERNAME>` with your Git username.
-```bash 
-git clone --recursive https://github.com/<YOUR-GITHUB-USERNAME>/ballerina-lang.git
-```
-2. Execute the below command to update the Git submodules.
-```bash 
-git submodule update --init
-```
-## Build the project
-
-1. Navigate to the root directory of the Ballerina project (i.e., `<BALLERINA_PROJECT_ROOT>`) and execute the below Gradle command.
-```bash 
-./gradlew clean build
-```
-2. Extract the built Ballerina distributions in the below locations.
--  **runtime only:** `<BALLERINA_PROJECT_ROOT>/distribution/zip/jballerina/build/distributions/jballerina-<version>-SNAPSHOT.zip`
--  **runtime and tools (e.g., Ballerina Language Server):** `<BALLERINA_PROJECT_ROOT>/distribution/zip/jballerina-tools/build/distributions/jballerina-tools-<version>-SNAPSHOT.zip`
->**Note:** If you face an IOException error stating "Too many open files", this is due to the default number of possible open files being set to a lower number on your operating system than required for Ballerina to be compiled. You may have to increase the number of open files/file descriptors (FD) on your operating system to 1000000 (or higher).
+For instructions, see [Installing from source](https://ballerina.io/v1-1/learn/installing-ballerina/installing-from-source).
 
 ## Set up the development environment
 

--- a/contribution-guide.md
+++ b/contribution-guide.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-inner-page
 title: The Ballerina Contribution Guide
-permalink: /contribution-guide/
+permalink: /contribution-guide
 ---
 
 # The Ballerina Contribution Guide
@@ -63,7 +63,7 @@ We appreciate your help!
 
 ## Set up the prerequisites
 1. Download [Ballerina](https://ballerina.io) and go through the [learning resources](https://ballerina.io/learn).
-2. Read the [Ballerina Code of Conduct](https://ballerina.io/code-of-conduct).
+2. Read the <a href="/code-of-conduct">Ballerina Code of Conduct</a>.
 
 ## Build the source code 
 

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -65,10 +65,10 @@ You need to have the below installed to build particlura Ballerina modules.
 ```
 git clone --recursive https://github.com/ballerina-platform/ballerina-lang
 ```
-2. Execute one of the below commands to build project using Gradle. 
+2. Execute one of the below commands to build the project using Gradle. 
 
-    **On Unix/Mac OS:** ```./gradlew build ```
-    **Windows:** ```gradlew build ```
+  - **On Unix/Mac OS:** ```./gradlew build ```
+  - **Windows:** ```gradlew build ```
 
 3. Extract the Ballerina distribution created at: `distribution/zip/jballerina-tools/build/extracted-distributions/ballerina-<VERSION>-SNAPSHOT.zip`.
 

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -8,6 +8,13 @@ redirect_from:
 
 # Installing Ballerina
 
+- [Downloading the Ballerina distribution](#downloading-the-ballerina-distribution)
+- [Installing Ballerina via installers](#installing-ballerina-via-installers)
+- [Installing from source](#installing-from-source)
+- [Uninstalling Ballerina](#uninstalling-ballerina)
+- [Getting help](#getting-help)
+- [What's next](#what's-next)
+
 ## Downloading the Ballerina distribution
 
 [Download](https://ballerina.io/downloads/) a Ballerina distribution based on your operating system.
@@ -17,7 +24,7 @@ redirect_from:
 - Ubuntu Linux 12.04 x64 - LTS and above
 - OS X 10.8.3 x64 and above
 
-If a binary distribution is not available for your combination of operating system and architecture, try [installing from source](https://github.com/ballerina-platform/ballerina-lang#install-from-source).
+If a binary distribution is not available for your combination of operating system and architecture, try [installing from source](#installing-from-source).
 
 ## Installing Ballerina via installers
 

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -46,6 +46,32 @@ The installer should put the `C:\Program Files\Ballerina\<ballerina-directory>\b
 dpkg -i <ballerina-binary>.deb
 ```
 
+## Installing from source
+
+Alternatively, follow the instructions below to install Ballerina from the source.
+
+### Prerequisites
+
+You need to have the below installed to build particlura Ballerina modules.
+
+- [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or [OpenJDK 8](http://openjdk.java.net/install/)
+- [Node (version 8.9.x or later) and npm (version 5.6.0 or later)](https://nodejs.org/en/download/)
+- [Docker](https://www.docker.com/get-started)
+
+### Building the source
+
+1. Execute the below command to clone the ['ballerina-lang'](https://github.com/ballerina-platform/ballerina-lang) source repository.
+
+```
+git clone --recursive https://github.com/ballerina-platform/ballerina-lang
+```
+2. Execute one of the below commands to build project using Gradle. 
+
+    **On Unix/Mac OS:** ```./gradlew build ```
+    **Windows:** ```gradlew build ```
+
+3. Extract the Ballerina distribution created at: `distribution/zip/jballerina-tools/build/extracted-distributions/ballerina-<VERSION>-SNAPSHOT.zip`.
+
 ## Uninstalling Ballerina
 
 To remove an existing Ballerina installation, go to the Ballerina installation location and delete the Ballerina directory.

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -50,27 +50,54 @@ dpkg -i <ballerina-binary>.deb
 
 Alternatively, follow the instructions below to install Ballerina from the source.
 
-### Prerequisites
+### Setting up the prerequisites
 
-You need to have the below installed to build particlura Ballerina modules.
+You need to download and install the below to build the Ballerina modules.
+1. Java SE Development Kit (JDK) version 8 (from one of the following locations) 
+    - [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+    - [OpenJDK](http://openjdk.java.net/install/index.html)
 
-- [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or [OpenJDK 8](http://openjdk.java.net/install/)
-- [Node (version 8.9.x or later) and npm (version 5.6.0 or later)](https://nodejs.org/en/download/)
-- [Docker](https://www.docker.com/get-started)
+>**Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
 
-### Building the source
+2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
+3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
+4. [Docker](https://www.docker.com/get-started)
+
+### Obtaining the source code
+Follow the steps below to obtain the Ballerina source code.
 
 1. Execute the below command to clone the ['ballerina-lang'](https://github.com/ballerina-platform/ballerina-lang) source repository.
 
 ```
-git clone --recursive https://github.com/ballerina-platform/ballerina-lang
+git clone --recursive https://github.com/ballerina-platform/ballerina-lang.git
 ```
-2. Execute one of the below commands to build the project using Gradle. 
+>**Tip:** If you have already forked the repository to your GitHub account, then execute the below command replacing <YOUR-GITHUB-USERNAME> with your Git username.
+
+```
+git clone --recursive https://github.com/<YOUR-GITHUB-USERNAME>/ballerina-lang.git
+```
+
+2. Execute the below command to update the Git submodules.
+
+```
+git submodule update --init
+```
+
+### Building the source
+
+Follow the steps below to build the project of the obtained source.
+
+1. Navigate to the root directory of the Ballerina repo (i.e., <BALLERINA_PROJECT_ROOT>) and execute one of the below Gradle commands to build the project using Gradle.
 
   - **On Unix/Mac OS:** ```./gradlew build ```
   - **Windows:** ```gradlew build ```
 
-3. Extract the Ballerina distribution created at: `distribution/zip/jballerina-tools/build/extracted-distributions/ballerina-<VERSION>-SNAPSHOT.zip`.
+2. Extract the built Ballerina distributions created in the below locations: 
+
+- **runtime only:** <BALLERINA_PROJECT_ROOT>/distribution/zip/jballerina/build/distributions/jballerina-<version>-SNAPSHOT.zip
+- **runtime and tools (e.g., Ballerina Language Server):** <BALLERINA_PROJECT_ROOT>/distribution/zip/jballerina-tools/build/distributions/jballerina-tools-<version>-SNAPSHOT.zip
+
+>**Note:** If you face an IOException error stating “Too many open files”, this is due to the default number of possible open files being set to a lower number on your operating system than required for Ballerina to be compiled. You may have to increase the number of open files/file descriptors (FD) on your operating system to 1000000 (or higher).
 
 ## Uninstalling Ballerina
 

--- a/v0-991/learn/getting-started.md
+++ b/v0-991/learn/getting-started.md
@@ -74,27 +74,54 @@ Follow one of the steps below depending on your operating system to configure yo
 
 Alternatively, follow the instructions below to install Ballerina from the source.
 
-### Prerequisites
+### Setting up the prerequisites
 
-You need to have the below installed to build particlura Ballerina modules.
+You need to download and install the below to build the Ballerina modules.
+1. Java SE Development Kit (JDK) version 8 (from one of the following locations) 
+    - [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+    - [OpenJDK](http://openjdk.java.net/install/index.html)
 
-- [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or [OpenJDK 8](http://openjdk.java.net/install/)
-- [Node (version 8.9.x or later) and npm (version 5.6.0 or later)](https://nodejs.org/en/download/)
-- [Docker](https://www.docker.com/get-started)
+>**Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
 
-### Building the source
+2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
+3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
+4. [Docker](https://www.docker.com/get-started)
+
+### Obtaining the source code
+Follow the steps below to obtain the Ballerina source code.
 
 1. Execute the below command to clone the ['ballerina-lang'](https://github.com/ballerina-platform/ballerina-lang) source repository.
 
 ```
-git clone --recursive https://github.com/ballerina-platform/ballerina-lang
+git clone --recursive https://github.com/ballerina-platform/ballerina-lang.git
 ```
-2. Execute one of the below commands to build the project using Gradle. 
+>**Tip:** If you have already forked the repository to your GitHub account, then execute the below command replacing <YOUR-GITHUB-USERNAME> with your Git username.
+
+```
+git clone --recursive https://github.com/<YOUR-GITHUB-USERNAME>/ballerina-lang.git
+```
+
+2. Execute the below command to update the Git submodules.
+
+```
+git submodule update --init
+```
+
+### Building the source
+
+Follow the steps below to build the project of the obtained source.
+
+1. Navigate to the root directory of the Ballerina repo (i.e., <BALLERINA_PROJECT_ROOT>) and execute one of the below Gradle commands to build the project using Gradle.
 
   - **On Unix/Mac OS:** ```./gradlew build ```
   - **Windows:** ```gradlew build ```
 
-3. Extract the Ballerina distribution created at: `distribution/zip/jballerina-tools/build/extracted-distributions/ballerina-<VERSION>-SNAPSHOT.zip`.
+2. Extract the built Ballerina distributions created in the below locations: 
+
+- **runtime only:** <BALLERINA_PROJECT_ROOT>/distribution/zip/jballerina/build/distributions/jballerina-<version>-SNAPSHOT.zip
+- **runtime and tools (e.g., Ballerina Language Server):** <BALLERINA_PROJECT_ROOT>/distribution/zip/jballerina-tools/build/distributions/jballerina-tools-<version>-SNAPSHOT.zip
+
+>**Note:** If you face an IOException error stating “Too many open files”, this is due to the default number of possible open files being set to a lower number on your operating system than required for Ballerina to be compiled. You may have to increase the number of open files/file descriptors (FD) on your operating system to 1000000 (or higher).
   
 ## Uninstalling Ballerina
 

--- a/v0-991/learn/getting-started.md
+++ b/v0-991/learn/getting-started.md
@@ -6,7 +6,15 @@ permalink: /v0-991/learn/getting-started/
 
 # Getting Started
 
-## Download the Ballerina distribution
+- [Downloading the Ballerina distribution](#downloading-the-ballerina-distribution)
+- [Installing Ballerina via installers](#installing-ballerina-via-installers)
+- [Installing via the Ballerina language ZIP file](#installing-via-the-ballerinalanguag-zip-file)
+- [Installing from source](#installing-from-source)
+- [Uninstalling Ballerina](#uninstalling-ballerina)
+- [Getting help](#getting-help)
+- [What's next](#what's-next)
+
+## Downloading the Ballerina distribution
 
 You can download the Ballerina distribution from [download page](https://ballerina.io/downloads/) for your operating system.
 
@@ -22,7 +30,7 @@ Ballerina binary distributions are available for the following supported operati
 - Red Hat Enterprise Linux 5.5 x64 and above
 - OS X 10.8.3 x64 and above
 
-If your operating system or architecture is not on the list, you can [install from source](https://github.com/ballerina-platform/ballerina-lang#install-from-source) instead.
+If your operating system or architecture is not on the list, you can [install from source](#installing-from-source) instead.
 
 ## Installing Ballerina via installers
 

--- a/v0-991/learn/getting-started.md
+++ b/v0-991/learn/getting-started.md
@@ -69,6 +69,32 @@ Follow one of the steps below depending on your operating system to configure yo
 - If your operating system is Windows, add a new environment variable specifying the following values:
   - Variable name: PATH
   - Variable value: The location of the bin directory of the unzipped Ballerina distribution. For example,  `C:\Program Files\Ballerina\ballerina-<version>\bin`
+
+## Installing from source
+
+Alternatively, follow the instructions below to install Ballerina from the source.
+
+### Prerequisites
+
+You need to have the below installed to build particlura Ballerina modules.
+
+- [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or [OpenJDK 8](http://openjdk.java.net/install/)
+- [Node (version 8.9.x or later) and npm (version 5.6.0 or later)](https://nodejs.org/en/download/)
+- [Docker](https://www.docker.com/get-started)
+
+### Building the source
+
+1. Execute the below command to clone the ['ballerina-lang'](https://github.com/ballerina-platform/ballerina-lang) source repository.
+
+```
+git clone --recursive https://github.com/ballerina-platform/ballerina-lang
+```
+2. Execute one of the below commands to build the project using Gradle. 
+
+  - **On Unix/Mac OS:** ```./gradlew build ```
+  - **Windows:** ```gradlew build ```
+
+3. Extract the Ballerina distribution created at: `distribution/zip/jballerina-tools/build/extracted-distributions/ballerina-<VERSION>-SNAPSHOT.zip`.
   
 ## Uninstalling Ballerina
 

--- a/v1-0/learn/installing-ballerina.md
+++ b/v1-0/learn/installing-ballerina.md
@@ -8,6 +8,13 @@ redirect_from:
 
 # Installing Ballerina
 
+- [Downloading the Ballerina distribution](#downloading-the-ballerina-distribution)
+- [Installing Ballerina via installers](#installing-ballerina-via-installers)
+- [Installing from source](#installing-from-source)
+- [Uninstalling Ballerina](#uninstalling-ballerina)
+- [Getting help](#getting-help)
+- [What's next](#what's-next)
+
 ## Downloading the Ballerina distribution
 
 [Download](https://ballerina.io/downloads/) a Ballerina distribution based on your operating system.
@@ -17,7 +24,7 @@ redirect_from:
 - Ubuntu Linux 12.04 x64 - LTS and above
 - OS X 10.8.3 x64 and above
 
-If a binary distribution is not available for your combination of operating system and architecture, try [installing from source](https://github.com/ballerina-platform/ballerina-lang#install-from-source).
+If a binary distribution is not available for your combination of operating system and architecture, try [installing from source](#installing-from-source).
 
 ## Installing Ballerina via installers
 

--- a/v1-0/learn/installing-ballerina.md
+++ b/v1-0/learn/installing-ballerina.md
@@ -49,27 +49,54 @@ dpkg -i <ballerina-binary>.deb
 
 Alternatively, follow the instructions below to install Ballerina from the source.
 
-### Prerequisites
+### Setting up the prerequisites
 
-You need to have the below installed to build particlura Ballerina modules.
+You need to download and install the below to build the Ballerina modules.
+1. Java SE Development Kit (JDK) version 8 (from one of the following locations) 
+    - [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+    - [OpenJDK](http://openjdk.java.net/install/index.html)
 
-- [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or [OpenJDK 8](http://openjdk.java.net/install/)
-- [Node (version 8.9.x or later) and npm (version 5.6.0 or later)](https://nodejs.org/en/download/)
-- [Docker](https://www.docker.com/get-started)
+>**Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
 
-### Building the source
+2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
+3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
+4. [Docker](https://www.docker.com/get-started)
+
+### Obtaining the source code
+Follow the steps below to obtain the Ballerina source code.
 
 1. Execute the below command to clone the ['ballerina-lang'](https://github.com/ballerina-platform/ballerina-lang) source repository.
 
 ```
-git clone --recursive https://github.com/ballerina-platform/ballerina-lang
+git clone --recursive https://github.com/ballerina-platform/ballerina-lang.git
 ```
-2. Execute one of the below commands to build the project using Gradle. 
+>**Tip:** If you have already forked the repository to your GitHub account, then execute the below command replacing <YOUR-GITHUB-USERNAME> with your Git username.
+
+```
+git clone --recursive https://github.com/<YOUR-GITHUB-USERNAME>/ballerina-lang.git
+```
+
+2. Execute the below command to update the Git submodules.
+
+```
+git submodule update --init
+```
+
+### Building the source
+
+Follow the steps below to build the project of the obtained source.
+
+1. Navigate to the root directory of the Ballerina repo (i.e., <BALLERINA_PROJECT_ROOT>) and execute one of the below Gradle commands to build the project using Gradle.
 
   - **On Unix/Mac OS:** ```./gradlew build ```
   - **Windows:** ```gradlew build ```
 
-3. Extract the Ballerina distribution created at: `distribution/zip/jballerina-tools/build/extracted-distributions/ballerina-<VERSION>-SNAPSHOT.zip`.
+2. Extract the built Ballerina distributions created in the below locations: 
+
+- **runtime only:** <BALLERINA_PROJECT_ROOT>/distribution/zip/jballerina/build/distributions/jballerina-<version>-SNAPSHOT.zip
+- **runtime and tools (e.g., Ballerina Language Server):** <BALLERINA_PROJECT_ROOT>/distribution/zip/jballerina-tools/build/distributions/jballerina-tools-<version>-SNAPSHOT.zip
+
+>**Note:** If you face an IOException error stating “Too many open files”, this is due to the default number of possible open files being set to a lower number on your operating system than required for Ballerina to be compiled. You may have to increase the number of open files/file descriptors (FD) on your operating system to 1000000 (or higher).
 
 ## Uninstalling Ballerina
 

--- a/v1-0/learn/installing-ballerina.md
+++ b/v1-0/learn/installing-ballerina.md
@@ -45,6 +45,31 @@ The installer should put the `C:\Program Files\Ballerina\<ballerina-directory>\b
 ```
 dpkg -i <ballerina-binary>.deb
 ```
+## Installing from source
+
+Alternatively, follow the instructions below to install Ballerina from the source.
+
+### Prerequisites
+
+You need to have the below installed to build particlura Ballerina modules.
+
+- [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or [OpenJDK 8](http://openjdk.java.net/install/)
+- [Node (version 8.9.x or later) and npm (version 5.6.0 or later)](https://nodejs.org/en/download/)
+- [Docker](https://www.docker.com/get-started)
+
+### Building the source
+
+1. Execute the below command to clone the ['ballerina-lang'](https://github.com/ballerina-platform/ballerina-lang) source repository.
+
+```
+git clone --recursive https://github.com/ballerina-platform/ballerina-lang
+```
+2. Execute one of the below commands to build the project using Gradle. 
+
+  - **On Unix/Mac OS:** ```./gradlew build ```
+  - **Windows:** ```gradlew build ```
+
+3. Extract the Ballerina distribution created at: `distribution/zip/jballerina-tools/build/extracted-distributions/ballerina-<VERSION>-SNAPSHOT.zip`.
 
 ## Uninstalling Ballerina
 

--- a/v1-1/learn/installing-ballerina.md
+++ b/v1-1/learn/installing-ballerina.md
@@ -8,6 +8,13 @@ redirect_from:
 
 # Installing Ballerina
 
+- [Downloading the Ballerina distribution](#downloading-the-ballerina-distribution)
+- [Installing Ballerina via installers](#installing-ballerina-via-installers)
+- [Installing from source](#installing-from-source)
+- [Uninstalling Ballerina](#uninstalling-ballerina)
+- [Getting help](#getting-help)
+- [What's next](#what's-next)
+
 ## Downloading the Ballerina distribution
 
 [Download](https://ballerina.io/downloads/) a Ballerina distribution based on your operating system.
@@ -17,7 +24,7 @@ redirect_from:
 - Ubuntu Linux 12.04 x64 - LTS and above
 - OS X 10.8.3 x64 and above
 
-If a binary distribution is not available for your combination of operating system and architecture, try [installing from source](https://github.com/ballerina-platform/ballerina-lang#install-from-source).
+If a binary distribution is not available for your combination of operating system and architecture, try [installing from source](#installing-from-source).
 
 ## Installing Ballerina via installers
 

--- a/v1-1/learn/installing-ballerina.md
+++ b/v1-1/learn/installing-ballerina.md
@@ -49,27 +49,54 @@ dpkg -i <ballerina-binary>.deb
 
 Alternatively, follow the instructions below to install Ballerina from the source.
 
-### Prerequisites
+### Setting up the prerequisites
 
-You need to have the below installed to build particlura Ballerina modules.
+You need to download and install the below to build the Ballerina modules.
+1. Java SE Development Kit (JDK) version 8 (from one of the following locations) 
+    - [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+    - [OpenJDK](http://openjdk.java.net/install/index.html)
 
-- [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or [OpenJDK 8](http://openjdk.java.net/install/)
-- [Node (version 8.9.x or later) and npm (version 5.6.0 or later)](https://nodejs.org/en/download/)
-- [Docker](https://www.docker.com/get-started)
+>**Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
 
-### Building the source
+2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
+3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
+4. [Docker](https://www.docker.com/get-started)
+
+### Obtaining the source code
+Follow the steps below to obtain the Ballerina source code.
 
 1. Execute the below command to clone the ['ballerina-lang'](https://github.com/ballerina-platform/ballerina-lang) source repository.
 
 ```
-git clone --recursive https://github.com/ballerina-platform/ballerina-lang
+git clone --recursive https://github.com/ballerina-platform/ballerina-lang.git
 ```
-2. Execute one of the below commands to build the project using Gradle. 
+>**Tip:** If you have already forked the repository to your GitHub account, then execute the below command replacing <YOUR-GITHUB-USERNAME> with your Git username.
+
+```
+git clone --recursive https://github.com/<YOUR-GITHUB-USERNAME>/ballerina-lang.git
+```
+
+2. Execute the below command to update the Git submodules.
+
+```
+git submodule update --init
+```
+
+### Building the source
+
+Follow the steps below to build the project of the obtained source.
+
+1. Navigate to the root directory of the Ballerina repo (i.e., <BALLERINA_PROJECT_ROOT>) and execute one of the below Gradle commands to build the project using Gradle.
 
   - **On Unix/Mac OS:** ```./gradlew build ```
   - **Windows:** ```gradlew build ```
 
-3. Extract the Ballerina distribution created at: `distribution/zip/jballerina-tools/build/extracted-distributions/ballerina-<VERSION>-SNAPSHOT.zip`.
+2. Extract the built Ballerina distributions created in the below locations: 
+
+- **runtime only:** <BALLERINA_PROJECT_ROOT>/distribution/zip/jballerina/build/distributions/jballerina-<version>-SNAPSHOT.zip
+- **runtime and tools (e.g., Ballerina Language Server):** <BALLERINA_PROJECT_ROOT>/distribution/zip/jballerina-tools/build/distributions/jballerina-tools-<version>-SNAPSHOT.zip
+
+>**Note:** If you face an IOException error stating “Too many open files”, this is due to the default number of possible open files being set to a lower number on your operating system than required for Ballerina to be compiled. You may have to increase the number of open files/file descriptors (FD) on your operating system to 1000000 (or higher).
 
 ## Uninstalling Ballerina
 

--- a/v1-1/learn/installing-ballerina.md
+++ b/v1-1/learn/installing-ballerina.md
@@ -45,6 +45,31 @@ The installer should put the `C:\Program Files\Ballerina\<ballerina-directory>\b
 ```
 dpkg -i <ballerina-binary>.deb
 ```
+## Installing from source
+
+Alternatively, follow the instructions below to install Ballerina from the source.
+
+### Prerequisites
+
+You need to have the below installed to build particlura Ballerina modules.
+
+- [Oracle JDK 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) or [OpenJDK 8](http://openjdk.java.net/install/)
+- [Node (version 8.9.x or later) and npm (version 5.6.0 or later)](https://nodejs.org/en/download/)
+- [Docker](https://www.docker.com/get-started)
+
+### Building the source
+
+1. Execute the below command to clone the ['ballerina-lang'](https://github.com/ballerina-platform/ballerina-lang) source repository.
+
+```
+git clone --recursive https://github.com/ballerina-platform/ballerina-lang
+```
+2. Execute one of the below commands to build the project using Gradle. 
+
+  - **On Unix/Mac OS:** ```./gradlew build ```
+  - **Windows:** ```gradlew build ```
+
+3. Extract the Ballerina distribution created at: `distribution/zip/jballerina-tools/build/extracted-distributions/ballerina-<VERSION>-SNAPSHOT.zip`.
 
 ## Uninstalling Ballerina
 


### PR DESCRIPTION
## Purpose
This is to add the "Install from source" section in [1] to [2].

[1] https://github.com/ballerina-platform/ballerina-lang
[2] https://ballerina.io/v1-1/learn/installing-ballerina/
> Fixes #214

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
