### PR TITLE
Add GitHub workflow to publish vscode pulgin

### DIFF
--- a/.github/workflows/publish_script/publish_vscode_plugin.py
+++ b/.github/workflows/publish_script/publish_vscode_plugin.py
@@ -1,0 +1,10 @@
+import json
+import os
+
+with open('latest_release.json') as f:
+    data =json.load(f)
+
+version = data['version'] 
+url = 'https://product-dist.ballerina.io/downloads/'+version+'/ballerina-'+version+'.vsix'
+
+os.system("wget -O ballerina.vsix "+url)

--- a/.github/workflows/publish_vscode_plugin.yml
+++ b/.github/workflows/publish_vscode_plugin.yml
@@ -25,7 +25,7 @@ jobs:
           npm install
           wget -O latest_release.json https://raw.githubusercontent.com/ballerina-platform/ballerina-dev-website/master/_data/latest/metadata.json
           jq .version latest_release.json
-          python3  .github/workflows/publish_scripts/publish_vscode_plugin.py  
+          python3  .github/workflows/publish_script/publish_vscode_plugin.py  
              
       - name: Execute the VSCE commands
         uses: lannonbr/vsce-action@master

--- a/.github/workflows/publish_vscode_plugin.yml
+++ b/.github/workflows/publish_vscode_plugin.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches:
+      - prod-sync
+    paths:
+      - '_data/latest/**'
+                        
+name: Publish Extension with json
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository.
+        uses: actions/checkout@v2
+      
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+        
+      - name: Wget required files
+        id: version
+        run: |
+          npm install
+          wget -O latest_release.json https://raw.githubusercontent.com/ballerina-platform/ballerina-dev-website/master/_data/latest/metadata.json
+          jq .version latest_release.json
+          python3  .github/workflows/publish_scripts/publish_vscode_plugin.py  
+             
+      - name: Execute the VSCE commands
+        uses: lannonbr/vsce-action@master
+        with:
+          args: publish -p $VSCE_TOKEN --packagePath ballerina.vsix
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCODE_PAT }}


### PR DESCRIPTION
## Purpose
> Automated the publishing vscode plugin to vscode marketplace.
## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
