### PR TITLE
Fix the Diagram in the Interoperability How To Guide

### DIFF
--- a/learn/how-to-use-java-interoperability.md
+++ b/learn/how-to-use-java-interoperability.md
@@ -16,7 +16,7 @@ Ballerina offers a straightforward way to call the existing Java code from Balle
 ### Ballerina bindings to Java code
 Your task is to write Ballerina code (Ballerina bindings) that lets you call the corresponding Java API as illustrated in the below diagram. 
 
-<img src="/images/interoperability-diagram.png" alt="Ballerina bindings to Java code" width="300" height="350">
+<img src="images/interoperability-diagram.png" alt="Ballerina bindings to Java code" width="300" height="350">
 
 This guide teaches you how to write those bindings manually as well as how to generate those bindings automatically but first, let's look at why you want to call Java from Ballerina. 
 

--- a/learn/how-to-use-java-interoperability.md
+++ b/learn/how-to-use-java-interoperability.md
@@ -16,7 +16,7 @@ Ballerina offers a straightforward way to call the existing Java code from Balle
 ### Ballerina bindings to Java code
 Your task is to write Ballerina code (Ballerina bindings) that lets you call the corresponding Java API as illustrated in the below diagram. 
 
-<img src="/v1-2/learn/images/interoperability-diagram.png" alt="Ballerina bindings to Java code" width="300" height="350">
+<img src="/images/interoperability-diagram.png" alt="Ballerina bindings to Java code" width="300" height="350">
 
 This guide teaches you how to write those bindings manually as well as how to generate those bindings automatically but first, let's look at why you want to call Java from Ballerina. 
 

--- a/learn/how-to-use-java-interoperability.md
+++ b/learn/how-to-use-java-interoperability.md
@@ -16,7 +16,7 @@ Ballerina offers a straightforward way to call the existing Java code from Balle
 ### Ballerina bindings to Java code
 Your task is to write Ballerina code (Ballerina bindings) that lets you call the corresponding Java API as illustrated in the below diagram. 
 
-<img src="/learn/images/interoperability-diagram.png" alt="Ballerina bindings to Java code" width="300" height="350">
+<img src="learn/images/interoperability-diagram.png" alt="Ballerina bindings to Java code" width="300" height="350">
 
 This guide teaches you how to write those bindings manually as well as how to generate those bindings automatically but first, let's look at why you want to call Java from Ballerina. 
 

--- a/learn/how-to-use-java-interoperability.md
+++ b/learn/how-to-use-java-interoperability.md
@@ -16,7 +16,7 @@ Ballerina offers a straightforward way to call the existing Java code from Balle
 ### Ballerina bindings to Java code
 Your task is to write Ballerina code (Ballerina bindings) that lets you call the corresponding Java API as illustrated in the below diagram. 
 
-<img src="images/interoperability-diagram.png" alt="Ballerina bindings to Java code" width="300" height="350">
+<img src="/learn/images/interoperability-diagram.png" alt="Ballerina bindings to Java code" width="300" height="350">
 
 This guide teaches you how to write those bindings manually as well as how to generate those bindings automatically but first, let's look at why you want to call Java from Ballerina. 
 


### PR DESCRIPTION
## Purpose
This is fix the diagram in the Interoperability How To Guide[1] after the /learn URl change.

[1] https://ballerina.io/learn/how-to-use-java-interoperability/
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
