### PR TITLE
Remove Edit on Github Link on BBE Home Page 

### DIFF
--- a/css/ballerina-io-bbe.css
+++ b/css/ballerina-io-bbe.css
@@ -404,7 +404,15 @@ width:100%;
     }
 }
 
-.fa-github, .icon-github {
+/*.fa-github, .icon-github {
+    background-image: url("/img/github.svg");
+    background-size: 20px;
+    background-position: left;
+    background-repeat: no-repeat;
+    padding-left: 28px !important;
+} */
+
+.fa-github {
     background-image: url("/img/github.svg");
     background-size: 20px;
     background-position: left;

--- a/css/ballerina-io-bbe.css
+++ b/css/ballerina-io-bbe.css
@@ -404,21 +404,13 @@ width:100%;
     }
 }
 
-/*.fa-github, .icon-github {
+.fa-github, .icon-github {
     background-image: url("/img/github.svg");
     background-size: 20px;
     background-position: left;
     background-repeat: no-repeat;
     padding-left: 28px !important;
-} */
-
-.fa-github {
-    background-image: url("/img/github.svg");
-    background-size: 20px;
-    background-position: left;
-    background-repeat: no-repeat;
-    padding-left: 28px !important;
-}
+} 
 
 .cBallerina-io-breadcrumbs {
     padding: 15px 0px 5px 0px;

--- a/css/ballerina-io-bbe.css
+++ b/css/ballerina-io-bbe.css
@@ -410,7 +410,7 @@ width:100%;
     background-position: left;
     background-repeat: no-repeat;
     padding-left: 28px !important;
-} */
+} 
 
 .fa-github {
     background-image: url("/img/github.svg");
@@ -422,7 +422,7 @@ width:100%;
 
 .icon-github {
     display: none !important;
-} 
+} */
 
 .cBallerina-io-breadcrumbs {
     padding: 15px 0px 5px 0px;

--- a/css/ballerina-io-bbe.css
+++ b/css/ballerina-io-bbe.css
@@ -421,7 +421,7 @@ width:100%;
 } 
 
 .icon-github {
-    display: none;
+    display: none !important;
 } 
 
 .cBallerina-io-breadcrumbs {

--- a/css/ballerina-io-bbe.css
+++ b/css/ballerina-io-bbe.css
@@ -404,12 +404,24 @@ width:100%;
     }
 }
 
-.fa-github, .icon-github {
+/*.fa-github, .icon-github {
     background-image: url("/img/github.svg");
     background-size: 20px;
     background-position: left;
     background-repeat: no-repeat;
     padding-left: 28px !important;
+} */
+
+.fa-github {
+    background-image: url("/img/github.svg");
+    background-size: 20px;
+    background-position: left;
+    background-repeat: no-repeat;
+    padding-left: 28px !important;
+} 
+
+.icon-github {
+    display: none;
 } 
 
 .cBallerina-io-breadcrumbs {


### PR DESCRIPTION
## Purpose
$subject for [1] as it gives 404. Also, it doesn't make sense to have an edit link for that page as it gets generated based on a .json file.

[1] https://ballerina.io/v1-1/learn/by-example/

> Fixes #250 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
