### PR TITLE
Add the Text "API" to the Learn Page 

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -70,7 +70,7 @@ redirect_from:
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
-     <p class="cBoxpara">Learn the “batteries-included” standard library (APIs).</p>
+     <p class="cBoxpara">Learn the “batteries-included” standard library.</p>
          <a class="cBallerinaLearnButtons" href="/learn/api-docs/ballerina">The Standard Library</a>
       </div>
    </div>

--- a/learn.md
+++ b/learn.md
@@ -70,7 +70,7 @@ redirect_from:
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
-     <p class="cBoxpara">Learn the “batteries-included” standard library.</p>
+     <p class="cBoxpara">Learn the “batteries-included” in the standard library APIs.</p>
          <a class="cBallerinaLearnButtons" href="/learn/api-docs/ballerina">The Standard Library</a>
       </div>
    </div>

--- a/learn.md
+++ b/learn.md
@@ -70,7 +70,7 @@ redirect_from:
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
-     <p class="cBoxpara">Learn the “batteries-included” in the standard library APIs.</p>
+     <p class="cBoxpara">Learn the “batteries-included” standard library (APIs).</p>
          <a class="cBallerinaLearnButtons" href="/learn/api-docs/ballerina">The Standard Library</a>
       </div>
    </div>

--- a/v1-0/learn.md
+++ b/v1-0/learn.md
@@ -69,7 +69,7 @@ redirect_from:
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
      <p class="cBoxpara">Learn the “batteries-included” standard library (APIs).</p>
-         <a class="cBallerinaLearnButtons" href="/v1-0/learn/api-docs/ballerina">Standard Library</a>
+         <a class="cBallerinaLearnButtons" href="/v1-0/learn/api-docs/ballerina">The Standard Library</a>
       </div>
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">

--- a/v1-0/learn.md
+++ b/v1-0/learn.md
@@ -68,7 +68,7 @@ redirect_from:
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
-     <p class="cBoxpara">Learn the “batteries-included” standard library.</p>
+     <p class="cBoxpara">Learn the “batteries-included” standard library (APIs).</p>
          <a class="cBallerinaLearnButtons" href="/v1-0/learn/api-docs/ballerina">The Standard Library APIs</a>
       </div>
    </div>

--- a/v1-0/learn.md
+++ b/v1-0/learn.md
@@ -69,7 +69,7 @@ redirect_from:
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
      <p class="cBoxpara">Learn the “batteries-included” standard library (APIs).</p>
-         <a class="cBallerinaLearnButtons" href="/v1-0/learn/api-docs/ballerina">The Standard Library APIs</a>
+         <a class="cBallerinaLearnButtons" href="/v1-0/learn/api-docs/ballerina">Standard Library</a>
       </div>
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">

--- a/v1-0/learn.md
+++ b/v1-0/learn.md
@@ -69,7 +69,7 @@ redirect_from:
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
      <p class="cBoxpara">Learn the “batteries-included” standard library.</p>
-         <a class="cBallerinaLearnButtons" href="/v1-0/learn/api-docs/ballerina">The Standard Library</a>
+         <a class="cBallerinaLearnButtons" href="/v1-0/learn/api-docs/ballerina">The Standard Library APIs</a>
       </div>
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">

--- a/v1-0/learn.md
+++ b/v1-0/learn.md
@@ -68,7 +68,7 @@ redirect_from:
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
-     <p class="cBoxpara">Learn the “batteries-included” standard library (APIs).</p>
+     <p class="cBoxpara">Check out the API docs of the “batteries-included” standard library.</p>
          <a class="cBallerinaLearnButtons" href="/v1-0/learn/api-docs/ballerina">The Standard Library</a>
       </div>
    </div>

--- a/v1-1/learn.md
+++ b/v1-1/learn.md
@@ -69,7 +69,7 @@ redirect_from:
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
-     <p class="cBoxpara">Learn the “batteries-included” standard library APIs.</p>
+     <p class="cBoxpara">Learn the “batteries-included” standard library (APIs).</p>
          <a class="cBallerinaLearnButtons" href="/v1-1/learn/api-docs/ballerina">The Standard Library</a>
       </div>
    </div>

--- a/v1-1/learn.md
+++ b/v1-1/learn.md
@@ -69,7 +69,7 @@ redirect_from:
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
-     <p class="cBoxpara">Learn the “batteries-included” standard library (APIs).</p>
+     <p class="cBoxpara">Check out the API docs of the “batteries-included” standard library.</p>
          <a class="cBallerinaLearnButtons" href="/v1-1/learn/api-docs/ballerina">The Standard Library</a>
       </div>
    </div>

--- a/v1-1/learn.md
+++ b/v1-1/learn.md
@@ -69,7 +69,7 @@ redirect_from:
    </div>
    <div class="col-sm-12 col-md-4 cBoxContainer">
       <div class="cBallerina-Box">
-     <p class="cBoxpara">Learn the “batteries-included” standard library.</p>
+     <p class="cBoxpara">Learn the “batteries-included” standard library APIs.</p>
          <a class="cBallerinaLearnButtons" href="/v1-1/learn/api-docs/ballerina">The Standard Library</a>
       </div>
    </div>


### PR DESCRIPTION
## Purpose
This adds the text "API Docs" so that it can be searched easily.
> Fixes #257 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
