### PR TITLE
Fix the Broken Links Identified in the 1.2.0 RC Stage

### DIFF
--- a/license-of-site.md
+++ b/license-of-site.md
@@ -44,7 +44,7 @@ If you produce non-hypertext works, such as books, audio, or video, we ask that 
 ### Ballerina Website Attributions
 In the creation of this website, we used the following Creative Commons Attribution license: 
 
-* [Ballerina by Example](https://ballerina.io/learn/by-example/) sample pages are generated using a [tool](https://github.com/mmcgrana/gobyexample/) developed by [mmcgrana](https://github.com/mmcgrana), licensed under [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/) and modified from the original.
+* [Ballerina by Example](https://ballerina.io/v1-2/learn/by-example/) sample pages are generated using a [tool](https://github.com/mmcgrana/gobyexample/) developed by [mmcgrana](https://github.com/mmcgrana), licensed under [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/) and modified from the original.
 
 ## Contact
 If you have any comments regarding Ballerina.io license policies, please send feedback to [legal@wso2.com](mailto:legal@wso2.com).

--- a/v1-2/learn/how-to-keep-ballerina-up-to-date.md
+++ b/v1-2/learn/how-to-keep-ballerina-up-to-date.md
@@ -6,7 +6,7 @@ permalink: /v1-2/learn/how-to-keep-ballerina-up-to-date/
 
 # How to Keep Ballerina up to date
 
-This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases. If you haven’t installed Ballerina yet, visit [installation guide](https://ballerina.io/v1-2/learn/installing-ballerina/).
+This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases. If you haven’t installed Ballerina yet, visit [installation guide](/v1-2/learn/installing-ballerina/).
 
 - [Terminology](#terminology)
   - [Ballerina tool](#ballerina-tool)
@@ -74,7 +74,7 @@ This channel gives you access to feature releases of Ballerina distributions. Ba
 
 Now that you are familiar with the terminology, let’s look at how you can keep your Ballerina distributions up to date.
 
-- The first step is to install Ballerina. Visit our [installation guide](https://ballerina.io/v1-2/learn/installing-ballerina/) guide for details. Once the installation is complete, you would see the following directory structure inside the installation directory.
+- The first step is to install Ballerina. Visit our [installation guide](/v1-2/learn/installing-ballerina/) guide for details. Once the installation is complete, you would see the following directory structure inside the installation directory.
 
 ```sh
 .

--- a/v1-2/learn/how-to-write-secure-ballerina-code.md
+++ b/v1-2/learn/how-to-write-secure-ballerina-code.md
@@ -179,7 +179,7 @@ function sanitizeSortColumn (string columnName) returns @untainted string {
 
 ## Securing Passwords and Secrets
 
-Ballerina provides an API to access configuration values from different sources. For more information, see [Config Ballerina by Example](https://ballerina.io/v1-2/learn/by-example/config-api.html).
+Ballerina provides an API to access configuration values from different sources. For more information, see [Config Ballerina by Example](/v1-2/learn/by-example/config-api.html).
 
 Configuration values containing passwords or secrets should be encrypted. The Ballerina Config API will decrypt such configuration values when being accessed.
 

--- a/v1-2/learn/installing-ballerina.md
+++ b/v1-2/learn/installing-ballerina.md
@@ -6,6 +6,9 @@ redirect_from:
   - /v1-2/learn/getting-started
   - /learn/getting-started
   - /learn/getting-started/
+  - /learn/installing-ballerina/
+  - /learn/installing-ballerina
+  - /learn/installing-ballerina/#installing-from-source
 ---
 
 # Installing Ballerina

--- a/v1-2/learn/set-up-ballerina-sdk.md
+++ b/v1-2/learn/set-up-ballerina-sdk.md
@@ -5,6 +5,7 @@ permalink: /v1-2/learn/set-up-ballerina-sdk
 redirect_from:
   - /learn/set-up-ballerina-sdk
   - /learn/set-up-ballerina-sdk/
+  - /v1-2/learn/set-up-ballerina-sdk/
 ---
 
 # Setting up Ballerina SDK

--- a/v1-2/learn/tools-ides/intellij-plugin.md
+++ b/v1-2/learn/tools-ides/intellij-plugin.md
@@ -7,6 +7,8 @@ redirect_from:
   - /v1-2/learn/tools-ides/intellij-plugin/
   - /learn/tools-ides/intellij-plugin/
   - /learn/tools-ides/intellij-plugin
+  - /learn/intellij-plugin/
+  - /learn/intellij-plugin
 ---
 
 # The IntelliJ IDEA Ballerina Plugin

--- a/v1-2/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/v1-2/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -169,7 +169,7 @@ You expand/collapse the following Ballerina code segments using the icons in the
 
 ## Go to definition
 
-This option allows you to view the definition of a selected variable, function, an object etc. within the same file, in a separate file, in the same module, or in a file of a different module, of the same project or of the [Standard Library](v1-2/learn/api-docs/ballerina/).
+This option allows you to view the definition of a selected variable, function, an object etc. within the same file, in a separate file, in the same module, or in a file of a different module, of the same project or of the [Standard Library](/v1-2/learn/api-docs/ballerina/).
 
 ![Go to definition](/v1-2/learn/images/go-to-definition-intellij.gif)
 

--- a/v1-2/learn/tools-ides/vscode-plugin.md
+++ b/v1-2/learn/tools-ides/vscode-plugin.md
@@ -73,5 +73,5 @@ The below sections include information on the various capabilities that are faci
 - [Run and Debug](/v1-2/learn/vscode-plugin/run-and-debug)
 - [Graphical View](/v1-2/learn/vscode-plugin/graphical-editor)
 - [Documentation Viewer](/v1-2/learn/vscode-plugin/documentation-viewer)
-- [Run all Tests](/v1-2/learn/vscode-plugin/run-all-tests)
+- [Run All Tests](/v1-2/learn/vscode-plugin/run-all-tests)
 

--- a/v1-2/learn/tools-ides/vscode-plugin.md
+++ b/v1-2/learn/tools-ides/vscode-plugin.md
@@ -7,6 +7,8 @@ redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/
   - /learn/tools-ides/vscode-plugin
   - /learn/tools-ides/vscode-plugin/
+  - /learn/vscode-plugin/
+  - /learn/vscode-plugin
 ---
 
 # The Visual Studio Code Extension

--- a/v1-2/learn/tools-ides/vscode-plugin.md
+++ b/v1-2/learn/tools-ides/vscode-plugin.md
@@ -69,9 +69,9 @@ $ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 
 The below sections include information on the various capabilities that are facilitated by the VS Code Ballerina Extension for the development process.
 
-- [Language intelligence](/v1-2/learn/vscode-plugin/language-intelligence)
-- [Run and debug](/v1-2/learn/vscode-plugin/run-and-debug)
+- [Language Intelligence](/v1-2/learn/vscode-plugin/language-intelligence)
+- [Run and Debug](/v1-2/learn/vscode-plugin/run-and-debug)
 - [Graphical View](/v1-2/learn/vscode-plugin/graphical-editor)
 - [Documentation Viewer](/v1-2/learn/vscode-plugin/documentation-viewer)
-- [Go to definition](/v1-2/learn/vscode-plugin/go-to-definition)
+- [Run all Tests](/v1-2/learn/vscode-plugin/run-all-tests)
 

--- a/v1-2/learn/tools-ides/vscode-plugin/graphical-editor.md
+++ b/v1-2/learn/tools-ides/vscode-plugin/graphical-editor.md
@@ -5,6 +5,8 @@ permalink: /v1-2/learn/vscode-plugin/graphical-editor
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/graphical-editor
   - /v1-2/learn/tools-ides/vscode-plugin/graphical-editor/
+  - /learn/tools-ides/vscode-plugin/graphical-editor
+  - /learn/tools-ides/vscode-plugin/graphical-editor/
 ---
 
 # Graphical View

--- a/v1-2/learn/tools-ides/vscode-plugin/language-intelligence.md
+++ b/v1-2/learn/tools-ides/vscode-plugin/language-intelligence.md
@@ -61,7 +61,7 @@ For example, you can add documentation for a function as shown below.
 
 ## Go to definition
 
-This option allows you to view the definition of a selected variable, function, an object etc. within the same file, in a separate file, in the same module, or in a file of a different module, of the same project or of the [Standard Library](v1-2/learn/api-docs/ballerina/).
+This option allows you to view the definition of a selected variable, function, an object etc. within the same file, in a separate file, in the same module, or in a file of a different module, of the same project or of the [Standard Library](/v1-2/learn/api-docs/ballerina/).
 
 ![Go to definition](/v1-2/learn/images/go-to-definition-vscode.gif)
 

--- a/v1-2/learn/tools-ides/vscode-plugin/language-intelligence.md
+++ b/v1-2/learn/tools-ides/vscode-plugin/language-intelligence.md
@@ -5,6 +5,8 @@ permalink: /v1-2/learn/vscode-plugin/language-intelligence
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/language-intelligence
   - /v1-2/learn/tools-ides/vscode-plugin/language-intelligence/
+  - /learn/tools-ides/vscode-plugin/language-intelligence
+  - /learn/tools-ides/vscode-plugin/language-intelligence/
 ---
 
 # Language intelligence

--- a/v1-2/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/v1-2/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -5,6 +5,8 @@ permalink: /v1-2/learn/vscode-plugin/run-all-tests
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/run-all-tests
   - /v1-2/learn/tools-ides/vscode-plugin/run-all-tests/
+  - /learn/tools-ides/vscode-plugin/run-all-tests
+  - /learn/tools-ides/vscode-plugin/run-all-tests
 ---
 
 # Run all tests

--- a/v1-2/learn/tools-ides/vscode-plugin/run-and-debug.md
+++ b/v1-2/learn/tools-ides/vscode-plugin/run-and-debug.md
@@ -5,6 +5,8 @@ permalink: /v1-2/learn/vscode-plugin/run-and-debug
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/run-and-debug
   - /v1-2/learn/tools-ides/vscode-plugin/run-and-debug/
+  - /learn/tools-ides/vscode-plugin/run-and-debug/
+  - /learn/tools-ides/vscode-plugin/run-and-debug
 ---
 
 # Run and debug


### PR DESCRIPTION
## Purpose
We need to fix the broken links identified while testing the staging website for the 1.2 release.
> Fixes #307

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
