### PR TITLE
Add a space after record definition ":" sign

### DIFF
--- a/learn/style-guide.md
+++ b/learn/style-guide.md
@@ -66,7 +66,7 @@ int[] arrayOfInteger = [1, 2, 3, 4];
     
 map<string> stringMap = {one: st1, two: st2, three: st3};
     
-Person personRecord = {name:"marcus", id: 0};
+Person personRecord = {name: "marcus", id: 0};
     
 function foo(string name, int id) {}
     


### PR DESCRIPTION
## Purpose
In record definition in style guide section for line, spaces there is a missing a space after the ":" sign. This PR is fixing it.

#### Before
```Ballerina
Person personRecord = {name:"marcus", id: 0};
```
### After
```Ballerina
Person personRecord = {name: "marcus", id: 0};
```

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
