### PR TITLE
Fix version dropdown issues for latest versions

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -29,7 +29,7 @@
                                 <div class="cVersionContainer">
                                     <lable class="cVlable">Version</lable>
                                     <select name="versions" id="versions" class="select-css">
-                                        <option value="1.2">1.2</option>
+                                        <option value="1.2" data-value="latest">1.2</option>
                                         <option value="1.1">1.1</option>
                                         <option value="1.0">1.0</option>
                                         <option value="0.991">0.991</option>

--- a/js/api-doc-template.js
+++ b/js/api-doc-template.js
@@ -29,10 +29,10 @@ $(document).ready(function () {
         '                                <div class="cVersionContainer">\n' +
         '                                    <lable class="cVlable">Version</lable>\n' +
         '                                    <select name="versions" id="versions" class="select-css">\n' +
-        '                                        <option value="v1-2">1.2</option>\n' +
-        '                                        <option value="v1-1">1.1</option>\n' +
-        '                                        <option value="v1-0">1.0</option>\n' +
-        '                                        <option value="v0-991">0.991</option>\n' +
+        '                                        <option value="1.2" data-value="latest">1.2</option>\n' +
+        '                                        <option value="1.1">1.1</option>\n' +
+        '                                        <option value="1.0">1.0</option>\n' +
+        '                                        <option value="0.991">0.991</option>\n' +
         '                                    </select>\n' +
         '                                </div>\n' +
         '                            </li>\n' +

--- a/js/ballerina-common.js
+++ b/js/ballerina-common.js
@@ -161,8 +161,7 @@ function versionSelectorValue(){
     let options = $("#versions").find("option");
     $.each(options, function (key, option) {
         let optionText = $(option).text();
-        //let ver = "v" + optionText.replace(".", "-");
-        if(pathValue.indexOf(ver) > -1){
+        if(pathValue.indexOf(optionText) > -1) {
             $(option).attr("selected", "selected");
         }
     });
@@ -453,7 +452,15 @@ $(document).ready(function() {
     urlmenu.onchange = function() {
         let pathname = window.location.pathname;
         let splitedPath = pathname.split("/learn/");
-        let newPath = "/" + this.options[ this.selectedIndex ].value + "/learn/" + splitedPath[1];
+        let selectedOption = this.options[ this.selectedIndex ];
+        let isLatest = selectedOption.getAttribute("data-value") === "latest";
+        let newPath = "";
+        if(isLatest) {
+            newPath =  "/learn/" + splitedPath[1];
+        } else {
+            let selectedValue = this.options[this.selectedIndex].value;
+            newPath = "/" + selectedValue + "/learn/" + splitedPath[1];
+        }
         window.open( newPath , "_self" );
     };
 


### PR DESCRIPTION
## Purpose
This will fix the issue where selecting latest version won't redirect to the correct URL.

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
