### PR TITLE
Fix home page BBE link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ breadcrumbs:
     image: false # Show image or title text  
 github_username:  ballerina-platform
 git_repo: ballerina-platform.github.io
-
+latest_version: v1-1
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ title: Home
                Download Ballerina
                <p>Distributions available for <br>Linux, OS X, and Windows</p>
             </a>
-            <a class="cBallerina-io-Home-main-download-button cBBEButton" href="/learn/by-example/">
+            <a class="cBallerina-io-Home-main-download-button cBBEButton" href="/{{ site.latest_version }}/learn/by-example/">
                <img src="/img/ballerina-bbe-logo.svg"/>
                <p>Commented examples to learn <br>and cut-n-paste from</p>
             </a>


### PR DESCRIPTION
## Purpose
This will fix the home page link for the BBE to direct to the latest version's BBE location.

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
