### PR TITLE
Fix broken links in API docs

### DIFF
--- a/v1-0/learn/api-docs/ballerina/auth/constants.html
+++ b/v1-0/learn/api-docs/ballerina/auth/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - auth
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//auth/constants
+permalink: /v1-0/learn/api-docs/ballerina/auth/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/auth/errors.html
+++ b/v1-0/learn/api-docs/ballerina/auth/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - auth
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//auth/errors
+permalink: /v1-0/learn/api-docs/ballerina/auth/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/auth/functions.html
+++ b/v1-0/learn/api-docs/ballerina/auth/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - auth
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//auth/functions
+permalink: /v1-0/learn/api-docs/ballerina/auth/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
+++ b/v1-0/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - auth
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//auth/objects/InboundAuthProvider
+permalink: /v1-0/learn/api-docs/ballerina/auth/objects/InboundAuthProvider
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
+++ b/v1-0/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - auth
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//auth/objects/InboundBasicAuthProvider
+permalink: /v1-0/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
+++ b/v1-0/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - auth
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//auth/objects/OutboundAuthProvider
+permalink: /v1-0/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
+++ b/v1-0/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - auth
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//auth/objects/OutboundBasicAuthProvider
+permalink: /v1-0/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
+++ b/v1-0/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - auth
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//auth/records/BasicAuthConfig
+permalink: /v1-0/learn/api-docs/ballerina/auth/records/BasicAuthConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/auth/records/Credential.html
+++ b/v1-0/learn/api-docs/ballerina/auth/records/Credential.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - auth
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//auth/records/Credential
+permalink: /v1-0/learn/api-docs/ballerina/auth/records/Credential
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/auth/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/auth/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - auth
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//auth/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/auth/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/cache/constants.html
+++ b/v1-0/learn/api-docs/ballerina/cache/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - cache
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//cache/constants
+permalink: /v1-0/learn/api-docs/ballerina/cache/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/cache/errors.html
+++ b/v1-0/learn/api-docs/ballerina/cache/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - cache
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//cache/errors
+permalink: /v1-0/learn/api-docs/ballerina/cache/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/cache/objects/Cache.html
+++ b/v1-0/learn/api-docs/ballerina/cache/objects/Cache.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - cache
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//cache/objects/Cache
+permalink: /v1-0/learn/api-docs/ballerina/cache/objects/Cache
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/cache/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/cache/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - cache
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//cache/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/cache/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/config/functions.html
+++ b/v1-0/learn/api-docs/ballerina/config/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - config
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//config/functions
+permalink: /v1-0/learn/api-docs/ballerina/config/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/crypto/constants.html
+++ b/v1-0/learn/api-docs/ballerina/crypto/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - crypto
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//crypto/constants
+permalink: /v1-0/learn/api-docs/ballerina/crypto/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/crypto/errors.html
+++ b/v1-0/learn/api-docs/ballerina/crypto/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - crypto
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//crypto/errors
+permalink: /v1-0/learn/api-docs/ballerina/crypto/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/crypto/functions.html
+++ b/v1-0/learn/api-docs/ballerina/crypto/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - crypto
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//crypto/functions
+permalink: /v1-0/learn/api-docs/ballerina/crypto/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/crypto/records/Certificate.html
+++ b/v1-0/learn/api-docs/ballerina/crypto/records/Certificate.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - crypto
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//crypto/records/Certificate
+permalink: /v1-0/learn/api-docs/ballerina/crypto/records/Certificate
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/crypto/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/crypto/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - crypto
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//crypto/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/crypto/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/crypto/records/KeyStore.html
+++ b/v1-0/learn/api-docs/ballerina/crypto/records/KeyStore.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - crypto
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//crypto/records/KeyStore
+permalink: /v1-0/learn/api-docs/ballerina/crypto/records/KeyStore
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/crypto/records/PrivateKey.html
+++ b/v1-0/learn/api-docs/ballerina/crypto/records/PrivateKey.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - crypto
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//crypto/records/PrivateKey
+permalink: /v1-0/learn/api-docs/ballerina/crypto/records/PrivateKey
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/crypto/records/PublicKey.html
+++ b/v1-0/learn/api-docs/ballerina/crypto/records/PublicKey.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - crypto
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//crypto/records/PublicKey
+permalink: /v1-0/learn/api-docs/ballerina/crypto/records/PublicKey
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/crypto/records/TrustStore.html
+++ b/v1-0/learn/api-docs/ballerina/crypto/records/TrustStore.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - crypto
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//crypto/records/TrustStore
+permalink: /v1-0/learn/api-docs/ballerina/crypto/records/TrustStore
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/crypto/types.html
+++ b/v1-0/learn/api-docs/ballerina/crypto/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - crypto
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//crypto/types
+permalink: /v1-0/learn/api-docs/ballerina/crypto/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/docker/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/docker/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - docker
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//docker/annotations
+permalink: /v1-0/learn/api-docs/ballerina/docker/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/docker/records/DockerConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/docker/records/DockerConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - docker
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//docker/records/DockerConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/docker/records/DockerConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/docker/records/ExposeConfig.html
+++ b/v1-0/learn/api-docs/ballerina/docker/records/ExposeConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - docker
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//docker/records/ExposeConfig
+permalink: /v1-0/learn/api-docs/ballerina/docker/records/ExposeConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/docker/records/FileConfig.html
+++ b/v1-0/learn/api-docs/ballerina/docker/records/FileConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - docker
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//docker/records/FileConfig
+permalink: /v1-0/learn/api-docs/ballerina/docker/records/FileConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/docker/records/FileConfigs.html
+++ b/v1-0/learn/api-docs/ballerina/docker/records/FileConfigs.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - docker
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//docker/records/FileConfigs
+permalink: /v1-0/learn/api-docs/ballerina/docker/records/FileConfigs
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/encoding/constants.html
+++ b/v1-0/learn/api-docs/ballerina/encoding/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - encoding
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//encoding/constants
+permalink: /v1-0/learn/api-docs/ballerina/encoding/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/encoding/errors.html
+++ b/v1-0/learn/api-docs/ballerina/encoding/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - encoding
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//encoding/errors
+permalink: /v1-0/learn/api-docs/ballerina/encoding/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/encoding/functions.html
+++ b/v1-0/learn/api-docs/ballerina/encoding/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - encoding
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//encoding/functions
+permalink: /v1-0/learn/api-docs/ballerina/encoding/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/encoding/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/encoding/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - encoding
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//encoding/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/encoding/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/file/constants.html
+++ b/v1-0/learn/api-docs/ballerina/file/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - file
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//file/constants
+permalink: /v1-0/learn/api-docs/ballerina/file/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/file/errors.html
+++ b/v1-0/learn/api-docs/ballerina/file/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - file
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//file/errors
+permalink: /v1-0/learn/api-docs/ballerina/file/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/file/functions.html
+++ b/v1-0/learn/api-docs/ballerina/file/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - file
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//file/functions
+permalink: /v1-0/learn/api-docs/ballerina/file/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/file/listeners/Listener.html
+++ b/v1-0/learn/api-docs/ballerina/file/listeners/Listener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - file
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//file/listeners/listener
+permalink: /v1-0/learn/api-docs/ballerina/file/listeners/listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/file/objects/FileInfo.html
+++ b/v1-0/learn/api-docs/ballerina/file/objects/FileInfo.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - file
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//file/objects/FileInfo
+permalink: /v1-0/learn/api-docs/ballerina/file/objects/FileInfo
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/file/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/file/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - file
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//file/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/file/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/file/records/FileEvent.html
+++ b/v1-0/learn/api-docs/ballerina/file/records/FileEvent.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - file
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//file/records/FileEvent
+permalink: /v1-0/learn/api-docs/ballerina/file/records/FileEvent
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/file/records/ListenerConfig.html
+++ b/v1-0/learn/api-docs/ballerina/file/records/ListenerConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - file
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//file/records/ListenerConfig
+permalink: /v1-0/learn/api-docs/ballerina/file/records/ListenerConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/file/types.html
+++ b/v1-0/learn/api-docs/ballerina/file/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - file
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//file/types
+permalink: /v1-0/learn/api-docs/ballerina/file/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/filepath/constants.html
+++ b/v1-0/learn/api-docs/ballerina/filepath/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - filepath
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//filepath/constants
+permalink: /v1-0/learn/api-docs/ballerina/filepath/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/filepath/errors.html
+++ b/v1-0/learn/api-docs/ballerina/filepath/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - filepath
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//filepath/errors
+permalink: /v1-0/learn/api-docs/ballerina/filepath/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/filepath/functions.html
+++ b/v1-0/learn/api-docs/ballerina/filepath/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - filepath
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//filepath/functions
+permalink: /v1-0/learn/api-docs/ballerina/filepath/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/filepath/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/filepath/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - filepath
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//filepath/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/filepath/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/filepath/types.html
+++ b/v1-0/learn/api-docs/ballerina/filepath/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - filepath
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//filepath/types
+permalink: /v1-0/learn/api-docs/ballerina/filepath/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/annotations
+permalink: /v1-0/learn/api-docs/ballerina/grpc/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/clients/Caller.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/clients/Caller.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/clients/Caller
+permalink: /v1-0/learn/api-docs/ballerina/grpc/clients/Caller
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/clients/Client.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/clients/Client.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/clients/Client
+permalink: /v1-0/learn/api-docs/ballerina/grpc/clients/Client
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/clients/StreamingClient
+permalink: /v1-0/learn/api-docs/ballerina/grpc/clients/StreamingClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/constants.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/constants
+permalink: /v1-0/learn/api-docs/ballerina/grpc/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/errors.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/errors
+permalink: /v1-0/learn/api-docs/ballerina/grpc/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/functions.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/functions
+permalink: /v1-0/learn/api-docs/ballerina/grpc/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/listeners/Listener.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/listeners/Listener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/listeners/listener
+permalink: /v1-0/learn/api-docs/ballerina/grpc/listeners/listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/objects/AbstractClientEndpoint
+permalink: /v1-0/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/objects/Headers.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/objects/Headers.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/objects/Headers
+permalink: /v1-0/learn/api-docs/ballerina/grpc/objects/Headers
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/ClientConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/ClientConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/GrpcResourceConfig
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/GrpcServiceConfig
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/ListenerConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/ListenerConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/ListenerOcspStapling
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/ListenerSecureSocket
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/Local.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/Local.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/Local
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/Local
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/PoolConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/PoolConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/Protocols.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/Protocols.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/Protocols
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/Protocols
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/Remote.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/Remote.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/Remote
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/Remote
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/SecureSocket.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/SecureSocket.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/SecureSocket
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/SecureSocket
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/ServiceDescriptorData
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/records/ValidateCert.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/records/ValidateCert.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/records/ValidateCert
+permalink: /v1-0/learn/api-docs/ballerina/grpc/records/ValidateCert
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/grpc/types.html
+++ b/v1-0/learn/api-docs/ballerina/grpc/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - grpc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//grpc/types
+permalink: /v1-0/learn/api-docs/ballerina/grpc/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/http/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/annotations
+permalink: /v1-0/learn/api-docs/ballerina/http/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/Caller.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/Caller.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/Caller
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/Caller
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/CircuitBreakerClient
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/CircuitBreakerClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/Client.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/Client.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/Client
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/Client
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/FailoverClient.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/FailoverClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/FailoverClient
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/FailoverClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/HttpCachingClient
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/HttpCachingClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/HttpClient.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/HttpClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/HttpClient
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/HttpClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/HttpSecureClient
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/HttpSecureClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/LoadBalanceClient
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/LoadBalanceClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/RedirectClient.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/RedirectClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/RedirectClient
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/RedirectClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/RetryClient.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/RetryClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/RetryClient
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/RetryClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/WebSocketCaller
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/WebSocketCaller
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/clients/WebSocketClient.html
+++ b/v1-0/learn/api-docs/ballerina/http/clients/WebSocketClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/clients/WebSocketClient
+permalink: /v1-0/learn/api-docs/ballerina/http/clients/WebSocketClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/constants.html
+++ b/v1-0/learn/api-docs/ballerina/http/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/constants
+permalink: /v1-0/learn/api-docs/ballerina/http/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/errors.html
+++ b/v1-0/learn/api-docs/ballerina/http/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/errors
+permalink: /v1-0/learn/api-docs/ballerina/http/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/functions.html
+++ b/v1-0/learn/api-docs/ballerina/http/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/functions
+permalink: /v1-0/learn/api-docs/ballerina/http/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/listeners/Listener.html
+++ b/v1-0/learn/api-docs/ballerina/http/listeners/Listener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/listeners/listener
+permalink: /v1-0/learn/api-docs/ballerina/http/listeners/listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/listeners/MockListener.html
+++ b/v1-0/learn/api-docs/ballerina/http/listeners/MockListener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/listeners/listener
+permalink: /v1-0/learn/api-docs/ballerina/http/listeners/listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/AuthnFilter.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/AuthnFilter.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/AuthnFilter
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/AuthnFilter
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/AuthzFilter.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/AuthzFilter.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/AuthzFilter
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/AuthzFilter
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/AuthzHandler.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/AuthzHandler.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/AuthzHandler
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/AuthzHandler
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/BasicAuthHandler
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/BasicAuthHandler
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/BearerAuthHandler
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/BearerAuthHandler
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/FilterContext.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/FilterContext.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/FilterContext
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/FilterContext
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/HttpCache.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/HttpCache.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/HttpCache
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/HttpCache
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/HttpFuture.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/HttpFuture.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/HttpFuture
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/HttpFuture
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/InboundAuthHandler
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/InboundAuthHandler
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/LoadBalancerRoundRobinRule
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/LoadBalancerRule
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/LoadBalancerRule
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/OutboundAuthHandler
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/OutboundAuthHandler
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/PushPromise.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/PushPromise.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/PushPromise
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/PushPromise
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/Request.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/Request.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/Request
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/Request
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/RequestCacheControl
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/RequestCacheControl
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/RequestFilter.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/RequestFilter.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/RequestFilter
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/RequestFilter
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/Response.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/Response.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/Response
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/Response
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/ResponseCacheControl
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/ResponseCacheControl
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/objects/ResponseFilter.html
+++ b/v1-0/learn/api-docs/ballerina/http/objects/ResponseFilter.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/objects/ResponseFilter
+permalink: /v1-0/learn/api-docs/ballerina/http/objects/ResponseFilter
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/AuthzCacheConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/AuthzCacheConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/AuthzCacheConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/AuthzCacheConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/Bucket.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/Bucket.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/Bucket
+permalink: /v1-0/learn/api-docs/ballerina/http/records/Bucket
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/CacheConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/CacheConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/CacheConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/CacheConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/CircuitBreakerConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/CircuitBreakerConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/CircuitBreakerInferredConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/CircuitHealth.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/CircuitHealth.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/CircuitHealth
+permalink: /v1-0/learn/api-docs/ballerina/http/records/CircuitHealth
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ClientConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ClientConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ClientConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ClientConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ClientHttp1Settings
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ClientHttp1Settings
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ClientHttp2Settings
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ClientHttp2Settings
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ClientSecureSocket
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ClientSecureSocket
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/CompressionConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/CompressionConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/CompressionConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/CompressionConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/CorsConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/CorsConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/CorsConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/CorsConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/http/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/FailoverClientConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/http/records/FailoverClientConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/FailoverConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/FailoverConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/FailoverConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/FailoverConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/FailoverInferredConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/FailoverInferredConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/FollowRedirects.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/FollowRedirects.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/FollowRedirects
+permalink: /v1-0/learn/api-docs/ballerina/http/records/FollowRedirects
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/HttpResourceConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/HttpResourceConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/HttpServiceConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/HttpServiceConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/HttpTimeoutError
+permalink: /v1-0/learn/api-docs/ballerina/http/records/HttpTimeoutError
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ListenerAuth.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ListenerAuth.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ListenerAuth
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ListenerAuth
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ListenerConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ListenerConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ListenerHttp1Settings
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ListenerHttp1Settings
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ListenerOcspStapling
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ListenerOcspStapling
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ListenerSecureSocket
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ListenerSecureSocket
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/LoadBalanceActionErrorData
+permalink: /v1-0/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/LoadBalanceClientConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/Local.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/Local.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/Local
+permalink: /v1-0/learn/api-docs/ballerina/http/records/Local
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/MutualSslHandshake
+permalink: /v1-0/learn/api-docs/ballerina/http/records/MutualSslHandshake
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/OutboundAuthConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/OutboundAuthConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/PoolConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/PoolConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/PoolConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/http/records/PoolConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/Protocols.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/Protocols.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/Protocols
+permalink: /v1-0/learn/api-docs/ballerina/http/records/Protocols
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ProxyConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ProxyConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ProxyConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ProxyConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/Remote.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/Remote.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/Remote
+permalink: /v1-0/learn/api-docs/ballerina/http/records/Remote
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/RetryConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/RetryConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/RetryConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/RetryConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/RetryInferredConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/RetryInferredConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/RollingWindow.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/RollingWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/RollingWindow
+permalink: /v1-0/learn/api-docs/ballerina/http/records/RollingWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ServiceResourceAuth.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ServiceResourceAuth.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ServiceResourceAuth
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ServiceResourceAuth
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/TargetService.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/TargetService.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/TargetService
+permalink: /v1-0/learn/api-docs/ballerina/http/records/TargetService
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/ValidateCert.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/ValidateCert.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/ValidateCert
+permalink: /v1-0/learn/api-docs/ballerina/http/records/ValidateCert
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/Versioning.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/Versioning.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/Versioning
+permalink: /v1-0/learn/api-docs/ballerina/http/records/Versioning
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/WSServiceConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/WSServiceConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/WSServiceConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/WSServiceConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/WebSocketClientConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
+++ b/v1-0/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/records/WebSocketUpgradeConfig
+permalink: /v1-0/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/http/types.html
+++ b/v1-0/learn/api-docs/ballerina/http/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - http
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//http/types
+permalink: /v1-0/learn/api-docs/ballerina/http/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/constants.html
+++ b/v1-0/learn/api-docs/ballerina/io/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/constants
+permalink: /v1-0/learn/api-docs/ballerina/io/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/errors.html
+++ b/v1-0/learn/api-docs/ballerina/io/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/errors
+permalink: /v1-0/learn/api-docs/ballerina/io/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/functions.html
+++ b/v1-0/learn/api-docs/ballerina/io/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/functions
+permalink: /v1-0/learn/api-docs/ballerina/io/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/ReadableByteChannel
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/ReadableByteChannel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/ReadableCSVChannel
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/ReadableCSVChannel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/ReadableCharacterChannel
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/ReadableDataChannel
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/ReadableDataChannel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/ReadableTextRecordChannel
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/StringReader.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/StringReader.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/StringReader
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/StringReader
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/WritableByteChannel
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/WritableByteChannel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/WritableCSVChannel
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/WritableCSVChannel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/WritableCharacterChannel
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/WritableCharacterChannel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/WritableDataChannel
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/WritableDataChannel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
+++ b/v1-0/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/objects/WritableTextRecordChannel
+permalink: /v1-0/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/io/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/io/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/io/types.html
+++ b/v1-0/learn/api-docs/ballerina/io/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - io
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//io/types
+permalink: /v1-0/learn/api-docs/ballerina/io/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/istio/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/istio/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - istio
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//istio/annotations
+permalink: /v1-0/learn/api-docs/ballerina/istio/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/istio/records/DestinationConfig.html
+++ b/v1-0/learn/api-docs/ballerina/istio/records/DestinationConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - istio
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//istio/records/DestinationConfig
+permalink: /v1-0/learn/api-docs/ballerina/istio/records/DestinationConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/istio/records/DestinationWeightConfig.html
+++ b/v1-0/learn/api-docs/ballerina/istio/records/DestinationWeightConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - istio
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//istio/records/DestinationWeightConfig
+permalink: /v1-0/learn/api-docs/ballerina/istio/records/DestinationWeightConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/istio/records/GatewayConfig.html
+++ b/v1-0/learn/api-docs/ballerina/istio/records/GatewayConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - istio
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//istio/records/GatewayConfig
+permalink: /v1-0/learn/api-docs/ballerina/istio/records/GatewayConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/istio/records/HTTPRouteConfig.html
+++ b/v1-0/learn/api-docs/ballerina/istio/records/HTTPRouteConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - istio
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//istio/records/HTTPRouteConfig
+permalink: /v1-0/learn/api-docs/ballerina/istio/records/HTTPRouteConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/istio/records/PortConfig.html
+++ b/v1-0/learn/api-docs/ballerina/istio/records/PortConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - istio
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//istio/records/PortConfig
+permalink: /v1-0/learn/api-docs/ballerina/istio/records/PortConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/istio/records/ServerConfig.html
+++ b/v1-0/learn/api-docs/ballerina/istio/records/ServerConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - istio
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//istio/records/ServerConfig
+permalink: /v1-0/learn/api-docs/ballerina/istio/records/ServerConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/istio/records/TLSOptionConfig.html
+++ b/v1-0/learn/api-docs/ballerina/istio/records/TLSOptionConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - istio
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//istio/records/TLSOptionConfig
+permalink: /v1-0/learn/api-docs/ballerina/istio/records/TLSOptionConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/istio/records/VirtualServiceConfig.html
+++ b/v1-0/learn/api-docs/ballerina/istio/records/VirtualServiceConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - istio
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//istio/records/VirtualServiceConfig
+permalink: /v1-0/learn/api-docs/ballerina/istio/records/VirtualServiceConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/istio/types.html
+++ b/v1-0/learn/api-docs/ballerina/istio/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - istio
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//istio/types
+permalink: /v1-0/learn/api-docs/ballerina/istio/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.arrays/functions.html
+++ b/v1-0/learn/api-docs/ballerina/java.arrays/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.arrays
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.arrays/functions
+permalink: /v1-0/learn/api-docs/ballerina/java.arrays/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/clients/Client.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/clients/Client.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/clients/Client
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/clients/Client
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/constants.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/constants
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/errors.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/errors
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/records/ApplicationErrorData
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/records/BatchUpdateResult
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/records/ClientConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/records/DatabaseErrorData
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/records/Parameter
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/records/Parameter
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/records/PoolOptions
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/records/PoolOptions
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/records/UpdateResult
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/records/UpdateResult
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java.jdbc/types.html
+++ b/v1-0/learn/api-docs/ballerina/java.jdbc/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java.jdbc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java.jdbc/types
+permalink: /v1-0/learn/api-docs/ballerina/java.jdbc/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/java/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java/annotations
+permalink: /v1-0/learn/api-docs/ballerina/java/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java/functions.html
+++ b/v1-0/learn/api-docs/ballerina/java/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java/functions
+permalink: /v1-0/learn/api-docs/ballerina/java/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java/records/ArrayType.html
+++ b/v1-0/learn/api-docs/ballerina/java/records/ArrayType.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java/records/ArrayType
+permalink: /v1-0/learn/api-docs/ballerina/java/records/ArrayType
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java/records/ConstructorData.html
+++ b/v1-0/learn/api-docs/ballerina/java/records/ConstructorData.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java/records/ConstructorData
+permalink: /v1-0/learn/api-docs/ballerina/java/records/ConstructorData
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java/records/FieldData.html
+++ b/v1-0/learn/api-docs/ballerina/java/records/FieldData.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java/records/FieldData
+permalink: /v1-0/learn/api-docs/ballerina/java/records/FieldData
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/java/records/MethodData.html
+++ b/v1-0/learn/api-docs/ballerina/java/records/MethodData.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - java
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//java/records/MethodData
+permalink: /v1-0/learn/api-docs/ballerina/java/records/MethodData
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jsonutils/functions.html
+++ b/v1-0/learn/api-docs/ballerina/jsonutils/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jsonutils
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jsonutils/functions
+permalink: /v1-0/learn/api-docs/ballerina/jsonutils/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
+++ b/v1-0/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jsonutils
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jsonutils/records/XmlOptions
+permalink: /v1-0/learn/api-docs/ballerina/jsonutils/records/XmlOptions
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/constants.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/constants
+permalink: /v1-0/learn/api-docs/ballerina/jwt/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/errors.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/errors
+permalink: /v1-0/learn/api-docs/ballerina/jwt/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/functions.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/functions
+permalink: /v1-0/learn/api-docs/ballerina/jwt/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/objects/InboundJwtAuthProvider
+permalink: /v1-0/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/objects/OutboundJwtAuthProvider
+permalink: /v1-0/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/records/CachedJwt.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/records/CachedJwt.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/records/CachedJwt
+permalink: /v1-0/learn/api-docs/ballerina/jwt/records/CachedJwt
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/jwt/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/records/JwtHeader.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/records/JwtHeader.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/records/JwtHeader
+permalink: /v1-0/learn/api-docs/ballerina/jwt/records/JwtHeader
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/records/JwtIssuerConfig
+permalink: /v1-0/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/records/JwtKeyStoreConfig
+permalink: /v1-0/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/records/JwtPayload.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/records/JwtPayload.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/records/JwtPayload
+permalink: /v1-0/learn/api-docs/ballerina/jwt/records/JwtPayload
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/records/JwtTrustStoreConfig
+permalink: /v1-0/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/records/JwtValidatorConfig
+permalink: /v1-0/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/jwt/types.html
+++ b/v1-0/learn/api-docs/ballerina/jwt/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - jwt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//jwt/types
+permalink: /v1-0/learn/api-docs/ballerina/jwt/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/clients/Consumer.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/clients/Consumer.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/clients/Consumer
+permalink: /v1-0/learn/api-docs/ballerina/kafka/clients/Consumer
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/clients/Producer.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/clients/Producer.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/clients/Producer
+permalink: /v1-0/learn/api-docs/ballerina/kafka/clients/Producer
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/constants.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/constants
+permalink: /v1-0/learn/api-docs/ballerina/kafka/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/errors.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/errors
+permalink: /v1-0/learn/api-docs/ballerina/kafka/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/records/ConsumerConfig.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/records/ConsumerConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/records/ConsumerConfig
+permalink: /v1-0/learn/api-docs/ballerina/kafka/records/ConsumerConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/records/ConsumerRecord
+permalink: /v1-0/learn/api-docs/ballerina/kafka/records/ConsumerRecord
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/kafka/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/records/KeyStore.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/records/KeyStore.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/records/KeyStore
+permalink: /v1-0/learn/api-docs/ballerina/kafka/records/KeyStore
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/records/PartitionOffset
+permalink: /v1-0/learn/api-docs/ballerina/kafka/records/PartitionOffset
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/records/ProducerConfig.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/records/ProducerConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/records/ProducerConfig
+permalink: /v1-0/learn/api-docs/ballerina/kafka/records/ProducerConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/records/Protocols.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/records/Protocols.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/records/Protocols
+permalink: /v1-0/learn/api-docs/ballerina/kafka/records/Protocols
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/records/SecureSocket.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/records/SecureSocket.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/records/SecureSocket
+permalink: /v1-0/learn/api-docs/ballerina/kafka/records/SecureSocket
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/records/TopicPartition.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/records/TopicPartition.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/records/TopicPartition
+permalink: /v1-0/learn/api-docs/ballerina/kafka/records/TopicPartition
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/records/TrustStore.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/records/TrustStore.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/records/TrustStore
+permalink: /v1-0/learn/api-docs/ballerina/kafka/records/TrustStore
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kafka/types.html
+++ b/v1-0/learn/api-docs/ballerina/kafka/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kafka
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kafka/types
+permalink: /v1-0/learn/api-docs/ballerina/kafka/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/annotations
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/constants.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/constants
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/BuildExtension.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/BuildExtension.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/BuildExtension
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/BuildExtension
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMap.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMap.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/ConfigMap
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMap
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyRef.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyRef.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/ConfigMapKeyRef
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyRef
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyValue.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyValue.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/ConfigMapKeyValue
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyValue
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/ConfigMapMount
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/DeploymentConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/FieldRef.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/FieldRef.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/FieldRef
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/FieldRef
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/FieldValue.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/FieldValue.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/FieldValue
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/FieldValue
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/FileConfig.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/FileConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/FileConfig
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/FileConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/IngressConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/IngressConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/IngressConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/IngressConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/JobConfig
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/JobConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/Metadata.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/Metadata.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/Metadata
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/Metadata
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/OpenShiftBuildConfigConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/OpenShiftBuildConfigConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/OpenShiftBuildConfigConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/OpenShiftBuildConfigConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaimConfig.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaimConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/PersistentVolumeClaimConfig
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaimConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/PersistentVolumeClaims
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/PodAutoscalerConfig.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/PodAutoscalerConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/PodAutoscalerConfig
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/PodAutoscalerConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/PodTolerationConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/PodTolerationConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/PodTolerationConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/PodTolerationConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/ProbeConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/ProbeConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/ProbeConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/ProbeConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceFieldRef.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceFieldRef.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/ResourceFieldRef
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceFieldRef
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceFieldValue.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceFieldValue.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/ResourceFieldValue
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceFieldValue
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceQuotaConfig.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceQuotaConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/ResourceQuotaConfig
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceQuotaConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/ResourceQuotas
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/Secret.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/Secret.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/Secret
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/Secret
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/SecretKeyRef.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/SecretKeyRef.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/SecretKeyRef
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/SecretKeyRef
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/SecretKeyValue.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/SecretKeyValue.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/SecretKeyValue
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/SecretKeyValue
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/SecretMount
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/SecretMount
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/records/ServiceConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/records/ServiceConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/records/ServiceConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/records/ServiceConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/kubernetes/types.html
+++ b/v1-0/learn/api-docs/ballerina/kubernetes/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - kubernetes
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//kubernetes/types
+permalink: /v1-0/learn/api-docs/ballerina/kubernetes/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.array/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.array/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.array
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.array/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.array/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.array/objects/$anonType$1.html
+++ b/v1-0/learn/api-docs/ballerina/lang.array/objects/$anonType$1.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.array
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.array/objects/$anonType$1
+permalink: /v1-0/learn/api-docs/ballerina/lang.array/objects/$anonType$1
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.decimal/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.decimal/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.decimal
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.decimal/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.decimal/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.error/errors.html
+++ b/v1-0/learn/api-docs/ballerina/lang.error/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.error
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.error/errors
+permalink: /v1-0/learn/api-docs/ballerina/lang.error/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.error/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.error/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.error
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.error/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.error/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.error/objects/CallStack.html
+++ b/v1-0/learn/api-docs/ballerina/lang.error/objects/CallStack.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.error
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.error/objects/CallStack
+permalink: /v1-0/learn/api-docs/ballerina/lang.error/objects/CallStack
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
+++ b/v1-0/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.error
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.error/records/CallStackElement
+permalink: /v1-0/learn/api-docs/ballerina/lang.error/records/CallStackElement
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.error/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/lang.error/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.error
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.error/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/lang.error/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.float/constants.html
+++ b/v1-0/learn/api-docs/ballerina/lang.float/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.float
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.float/constants
+permalink: /v1-0/learn/api-docs/ballerina/lang.float/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.float/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.float/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.float
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.float/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.float/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.future/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.future/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.future
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.future/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.future/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.int/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.int/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.int
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.int/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.int/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.map/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.map/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.map
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.map/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.map/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.map/objects/$anonType$2.html
+++ b/v1-0/learn/api-docs/ballerina/lang.map/objects/$anonType$2.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.map
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.map/objects/$anonType$2
+permalink: /v1-0/learn/api-docs/ballerina/lang.map/objects/$anonType$2
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.object/objects/Listener.html
+++ b/v1-0/learn/api-docs/ballerina/lang.object/objects/Listener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.object
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.object/objects/Listener
+permalink: /v1-0/learn/api-docs/ballerina/lang.object/objects/Listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.stream/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.stream/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.stream
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.stream/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.stream/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.string/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.string/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.string
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.string/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.string/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.string/objects/$anonType$2.html
+++ b/v1-0/learn/api-docs/ballerina/lang.string/objects/$anonType$2.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.string
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.string/objects/$anonType$2
+permalink: /v1-0/learn/api-docs/ballerina/lang.string/objects/$anonType$2
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.table/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.table/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.table
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.table/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.table/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.table/objects/$anonType$2.html
+++ b/v1-0/learn/api-docs/ballerina/lang.table/objects/$anonType$2.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.table
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.table/objects/$anonType$2
+permalink: /v1-0/learn/api-docs/ballerina/lang.table/objects/$anonType$2
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.typedesc/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.typedesc/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.typedesc
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.typedesc/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.typedesc/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.value/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.value/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.value
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.value/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.value/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.xml/constants.html
+++ b/v1-0/learn/api-docs/ballerina/lang.xml/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.xml
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.xml/constants
+permalink: /v1-0/learn/api-docs/ballerina/lang.xml/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.xml/functions.html
+++ b/v1-0/learn/api-docs/ballerina/lang.xml/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.xml
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.xml/functions
+permalink: /v1-0/learn/api-docs/ballerina/lang.xml/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.xml/objects/$anonType$9.html
+++ b/v1-0/learn/api-docs/ballerina/lang.xml/objects/$anonType$9.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.xml
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.xml/objects/$anonType$9
+permalink: /v1-0/learn/api-docs/ballerina/lang.xml/objects/$anonType$9
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/lang.xml/types.html
+++ b/v1-0/learn/api-docs/ballerina/lang.xml/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - lang.xml
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//lang.xml/types
+permalink: /v1-0/learn/api-docs/ballerina/lang.xml/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/log/functions.html
+++ b/v1-0/learn/api-docs/ballerina/log/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - log
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//log/functions
+permalink: /v1-0/learn/api-docs/ballerina/log/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/math/constants.html
+++ b/v1-0/learn/api-docs/ballerina/math/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - math
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//math/constants
+permalink: /v1-0/learn/api-docs/ballerina/math/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/math/errors.html
+++ b/v1-0/learn/api-docs/ballerina/math/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - math
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//math/errors
+permalink: /v1-0/learn/api-docs/ballerina/math/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/math/functions.html
+++ b/v1-0/learn/api-docs/ballerina/math/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - math
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//math/functions
+permalink: /v1-0/learn/api-docs/ballerina/math/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/math/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/math/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - math
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//math/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/math/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/mime/constants.html
+++ b/v1-0/learn/api-docs/ballerina/mime/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - mime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//mime/constants
+permalink: /v1-0/learn/api-docs/ballerina/mime/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/mime/errors.html
+++ b/v1-0/learn/api-docs/ballerina/mime/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - mime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//mime/errors
+permalink: /v1-0/learn/api-docs/ballerina/mime/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/mime/functions.html
+++ b/v1-0/learn/api-docs/ballerina/mime/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - mime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//mime/functions
+permalink: /v1-0/learn/api-docs/ballerina/mime/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
+++ b/v1-0/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - mime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//mime/objects/ContentDisposition
+permalink: /v1-0/learn/api-docs/ballerina/mime/objects/ContentDisposition
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/mime/objects/Entity.html
+++ b/v1-0/learn/api-docs/ballerina/mime/objects/Entity.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - mime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//mime/objects/Entity
+permalink: /v1-0/learn/api-docs/ballerina/mime/objects/Entity
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/mime/objects/MediaType.html
+++ b/v1-0/learn/api-docs/ballerina/mime/objects/MediaType.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - mime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//mime/objects/MediaType
+permalink: /v1-0/learn/api-docs/ballerina/mime/objects/MediaType
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/mime/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/mime/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - mime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//mime/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/mime/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/mime/types.html
+++ b/v1-0/learn/api-docs/ballerina/mime/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - mime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//mime/types
+permalink: /v1-0/learn/api-docs/ballerina/mime/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/nats/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/annotations
+permalink: /v1-0/learn/api-docs/ballerina/nats/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/clients/Producer.html
+++ b/v1-0/learn/api-docs/ballerina/nats/clients/Producer.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/clients/Producer
+permalink: /v1-0/learn/api-docs/ballerina/nats/clients/Producer
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
+++ b/v1-0/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/clients/StreamingMessage
+permalink: /v1-0/learn/api-docs/ballerina/nats/clients/StreamingMessage
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
+++ b/v1-0/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/clients/StreamingProducer
+permalink: /v1-0/learn/api-docs/ballerina/nats/clients/StreamingProducer
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/constants.html
+++ b/v1-0/learn/api-docs/ballerina/nats/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/constants
+permalink: /v1-0/learn/api-docs/ballerina/nats/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/errors.html
+++ b/v1-0/learn/api-docs/ballerina/nats/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/errors
+permalink: /v1-0/learn/api-docs/ballerina/nats/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/listeners/Listener.html
+++ b/v1-0/learn/api-docs/ballerina/nats/listeners/Listener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/listeners/listener
+permalink: /v1-0/learn/api-docs/ballerina/nats/listeners/listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
+++ b/v1-0/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/listeners/listener
+permalink: /v1-0/learn/api-docs/ballerina/nats/listeners/listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/objects/Connection.html
+++ b/v1-0/learn/api-docs/ballerina/nats/objects/Connection.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/objects/Connection
+permalink: /v1-0/learn/api-docs/ballerina/nats/objects/Connection
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/objects/Message.html
+++ b/v1-0/learn/api-docs/ballerina/nats/objects/Message.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/objects/Message
+permalink: /v1-0/learn/api-docs/ballerina/nats/objects/Message
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
+++ b/v1-0/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/records/ConnectionConfig
+permalink: /v1-0/learn/api-docs/ballerina/nats/records/ConnectionConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/nats/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/nats/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/records/PendingLimits.html
+++ b/v1-0/learn/api-docs/ballerina/nats/records/PendingLimits.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/records/PendingLimits
+permalink: /v1-0/learn/api-docs/ballerina/nats/records/PendingLimits
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/records/SecureSocket.html
+++ b/v1-0/learn/api-docs/ballerina/nats/records/SecureSocket.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/records/SecureSocket
+permalink: /v1-0/learn/api-docs/ballerina/nats/records/SecureSocket
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/records/StreamingConfig.html
+++ b/v1-0/learn/api-docs/ballerina/nats/records/StreamingConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/records/StreamingConfig
+permalink: /v1-0/learn/api-docs/ballerina/nats/records/StreamingConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
+++ b/v1-0/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/records/StreamingSubscriptionConfigData
+permalink: /v1-0/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
+++ b/v1-0/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/records/SubscriptionConfigData
+permalink: /v1-0/learn/api-docs/ballerina/nats/records/SubscriptionConfigData
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/nats/types.html
+++ b/v1-0/learn/api-docs/ballerina/nats/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - nats
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//nats/types
+permalink: /v1-0/learn/api-docs/ballerina/nats/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/constants.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/constants
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/errors.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/errors
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/functions.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/functions
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/objects/InboundOAuth2Provider
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/objects/OutboundOAuth2Provider
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/records/CachedToken.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/records/CachedToken.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/records/CachedToken
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/records/CachedToken
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/records/ClientCredentialsGrantConfig
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/records/DirectTokenConfig
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/records/DirectTokenRefreshConfig
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/records/IntrospectionServerConfig
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/records/PasswordGrantConfig
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
+++ b/v1-0/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - oauth2
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//oauth2/records/RefreshConfig
+permalink: /v1-0/learn/api-docs/ballerina/oauth2/records/RefreshConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/observe/functions.html
+++ b/v1-0/learn/api-docs/ballerina/observe/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - observe
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//observe/functions
+permalink: /v1-0/learn/api-docs/ballerina/observe/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/observe/objects/Counter.html
+++ b/v1-0/learn/api-docs/ballerina/observe/objects/Counter.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - observe
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//observe/objects/Counter
+permalink: /v1-0/learn/api-docs/ballerina/observe/objects/Counter
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/observe/objects/Gauge.html
+++ b/v1-0/learn/api-docs/ballerina/observe/objects/Gauge.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - observe
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//observe/objects/Gauge
+permalink: /v1-0/learn/api-docs/ballerina/observe/objects/Gauge
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/observe/records/Metric.html
+++ b/v1-0/learn/api-docs/ballerina/observe/records/Metric.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - observe
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//observe/records/Metric
+permalink: /v1-0/learn/api-docs/ballerina/observe/records/Metric
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/observe/records/PercentileValue.html
+++ b/v1-0/learn/api-docs/ballerina/observe/records/PercentileValue.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - observe
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//observe/records/PercentileValue
+permalink: /v1-0/learn/api-docs/ballerina/observe/records/PercentileValue
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/observe/records/Snapshot.html
+++ b/v1-0/learn/api-docs/ballerina/observe/records/Snapshot.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - observe
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//observe/records/Snapshot
+permalink: /v1-0/learn/api-docs/ballerina/observe/records/Snapshot
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/observe/records/StatisticConfig.html
+++ b/v1-0/learn/api-docs/ballerina/observe/records/StatisticConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - observe
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//observe/records/StatisticConfig
+permalink: /v1-0/learn/api-docs/ballerina/observe/records/StatisticConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/openapi/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/openapi/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - openapi
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//openapi/annotations
+permalink: /v1-0/learn/api-docs/ballerina/openapi/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/openapi/records/ClientInformation.html
+++ b/v1-0/learn/api-docs/ballerina/openapi/records/ClientInformation.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - openapi
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//openapi/records/ClientInformation
+permalink: /v1-0/learn/api-docs/ballerina/openapi/records/ClientInformation
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
+++ b/v1-0/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - openapi
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//openapi/records/ServiceInformation
+permalink: /v1-0/learn/api-docs/ballerina/openapi/records/ServiceInformation
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/openshift/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/openshift/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - openshift
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//openshift/annotations
+permalink: /v1-0/learn/api-docs/ballerina/openshift/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/openshift/constants.html
+++ b/v1-0/learn/api-docs/ballerina/openshift/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - openshift
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//openshift/constants
+permalink: /v1-0/learn/api-docs/ballerina/openshift/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/openshift/records/RouteConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/openshift/records/RouteConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - openshift
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//openshift/records/RouteConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/openshift/records/RouteConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/openshift/records/RouteDomainConfig.html
+++ b/v1-0/learn/api-docs/ballerina/openshift/records/RouteDomainConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - openshift
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//openshift/records/RouteDomainConfig
+permalink: /v1-0/learn/api-docs/ballerina/openshift/records/RouteDomainConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/annotations
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/clients/Channel
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/clients/Channel
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/clients/Message.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/clients/Message.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/clients/Message
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/clients/Message
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/constants.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/constants
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/errors.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/errors
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/listeners/listener
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/listeners/listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/objects/Connection
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/objects/Connection
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/records/BasicProperties
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/records/BasicProperties
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/records/ConnectionConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/records/ExchangeConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/records/QueueConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/records/RabbitMQServiceConfig
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/records/SecureSocket
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/records/SecureSocket
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/rabbitmq/types.html
+++ b/v1-0/learn/api-docs/ballerina/rabbitmq/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - rabbitmq
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//rabbitmq/types
+permalink: /v1-0/learn/api-docs/ballerina/rabbitmq/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/reflect/functions.html
+++ b/v1-0/learn/api-docs/ballerina/reflect/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - reflect
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//reflect/functions
+permalink: /v1-0/learn/api-docs/ballerina/reflect/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/runtime/functions.html
+++ b/v1-0/learn/api-docs/ballerina/runtime/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - runtime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//runtime/functions
+permalink: /v1-0/learn/api-docs/ballerina/runtime/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
+++ b/v1-0/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - runtime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//runtime/records/AuthenticationContext
+permalink: /v1-0/learn/api-docs/ballerina/runtime/records/AuthenticationContext
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/runtime/records/CallStackElement.html
+++ b/v1-0/learn/api-docs/ballerina/runtime/records/CallStackElement.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - runtime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//runtime/records/CallStackElement
+permalink: /v1-0/learn/api-docs/ballerina/runtime/records/CallStackElement
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/runtime/records/InvocationContext.html
+++ b/v1-0/learn/api-docs/ballerina/runtime/records/InvocationContext.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - runtime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//runtime/records/InvocationContext
+permalink: /v1-0/learn/api-docs/ballerina/runtime/records/InvocationContext
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/runtime/records/Principal.html
+++ b/v1-0/learn/api-docs/ballerina/runtime/records/Principal.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - runtime
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//runtime/records/Principal
+permalink: /v1-0/learn/api-docs/ballerina/runtime/records/Principal
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/clients/Client.html
+++ b/v1-0/learn/api-docs/ballerina/socket/clients/Client.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/clients/Client
+permalink: /v1-0/learn/api-docs/ballerina/socket/clients/Client
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/clients/UdpClient.html
+++ b/v1-0/learn/api-docs/ballerina/socket/clients/UdpClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/clients/UdpClient
+permalink: /v1-0/learn/api-docs/ballerina/socket/clients/UdpClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/constants.html
+++ b/v1-0/learn/api-docs/ballerina/socket/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/constants
+permalink: /v1-0/learn/api-docs/ballerina/socket/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/errors.html
+++ b/v1-0/learn/api-docs/ballerina/socket/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/errors
+permalink: /v1-0/learn/api-docs/ballerina/socket/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/listeners/Listener.html
+++ b/v1-0/learn/api-docs/ballerina/socket/listeners/Listener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/listeners/listener
+permalink: /v1-0/learn/api-docs/ballerina/socket/listeners/listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/records/Address.html
+++ b/v1-0/learn/api-docs/ballerina/socket/records/Address.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/records/Address
+permalink: /v1-0/learn/api-docs/ballerina/socket/records/Address
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/records/ClientConfig.html
+++ b/v1-0/learn/api-docs/ballerina/socket/records/ClientConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/records/ClientConfig
+permalink: /v1-0/learn/api-docs/ballerina/socket/records/ClientConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/socket/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/socket/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/records/ListenerConfig.html
+++ b/v1-0/learn/api-docs/ballerina/socket/records/ListenerConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/records/ListenerConfig
+permalink: /v1-0/learn/api-docs/ballerina/socket/records/ListenerConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
+++ b/v1-0/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/records/UdpClientConfig
+permalink: /v1-0/learn/api-docs/ballerina/socket/records/UdpClientConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/socket/types.html
+++ b/v1-0/learn/api-docs/ballerina/socket/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - socket
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//socket/types
+permalink: /v1-0/learn/api-docs/ballerina/socket/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/constants.html
+++ b/v1-0/learn/api-docs/ballerina/streams/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/constants
+permalink: /v1-0/learn/api-docs/ballerina/streams/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/functions.html
+++ b/v1-0/learn/api-docs/ballerina/streams/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/functions
+permalink: /v1-0/learn/api-docs/ballerina/streams/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/AbstractOperatorProcessor.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/AbstractOperatorProcessor.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/AbstractOperatorProcessor
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/AbstractOperatorProcessor
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/AbstractPatternProcessor.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/AbstractPatternProcessor.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/AbstractPatternProcessor
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/AbstractPatternProcessor
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Aggregator.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Aggregator.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Aggregator
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Aggregator
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/AndOperatorProcessor.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/AndOperatorProcessor.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/AndOperatorProcessor
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/AndOperatorProcessor
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Average.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Average.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Average
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Average
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/CompoundPatternProcessor.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/CompoundPatternProcessor.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/CompoundPatternProcessor
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/CompoundPatternProcessor
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Count.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Count.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Count
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Count
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/DelayWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/DelayWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/DelayWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/DelayWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/DistinctCount.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/DistinctCount.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/DistinctCount
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/DistinctCount
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/ExternalTimeBatchWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/ExternalTimeBatchWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/ExternalTimeBatchWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/ExternalTimeBatchWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/ExternalTimeWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/ExternalTimeWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/ExternalTimeWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/ExternalTimeWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Filter.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Filter.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Filter
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Filter
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/FollowedByProcessor.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/FollowedByProcessor.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/FollowedByProcessor
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/FollowedByProcessor
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/HoppingWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/HoppingWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/HoppingWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/HoppingWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/IntSort.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/IntSort.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/IntSort
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/IntSort
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/LengthBatchWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/LengthBatchWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/LengthBatchWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/LengthBatchWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/LengthWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/LengthWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/LengthWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/LengthWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/LinkedList.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/LinkedList.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/LinkedList
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/LinkedList
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Max.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Max.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Max
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Max
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/MaxForever.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/MaxForever.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/MaxForever
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/MaxForever
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/MergeSort.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/MergeSort.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/MergeSort
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/MergeSort
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Min.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Min.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Min
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Min
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/MinForever.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/MinForever.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/MinForever
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/MinForever
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Node.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Node.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Node
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Node
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/NotOperatorProcessor.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/NotOperatorProcessor.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/NotOperatorProcessor
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/NotOperatorProcessor
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/OperandProcessor.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/OperandProcessor.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/OperandProcessor
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/OperandProcessor
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/OrOperatorProcessor.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/OrOperatorProcessor.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/OrOperatorProcessor
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/OrOperatorProcessor
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/OrderBy.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/OrderBy.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/OrderBy
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/OrderBy
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/OutputProcess.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/OutputProcess.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/OutputProcess
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/OutputProcess
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Scheduler.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Scheduler.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Scheduler
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Scheduler
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Select.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Select.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Select
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Select
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Snapshotable.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Snapshotable.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Snapshotable
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Snapshotable
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/SortWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/SortWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/SortWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/SortWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/StateMachine.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/StateMachine.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/StateMachine
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/StateMachine
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/StdDev.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/StdDev.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/StdDev
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/StdDev
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/StreamEvent.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/StreamEvent.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/StreamEvent
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/StreamEvent
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/StreamJoinProcessor.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/StreamJoinProcessor.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/StreamJoinProcessor
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/StreamJoinProcessor
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Sum.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Sum.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Sum
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Sum
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/TableJoinProcessor.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/TableJoinProcessor.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/TableJoinProcessor
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/TableJoinProcessor
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/TimeAccumulatingWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/TimeAccumulatingWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/TimeAccumulatingWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/TimeAccumulatingWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/TimeBatchWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/TimeBatchWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/TimeBatchWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/TimeBatchWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/TimeLengthWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/TimeLengthWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/TimeLengthWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/TimeLengthWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/TimeOrderWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/TimeOrderWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/TimeOrderWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/TimeOrderWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/TimeWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/TimeWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/TimeWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/TimeWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/UniqueLengthWindow.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/UniqueLengthWindow.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/UniqueLengthWindow
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/UniqueLengthWindow
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/objects/Window.html
+++ b/v1-0/learn/api-docs/ballerina/streams/objects/Window.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/objects/Window
+permalink: /v1-0/learn/api-docs/ballerina/streams/objects/Window
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/records/SnapshottableStreamEvent.html
+++ b/v1-0/learn/api-docs/ballerina/streams/records/SnapshottableStreamEvent.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/records/SnapshottableStreamEvent
+permalink: /v1-0/learn/api-docs/ballerina/streams/records/SnapshottableStreamEvent
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/streams/types.html
+++ b/v1-0/learn/api-docs/ballerina/streams/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - streams
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//streams/types
+permalink: /v1-0/learn/api-docs/ballerina/streams/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/stringutils/functions.html
+++ b/v1-0/learn/api-docs/ballerina/stringutils/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - stringutils
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//stringutils/functions
+permalink: /v1-0/learn/api-docs/ballerina/stringutils/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/system/constants.html
+++ b/v1-0/learn/api-docs/ballerina/system/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - system
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//system/constants
+permalink: /v1-0/learn/api-docs/ballerina/system/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/system/errors.html
+++ b/v1-0/learn/api-docs/ballerina/system/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - system
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//system/errors
+permalink: /v1-0/learn/api-docs/ballerina/system/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/system/functions.html
+++ b/v1-0/learn/api-docs/ballerina/system/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - system
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//system/functions
+permalink: /v1-0/learn/api-docs/ballerina/system/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/system/objects/Process.html
+++ b/v1-0/learn/api-docs/ballerina/system/objects/Process.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - system
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//system/objects/Process
+permalink: /v1-0/learn/api-docs/ballerina/system/objects/Process
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/system/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/system/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - system
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//system/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/system/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/system/types.html
+++ b/v1-0/learn/api-docs/ballerina/system/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - system
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//system/types
+permalink: /v1-0/learn/api-docs/ballerina/system/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/task/constants.html
+++ b/v1-0/learn/api-docs/ballerina/task/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - task
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//task/constants
+permalink: /v1-0/learn/api-docs/ballerina/task/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/task/errors.html
+++ b/v1-0/learn/api-docs/ballerina/task/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - task
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//task/errors
+permalink: /v1-0/learn/api-docs/ballerina/task/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/task/listeners/Listener.html
+++ b/v1-0/learn/api-docs/ballerina/task/listeners/Listener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - task
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//task/listeners/listener
+permalink: /v1-0/learn/api-docs/ballerina/task/listeners/listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/task/objects/Scheduler.html
+++ b/v1-0/learn/api-docs/ballerina/task/objects/Scheduler.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - task
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//task/objects/Scheduler
+permalink: /v1-0/learn/api-docs/ballerina/task/objects/Scheduler
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - task
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//task/records/AppointmentConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/task/records/AppointmentConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/task/records/AppointmentData.html
+++ b/v1-0/learn/api-docs/ballerina/task/records/AppointmentData.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - task
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//task/records/AppointmentData
+permalink: /v1-0/learn/api-docs/ballerina/task/records/AppointmentData
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/task/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/task/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - task
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//task/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/task/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/task/records/TimerConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/task/records/TimerConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - task
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//task/records/TimerConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/task/records/TimerConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/task/types.html
+++ b/v1-0/learn/api-docs/ballerina/task/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - task
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//task/types
+permalink: /v1-0/learn/api-docs/ballerina/task/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/test/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/test/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - test
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//test/annotations
+permalink: /v1-0/learn/api-docs/ballerina/test/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/test/functions.html
+++ b/v1-0/learn/api-docs/ballerina/test/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - test
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//test/functions
+permalink: /v1-0/learn/api-docs/ballerina/test/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/test/records/MockConfig.html
+++ b/v1-0/learn/api-docs/ballerina/test/records/MockConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - test
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//test/records/MockConfig
+permalink: /v1-0/learn/api-docs/ballerina/test/records/MockConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/test/records/TestConfig.html
+++ b/v1-0/learn/api-docs/ballerina/test/records/TestConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - test
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//test/records/TestConfig
+permalink: /v1-0/learn/api-docs/ballerina/test/records/TestConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/time/constants.html
+++ b/v1-0/learn/api-docs/ballerina/time/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - time
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//time/constants
+permalink: /v1-0/learn/api-docs/ballerina/time/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/time/errors.html
+++ b/v1-0/learn/api-docs/ballerina/time/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - time
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//time/errors
+permalink: /v1-0/learn/api-docs/ballerina/time/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/time/functions.html
+++ b/v1-0/learn/api-docs/ballerina/time/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - time
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//time/functions
+permalink: /v1-0/learn/api-docs/ballerina/time/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/time/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/time/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - time
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//time/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/time/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/time/records/Time.html
+++ b/v1-0/learn/api-docs/ballerina/time/records/Time.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - time
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//time/records/Time
+permalink: /v1-0/learn/api-docs/ballerina/time/records/Time
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/time/records/TimeZone.html
+++ b/v1-0/learn/api-docs/ballerina/time/records/TimeZone.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - time
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//time/records/TimeZone
+permalink: /v1-0/learn/api-docs/ballerina/time/records/TimeZone
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/time/types.html
+++ b/v1-0/learn/api-docs/ballerina/time/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - time
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//time/types
+permalink: /v1-0/learn/api-docs/ballerina/time/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/transactions/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/transactions/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - transactions
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//transactions/annotations
+permalink: /v1-0/learn/api-docs/ballerina/transactions/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/transactions/functions.html
+++ b/v1-0/learn/api-docs/ballerina/transactions/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - transactions
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//transactions/functions
+permalink: /v1-0/learn/api-docs/ballerina/transactions/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/websub/annotations.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/annotations
+permalink: /v1-0/learn/api-docs/ballerina/websub/annotations
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/clients/Caller.html
+++ b/v1-0/learn/api-docs/ballerina/websub/clients/Caller.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/clients/Caller
+permalink: /v1-0/learn/api-docs/ballerina/websub/clients/Caller
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/clients/PublisherClient.html
+++ b/v1-0/learn/api-docs/ballerina/websub/clients/PublisherClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/clients/PublisherClient
+permalink: /v1-0/learn/api-docs/ballerina/websub/clients/PublisherClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
+++ b/v1-0/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/clients/SubscriptionClient
+permalink: /v1-0/learn/api-docs/ballerina/websub/clients/SubscriptionClient
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/constants.html
+++ b/v1-0/learn/api-docs/ballerina/websub/constants.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/constants
+permalink: /v1-0/learn/api-docs/ballerina/websub/constants
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/errors.html
+++ b/v1-0/learn/api-docs/ballerina/websub/errors.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/errors
+permalink: /v1-0/learn/api-docs/ballerina/websub/errors
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/functions.html
+++ b/v1-0/learn/api-docs/ballerina/websub/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/functions
+permalink: /v1-0/learn/api-docs/ballerina/websub/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/listeners/Listener.html
+++ b/v1-0/learn/api-docs/ballerina/websub/listeners/Listener.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/listeners/listener
+permalink: /v1-0/learn/api-docs/ballerina/websub/listeners/listener
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/objects/Hub.html
+++ b/v1-0/learn/api-docs/ballerina/websub/objects/Hub.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/objects/Hub
+permalink: /v1-0/learn/api-docs/ballerina/websub/objects/Hub
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
+++ b/v1-0/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/objects/HubPersistenceStore
+permalink: /v1-0/learn/api-docs/ballerina/websub/objects/HubPersistenceStore
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
+++ b/v1-0/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/objects/IntentVerificationRequest
+permalink: /v1-0/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/objects/Notification.html
+++ b/v1-0/learn/api-docs/ballerina/websub/objects/Notification.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/objects/Notification
+permalink: /v1-0/learn/api-docs/ballerina/websub/objects/Notification
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/Detail.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/Detail.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/Detail
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/Detail
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/ExtensionConfig
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/ExtensionConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/HubConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/HubConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/HubConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/HubConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/HubStartedUpError
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/HubStartedUpError
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/RemotePublishConfig
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/RemotePublishConfig
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/SubscriberDetails
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/SubscriberDetails
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/SubscriberListenerConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/SubscriberServiceConfiguration
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/SubscriptionChangeRequest
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/SubscriptionChangeResponse
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
+++ b/v1-0/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/records/SubscriptionDetails
+permalink: /v1-0/learn/api-docs/ballerina/websub/records/SubscriptionDetails
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/websub/types.html
+++ b/v1-0/learn/api-docs/ballerina/websub/types.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - websub
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//websub/types
+permalink: /v1-0/learn/api-docs/ballerina/websub/types
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/xmlutils/functions.html
+++ b/v1-0/learn/api-docs/ballerina/xmlutils/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - xmlutils
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//xmlutils/functions
+permalink: /v1-0/learn/api-docs/ballerina/xmlutils/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
+++ b/v1-0/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - xmlutils
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//xmlutils/records/JsonOptions
+permalink: /v1-0/learn/api-docs/ballerina/xmlutils/records/JsonOptions
 ---
 <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">

--- a/v1-0/learn/api-docs/ballerina/xslt/functions.html
+++ b/v1-0/learn/api-docs/ballerina/xslt/functions.html
@@ -2,7 +2,7 @@
 layout: ballerina-api-doc-page
 title: Ballerina API Documentation - xslt
 keywords: Ballerina, ballerinalang
-permalink: /1.0.5/learn/api-docs//xslt/functions
+permalink: /v1-0/learn/api-docs/ballerina/xslt/functions
 ---
 <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
     <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">


### PR DESCRIPTION
## Purpose
This will fix the broken links in API docs for jekyll support.

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
