### PR TITLE
Fix the Installing from Source Link in the Contribution Guide

### DIFF
--- a/contribution-guide.md
+++ b/contribution-guide.md
@@ -67,7 +67,7 @@ We appreciate your help!
 
 ## Build the source code 
 
-For instructions, see <a href="/learn/installing-ballerina/#installing-from-source">Installing from source</a>.
+For instructions, see <a href="https://ballerina.io/learn/installing-ballerina/#installing-from-source">Installing from source</a>.
 
 ## Set up the development environment
 

--- a/contribution-guide.md
+++ b/contribution-guide.md
@@ -67,7 +67,7 @@ We appreciate your help!
 
 ## Build the source code 
 
-For instructions, see [Installing from source](https://ballerina.io/learn/installing-ballerina/installing-from-source).
+For instructions, see <a href="/learn/installing-ballerina/#installing-from-source">Installing from source</a>.
 
 ## Set up the development environment
 


### PR DESCRIPTION
## Purpose
Fix the "Installing from Source" Link in the Contribution Guide.

[2] 
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
