### PR TITLE
Fix the Appendix C link in the Spec

### DIFF
--- a/spec/lang/2020R1/index.html
+++ b/spec/lang/2020R1/index.html
@@ -468,7 +468,7 @@ unusual aspects that make it particularly suitable for its intended purpose.
 First, it provides language constructs specifically for consuming and providing
 network services. Future versions of Ballerina will add language constructs for
 other middleware functionality such as event stream processing, distributed
-transactions and reliable messaging; this is described in more detail in <a href="planned_future_functionality">Appendix C</a>.
+transactions and reliable messaging; this is described in more detail in <a href="#planned_future_functionality">Appendix C</a>.
 </p>
 <p>
 Second, its abstractions and syntax for concurrency and network interaction have


### PR DESCRIPTION
## Purpose
We need to fix the "Appendix C" broken link in [1].

<img width="1680" alt="Screenshot 2020-03-23 at 17 55 48" src="https://user-images.githubusercontent.com/11707273/77317205-c0e03b80-6d30-11ea-9991-304f7800efa2.png">

[1] https://ballerina.io/spec/lang/2020R1/
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
