### PR TITLE
Add redirection from to /learn

### DIFF
--- a/v1-1/learn.md
+++ b/v1-1/learn.md
@@ -8,6 +8,7 @@ redirect_from:
   - /v1-1/learn/tools-ides
   - /v1-1/learn/tools-ides/
   - /learn/
+  - /learn
 ---
 
 <h1>Let’s learn Ballerina!</h1>

--- a/v1-1/learn/cli-commands.md
+++ b/v1-1/learn/cli-commands.md
@@ -2,6 +2,9 @@
 layout: ballerina-inner-page
 title: CLI Commands
 permalink: /v1-1/learn/cli-commands/
+redirect_from:
+  - /learn/cli-commands/
+  - /learn/cli-commands
 ---
 
 # CLI Commands

--- a/v1-1/learn/installing-ballerina.md
+++ b/v1-1/learn/installing-ballerina.md
@@ -4,6 +4,8 @@ title: Installing Ballerina
 permalink: /v1-1/learn/installing-ballerina/
 redirect_from:
   - /v1-1/learn/getting-started
+  - /learn/getting-started
+  - /learn/getting-started/
 ---
 
 # Installing Ballerina

--- a/v1-1/learn/quick-tour.md
+++ b/v1-1/learn/quick-tour.md
@@ -2,6 +2,9 @@
 layout: ballerina-inner-page
 title: Quick Tour
 permalink: /v1-1/learn/quick-tour/
+redirect_from:
+  - /learn/quick-tour/
+  - /learn/quick-tour
 ---
 
 # Quick Tour

--- a/v1-1/learn/set-up-ballerina-sdk.md
+++ b/v1-1/learn/set-up-ballerina-sdk.md
@@ -2,6 +2,9 @@
 layout: ballerina-inner-page
 title: Setting up Ballerina SDK
 permalink: /v1-1/learn/set-up-ballerina-sdk
+redirect_from:
+  - /learn/set-up-ballerina-sdk
+  - /learn/set-up-ballerina-sdk/
 ---
 
 # Setting up Ballerina SDK

--- a/v1-1/learn/style-guide.md
+++ b/v1-1/learn/style-guide.md
@@ -2,6 +2,9 @@
 layout: ballerina-inner-page
 title: Ballerina Style Guide
 permalink: /v1-1/learn/style-guide/
+redirect_from:
+  - /learn/style-guide/
+  - /learn/style-guide
 ---
 
 # Ballerina Style Guide

--- a/v1-1/learn/tools-ides/intellij-plugin.md
+++ b/v1-1/learn/tools-ides/intellij-plugin.md
@@ -5,6 +5,8 @@ permalink: /v1-1/learn/intellij-plugin/
 redirect_from:
   - /v1-1/learn/tools-ides/intellij-plugin
   - /v1-1/learn/tools-ides/intellij-plugin/
+  - /learn/tools-ides/intellij-plugin/
+  - /learn/tools-ides/intellij-plugin
 ---
 
 # The IntelliJ IDEA Ballerina Plugin

--- a/v1-1/learn/tools-ides/vscode-plugin.md
+++ b/v1-1/learn/tools-ides/vscode-plugin.md
@@ -5,6 +5,8 @@ permalink: /v1-1/learn/vscode-plugin/
 redirect_from:
   - /v1-1/learn/tools-ides/vscode-plugin
   - /v1-1/learn/tools-ides/vscode-plugin/
+  - /learn/tools-ides/vscode-plugin
+  - /learn/tools-ides/vscode-plugin/
 ---
 
 # The Visual Studio Code Extension


### PR DESCRIPTION
## Purpose
This will add redirection from to old /learn path to redirect old URLs to new path. 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
