### PR TITLE
Add permalink to spec 2020R1

### DIFF
--- a/spec/lang/2020R1/index.html
+++ b/spec/lang/2020R1/index.html
@@ -1,3 +1,10 @@
+---
+permalink: /spec/lang/2020R1/
+redirect_from:
+  - spec/lang/v2020R1/
+  - spec/lang/v2020R1/lib/
+  - spec/lang/2020R1/lib/
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Purpose
Add perma link to the spec 2020R1 doc to resolve the issue in prod.

## Check List

- [ ] **Page Addition**
  - [x] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [x] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
