### PR TITLE
Remove the "Edit on GitHub" Option at the Top of Each BBE Page

### DIFF
--- a/_layouts/ballerina-example-page.html
+++ b/_layouts/ballerina-example-page.html
@@ -18,9 +18,9 @@
                     </div>
                     <div class="col-md-12 col-lg-2 cBallerina-io-breadcrumbs">
                         <ul class="wy-breadcrumbs">
-                            <li class="wy-breadcrumbs-aside">
+                            <!-- <li class="wy-breadcrumbs-aside">
                                 <a class="icon icon-github" target="_blank" href="https://www.github.com/{{ site.github_username }}/{{ site.git_repo }}/blob/master/{{ page.path }}">Edit on GitHub</a>
-                            </li>
+                            </li> -->
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
## Purpose
This is to remove the "Edit on GitHub" option at the top in all BBE pages.

> Fixes #334 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
