### PR TITLE
Fix Broken Links After the 1.2.2 Release

### DIFF
--- a/license-of-site.md
+++ b/license-of-site.md
@@ -44,7 +44,7 @@ If you produce non-hypertext works, such as books, audio, or video, we ask that 
 ### Ballerina Website Attributions
 In the creation of this website, we used the following Creative Commons Attribution license: 
 
-* [Ballerina by Example](https://ballerina.io/v1-2/learn/by-example/) sample pages are generated using a [tool](https://github.com/mmcgrana/gobyexample/) developed by [mmcgrana](https://github.com/mmcgrana), licensed under [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/) and modified from the original.
+* [Ballerina by Example](https://ballerina.io/learn/by-example/) sample pages are generated using a [tool](https://github.com/mmcgrana/gobyexample/) developed by [mmcgrana](https://github.com/mmcgrana), licensed under [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/) and modified from the original.
 
 ## Contact
 If you have any comments regarding Ballerina.io license policies, please send feedback to [legal@wso2.com](mailto:legal@wso2.com).

--- a/why/the-network-in-the-language.md
+++ b/why/the-network-in-the-language.md
@@ -319,7 +319,7 @@ twitter:Status|error status = twitterClient->tweet("Hello World!");
                                        <td><a href="https://ballerina.io/v1-2/learn/by-example/secured-client-with-basic-auth.html">Basic Auth</a></td>
                                     </tr>
                                     <tr>
-                                       <td><a href="https://ballerina.io/v1-2/learn/by-example/secured-service-with-jwt.html">JWT</a></td>
+                                       <td><a href="https://ballerina.io/v1-2/learn/by-example/secured-service-with-jwt-auth.html">JWT</a></td>
                                        <td><a href="https://ballerina.io/v1-2/learn/by-example/secured-client-with-jwt-auth.html">JWT</a></td>
                                     </tr>
                                     <tr>


### PR DESCRIPTION
## Purpose
This is to fix the broken links identified after the 1.2.2 release.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
