### PR TITLE
Link the Ballerina Tech Blog from the Community Page

### DIFF
--- a/community.md
+++ b/community.md
@@ -63,6 +63,7 @@ Getting a language established is like getting a new religion going. If you like
 - Start by starring the <a href="https://github.com/ballerina-platform/ballerina-lang">Ballerina GitHub repo</a>. Thank you!
 - Follow us on Twitter: <a href="https://twitter.com/ballerinalang">@ballerinalang</a>. Tweet with the "#ballerinalang" hashtag.
 - Share the wealth by publishing your Ballerina module on <a href="https://central.ballerina.io">Ballerina Central</a> so that the whole community can benefit from your work. 
+- Write your own blog and submit it to be published in the <a href=https://medium.com/ballerina-techblog>Ballerina Tech Blog</a>. 
 - Buzz us on <a href="mailto:contact@ballerina.io">contact@ballerina.io</a> if you want to organize a local meetup or hackathon. WSO2 will get right on it and help with presentation/training content, logistics, swag, and some funds for munchies.
 
 <!-- ## Want to be kept up-to-date?

--- a/community.md
+++ b/community.md
@@ -63,7 +63,7 @@ Getting a language established is like getting a new religion going. If you like
 - Start by starring the <a href="https://github.com/ballerina-platform/ballerina-lang">Ballerina GitHub repo</a>. Thank you!
 - Follow us on Twitter: <a href="https://twitter.com/ballerinalang">@ballerinalang</a>. Tweet with the "#ballerinalang" hashtag.
 - Share the wealth by publishing your Ballerina module on <a href="https://central.ballerina.io">Ballerina Central</a> so that the whole community can benefit from your work. 
-- Write your own blog and submit it to be published in the <a href=https://medium.com/ballerina-techblog>Ballerina Tech Blog</a>. 
+- Write your own blog and submit it to be published in our <a href=https://medium.com/ballerina-techblog>community-driven Tech Blog</a>. 
 - Buzz us on <a href="mailto:contact@ballerina.io">contact@ballerina.io</a> if you want to organize a local meetup or hackathon. WSO2 will get right on it and help with presentation/training content, logistics, swag, and some funds for munchies.
 
 <!-- ## Want to be kept up-to-date?


### PR DESCRIPTION
## Purpose
We need to link [1] from [2] to get more community involvement.

[1] https://medium.com/ballerina-techblog
[2] https://ballerina.io/community/
> Fixes #218

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
