### PR TITLE
Fix the V1.0 Links in the Style Guide

### DIFF
--- a/v1-0/learn/api-docs/ballerina/transactions/annotations.html
+++ b/v1-0/learn/api-docs/ballerina/transactions/annotations.html
@@ -598,7 +598,7 @@ permalink: /v1-0/learn/api-docs/ballerina/transactions/annotations
                         <div class="params-listing">
                             <ul>
                                 <li>
-                                    <b>Participant</b><span class="type"> <a href="../transactions/records/TransactionParticipantConfig.html">TransactionParticipantConfig</a></span> <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                    <b>Participant</b><span class="type"> TransactionParticipantConfig</span> <img class="attach-icon" src="../html-template-resources/images/attach.svg">
                                         function</li>
                                 <li>
                                     <p>The annotation which is used to configure local transaction participant function.</p>

--- a/v1-0/learn/api-docs/ballerina/websub/functions.html
+++ b/v1-0/learn/api-docs/ballerina/websub/functions.html
@@ -811,7 +811,7 @@ permalink: /v1-0/learn/api-docs/ballerina/websub/functions
             <h2> startHub </h2>
         
         <span class="method-types">
-            <p>(<a href="../http/objects/Listener.html">Listener</a> hubServiceListener, <span class="builtin-type">string</span> basePath, <span class="builtin-type">string</span> subscriptionResourcePath, <span class="builtin-type">string</span> publishResourcePath, <a href="../http/records/ServiceResourceAuth.html">ServiceResourceAuth</a> serviceAuth, <a href="../http/records/ServiceResourceAuth.html">ServiceResourceAuth</a> subscriptionResourceAuth, <a href="../http/records/ServiceResourceAuth.html">ServiceResourceAuth</a> publisherResourceAuth, <span class="builtin-type">string</span> publicUrl, <a href="../websub/records/HubConfiguration.html">HubConfiguration</a> hubConfiguration)</p>
+            <p>(<a href="../http/listeners/Listener.html">Listener</a> hubServiceListener, <span class="builtin-type">string</span> basePath, <span class="builtin-type">string</span> subscriptionResourcePath, <span class="builtin-type">string</span> publishResourcePath, <a href="../http/records/ServiceResourceAuth.html">ServiceResourceAuth</a> serviceAuth, <a href="../http/records/ServiceResourceAuth.html">ServiceResourceAuth</a> subscriptionResourceAuth, <a href="../http/records/ServiceResourceAuth.html">ServiceResourceAuth</a> publisherResourceAuth, <span class="builtin-type">string</span> publicUrl, <a href="../websub/records/HubConfiguration.html">HubConfiguration</a> hubConfiguration)</p>
             <b> returns </b><a href="../websub/objects/Hub.html">Hub</a> | <a href="../websub/records/HubStartedUpError.html">HubStartedUpError</a> | <a href="../websub/errors.html#HubStartupError">HubStartupError</a> 
         </span>
         
@@ -825,7 +825,7 @@ permalink: /v1-0/learn/api-docs/ballerina/websub/functions
             <div class="params-listing">
                 <ul>
                     <li>
-                        hubServiceListener<span class="type">  <a href="../http/objects/Listener.html">Listener</a> </span>
+                        hubServiceListener<span class="type">  <a href="../http/listeners/Listener.html">Listener</a> </span>
                         
                     </li>
                     <li>

--- a/v1-0/learn/api-docs/ballerina/websub/objects/Hub.html
+++ b/v1-0/learn/api-docs/ballerina/websub/objects/Hub.html
@@ -682,7 +682,7 @@ permalink: /v1-0/learn/api-docs/ballerina/websub/objects/Hub
                     
                         
                         <h2>Constructor</h2>
-<h3 >__init</h3><p>(<span class="builtin-type">string</span> subscriptionUrl, <span class="builtin-type">string</span> publishUrl, <a href="../../http/objects/Listener.html">Listener</a> hubHttpListener)</p>
+<h3 >__init</h3><p>(<span class="builtin-type">string</span> subscriptionUrl, <span class="builtin-type">string</span> publishUrl, <a href="../../http/listeners/Listener.html">Listener</a> hubHttpListener)</p>
 <div class="data-wrapper">
     
         <div class="params-listing">
@@ -705,7 +705,7 @@ permalink: /v1-0/learn/api-docs/ballerina/websub/objects/Hub
     
         <div class="params-listing">
             <ul>
-                <li> <b>hubHttpListener</b><span class="type">  <a href="../../http/objects/Listener.html">Listener</a></span> </li>
+                <li> <b>hubHttpListener</b><span class="type">  <a href="../../http/listeners/Listener.html">Listener</a></span> </li>
                 <li>
                     
                 </li>

--- a/v1-0/learn/style-guide/definitions.md
+++ b/v1-0/learn/style-guide/definitions.md
@@ -116,7 +116,7 @@ service hello on new http:Listener(9090) {
 ```
 
 * When formatting resource functions and function definitions, block indent each element and
-  follow the [function formatting guidelines](/learn/style-guide/definitions#function-definition).
+  follow the [function formatting guidelines](/v1-0/learn/style-guide/definitions#function-definition).
   
 **Example,**
 
@@ -140,7 +140,7 @@ service hello on ep1, ep2 {
 
 * Block indent each field definition and each function definition on their own line.
 * Init function should be placed before all the other functions. 
-* For function definitions in the object definition, follow the [function formatting guidelines](/learn/style-guide/definitions#function-definition).
+* For function definitions in the object definition, follow the [function formatting guidelines](/v1-0/learn/style-guide/definitions#function-definition).
 
 **Example,**
 

--- a/v1-0/learn/style-guide/expressions.md
+++ b/v1-0/learn/style-guide/expressions.md
@@ -83,7 +83,7 @@ Person p = {
 
 ## Map literal
 
-* For Map literals, follow the same formatting guidelines as [record literals](/learn/style-guide/expressions#record-literal). 
+* For Map literals, follow the same formatting guidelines as [record literals](/v1-0/learn/style-guide/expressions#record-literal). 
   
 **Example,**
 
@@ -173,7 +173,7 @@ string name = <string>json.name;
 
 ## Table literal
 
-* Follow [record literals](/learn/style-guide/expressions#record-literal) formatting when formatting a table block.
+* Follow [record literals](/v1-0/learn/style-guide/expressions#record-literal) formatting when formatting a table block.
   
 **Example,**
   


### PR DESCRIPTION
## Purpose
We need to fix the below links, which were caused by #259.

http://localhost:4000/v1-0/learn/style-guide/definitions#function-definition
http://localhost:4000/learn/style-guide/expressions#record-literal
> Fixes #260 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
