### PR TITLE
Remove Docker from Prerequisites

### DIFF
--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -68,7 +68,6 @@ You need to download and install the below to build the Ballerina modules.
 
 2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
 3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
-4. [Docker](https://www.docker.com/get-started)
 
 ### Obtaining the source code
 Follow the steps below to obtain the Ballerina source code.

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -61,11 +61,9 @@ Alternatively, follow the instructions below to install Ballerina from the sourc
 
 You need to download and install the below to build the Ballerina modules.
 1. Java SE Development Kit (JDK) version 8 (from one of the following locations) 
-    - [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-    - [OpenJDK](http://openjdk.java.net/install/index.html)
-
+- [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+- [OpenJDK](http://openjdk.java.net/install/index.html)
 >**Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
-
 2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
 3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
 

--- a/v0-991/learn/getting-started.md
+++ b/v0-991/learn/getting-started.md
@@ -86,11 +86,9 @@ Alternatively, follow the instructions below to install Ballerina from the sourc
 
 You need to download and install the below to build the Ballerina modules.
 1. Java SE Development Kit (JDK) version 8 (from one of the following locations) 
-    - [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-    - [OpenJDK](http://openjdk.java.net/install/index.html)
-
+- [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+- [OpenJDK](http://openjdk.java.net/install/index.html)
 >**Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
-
 2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
 3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
 

--- a/v0-991/learn/getting-started.md
+++ b/v0-991/learn/getting-started.md
@@ -93,7 +93,6 @@ You need to download and install the below to build the Ballerina modules.
 
 2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
 3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
-4. [Docker](https://www.docker.com/get-started)
 
 ### Obtaining the source code
 Follow the steps below to obtain the Ballerina source code.

--- a/v1-0/learn/installing-ballerina.md
+++ b/v1-0/learn/installing-ballerina.md
@@ -60,11 +60,9 @@ Alternatively, follow the instructions below to install Ballerina from the sourc
 
 You need to download and install the below to build the Ballerina modules.
 1. Java SE Development Kit (JDK) version 8 (from one of the following locations) 
-    - [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-    - [OpenJDK](http://openjdk.java.net/install/index.html)
-
+- [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+- [OpenJDK](http://openjdk.java.net/install/index.html)
 >**Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
-
 2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
 3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
 

--- a/v1-0/learn/installing-ballerina.md
+++ b/v1-0/learn/installing-ballerina.md
@@ -67,7 +67,6 @@ You need to download and install the below to build the Ballerina modules.
 
 2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
 3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
-4. [Docker](https://www.docker.com/get-started)
 
 ### Obtaining the source code
 Follow the steps below to obtain the Ballerina source code.

--- a/v1-1/learn/installing-ballerina.md
+++ b/v1-1/learn/installing-ballerina.md
@@ -60,11 +60,9 @@ Alternatively, follow the instructions below to install Ballerina from the sourc
 
 You need to download and install the below to build the Ballerina modules.
 1. Java SE Development Kit (JDK) version 8 (from one of the following locations) 
-    - [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
-    - [OpenJDK](http://openjdk.java.net/install/index.html)
-
+- [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+- [OpenJDK](http://openjdk.java.net/install/index.html)
 >**Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
-
 2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
 3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
 

--- a/v1-1/learn/installing-ballerina.md
+++ b/v1-1/learn/installing-ballerina.md
@@ -67,7 +67,6 @@ You need to download and install the below to build the Ballerina modules.
 
 2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
 3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
-4. [Docker](https://www.docker.com/get-started)
 
 ### Obtaining the source code
 Follow the steps below to obtain the Ballerina source code.


### PR DESCRIPTION
## Purpose
We need to remove Docker from the "Setting up the prerequisites" in [1].

[1] https://ballerina.io/v1-1/learn/installing-ballerina/
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
