### PR TITLE
Removed v1-2 from the URLs

### DIFF
--- a/learn/api-docs/ballerina/observe/index.html
+++ b/learn/api-docs/ballerina/observe/index.html
@@ -611,7 +611,7 @@
 Ballerina supports Observability out of the box. This module provides user api's to make Ballerina Observability more flexible for the user.</p>
 <p>To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service.
 i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true'
-For more information on Ballerina Observability visit <a href="https://ballerina.io/v1-2/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
+For more information on Ballerina Observability visit <a href="https://ballerina.io/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
 <h1>Tracing</h1>
 <h2>Samples</h2>
 <h3>Start a root span &amp; attach a child span</h3>

--- a/learn/api-docs/index.html
+++ b/learn/api-docs/index.html
@@ -1,3 +1,3 @@
 ---
-redirect_to: /v1-2/learn/api-docs/ballerina/
+redirect_to: /learn/api-docs/ballerina/
 ---

--- a/learn/by-example/index.html
+++ b/learn/by-example/index.html
@@ -2,6 +2,9 @@
 layout: ballerina-inner-page
 title: Ballerina-by-Example - Ballerina.io
 description: Ballerina by Example enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
+redirect_from:
+  - /v1-2/learn/by-example
+  - /v1-2/learn/by-example/
 ---
 <div class="row cBallerina-io-Gray-row">
     <div class="container">

--- a/learn/how-to-deploy-and-run-ballerina-programs.md
+++ b/learn/how-to-deploy-and-run-ballerina-programs.md
@@ -13,9 +13,9 @@ redirect_from:
 ## Running Ballerina Programs and Services
 A Ballerina application can have:
 
-1. A [`main()`](/v1-2/learn/by-example/the-main-function.html) function that runs as a terminating process.
+1. A [`main()`](/learn/by-example/the-main-function.html) function that runs as a terminating process.
 
-2. A [`service`](/v1-2/learn/by-example/hello-world-service.html), which is a hosted non-terminating process.
+2. A [`service`](/learn/by-example/hello-world-service.html), which is a hosted non-terminating process.
 
 Both of these are considered as entry points for program execution. 
 
@@ -44,7 +44,7 @@ $ ballerina run filename.jar
 ```
 
 ### Running a Project
-A project is a folder that manages modules as part of a common versioning, dependency management, build, and execution. You can build and run items collectively or individually as modules. See [How To Structure Ballerina Code](/v1-2/learn/how-to-structure-ballerina-code) for in-depth structuring of projects.
+A project is a folder that manages modules as part of a common versioning, dependency management, build, and execution. You can build and run items collectively or individually as modules. See [How To Structure Ballerina Code](/learn/how-to-structure-ballerina-code) for in-depth structuring of projects.
 
 Build all modules of a project:
 ```bash    
@@ -66,7 +66,7 @@ $ ballerina run main.jar
 
 ### Ballerina Runtime Configuration Files
 
-A Ballerina runtime can be configured using configuration parameters, which are arbitrary key/value pairs with structure. The `ballerina/config` module provides an API for sourcing configuration parameters and using them within your source code. See [Config API Documentation](/v1-2/learn/api-docs/ballerina/config/index.html) for details.
+A Ballerina runtime can be configured using configuration parameters, which are arbitrary key/value pairs with structure. The `ballerina/config` module provides an API for sourcing configuration parameters and using them within your source code. See [Config API Documentation](/learn/api-docs/ballerina/config/index.html) for details.
 
 The configuration APIs accept a key and an optional default value. If a mapping does not exist for the specified key, the default value is returned as the configuration value. The default values of these optional configurations are the default values of the return types of the functions.
 

--- a/learn/how-to-document-ballerina-code.md
+++ b/learn/how-to-document-ballerina-code.md
@@ -109,7 +109,7 @@ A typical project structure of a Ballerina project is like this:
 
 `ballerina doc` command will read the `Module.md` and prepend it to the generated HTML file.
 
-Check [HTTP module documentation](/v1-2/learn/api-docs/ballerina/http/index.html) for sample HTML that has `Module.md` content at the top, followed by the other module constructs.
+Check [HTTP module documentation](/learn/api-docs/ballerina/http/index.html) for sample HTML that has `Module.md` content at the top, followed by the other module constructs.
 
 
 ## Generating Ballerina Documentation

--- a/learn/how-to-keep-ballerina-up-to-date.md
+++ b/learn/how-to-keep-ballerina-up-to-date.md
@@ -10,7 +10,7 @@ redirect_from:
 
 # How to Keep Ballerina up to date
 
