### PR TITLE
Fixing the 0.991 API docs link issue

### DIFF
--- a/0.991/learn/api-docs/ballerina/auth.html
+++ b/0.991/learn/api-docs/ballerina/auth.html
@@ -1,3 +1,8 @@
+---
+redirect_from:
+  - /0.991/learn/api-docs/
+  - /0.991/learn/api-docs/ballerina
+---
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 

--- a/0.991/learn/api-docs/ballerina/auth.html
+++ b/0.991/learn/api-docs/ballerina/auth.html
@@ -1,6 +1,8 @@
 ---
 redirect_from:
   - /0.991/learn/api-docs/
+  - /0.991/learn/api-docs
+  - /0.991/learn/api-docs/ballerina/
   - /0.991/learn/api-docs/ballerina
 ---
 <!DOCTYPE html>

--- a/learn/tools-ides/intellij-plugin.md
+++ b/learn/tools-ides/intellij-plugin.md
@@ -7,7 +7,6 @@ redirect_from:
   - /v1-2/learn/tools-ides/intellij-plugin/
   - /learn/tools-ides/intellij-plugin/
   - /learn/tools-ides/intellij-plugin
-  - /learn/intellij-plugin/
   - /learn/intellij-plugin
   - /v1-2/learn/intellij-plugin
 ---


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
