### PR TITLE
Update the Terms of Service of the B.io

### DIFF
--- a/terms-of-service.md
+++ b/terms-of-service.md
@@ -20,4 +20,158 @@ display:none;
 
 # Terms of Service
 
-By using and/or visiting the Ballerina Website, you consent to be bound by WSO2's general [Terms of Service](https://wso2.com/terms-of-use) and WSO2's general [Privacy Policy](https://wso2.com/privacy-policy).
+The following Terms of Use (“Terms”) govern your access to and use of the [Ballerina website](https://ballerina.io/) and any other site to which a link to these terms may appear (“Sites”). These Terms are a legal agreement between you and WSO2. Your registration for, or use of the Sites and any software, repositories, other services, or projects hosted on the Sites (“Services”) shall be deemed to be your acceptance of these Terms. These Terms do not govern your access and use of the Ballerina programming language or related commercial support and services offerings, which may be made available to you under separate license terms.
+
+If you are agreeing to these Terms on behalf of a company or other legal entity, you represent that you have the authority to, and do hereby bind such entity to these Terms. You may not use the Ballerina Sites or Services if you are a person barred from using the Sites or Services under the laws of the United States or other countries, including the country in which you are resident or from which you use the Sites, or international laws or treaties. You may not use the Ballerina Sites or Services if you are or represent an entity that is listed on any U.S. Government Denied Party/Person List. You affirm that you are over the age of 13 as the Service is not intended for children under 13. IF YOU ARE 13 OR OLDER BUT UNDER THE AGE OF 18, OR THE LEGAL AGE OF MAJORITY WHERE YOU RESIDE IF THAT JURISDICTION HAS AN OLDER AGE OF MAJORITY, THEN YOU AGREE TO REVIEW THE TERMS WITH YOUR PARENT OR GUARDIAN TO MAKE SURE THAT BOTH YOU AND YOUR PARENT OR GUARDIAN UNDERSTAND AND AGREE TO THESE TERMS. YOU AGREE TO HAVE YOUR PARENT OR GUARDIAN REVIEW AND ACCEPT THESE TERMS ON YOUR BEHALF. IF YOU ARE A PARENT OR GUARDIAN AGREEING TO THE TERMS FOR THE BENEFIT OF A CHILD OVER 13, THEN YOU AGREE TO AND ACCEPT FULL RESPONSIBILITY FOR THAT CHILD'S USE OF THE SERVICE, INCLUDING ALL FINANCIAL CHARGES AND LEGAL LIABILITY THAT HE OR SHE MAY INCUR.
+
+- [Certain disclaimers](#certain-disclaimers)
+- [Your use of the Sites and Services](#your-use-of-the-sites-and-services)
+- [Privacy and restrictions on use](#privacy-and-restrictions-on-use)
+- [Our trademarks and proprietary rights](#our-trademarks-and-proprietary-rights)
+- [User content](#user-content)
+- [Copyright information](#copyright-information)
+- [User disagreements](#user-disagreements)
+- [Third party Sites and Services](#third-party-sites-and-services)
+- [Revisions to these Terms and termination](#revisions-to-these-terms-and-termination)
+- [Subscriptions and mail notifications: your choice](#subscriptions-and-mail-notifications:-your-choice)
+- [Limitation of liability; disclaimer of warranties](#limitation-of-liability;-disclaimer-of-warranties)
+- [Indemnification](#indemnification)
+- [General](#General)
+
+## Certain disclaimers
+
+You understand and agree that the Sites and all Services on it are provided “AS-IS” and that we assume no responsibility for the timeliness, deletion, mis-delivery, or failure to store any user communications or personalization settings. We also assume no responsibility in relation to User Content made available through the Sites. You are responsible for obtaining access to the Services and that access may involve third-party fees (such as internet service provider or airtime charges).
+
+You agree that you are responsible for your own use of the Services, for any posts you make, or code or data files you provide and for any consequences thereof. You agree that you will use the Services in compliance with all applicable local, state, national, and international laws, rules and regulations, including any laws regarding the transmission of technical data exported from your country of residence and all United States export control laws.
+
+## Your use of the Sites and Services
+
+1. As a condition to using certain Services on the Sites, we may require that you log in with your existing SSO credentials through certain federated identity service providers as set out in the account registration procedure on the Sites. You will provide us with true, accurate, current, and complete information. You may not use anyone else’s password. You are solely responsible for maintaining the confidentiality of your account and password. You agree to immediately notify WSO2 of any unauthorized use of your password or accounts or any other breach of security. WSO2 will not be responsible for any loss or damage that may result if you fail to comply with these requirements. You will not employ the use of automation, mashups, programs, robots, or agents in the process of registering your account.
+
+2. You will be responsible for all activity occurring under your accounts and will comply with all applicable local, state and foreign laws, treaties, and regulations in connection with your use of the Services, including without limitation, laws, and regulations governing data privacy, international communications, and transmission of technical or personal data.
+
+3. You agree not to (a) access (or attempt to access) the administrative interface of the Services by any means other than through the interface that is provided by WSO2 in connection with the Services unless you have been specifically allowed to do so in a separate agreement with WSO2, and (b) engage in any activity that interferes with or disrupts the Sites and Services (or the servers and networks which are connected to the Sites and Services).
+
+4. You may not access or use the Sites and Services for the purpose of bringing an intellectual property infringement claim against WSO2 or for the purpose of creating a product or service competitive with the Sites or Services.
+
+5. Your account may have usage limits as further explained on the Services or other documentation provided by WSO2. The Services may not permit you to exceed the hard usage limits. WSO2 reserves the right to enforce soft usage limits in its sole discretion. Repeated exceeding of the hard or soft usage limits may lead to termination of your account.
+
+6. The software and technology relating to the Ballerina Sites and the Services are the property of WSO2, its partners, and affiliates. You agree not to modify, adapt, distribute, reverse engineer, sell, assign, or otherwise transfer any portion of the Sites for any purpose including the unauthorized access to the Ballerina Sites. Copyright and other intellectual property laws protect these materials. Reproduction or retransmission of the materials, in whole or in part, in any manner, without the prior written consent of WSO2, is a violation of copyright law. For more details, see [Our Trademarks and Proprietary Rights](#our-trademarks-and-proprietary-rights).
+
+## Privacy and restrictions on use
+
+1. Our [Privacy Policy](https://ballerina.io/privacy-policy/) describes how we collect, use, and store any personal information belonging to you and is hereby incorporated by reference into these Terms. You agree that you will protect the privacy and legal rights of the end users of your repositories or other content stored or managed via the Services. You must provide a legally adequate privacy notice and protection for such end users.
+
+2. You agree that you are responsible for your own conduct while accessing or using the Sites and Services and for any consequences thereof. You agree to use the Services only for purposes that are legal, proper, and in accordance with these Terms and any applicable laws or regulations. By way of example, and not as a limitation, you may not and may not allow any third party to:
+
+	- send, upload, post, email, transmit, or otherwise make available any Content (as defined in the [User Content](#user-content) that is unlawful, harmful, threatening, abusive, harassing, tortious, defamatory, vulgar, obscene, libelous, invasive of another’s privacy, hateful, or racially,  ethnically, or otherwise objectionable;
+	- harm minors in any way;
+	- impersonate any person or entity (via the use of an email address or otherwise), including, but not limited to, a WSO2 official, guide or host, or falsely state, or otherwise misrepresent your affiliation with a person or entity;
+	- forge headers or otherwise manipulate identifiers in order to disguise the origin of any User Content transmitted through the service;
+	- remove any copyright, trademark, or other proprietary rights notices contained in or on the Sites and Services or any content posted thereon;
+	- send, upload, post, email, transmit, or otherwise make available any Content that you do not have a right to make available under any law or under contractual or fiduciary relationships (such as inside information, proprietary and confidential information learned or disclosed as part of employment relationships or under nondisclosure agreements);
+	- send, upload, post, email, transmit, or otherwise make available any Content that infringes any patent, trademark, trade secret, copyright, or other proprietary rights (“Rights”) of any party;
+	- send, upload, post, email, transmit, or otherwise make available any unsolicited or unauthorized advertising, promotional materials, spam, pyramid schemes, or any other form of solicitation;
+	- send, upload, post, email, transmit, or otherwise make available any material that contains software viruses or any other computer code, files, or programs designed to interrupt, destroy, or limit the functionality of any computer software, hardware, or telecommunications equipment;
+	- interfere with or disrupt the Sites and Services, servers, or networks connected to the Sites and Services, or disobey any requirements, procedures, policies, or regulations of networks connected to the Sites and Services;
+	- display any portion of the Site via an HTML IFRAME;
+	- submit content that falsely expresses or implies that such content is sponsored or endorsed by WSO2;
+	- use the Sites and Services to send emails to distribution lists, newsgroups, or group mail aliases;
+	- add deep hyperlinks to images or other non-hypertext content served by the Services;
+	- intentionally or unintentionally violate any applicable local, state, national, or international law, ordinance, or regulation;
+	- provide material support or resources (or to conceal or disguise the nature, location, source, or ownership of material support or resources) to any organization(s) designated by the United States government as a foreign terrorist organization pursuant to section 219 of the Immigration and  Nationality Act;
+	- stalk or otherwise harass another;
+	- exploit the Sites and Services for any unauthorized commercial purposes;
+	- use the Services in connection with illegal peer-to-peer file sharing;
+	- collect or store personal data about other users in connection with the prohibited conduct and activities set forth above; and
+	- use the Sites and Services or any interfaces provided with the Services to access any Ballerina software or Services in a manner that violates these Terms or other terms and conditions for use of such Ballerina software or Service.
+
+3. You acknowledge, consent, and agree that WSO2 may access, preserve, and disclose your account information and User Content if required to do so by law or in a good faith belief that such access preservation or disclosure is reasonably necessary to:
+
+	- comply with a legal process;
+	- enforce these Terms;
+	- perform any part of the Services;
+	- respond to claims that any User Content violates the rights of third parties;
+	- respond to your requests for customer service; or
+	- protect the rights, property, or personal safety of WSO2, its users, and the public.
+
+4. You understand that the Services and software embodied within the Services may include security components that permit digital materials to be protected, and that use of these materials is subject to usage rules set by WSO2 and/or content providers who provide content to the Services. You may not attempt to override or circumvent any of the usage rules embedded into the Services. Any unauthorized reproduction, publication, further distribution, or public exhibition of the materials provided on the service, in whole or in part, is strictly prohibited.
+
+5. Using the Ballerina Sites or Services for acts or content in violation of these Terms may result in disabling or blocking of your account or access to the Sites without warning and WSO2 may take maximum legal action applicable within law. If we determine (in our sole discretion) that your account has been used to submit any content that violates our terms, we may remove such content from the site at any time without notice to you, and your account will be considered for blocking or disabling in our sole discretion.
+
+## User content
+
+1. You understand that all code, data files, text, documentation, software, sound, graphics, illustrations, video, or other materials (“Content”), whether publicly posted or privately transmitted, are the sole responsibility of the person from whom such Content originated. This means that you, and not WSO2, are entirely responsible for all Content that you upload, post, email, transmit, or otherwise make available via the Services (“User Content”), as well as for any actions taken by WSO2 or other users as a result of your User Content. In connection with User Content, you affirm, represent, and warrant that you either own your User Content or have the necessary licenses, rights, consents, and permissions to grant the rights and licenses granted in these Terms.
+
+2. You retain all ownership rights in User Content owned by you. WSO2 simply displays or makes the User Content available and does not control the User Content posted via the Services and, as such, does not guarantee the accuracy, integrity or quality of such User Content. You understand that by using the Services, you may be exposed to Content that is inaccurate, misleading, offensive, indecent, infringing, or otherwise objectionable. Under no circumstances will WSO2 be liable in any way for any User Content, including, but not limited to, any errors or omissions in any User Content, or any loss or damage of any kind incurred as a result of the use of any User Content posted, emailed, transmitted, or otherwise made available via the Sites and Services. You understand that WSO2 cannot, and does not, review all User Content and does not endorse any User Content. You further understand that WSO2 does not scan the User Content for malicious computer code such as computer viruses, trojans, computer worms, rootkits, back doors, adware, or spyware and that such content may contain such malicious code, and you agree to use such User Content at your own risk.
+
+3. By submitting User Content to the Ballerina Sites you acknowledge and agree that:
+
+	- your User Content does not contain confidential or proprietary information;
+	- we are not under any obligation of confidentiality, express or implied, with respect to your User Content;
+	- you have the right to specify or upload the terms under which other users of the Sites or Services will be licensed to use your User Content. We encourage users to, where possible, grant permissive licenses to their User Content. However, we will neither monitor nor bear responsibility for ensuring that the license terms attached to your User Content are complied with. We undertake no liability for any violation of the license terms under which you make your User Content available. If you do not specify or upload such license terms with respect to any User Content, you hereby grant us and all other users of the Sites and Services, a worldwide, perpetual, non-exclusive, irrevocable, sub-licensable, royalty-free license to use, distribute, reproduce, modify, adapt, publish, translate, publicly perform, and publicly display your User Content (in whole or in part) on the Sites and Services and to incorporate such User Content into other works in any format or medium now known or later developed;
+	- we may delete or archive any User Content where such content has not been used for a certain period of time as determined by us, in our discretion. We may also delete or limit access to any User Content that we determine is violating these terms or any other applicable laws, rules, or regulations; and
+	- you are not entitled to any compensation or reimbursement of any kind from WSO2 under any circumstances.
+
+## Copyright information
+
+It is our policy to respond to notices of alleged infringement that comply with the Digital Millennium Copyright Act. If you believe that your work has been copied in a way that constitutes copyright infringement or your intellectual property rights have been otherwise violated, please provide WSO2’s Copyright Agent the following information:
+
+- an electronic or physical signature of the person authorized to act on behalf of the owner of the copyright or other intellectual property interest;
+- a description of the copyrighted work or other intellectual property that you claim has been infringed;
+- a description of where the material that you claim is infringing is located on the Sites;
+- your address, telephone number, and email address;
+- a statement by you that you have a good faith belief that the disputed use is not authorized by the copyright owner, its agent, or the law; and
+- a statement by you made under penalty of perjury, that the above information in your notice is accurate and that you are the copyright or intellectual property owner, or authorized to act on the copyright or intellectual property owner’s behalf.
+
+WSO2’s agent for notice of claims of copyright or other intellectual property infringement can be reached as follows:
+
+- **By mail:** Attn: Copyright Agent, WSO2 Inc. 787 Castro Street, Mountain View CA 94041, USA
+- **By phone:** (+1) 408 754 7388
+- **By Fax:** (+1) 408 689 4328
+
+## User disagreements
+
+You alone are responsible for your involvement and interactions with other users of the Services. WSO2 reserves the right but has no obligation to monitor disagreements between you and other users. If you have a dispute with any other users of the Services, you irrevocably and forever release WSO2 (and WSO2’s affiliates, officers, directors, agents, subsidiaries, joint ventures, and employees) from claims, demands, and damages (actual and consequential) of every kind and nature, known and unknown, arising out of or in any way connected with such disputes. IF YOU ARE A CALIFORNIA RESIDENT, YOU WAIVE CALIFORNIA CIVIL CODE SECTION 1542, WHICH SAYS: “A GENERAL RELEASE DOES NOT EXTEND TO CLAIMS WHICH THE CREDITOR DOES NOT KNOW OR SUSPECT TO EXIST IN HIS OR HER FAVOR AT THE TIME OF EXECUTING THE RELEASE, WHICH IF KNOWN BY HIM OR HER MUST HAVE MATERIALLY AFFECTED HIS OR HER SETTLEMENT WITH THE DEBTOR.”
+
+## Our trademarks and proprietary rights
+
+1. You acknowledge and agree that WSO2 (or its licensors) own all legal right, title, and interest in and to the Sites and the Services. The visual interfaces, graphics, design, systems, methods, information, computer code, software, services, “look and feel”, organization, compilation of the content, code, data, and all other elements of the Sites and Services (collectively, “Ballerina Materials“) are protected by United States copyright, trade dress, patent, and trademark laws, international conventions, and all other relevant intellectual property and proprietary rights, and applicable laws. Except for any User Content owned and/or posted by you or other users, all Ballerina Materials are the copyrighted property of WSO2 or its licensors. Furthermore, all trademarks, service marks, and trade names contained in the Ballerina Materials are proprietary to WSO2 or its licensors. Except as expressly set forth herein, your use of the Sites or Services does not grant you ownership of, or any other rights with respect to, any content, code, data, user comments or other materials that you may access on or through the Sites or Services. WSO2 reserves all rights to the Ballerina Materials not expressly granted in the Terms.
+
+2. The following names, trademarks, service marks, logos, and product and service names are trademarks of WSO2: “Ballerina”, “BallerinaCon”, “Ballerina Central”, and “WSO2” and the WSO2 and Ballerina logos. Without WSO2’s prior permission, you agree not to display or use in any manner such names and marks, except for reasonable attribution purposes.
+
+## Third party Sites and Services
+
+The Sites and Services may hyperlink to and integrate with third-party applications, websites, and other services. You decide whether and how to use and interact with such services. We do not make any warranty regarding such services or content they may provide, and will not be liable to you for any damages related to such services. Use of such third-party services may be governed by other terms and privacy notices that are not part of this Agreement and are not controlled by us.
+
+## Revisions to these Terms and termination
+
+1. We may at any time revise these Terms by updating this page. We will not send individual email notifications on these updates. By using the Ballerina Sites and Services, you agree to be bound by any such revisions and are therefore encouraged to periodically visit this page. Your continued use of the Sites and Services after revisions are made to this policy will constitute your acceptance of such revised terms.
+
+2. You agree that WSO2 in its sole discretion and for any or no reason may terminate these Terms and your account for the Services. You agree that any termination of your access to the Services may be without prior notice, and you agree that WSO2 will not be liable to you or any third party for such termination. If WSO2 terminates these Terms or your access or use of the Services due to your breach of these Terms or any suspected fraudulent, abusive, or illegal activity, then termination of these Terms shall be in addition to any other remedies WSO2 may have at law or in equity.
+
+3. Upon any termination or expiration of these Terms, whether by you or WSO2, ANY INFORMATION (INCLUDING USER CONTENT) THAT YOU HAVE POSTED OR SUBMITTED ON OR THROUGH THE SERVICE OR THAT WHICH IS RELATED TO YOUR ACCOUNT MAY NO LONGER BE ACCESSED BY YOU and WSO2 will have no obligation to maintain any such information in its databases or to forward any such information to you or any third party. However, you acknowledge that the ecosystem and community beyond WSO2 may build a lasting dependency upon your User Content once it is posted upon the Sites. To ensure community continuity, WSO2 retains the right to continue to host and maintain your User Content on the Sites and Services even after the termination of your account, or the expiration of these terms, at our sole discretion. In the event of any contradiction between the right granted herein and any term of the license specified with your User Content, you agree that the right granted in this section 9.3 shall prevail. You are solely responsible for retrieving your User Content from the Services prior to termination of your account for any reason, provided that if we terminate your account, we will attempt to provide you a with reasonable opportunity to retrieve your User Content.
+
+## Subscriptions and mail notifications: your choice
+
+If you have chosen to subscribe to receive any services related information, Ballerina updates, newsletters, or other informational material, you have the right to opt-out of receiving such email notifications at any point by clicking on the “unsubscribe” link at the bottom of any email sent by us, or by notifying us at [dpo@wso2.com](mailto:dpo@wso2.com) if you would like us to delete all contact information and personal data we have from you.
+
+## Limitation of liability; disclaimer of warranties
+
+YOUR USE OF THE SITES AND SERVICE IS AT YOUR SOLE RISK. THE SERVICE IS PROVIDED ON AN “AS IS” AND “AS AVAILABLE” BASIS. WSO2 AND ITS SUBSIDIARIES, AFFILIATES, OFFICERS, EMPLOYEES, AGENTS, PARTNERS, AND LICENSORS EXPRESSLY DISCLAIM ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+
+YOU EXPRESSLY UNDERSTAND AND AGREE THAT WSO2 AND ITS SUBSIDIARIES, AFFILIATES, OFFICERS, EMPLOYEES, AGENTS, PARTNERS, AND LICENSORS SHALL NOT BE LIABLE TO YOU FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES, INCLUDING, BUT NOT LIMITED TO, DAMAGES FOR LOSS OF PROFITS, GOODWILL, USE, DATA OR OTHER INTANGIBLE LOSSES (EVEN IF WSO2 HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES), RESULTING FROM:
+
+1. THE USE OR THE INABILITY TO USE THE SERVICE;
+2. THE COST OF PROCUREMENT OF SUBSTITUTE GOODS AND SERVICES RESULTING FROM ANY GOODS, DATA, INFORMATION OR SERVICES PURCHASED OR OBTAINED OR MESSAGES RECEIVED OR TRANSACTIONS ENTERED INTO THROUGH OR FROM THE SERVICE; 
+3. UNAUTHORIZED ACCESS TO OR ALTERATION OF YOUR TRANSMISSIONS OR DATA;
+4. STATEMENTS OR CONDUCT OF ANY THIRD PARTY ON THE SERVICE; OR
+5. ANY OTHER MATTER RELATING TO THE SERVICE.
+
+## Indemnification
+
+YOU AGREE TO HOLD HARMLESS AND INDEMNIFY WSO2 AND ITS SUBSIDIARIES, AFFILIATES, OFFICERS, AGENTS, EMPLOYEES, ADVERTISERS, LICENSORS, SUPPLIERS, OR PARTNERS FROM AND AGAINST ANY THIRD PARTY CLAIM ARISING FROM OR IN ANY WAY RELATED TO (A) YOUR BREACH OF THE TERMS, (B) YOUR VIOLATION OF APPLICABLE LAWS, RULES OR REGULATIONS IN CONNECTION WITH THE SERVICE, OR (C) YOUR USER CONTENT, INCLUDING ANY LIABILITY OR EXPENSE ARISING FROM ALL CLAIMS, LOSSES, DAMAGES (ACTUAL AND CONSEQUENTIAL), SUITS, JUDGMENTS, LITIGATION COSTS, AND ATTORNEYS' FEES, OF EVERY KIND AND NATURE. IN SUCH CASE, WSO2 WILL PROVIDE YOU WITH WRITTEN NOTICE OF SUCH CLAIM, SUIT OR ACTION; WILL PROVIDE YOU THE OPPORTUNITY TO CONTROL THE DEFENSE AND/OR SETTLEMENT OF SUCH CLAIM, SUIT OR ACTION; AND WILL PROVIDE YOU REASONABLE ASSISTANCE IN SUCH DEFENSE OR SETTLEMENT, UPON REASONABLE REQUEST.
+
+## General
+
+These Terms will be governed by and construed in accordance with the laws of the State of California, without giving effect to its conflict of laws provisions. Any claims, legal proceeding or litigation arising in connection with the service will be brought solely in Santa Clara County, California, and you consent to the jurisdiction of such courts. The failure of WSO2 to exercise or enforce any right or provision of these Terms not constitute a waiver of such right or provision. If any provision of the Terms is found by a court of competent jurisdiction to be invalid, the parties nevertheless agree that the court should endeavor to give effect to the parties’ intentions as reflected in the provision, and the other provisions of these Terms remain in full force and effect. These Terms constitute the entire agreement between you and WSO2 and govern your use of the Sites and Services superseding any prior agreements between you and WSO2 with respect to the Sites and Services.


### PR DESCRIPTION
## Purpose
Currently, the [Terms of Service in B.io](https://ballerina.io/terms-of-service/) links to the WSO2 Privacy Policy.

However, since the [Terms of Service  in Ballerina Central](https://central.ballerina.io/terms-of-service) is more relevant to Ballerina better to add it in B.io.
> Fixes #264 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
