### PR TITLE
Fix the /learn Redirections in Docerina V1-2 Links

### DIFF
--- a/learn/api-docs/index.html
+++ b/learn/api-docs/index.html
@@ -1,3 +1,4 @@
 ---
 redirect_to: /learn/api-docs/ballerina/
+redirect_from: /v1-2/learn/api-docs/ballerina/
 ---

--- a/learn/api-docs/index.html
+++ b/learn/api-docs/index.html
@@ -1,5 +1,4 @@
 ---
 redirect_to: /learn/api-docs/ballerina/
 redirect_from: /v1-2/learn/api-docs/ballerina/
-
 ---

--- a/learn/api-docs/index.html
+++ b/learn/api-docs/index.html
@@ -1,4 +1,5 @@
 ---
 redirect_to: /learn/api-docs/ballerina/
 redirect_from: /v1-2/learn/api-docs/ballerina/
+
 ---


### PR DESCRIPTION
## Purpose
This is to fix the /learn redirections in Docerina V1-2 links.
> Fixes https://github.com/ballerina-platform/ballerina-dev-website/issues/341

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
