### PR TITLE
Updated meta description section

### DIFF
--- a/_includes/ballerina-example-head.html
+++ b/_includes/ballerina-example-head.html
@@ -3,7 +3,11 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="{{ page.description }}">
+{% if page.description %}
+<meta name="description" content="{{ page.description }}" />
+{% else %}
+<meta name="description" content="Documentation for the Ballerina Programming Language">
+{% endif %}
 <meta name="author" content="WSO2, Inc.">
 {% if page.keywords %}
 <meta name="keywords" content="{{ page.keywords }}" />

--- a/_includes/ballerina-head-landing-page.html
+++ b/_includes/ballerina-head-landing-page.html
@@ -3,7 +3,11 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% if page.description %}
+<meta name="description" content="{{ page.description }}" />
+{% else %}
 <meta name="description" content="Documentation for the Ballerina Programming Language">
+{% endif %}
 <meta name="author" content="WSO2, Inc.">
 {% if page.keywords %}
 <meta name="keywords" content="{{ page.keywords }}" />

--- a/_includes/ballerina-head.html
+++ b/_includes/ballerina-head.html
@@ -3,7 +3,11 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="{{ page.description }}">
+{% if page.description %}
+<meta name="description" content="{{ page.description }}" />
+{% else %}
+<meta name="description" content="Documentation for the Ballerina Programming Language">
+{% endif %}
 <meta name="author" content="WSO2, Inc.">
 {% if page.keywords %}
 <meta name="keywords" content="{{ page.keywords }}" />

--- a/_includes/ballerina-home-head.html
+++ b/_includes/ballerina-home-head.html
@@ -2,7 +2,11 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% if page.description %}
+<meta name="description" content="{{ page.description }}" />
+{% else %}
 <meta name="description" content="Documentation for the Ballerina Programming Language">
+{% endif %}
 <meta name="author" content="WSO2, Inc.">
 {% if page.keywords %}
 <meta name="keywords" content="{{ page.keywords }}" />


### PR DESCRIPTION
## Purpose
> Enabled page-specific meta descriptions in the layouts 

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