-This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases. If you haven’t installed Ballerina yet, visit [installation guide](/v1-2/learn/installing-ballerina/).
+This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases. If you haven’t installed Ballerina yet, visit [installation guide](/learn/installing-ballerina/).
 
 - [Terminology](#terminology)
   - [Ballerina tool](#ballerina-tool)
@@ -78,7 +78,7 @@ This channel gives you access to feature releases of Ballerina distributions. Ba
 
 Now that you are familiar with the terminology, let’s look at how you can keep your Ballerina distributions up to date.
 
-- The first step is to install Ballerina. Visit our [installation guide](/v1-2/learn/installing-ballerina/) guide for details. Once the installation is complete, you would see the following directory structure inside the installation directory.
+- The first step is to install Ballerina. Visit our [installation guide](/learn/installing-ballerina/) guide for details. Once the installation is complete, you would see the following directory structure inside the installation directory.
 
 ```sh
 .

--- a/learn/how-to-observe-ballerina-code.md
+++ b/learn/how-to-observe-ballerina-code.md
@@ -491,7 +491,7 @@ $ docker run -d -p 9411:9411 openzipkin/zipkin
 ```
 
 **Step 2:** Go to <http://localhost:9411/zipkin/> and load the web UI of the Zipkin to make sure it is functioning
-properly. The below shown is the sample Zipkin dashboard for the hello world sample in the [Quick Start](/v1-2/learn/quick-tour)
+properly. The below shown is the sample Zipkin dashboard for the hello world sample in the [Quick Start](/learn/quick-tour)
 
 ![Zipkin Sample](../images/zipkin-sample.png "Zipkin Sample")
 

--- a/learn/how-to-write-secure-ballerina-code.md
+++ b/learn/how-to-write-secure-ballerina-code.md
@@ -183,7 +183,7 @@ function sanitizeSortColumn (string columnName) returns @untainted string {
 
 ## Securing Passwords and Secrets
 
-Ballerina provides an API to access configuration values from different sources. For more information, see [Config Ballerina by Example](/v1-2/learn/by-example/config-api.html).
+Ballerina provides an API to access configuration values from different sources. For more information, see [Config Ballerina by Example](/learn/by-example/config-api.html).
 
 Configuration values containing passwords or secrets should be encrypted. The Ballerina Config API will decrypt such configuration values when being accessed.
 

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -121,4 +121,4 @@ To get help when you work with Ballerina, see [Community](/community).
 
 ## What's next
 
-Once you have successfully installed Ballerina, try out the [Quick Tour](/v1-2/learn/quick-tour) and take Ballerina for its first spin.
+Once you have successfully installed Ballerina, try out the [Quick Tour](/learn/quick-tour) and take Ballerina for its first spin.

--- a/learn/quick-tour.md
+++ b/learn/quick-tour.md
@@ -15,8 +15,8 @@ Now, that you know a little bit of Ballerina, let's take it for a spin!
 ## Install Ballerina
 
 1. [Download](https://ballerina.io/downloads) Ballerina based on the Operating System you are using. 
-1. Follow the instructions given on the [Getting Started](/v1-2/learn/getting-started) page to set it up. 
-1. Follow the instructions given on the [Visual Studio Code Plugin](/v1-2/learn/tools-ides/vscode-plugin) page or the [IntelliJ IDEA Plugin](/v1-2/learn/tools-ides/intellij-plugin) page to set up your preferred editor for Ballerina.
+1. Follow the instructions given on the [Getting Started](/learn/getting-started) page to set it up. 
+1. Follow the instructions given on the [Visual Studio Code Plugin](/learn/tools-ides/vscode-plugin) page or the [IntelliJ IDEA Plugin](/learn/tools-ides/intellij-plugin) page to set up your preferred editor for Ballerina.
 
 ## Write a Service, Run It, and Invoke It
 
@@ -184,4 +184,4 @@ Star [GitHub repo](https://github.com/ballerina-platform/ballerina-lang) and sho
 
 Now, that you have taken Ballerina around for a quick tour, you can explore Ballerina more.
 
-* Go through [Ballerina by Example](/v1-2/learn/by-example) to learn Ballerina incrementally with commented examples that cover every nuance of the syntax.
+* Go through [Ballerina by Example](/learn/by-example) to learn Ballerina incrementally with commented examples that cover every nuance of the syntax.

--- a/learn/style-guide.md
+++ b/learn/style-guide.md
@@ -281,20 +281,20 @@ table<Employee> employee = table {
 
 ## Top Level Definitions
 
-For style guidelines on imports, service definition, object definition, record definition, referencing record or abstract object, etc., see [Top Level Definitions](/v1-2/learn/style-guide/definitions).
+For style guidelines on imports, service definition, object definition, record definition, referencing record or abstract object, etc., see [Top Level Definitions](/learn/style-guide/definitions).
 
 ## Operators, Keywords, and Types
 
-For style guidelines on operators, keywords, and types, see [Operators, Keywords, and Types](/v1-2/learn/style-guide/operators_keywords_and_types).
+For style guidelines on operators, keywords, and types, see [Operators, Keywords, and Types](/learn/style-guide/operators_keywords_and_types).
 
 ## Statements
 
-For style guidelines on statements such as if, match, transaction etc., see [Statements](/v1-2/learn/style-guide/statements).
+For style guidelines on statements such as if, match, transaction etc., see [Statements](/learn/style-guide/statements).
 
 ## Expressions
 
-For style guidelines on function invocation, literals, tuple, type casting etc. see [Expressions](/v1-2/learn/style-guide/expressions).
+For style guidelines on function invocation, literals, tuple, type casting etc. see [Expressions](/learn/style-guide/expressions).
 
 ## Annotations, Documentation, and Comments
 
-For style guidelines on annotations, documentation, and comments, see [Annotations, Documentation, and Comments](/v1-2/learn/style-guide/annotations_documentation_and_comments).
+For style guidelines on annotations, documentation, and comments, see [Annotations, Documentation, and Comments](/learn/style-guide/annotations_documentation_and_comments).

--- a/learn/style-guide/definitions.md
+++ b/learn/style-guide/definitions.md
@@ -121,7 +121,7 @@ service hello on new http:Listener(9090) {
 ```
 
 * When formatting resource functions and function definitions, block indent each element and
-  follow the [function formatting guidelines](/v1-2/learn/style-guide/definitions#function-definition).
+  follow the [function formatting guidelines](/learn/style-guide/definitions#function-definition).
   
 **Example,**
 
@@ -145,7 +145,7 @@ service hello on ep1, ep2 {
 
 * Block indent each field definition and each function definition on their own line.
 * Init function should be placed before all the other functions. 
-* For function definitions in the object definition, follow the [function formatting guidelines](/v1-2/learn/style-guide/definitions#function-definition).
+* For function definitions in the object definition, follow the [function formatting guidelines](/learn/style-guide/definitions#function-definition).
 
 **Example,**
 

--- a/learn/style-guide/expressions.md
+++ b/learn/style-guide/expressions.md
@@ -88,7 +88,7 @@ Person p = {
 
 ## Map literal
 
-* For Map literals, follow the same formatting guidelines as [record literals](/v1-2/learn/style-guide/expressions#record-literal). 
+* For Map literals, follow the same formatting guidelines as [record literals](/learn/style-guide/expressions#record-literal). 
   
 **Example,**
 
@@ -178,7 +178,7 @@ string name = <string>json.name;
 
 ## Table literal
 
-* Follow [record literals](/v1-2/learn/style-guide/expressions#record-literal) formatting when formatting a table block.
+* Follow [record literals](/learn/style-guide/expressions#record-literal) formatting when formatting a table block.
   
 **Example,**
   

--- a/learn/tools-ides/intellij-plugin.md
+++ b/learn/tools-ides/intellij-plugin.md
@@ -49,7 +49,7 @@ Use either of the below approaches to install the IntelliJ Ballerina plugin.
 3. Click **Install**, and then click **Accept**.
 4. Click **Restart IDE**, and then click **Restart**.
 
-![Install the plugin via IntelliJ IDEA](/v1-2/learn/images/install-plugin-via-intellij.gif)
+![Install the plugin via IntelliJ IDEA](/learn/images/install-plugin-via-intellij.gif)
 
 This downloads the plugin and installs it.
 
@@ -99,32 +99,32 @@ After obtaining the ZIP file using either of the above approaches, follow the st
 > **Important:** Make sure you install the ZIP file and not the extracted JAR files. This is because the ZIP file contains of an additional library that is required by the plugin to function as expected.
 4. Click the **Installed** tab, click **Restart IDE**, and then click **Restart**.
 
-![Install using the Preferences option of the IDE.](/v1-2/learn/images/install-via-editor-preferences.gif)
+![Install using the Preferences option of the IDE.](/learn/images/install-via-editor-preferences.gif)
 
 ## Using the plugin
 
 The below sections include information on using the IntelliJ Ballerina plugin to write Ballerina programs.
 
-- [Creating a new Ballerina project](/v1-2/learn/intellij-plugin/using-the-intellij-plugin#creating-a-new-ballerina-project)
-- [Setting up Ballerina SDK for an existing project](/v1-2/learn/intellij-plugin/using-the-intellij-plugin#setting-up-ballerina-sdk-for-an-existing-project)
-- [Creating a new Ballerina file](/v1-2/learn/intellij-plugin/using-the-intellij-plugin#creating-a-new-ballerina-file)
-- [Configuring the plugin settings](/v1-2/learn/intellij-plugin/using-the-intellij-plugin#configuring-the-plugin-settings)
+- [Creating a new Ballerina project](/learn/intellij-plugin/using-the-intellij-plugin#creating-a-new-ballerina-project)
+- [Setting up Ballerina SDK for an existing project](/learn/intellij-plugin/using-the-intellij-plugin#setting-up-ballerina-sdk-for-an-existing-project)
+- [Creating a new Ballerina file](/learn/intellij-plugin/using-the-intellij-plugin#creating-a-new-ballerina-file)
+- [Configuring the plugin settings](/learn/intellij-plugin/using-the-intellij-plugin#configuring-the-plugin-settings)
 
 ## Using the features of the plugin
 
 The below sections include information on the various capabilities that are facilitated by the IntelliJ Ballerina plugin for the development process.
 
-- [Running Ballerina programs](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#running-ballerina-programs)
-- [Debugging Ballerina programs](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#debugging-ballerina-programs)
-- [Viewing the sequence diagram](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#viewing-the-sequence-diagram)
-- [Importing modules on the fly](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#importing-modules-on-the-fly)
-- [Importing unambiguous modules](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#importing-unambiguous-modules)
-- [Formatting Ballerina codes](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#formatting-ballerina-codes)
-- [Viewing documentation](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#viewing-documentation)
-- [Adding annotation fields via suggestions](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#adding-annotation-fields-via-suggestions)
-- [Using file templates](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#using-file-templates)
-- [Using code snippet templates](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#using-code-snippet-templates)
-- [Checking spellings](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#checking-spellings)
-- [Analyzing semantics](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#analyzing-semantics)
-- [Code folding](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#code-folding)
-- [Go to definition](/v1-2/learn/intellij-plugin/using-intellij-plugin-features#go-to-definition)
+- [Running Ballerina programs](/learn/intellij-plugin/using-intellij-plugin-features#running-ballerina-programs)
+- [Debugging Ballerina programs](/learn/intellij-plugin/using-intellij-plugin-features#debugging-ballerina-programs)
+- [Viewing the sequence diagram](/learn/intellij-plugin/using-intellij-plugin-features#viewing-the-sequence-diagram)
+- [Importing modules on the fly](/learn/intellij-plugin/using-intellij-plugin-features#importing-modules-on-the-fly)
+- [Importing unambiguous modules](/learn/intellij-plugin/using-intellij-plugin-features#importing-unambiguous-modules)
+- [Formatting Ballerina codes](/learn/intellij-plugin/using-intellij-plugin-features#formatting-ballerina-codes)
+- [Viewing documentation](/learn/intellij-plugin/using-intellij-plugin-features#viewing-documentation)
+- [Adding annotation fields via suggestions](/learn/intellij-plugin/using-intellij-plugin-features#adding-annotation-fields-via-suggestions)
+- [Using file templates](/learn/intellij-plugin/using-intellij-plugin-features#using-file-templates)
+- [Using code snippet templates](/learn/intellij-plugin/using-intellij-plugin-features#using-code-snippet-templates)
+- [Checking spellings](/learn/intellij-plugin/using-intellij-plugin-features#checking-spellings)
+- [Analyzing semantics](/learn/intellij-plugin/using-intellij-plugin-features#analyzing-semantics)
+- [Code folding](/learn/intellij-plugin/using-intellij-plugin-features#code-folding)
+- [Go to definition](/learn/intellij-plugin/using-intellij-plugin-features#go-to-definition)

--- a/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -44,15 +44,15 @@ Follow the steps below to run the main function of a Ballerina file.
 
 1. Click the green color icon located near the main function.
 
-    ![Click the Run Application icon](/v1-2/learn/images/run-application-icon.png)
+    ![Click the Run Application icon](/learn/images/run-application-icon.png)
 
 2. Click the corresponding **Run <FILE_NAME>** command.
 
-    ![Click the Run command](/v1-2/learn/images/select-run-command.png)
+    ![Click the Run command](/learn/images/select-run-command.png)
 
 This executes the main function of the Ballerina file and displays the output in the **Run** window.
 
-![Output of running the main function](/v1-2/learn/images/output-of-main-function.png)
+![Output of running the main function](/learn/images/output-of-main-function.png)
 
 > **Tip:** Alternatively, you can right click on the name of the file and run the main method of it.
 
@@ -66,7 +66,7 @@ Follow the steps below to run a service of a Ballerina file.
 
 This starts the service and displays the output in the **Run** window. If you have multiple services in the Ballerina file, this starts all of them.
 
-![Output of running a service](/v1-2/learn/images/output-of-ballerina-service.png)
+![Output of running a service](/learn/images/output-of-ballerina-service.png)
 
 > **Tip:** Alternatively, you can right click on the name of the file and run the service(s) of it.
 
@@ -75,7 +75,7 @@ This starts the service and displays the output in the **Run** window. If you ha
 
 You can debug Ballerina main/service programs with a few clicks.
 
-![Debug Ballerina programs](/v1-2/learn/images/debug-ballerina-intellij.gif)
+![Debug Ballerina programs](/learn/images/debug-ballerina-intellij.gif)
 
 ### Troubleshooting
 - Stepping over code lines in non-blocking paths (eg: action invocations) will not pause VM on next line
@@ -89,13 +89,13 @@ The underlying language semantics of Ballerina were designed by modeling how ind
 
 To view the sequence diagram of a Ballerina file, click the (![design view icon](https://raw.githubusercontent.com/ballerina-platform/ballerina-lang/2fd0bdd4e7d081adf23901ed65eca32623d81889/tool-plugins/vscode/docs/show-diagram-icon.png)) in the top right corner of the IDE window as shown in the below example.
 
-![HTTP circuit breaker sequence diagram](/v1-2/learn/images/circuit-breaker-sequence-diagram.gif)
+![HTTP circuit breaker sequence diagram](/learn/images/circuit-breaker-sequence-diagram.gif)
 
 ## Importing modules on the fly
 
 You can add import declarations to your Ballerina programs on the fly. When you select the module name from the lookup list, the module declaration will be added automatically.
 
-![Import modules on the fly](/v1-2/learn/images/import-modules-on-the-fly.gif)
+![Import modules on the fly](/learn/images/import-modules-on-the-fly.gif)
 
 ## Importing unambiguous modules 
 
@@ -107,25 +107,25 @@ When you copy and paste Ballerina code to IntelliJ, this feature allows you to i
 >2. Click **Ballerina** and then click **Auto Import**.
 >3. Select the **Add unambiguous imports on the fly** checkbox and click **OK**.
 
-![Import unambiguous modules](/v1-2/learn/images/import-unambiguous-modules.gif)
+![Import unambiguous modules](/learn/images/import-unambiguous-modules.gif)
 
 ## Formatting Ballerina codes
 
 You can reformat the Ballerina codes by pressing the **Ctrl+Alt+L** keys.
 
-![Formatting Ballerina codes](/v1-2/learn/images/format-code.gif)
+![Formatting Ballerina codes](/learn/images/format-code.gif)
 
 ## Viewing documentation
 
 You can view the documentation of a function, remote function, etc. by pressing the **Ctrl+Q** keys or by hovering over the element while pressing the **Ctrl** key.
 
-![Viewing documentation](/v1-2/learn/images/view-documentation.gif)
+![Viewing documentation](/learn/images/view-documentation.gif)
 
 ## Adding annotation fields via suggestions
 
 You can add annotation fields to your code using the annotation field names that are suggested inside annotation attachments.
 
-![Adding annotation fields via suggestions](/v1-2/learn/images/annotation-field-suggestion.gif)
+![Adding annotation fields via suggestions](/learn/images/annotation-field-suggestion.gif)
 
 ## Using file templates
 
@@ -135,25 +135,25 @@ Three types of Ballerina file templates are available.
 2. **Ballerina Service** - contains a sample service
 3. **Empty File** - contains an empty file
 
-![Using file templates](/v1-2/learn/images/file-templates.gif)
+![Using file templates](/learn/images/file-templates.gif)
 
 ## Using code snippet templates
 
 Code snippet templates contain boilerplate codes and allows you to write your code efficiently. 
 
-![Using code snippet templates](/v1-2/learn/images/code-snippet-templates.gif)
+![Using code snippet templates](/learn/images/code-snippet-templates.gif)
 
 ## Checking spellings
 
 The spell-checker is enabled for all identifiers. You can rename all of the definitions and references as well.
 
-![Checking spellings](/v1-2/learn/images/check-spellings.gif)
+![Checking spellings](/learn/images/check-spellings.gif)
 
 ## Analyzing semantics
 
 The Ballerina IDEA plugin provides capabilities to diagnose and analyze semantics of your Ballerina programs through the Ballerina Language Server.
 
-![Analyzing semantics](/v1-2/learn/images/analyzing-semantics.gif)
+![Analyzing semantics](/learn/images/analyzing-semantics.gif)
 
 ## Code folding
 
@@ -168,15 +168,15 @@ You expand/collapse the following Ballerina code segments using the icons in the
 - markdown documentation
 - multiline comments
  
-![Code folding](/v1-2/learn/images/code-folding.gif)
+![Code folding](/learn/images/code-folding.gif)
 
 ## Go to definition
 
-This option allows you to view the definition of a selected variable, function, an object etc. within the same file, in a separate file, in the same module, or in a file of a different module, of the same project or of the [Standard Library](/v1-2/learn/api-docs/ballerina/).
+This option allows you to view the definition of a selected variable, function, an object etc. within the same file, in a separate file, in the same module, or in a file of a different module, of the same project or of the [Standard Library](/learn/api-docs/ballerina/).
 
-![Go to definition](/v1-2/learn/images/go-to-definition-intellij.gif)
+![Go to definition](/learn/images/go-to-definition-intellij.gif)
 
 ## What's next?
 
-- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Plugin](/v1-2/learn/intellij-plugin).
+- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Plugin](/learn/intellij-plugin).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-2/learn).

--- a/learn/tools-ides/intellij-plugin/using-the-intellij-plugin.md
+++ b/learn/tools-ides/intellij-plugin/using-the-intellij-plugin.md
@@ -12,7 +12,7 @@ redirect_from:
 
 # Using the IntelliJ Ballerina Plugin
 
-The below sections include information to start using the IntelliJ Ballerina plugin after [installing it](/v1-2/learn/intellij-plugin).
+The below sections include information to start using the IntelliJ Ballerina plugin after [installing it](/learn/intellij-plugin).
 
 - [Creating a new Ballerina project](#creating-a-new-ballerina-project)
 - [Setting up Ballerina SDK for an existing project](#setting-up-ballerina-sdk-for-an-existing-project)
@@ -26,21 +26,21 @@ Follow the steps below to create a new Ballerina project.
 1. Open IntelliJ, click **File** in the top menu, click **New**, and then click **Project**.
 
 2. Select **Ballerina** as the type of the project, and click **Next**.
-![Install the plugin via IntelliJ IDEA](/v1-2/learn/images/select-project-type.png)
+![Install the plugin via IntelliJ IDEA](/learn/images/select-project-type.png)
 
 3. Select a Ballerina SDK for the project, and click **Next**.
 
     >**Tip:** **If you do not have an already-configured Ballerina SDK to select,** click **Configure**, select the location of the Ballerina distribution, click **Open**, and then click **Next** to continue with the project creation. However, if you do not configure, the plugin will auto detect the Ballerina Home by executing the `ballerina home` command.
 
-    ![Select a Ballerina SDK](/v1-2/learn/images/select-sdk.png)
+    ![Select a Ballerina SDK](/learn/images/select-sdk.png)
    
 4. Enter a name for the project, a location to save it, and click **Finish**.
 
-    ![Enter project name and location](/v1-2/learn/images/enter-project-name-and-location.png)
+    ![Enter project name and location](/learn/images/enter-project-name-and-location.png)
 
 Now, you have successfully created a new Ballerina project.
 
-![New Ballerina project](/v1-2/learn/images/new-ballerina-project.png)
+![New Ballerina project](/learn/images/new-ballerina-project.png)
 
 ## Setting up Ballerina SDK for an existing project
 
@@ -49,18 +49,18 @@ Follow the steps below to set up Ballerina SDK for an existing project.
 1. Open the Project to which you want to set up a Ballerina SDK.
 2. In the IDE, click **File** in the top menu, and then click **Project Structure**.
 
-    ![Open the project structure](/v1-2/learn/images/open-project-structure.png)
+    ![Open the project structure](/learn/images/open-project-structure.png)
 3. If you do not have an already-configured Ballerina SDK, in the **Project** tab, click **New** under **Project SDK:**, click **Ballerina SDK**, and then click **OK**. 
 
     >**Tip:** If you have already-configured Ballerina SDKs, select one under **Project SDK:**, and click **OK** to continue.
 
-    ![Add a new Ballerina SDK](/v1-2/learn/images/add-new-sdk.png)
+    ![Add a new Ballerina SDK](/learn/images/add-new-sdk.png)
 4. Select the location of the Ballerina distribution and click **Open**.
 
-    ![Select the Ballerina distribution](/v1-2/learn/images/select-ballerina-distribution.png)
+    ![Select the Ballerina distribution](/learn/images/select-ballerina-distribution.png)
 5. Click **Apply** to save the changes.
 
-    ![Restart IntelliJ to apply the changes](/v1-2/learn/images/apply-changes.png)
+    ![Restart IntelliJ to apply the changes](/learn/images/apply-changes.png)
 
     >**Tip** This prompts a restart request. Click **Restart** to apply the changes.
 
@@ -72,17 +72,17 @@ Follow the steps below to create a new Ballerina file within a Ballerina project
 
 1. Right-click on the name of the project, click **New**, and then click **Ballerina File**.
 
-    ![Create a new Ballerina file](/v1-2/learn/images/create-new-ballerina-file.png)
+    ![Create a new Ballerina file](/learn/images/create-new-ballerina-file.png)
 
 2. Enter a name for the file, and click **OK**. 
 
     > **Tip:** In this example, since the default **Main** template is selected as the **Kind**, it creates a new file with a main function.
 
-    ![Select the type of the file template](/v1-2/learn/images/select-file-kind.png)
+    ![Select the type of the file template](/learn/images/select-file-kind.png)
 
 Now, you have successfully created a new Ballerina file with a **main** function.
 
-![New Ballerina file with a main function](/v1-2/learn/images/new-ballerina-file-with-main-function.png)
+![New Ballerina file with a main function](/learn/images/new-ballerina-file-with-main-function.png)
 
 ## Configuring the plugin settings
 
@@ -90,13 +90,13 @@ Now, you have successfully created a new Ballerina file with a **main** function
 
 In order to automatically detect the Ballerina Home that is being used (without setting up a Ballerina SDK), enable the **Settings** **->** **Languages and Frameworks** **->** **Ballerina** **->** **Ballerina Home Auto Detection** option.
 
-![Ballerina Home auto detection](/v1-2/learn/images/auto-detection.png)
+![Ballerina Home auto detection](/learn/images/auto-detection.png)
 
 ### Experimental features
 
 Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in IntelliJ plugin, enable the **Allow Experimental** option in **Settings** **->** **Languages and Frameworks** **->** **Ballerina** **->** **Experimental Features**.
 
-![Experimental features](/v1-2/learn/images/experimental-features.png)
+![Experimental features](/learn/images/experimental-features.png)
 
 ### Language Server Debug logs
 
@@ -104,11 +104,11 @@ In order to view the plugin debug logs, enable the **Settings** **->** **Languag
 
 Then, the language server debug logs will be added to the IDEA log files. (Click **Help** **->** **Show Log In Files** option to view them).
 
-![Debug logs](/v1-2/learn/images/debug-logs.png)
+![Debug logs](/learn/images/debug-logs.png)
 
 ## What's next?
 
- Next, for information on using the features of the IntelliJ Ballerina plugin, see [Using the IntelliJ plugin features](/v1-2/learn/intellij-plugin/using-intellij-plugin-features).
+ Next, for information on using the features of the IntelliJ Ballerina plugin, see [Using the IntelliJ plugin features](/learn/intellij-plugin/using-intellij-plugin-features).
  
 
 

--- a/learn/tools-ides/vscode-plugin.md
+++ b/learn/tools-ides/vscode-plugin.md
@@ -38,7 +38,7 @@ Click **Extensions** on the left-most menu of the editor, search for the Balleri
 
 > **Tip**: Click **Reload** to reload the editor to apply the change.
 
-![Install the extension via VS Code](/v1-2/learn/images/install-via-editor.gif)
+![Install the extension via VS Code](/learn/images/install-via-editor.gif)
 
 This downloads the extension and installs it.
 
@@ -55,7 +55,7 @@ This downloads the extension and installs it.
 2. In the search bar, type "vsix" and click **Extensions: Install from VSIX...**.
 3. Browse and select the VSIX file of the extension you downloaded.
 
-![Install using the Command Palette of the editor.](/v1-2/learn/images/install-via-palette.gif)
+![Install using the Command Palette of the editor.](/learn/images/install-via-palette.gif)
 
 #### Using the Command Line
 In a new Command Line tab, execute the below command.
@@ -72,9 +72,9 @@ $ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 
 The below sections include information on the various capabilities that are facilitated by the VS Code Ballerina Extension for the development process.
 
-- [Language Intelligence](/v1-2/learn/vscode-plugin/language-intelligence)
-- [Run and Debug](/v1-2/learn/vscode-plugin/run-and-debug)
-- [Graphical View](/v1-2/learn/vscode-plugin/graphical-editor)
-- [Documentation Viewer](/v1-2/learn/vscode-plugin/documentation-viewer)
-- [Run All Tests](/v1-2/learn/vscode-plugin/run-all-tests)
+- [Language Intelligence](/learn/vscode-plugin/language-intelligence)
+- [Run and Debug](/learn/vscode-plugin/run-and-debug)
+- [Graphical View](/learn/vscode-plugin/graphical-editor)
+- [Documentation Viewer](/learn/vscode-plugin/documentation-viewer)
+- [Run All Tests](/learn/vscode-plugin/run-all-tests)
 

--- a/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -19,10 +19,10 @@ The Documentation Viewer represents the documented entities in a file in an orga
 1. Click **View** in the top menu and click **Command Palette**.
 2. In the search box, type "Show" and click **Ballerina: Show Documentation Preview**.
 
-![Documentation Viewer](/v1-2/learn/images/documentation-viewer.gif)
+![Documentation Viewer](/learn/images/documentation-viewer.gif)
 
 ## What's next?
 
-- For information on the Ballerina VSCode extension, see [VSCode Extension](/v1-2/learn/vscode-plugin)
+- For information on the Ballerina VSCode extension, see [VSCode Extension](/learn/vscode-plugin)
 - For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-2/learn).
 

--- a/learn/tools-ides/vscode-plugin/graphical-editor.md
+++ b/learn/tools-ides/vscode-plugin/graphical-editor.md
@@ -29,7 +29,7 @@ The below are the two types of Graphical Views you can find in the VSCode extens
 
 This gives a graphical representation of a grouping of the content in the project modules. Click the name of the entity under **BALLERINA PROJECT OVERVIEW** to view its graphical representation.
 
-![Open using the project overview](/v1-2/learn/images/select-from-overview.gif)
+![Open using the project overview](/learn/images/select-from-overview.gif)
 
 **2. File Overview**
 
@@ -37,7 +37,7 @@ This gives a graphical representation of the content of the current Ballerina fi
 
 1. Click the **Show File Overview** icon in the top right corner.
 
-   ![Open Using the Show Diagram icon](/v1-2/learn/images/show-diagram-icon.gif)
+   ![Open Using the Show Diagram icon](/learn/images/show-diagram-icon.gif)
 
 2. Select the **Show File Overview** command option from the **Command Palette**.
 
@@ -52,15 +52,15 @@ The below sections include information to explore the features of the Graphical 
 
 From the design view you can jump to the respective source segment as shown below.
 
-![Viewing the source](/v1-2/learn/images/jump-to-source-view.gif)
+![Viewing the source](/learn/images/jump-to-source-view.gif)
 
 ### Expanding the Diagram View
 
 You can expand the Diagram View to show not only the control flow but also to show more fine-grained statements of the constructs.
 
-![Expanding the Diagram View](/v1-2/learn/images/expand-diagram-view.gif)
+![Expanding the Diagram View](/learn/images/expand-diagram-view.gif)
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina plugin, see [Documentation Viewer](/v1-2/learn/vscode-plugin/documentation-viewer).
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/v1-2/learn/vscode-plugin).
+ - For information on the next capability of the VS Code Ballerina plugin, see [Documentation Viewer](/learn/vscode-plugin/documentation-viewer).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/vscode-plugin).

--- a/learn/tools-ides/vscode-plugin/language-intelligence.md
+++ b/learn/tools-ides/vscode-plugin/language-intelligence.md
@@ -28,13 +28,13 @@ When there are syntax or semantic errors in your code, you will be notified with
 
 > **Tip**: The detailed description that appears when you hover over the lines underlined in red will be consistent with the error message that you get during compile-time.
 
-![Semantic and syntactic diagnostics](/v1-2/learn/images/semantic-and-syntactic.gif)
+![Semantic and syntactic diagnostics](/learn/images/semantic-and-syntactic.gif)
 
 ## Suggestions and auto completion
 
 The extension provides you with suggestions on keywords, variables, and code snippets of language constructs (such as functions, services, and iterable constructs etc.).
 
-![Suggestions and auto completion](/v1-2/learn/images/suggestions.gif)
+![Suggestions and auto completion](/learn/images/suggestions.gif)
 
 > **Tip**: You can use these suggestions to access the contents of the modules available in your Ballerina home repo as well as in the Ballerina distribution.
 
@@ -50,7 +50,7 @@ These allow you to perform the below tasks easily based on the diagnostics and t
 
 For example, you can add documentation for a function as shown below.
 
- ![Code actions](/v1-2/learn/images/code-actions.gif)
+ ![Code actions](/learn/images/code-actions.gif)
 
 ## Hover support
 
@@ -58,17 +58,17 @@ For example, you can add documentation for a function as shown below.
  
  For an example, if you hover over a function name, you can view its description, information about its parameters, and the description of its return type as shown below.
 
-  ![Hover support](/v1-2/learn/images/hover-support.gif)
+  ![Hover support](/learn/images/hover-support.gif)
  
  > **Tip**: Likewise, if you hover over an entity name of an object or a record, you can view the description of the object/record as well as descriptions of its fields.
 
 ## Go to definition
 
-This option allows you to view the definition of a selected variable, function, an object etc. within the same file, in a separate file, in the same module, or in a file of a different module, of the same project or of the [Standard Library](/v1-2/learn/api-docs/ballerina/).
+This option allows you to view the definition of a selected variable, function, an object etc. within the same file, in a separate file, in the same module, or in a file of a different module, of the same project or of the [Standard Library](/learn/api-docs/ballerina/).
 
-![Go to definition](/v1-2/learn/images/go-to-definition-vscode.gif)
+![Go to definition](/learn/images/go-to-definition-vscode.gif)
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina extension, see [Run and Debug](/v1-2/learn/vscode-plugin/run-and-debug).
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/v1-2/learn/vscode-plugin).
+ - For information on the next capability of the VS Code Ballerina extension, see [Run and Debug](/learn/vscode-plugin/run-and-debug).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin).

--- a/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -17,9 +17,9 @@ This option allows you to run all the tests that belong to multiple modules of y
 1. Click **View** in the top menu and click **Command Palette**.
 2. In the search box, type "Ballerina" and click **Ballerina: Run All Tests**.
 
-![Run all tests](/v1-2/learn/images/run-all-tests.gif)
+![Run all tests](/learn/images/run-all-tests.gif)
 
 ## What's next?
 
-- For information on the next capability of the VS Code Ballerina extension, see [Graphical Editor](/v1-2/learn/vscode-plugin/graphical-editor).
-- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/v1-2/learn/vscode-plugin/)
+- For information on the next capability of the VS Code Ballerina extension, see [Graphical Editor](/learn/vscode-plugin/graphical-editor).
+- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/vscode-plugin/)

--- a/learn/tools-ides/vscode-plugin/run-and-debug.md
+++ b/learn/tools-ides/vscode-plugin/run-and-debug.md
@@ -28,7 +28,7 @@ debug session.
 
 You view the output in the **DEBUG CONSOLE**.
 
-![Run and debug](/v1-2/learn/images/run-and-debug.gif)
+![Run and debug](/learn/images/run-and-debug.gif)
 
 For more information on debugging your code using VS Code, go to [VS Code Documentation](https://code.visualstudio.com/docs/editor/debugging).
 
@@ -40,5 +40,5 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
 
 ## What's next?
 
- - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/v1-2/learn/vscode-plugin/graphical-editor).
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/v1-2/learn/vscode-plugin).
+ - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/learn/vscode-plugin/graphical-editor).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/vscode-plugin).


### PR DESCRIPTION
## Purpose
> Updating the /learn URL structure
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
