### PR TITLE
Fix the How To Guide Links in Docerina HTMLs

### DIFF
--- a/v1-2/learn/api-docs/ballerina/observe/index.html
+++ b/v1-2/learn/api-docs/ballerina/observe/index.html
@@ -603,7 +603,7 @@
 Ballerina supports Observability out of the box. This module provides user api's to make Ballerina Observability more flexible for the user.</p>
 <p>To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service.
 i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true'
-For more information on Ballerina Observability visit <a href="https://v1-0.ballerina.io/v1-2/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
+For more information on Ballerina Observability visit <a href="https://ballerina.io/v1-2/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
 <h1>Tracing</h1>
 <h2>Samples</h2>
 <h3>Start a root span &amp; attach a child span</h3>

--- a/v1-2/learn/api-docs/ballerina/observe/index.html
+++ b/v1-2/learn/api-docs/ballerina/observe/index.html
@@ -603,7 +603,7 @@
 Ballerina supports Observability out of the box. This module provides user api's to make Ballerina Observability more flexible for the user.</p>
 <p>To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service.
 i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true'
-For more information on Ballerina Observability visit <a href="https://v1-0.ballerina.io/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
+For more information on Ballerina Observability visit <a href="https://v1-0.ballerina.io/v1-2/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
 <h1>Tracing</h1>
 <h2>Samples</h2>
 <h3>Start a root span &amp; attach a child span</h3>

--- a/v1-2/learn/api-docs/ballerina/websub/index.html
+++ b/v1-2/learn/api-docs/ballerina/websub/index.html
@@ -1106,7 +1106,7 @@ service specificSubscriber on new WebhookListener(8080) {
     }
 }
 </code></pre>
-<p>For a step-by-step guide on introducing custom subscriber services, see the <a href="https://ballerina.io/learn/how-to-extend-ballerina/#create-webhook-callback-services">&quot;Create Webhook Callback Services&quot;</a> section of &quot;How to Extend Ballerina&quot;.</p>
+<p>For a step-by-step guide on introducing custom subscriber services, see the <a href="https://ballerina.io/v1-2/learn/how-to-extend-ballerina/#create-webhook-callback-services">&quot;Create Webhook Callback Services&quot;</a> section of &quot;How to Extend Ballerina&quot;.</p>
 
 
             


### PR DESCRIPTION
## Purpose
This is to fix the How To Guide links in Docerina HTMLs to fix them in the Bio site.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
