### PR TITLE
Fix Links in Using the Features of the IntelliJ Plugin Page

### DIFF
--- a/v1-0/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/v1-0/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -168,5 +168,5 @@ You expand/collapse the following Ballerina code segments using the icons in the
 
 ## What's next?
 
-- For information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Plugin](v1-0/learn/intellij-plugin)
-- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](v1-0/learn).
+- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Plugin](/v1-0/learn/intellij-plugin).
+- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-0/learn).

--- a/v1-1/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/v1-1/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -168,5 +168,5 @@ You expand/collapse the following Ballerina code segments using the icons in the
 
 ## What's next?
 
-- For information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Plugin](v1-1/learn/intellij-plugin)
-- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](v1-1/learn).
+- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Plugin](/v1-1/learn/intellij-plugin).
+- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-1/learn).


### PR DESCRIPTION
## Purpose
This fixes the 2 links in the "What's Next" section of https://ballerina.io/v1-1/learn/intellij-plugin/using-intellij-plugin-features.
> Fixes #252 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
