### PR TITLE
Update the Privacy Policy of the B.io

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -18,6 +18,137 @@ display:none;
 	bottom: 0;
 }
 </style>
+- [Privacy Policy](#privacy-policy)
+- [Cookie Policy](#cookie-policy)
+- [Contact us](#contact-us)
+
 # Privacy Policy
 
-By using and/or visiting the Ballerina Website, you consent to be bound by WSO2's general [Terms of Service](https://wso2.com/terms-of-use) and WSO2's general [Privacy Policy](https://wso2.com/privacy-policy).
+At WSO2, we recognize that privacy is important. This privacy policy applies to the Ballerina sites and services offered at [https://ballerina.io](https://ballerina.io/) and any other site to which a link to these terms may appear. We’ve set out below the details of how we collect, use, share and secure the personal information you provide. “You” or “Your” means the person visiting the above mentioned Ballerina sites (the “Sites”) or using any services on it. “We” “us” and “our” means WSO2 Inc.
+
+## What information do we collect?
+
+When you register on the Ballerina Sites for updates or sign up for an event or service, or when you login through single sign on through certain designated federated identity providers mentioned on the Sites, we may ask that you submit some or all of the following information:
+
+- Your user name
+- Your email address
+
+You may choose to visit our site anonymously without providing any of the above information. However, certain services on our site – may require that such details be entered on a mandatory basis. This is because those details are essential for us to be able to provide you with such services.
+
+We also collect certain standard information that your browser sends to every website you visit, such as your IP address, browser type and language, access times, and referring website addresses.
+
+## Why do we collect your information?
+
+The information we collect from you maybe used in one of the following ways:
+
+- To perform the services requested (for instance if you’ve filled in a contact us form asking to receive updates we use your information to get in  touch with you).
+- To improve our website (we continually strive to improve our website offerings based on the type of content our users click on or download).
+- To conduct analysis on how effective our marketing campaigns are, how our products and services are used or downloaded, and to track lead generation for  our sales process.
+- To create your online profile, which we create for every user who registers on our site or for a service.
+- To send marketing material, event invitations and updates - If you indicate that you are interested in certain areas or subjects when you give us your contact details, we will send you marketing material and/or event and workshop invitations related to those areas. The email address you provide may also be used to send you important updates related to the site or the services you use.
+- To administer a contest, survey, or other site feature.
+- We track and analyze your actions on our website such as navigation, number of visits, downloads, and search items to gain a better understanding of  our visitors and their movements through the site. Please see our [cookie policy](#cookie-policy) on how we use and store cookies.
+
+## Who is your information shared with?
+
+We do not sell, trade, or otherwise share your information with outside parties. However, we do share your information with our subsidiaries, affiliates, service providers, and partners who assist us in operating our website, conducting our business, or servicing you.
+
+We sometimes need to give our service providers who help us run our website and services access to the data we have in order for them to perform those services. They are only authorised to use information that is strictly relevant for them to perform their tasks and we ensure that they are under obligations of confidentiality to us so that your data is secure.
+
+We may share your data with our subsidiaries or affiliates within our corporate group. WSO2 ‘s parent company is WSO2 Inc. and is located in the United States of America. Our affiliates are WSO2 UK Limited (located in the United Kingdom), WSO2 Lanka (Private) Limited (located in Sri Lanka), and WSO2 Brasil Tecnologia E Software Ltda (located in Brazil). We share information within this group because these entities also carry out support, marketing, account management, and technical operations for WSO2 that are relevant to the provision of the website and services.
+
+We may also release your information when we believe release is appropriate to comply with the law, enforce our privacy policy, or protect our or others’ rights, property, or safety.
+
+## How do we process your data?
+
+We will only collect and process personal data about you where we have lawful bases. Lawful bases include consent (where you have given consent), contract (where processing is necessary for the performance of a contract with you), and legitimate interests (such as to protect you, us, or others from security threats, comply with laws that apply to us and to enable or administer our business through consolidated reporting, customer service etc.).
+
+Where we rely on your consent to process personal data, you have the right to withdraw or decline your consent at any time and where we rely on legitimate interests, you have the right to object. If you have any questions about the lawful bases upon which we collect and use your personal data or wish to withdraw consent or object, please contact our Data Protection Officer at [dpo@wso2.com](mailto:dpo@wso2.com).
+
+## Security of your data
+
+We implement security safeguards designed to protect your data such as HTTPS. We regularly monitor our systems for possible vulnerabilities and attacks. However, we cannot warrant the security of any information that you send us. There is no guarantee that data may not be accessed, disclosed, altered, or destroyed by breach of any of our physical, technical, or managerial safeguards.
+
+## Your rights to your data and how to manage your preferences
+
+We may retain your information for a period of time consistent with the original purpose of collection. For instance, we may retain your information during the time in which you have an account to use our website or services. We also may retain your information during the period of time needed for WSO2 to pursue our legitimate business interests, conduct audits, comply with our legal obligations, resolve disputes, and enforce our agreements. At the end of these periods, we ensure that your data is deleted securely using an industry standard methodology.
+
+WSO2 acknowledges your right to access your data. If information pertaining to you as an individual has been submitted to us then you have the right to access, correct, or edit your data. If you wish, we can provide all the personal information on our records to you or to someone you nominate in a portable format as well. Our contact details are provided at the bottom of the page or you can reach out to us as dpo@wso2.com. All you have to do is to request, and we are happy to help.
+
+You can ask us to stop using all or some of your personal data (e.g., if we have no legal right to keep using it) or to limit our use of it (e.g., if your personal data is inaccurate or unlawfully held).
+
+You may also choose to delete your data from our website at any time you choose, and unsubscribe from any Ballerina mailing lists you are on. You can unsubscribe from our emails by clicking on the unsubscribe link which is at the bottom of every marketing email we send. You can also contact us on the email address(es) provided at the bottom of this notice, if you would like us to this on your behalf.
+
+We only ever retain your personal data even after you have ceased using our services, requested to unsubscribe or delete your data only if reasonably necessary to comply with our legal obligations (including law enforcement requests), meet regulatory requirements, resolve disputes, maintain security, prevent fraud and abuse, or fulfill your request to "unsubscribe" from further messages from us.
+
+## Thord party offerings and services
+
+At our discretion, we may include or offer third party products or services on our site. These third party sites have separate and independent privacy policies. We have no responsibility or liability for the content and activities of these linked sites. We encourage you to review the privacy statements of those websites to understand how your data is secured by them. Nonetheless, we seek to protect the integrity of our site and welcome any feedback about these sites.
+
+## Information about our website
+
+This privacy policy applies only to information collected through the Sites and not to information collected offline. Please also visit our [Terms of Service](https://ballerina.io/terms-of-service/) section relating to use, disclaimers, indemnities, and limitations of liability governing the use of our site and services. 
+
+## Changes to our Privacy Policy
+
+We reserve the right to amend this Privacy Policy at any time. We will not send individual email notifications on the updates. Any amendments will be posted on this page. You are therefore encouraged to visit this page periodically.
+
+By using the Sites, you consent to our Privacy Policy and any revisions thereto. If you do not agree with our privacy policy or any changes we make to it, you may delete your profile.
+
+>**For EU/EEA/Switzerland residents:** If you are located within the European Union, the European Economic Area or Switzerland, WSO2 UK Limited will be the controller of your personal data provided to, or collected by or for, or processed in connection with our services. If you have any issues with regard to your data security on our website, then in addition to informing us, you also have the right to write directly to the independent data protection monitoring organization in your country. Within the UK, this is the [Information Commissioner’s Office](https://ico.org.uk/). The ICO is the UK’s independent authority set up to uphold information rights in the public interest, promoting openness by public bodies and data privacy for individuals. Please do email our data protection officer at [dpo@wso2.com](mailto:dpo@wso2.com) if you have any issues, concerns, or questions regarding your personal data and we are happy to help.
+
+# Cookie Policy
+
+Below is information about how the [Ballerina site](https://ballerina.io/) (the “Site”) uses cookies.
+
+The Site stores and retrieves information on your browser using cookies. This information is used to make the Site work as you expect it to. It is not personally identifiable to you, but it can be used to give you a more personalized web experience.
+
+This Cookie Policy is part of our Privacy Policy. It explains the following:
+
+## What are cookies?
+
+A browser cookie is a small piece of data that is stored on your device to help websites and mobile apps remember things about you. Other technologies, including Web storage and identifiers associated with your device, may be used for similar purposes. In this policy, we use the term “cookies” to discuss all of these technologies.
+
+## What do we use cookies for?
+
+Cookies are used to protect your data and account on the Ballerina Site. Cookies help us see which features are most popular, count visitors to a page, improve our users’ experience, keep our services secure, and to provide you with a better, more intuitive, and satisfying experience.
+
+We use cookies for the following purposes:
+
+### Security
+
+We use these cookies to help identify and prevent security risks.
+
+For example, we may use these cookies to store your session information to prevent others from changing your password without your username and password.
+
+### Performance
+
+We use these cookies to collect information about how you interact with our services and to help us improve them.
+
+For example, we may use these cookies to determine if you have interacted with a certain page.
+
+### Analytics
+
+We use these cookies to help us improve our services.
+
+For example, we can use these cookies to learn more about which features are the most popular with our users and which ones might need some tweaks.
+
+## Third party cookies
+
+Our website will set several types of third-party cookie, and we do not control the operation of any of them. The third-party cookies, which maybe set include:
+
+- Google Analytics - we use Google Analytics to collect data about website usage. This data does not include personally identifiable information. For more information, view the [Google Privacy Policy](https://policies.google.com/privacy).
+
+## What type of cokkies do we use?
+
+We use session cookies. A session cookie is a cookie that is erased when the user closes the Web browser. The session cookie is stored in temporary memory and is not retained after the browser is closed. Session cookies do not collect information from the users computer.
+
+## How do I control my cookies?
+
+Most browsers allow you to control cookies through their settings preferences. However, if you limit the ability of websites to set cookies, you may worsen your overall user experience since it will no longer be personalized to you. It may also stop you from saving customized settings like login information.
+
+# Contact us
+
+For further information about our Privacy Policy or if you have any questions, complaints, or concerns regarding the use of cookies, please contact our Data Protection Officer at [dpo@wso2.com](mailto:dpo@wso2.com).
+
+**Effective April 12, 2018**


### PR DESCRIPTION
## Purpose
Currently, the [Privacy Policy in B.io](https://ballerina.io/privacy-policy/) links to the WSO2 Privacy Policy.

However, since the [Privacy Policy in Ballerina Central](https://central.ballerina.io/privacy-policy) is more relevant to Ballerina better to add it in B.io.
> Fixes #263 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
