### PR TITLE
Make the Quick Tour a Main Page

### DIFF
--- a/_data/learnnav.yml
+++ b/_data/learnnav.yml
@@ -53,7 +53,7 @@
   sublinks:
     - title: Deploying Ballerina programs in the cloud
       url: /learn/how-to-deploy-ballerina-programs-in-cloud/
-      active: how-to-deploy-ballerina-programs-in-cloud/
+      active: how-to-deploy-ballerina-programs-in-cloud
 
 - title: Observability
   url: '#' 

--- a/learn.md
+++ b/learn.md
@@ -39,7 +39,7 @@ redirect_from:
    <p>Know more about Ballerina by exploring its features.</p>
 
    <ul class="cLearnLandingLinks">
-   <li><a href="/learn/how-to-structure-ballerina-code/" class="cGreenLinkArrow">Ballerina User Guide</a></li>
+   <li><a href="/learn/installing-ballerina//" class="cGreenLinkArrow">Ballerina User Guide</a></li>
    <!--<li><a href="/learn/network-integration/" class="cGreenLinkArrow">Network Integration</a></li>
     <li><a href="/learn/how-to-deploy-and-run-ballerina-programs/" class="cGreenLinkArrow">Cloud Development</a></li>
     <li><a href="/learn/how-to-observe-ballerina-code" class="cGreenLinkArrow">Observability</a></li>

--- a/learn/cli-commands.md
+++ b/learn/cli-commands.md
@@ -98,12 +98,12 @@ Ballerina Central is how you share Ballerina modules with others in a safe, secu
 
 ## Manage projects
 
-Ballerina projects are the way to organize real world Ballerina development tasks. Learn more about it in <a href="/learn/how-to-structure-ballerina-code">How to Structure Ballerina Code</a>.
+Ballerina projects are the way to organize real world Ballerina development tasks. 
 
 <table class="cComandTable">
 <tr>
 <td class="cCommand">new</td>
-<td class="cDescription">Create a Ballerina project.
+<td class="cDescription">Create a Ballerina project. For more information, see <a href="/learn/how-to-structure-ballerina-code">How to Structure Ballerina Code</a>.
 </td>
 </tr>
 </table>

--- a/learn/cli-commands.md
+++ b/learn/cli-commands.md
@@ -65,7 +65,7 @@ These everyday commands are your best friends! They address the very basics of p
 </tr>
 <tr>
 <td class="cCommand">doc</td>
-<td class="cDescription">Generate API documents for all public symbols of a Ballerina module or project.
+<td class="cDescription">Generate API documents for all public symbols of a Ballerina module or project. For more information, see <a href="/learn/how-to-document-ballerina-code">How to Document Ballerina Code</a>.
 </td>
 </tr>
 <tr>

--- a/learn/cli-commands.md
+++ b/learn/cli-commands.md
@@ -124,6 +124,6 @@ These powerful supporting tools extend Ballerina to various ecosystem technologi
 </tr>
 <tr>
 <td class="cCommand">grpc</td>
-<td class="cDescription">This is the gRPC stub/skeleton generation tool.</td>
+<td class="cDescription">This is the gRPC stub/skeleton generation tool. For more information, see <a href="/learn/how-to-generate-code-for-protocol-buffers">How to generate Ballerina code for Protocol Buffer Definition</a>.</td>
 </tr>
 </table>

--- a/learn/cli-commands.md
+++ b/learn/cli-commands.md
@@ -50,7 +50,7 @@ These everyday commands are your best friends! They address the very basics of p
 </tr>
 <tr>
 <td class="cCommand">test</td>
-<td class="cDescription">Run tests of a particular module or all the modules of a Ballerina project.
+<td class="cDescription">Run tests of a particular module or all the modules of a Ballerina project. For more information, see <a href="/learn/how-to-test-ballerina-code">How to Test Ballerina Code</a>.
 </td>
 </tr>
 <tr>

--- a/learn/cli-commands.md
+++ b/learn/cli-commands.md
@@ -55,7 +55,7 @@ These everyday commands are your best friends! They address the very basics of p
 </tr>
 <tr>
 <td class="cCommand">run</td>
-<td class="cDescription">Build and run a Ballerina program, a single BAL file, an entire project, or a previously-built program.
+<td class="cDescription">Build and run a Ballerina program, a single BAL file, an entire project, or a previously-built program. For more information, see <a href="/learn/how-to-run-ballerina-programs">How to Run Ballerina Programs</a>.
 </td>
 </tr>
 <tr>

--- a/learn/cli-commands.md
+++ b/learn/cli-commands.md
@@ -91,7 +91,7 @@ Ballerina Central is how you share Ballerina modules with others in a safe, secu
 </tr>
 <tr>
 <td class="cCommand">push</td>
-<td class="cDescription">Upload a module to Ballerina Central.
+<td class="cDescription">Upload a module to Ballerina Central. For more information, see <a href="/learn/how-to-publish-modules">How to Publish a Module</a>.
 </td>
 </tr>
 </table>

--- a/learn/how-to-deploy-ballerina-programs-in-cloud.md
+++ b/learn/how-to-deploy-ballerina-programs-in-cloud.md
@@ -18,7 +18,7 @@ These deployment artifacts can be a form of simple files or complex types, like 
 
 -   [Dockerfiles](https://docs.docker.com/engine/reference/builder/)
 -   [Docker images](https://docs.docker.com/engine/reference/commandline/images/)
--   [Kubernetes](http://kubernetes.io) artifacts
+-   [Kubernetes artifacts](http://kubernetes.io) 
 
 It is possible for third parties and the ecosystem to create their own annotations and builder extensions that generate different kinds of deployment artifacts. You can publish these extensions within Ballerina Central for others to use.
 

--- a/learn/quick-tour.md
+++ b/learn/quick-tour.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-inner-page
 title: Quick Tour
 permalink: /learn/quick-tour/
 active: quick-tour


### PR DESCRIPTION
## Purpose
Make the Quick Tour a main page of Learn.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
