### PR TITLE
Update IntelliJ Docs After the Learn Page Redesign

### DIFF
--- a/learn/how-to-keep-ballerina-up-to-date.md
+++ b/learn/how-to-keep-ballerina-up-to-date.md
@@ -102,7 +102,7 @@ Now that you are familiar with the terminology, let’s look at how you can keep
 
 - One only distribution from the above list can be active at a given time.
 - Ballerina tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke `ballerina build`, the Ballerina tool dispatches this request to the active distribution.
-- You can change the active distribution at any time. Refer the [Change the active distribution](#Change-the-active-distribution) section for more details.  
+- You can change the active distribution at any time. Refer the [Change the active distribution](#change-the-active-distribution) section for more details.  
 
 ### The `ballerina dist` command
 

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -124,5 +124,5 @@ To get help when you work with Ballerina, see [Community](/community).
 
 Once you have successfully installed Ballerina, click the below links to set up your IDE.
 
-- [Setting up VS Code](/learn/vscode-plugin/)
-- [Setting up IntelliJ](/learn/intellij-plugin/)
+- [Setting up VS Code](/learn/tools-ides/vscode-plugin/)
+- [Setting up IntelliJ](/learn/tools-ides/intellij-plugin/)

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -122,7 +122,7 @@ To get help when you work with Ballerina, see [Community](/community).
 
 ## What's next
 
-Once you have successfully installed Ballerina, click the below links to set up the Ballerina extensions in your IDE.
+Once you have successfully installed Ballerina, click the below links to set up your IDE.
 
 - [Setting up VS Code](learn/vscode-plugin/)
 - [Setting up IntelliJ](learn/intellij-plugin/)

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -122,4 +122,7 @@ To get help when you work with Ballerina, see [Community](/community).
 
 ## What's next
 
-Once you have successfully installed Ballerina, try out the [Quick Tour](/learn/quick-tour) and take Ballerina for its first spin.
+Once you have successfully installed Ballerina, click the below links to set up the Ballerina extensions in your IDE.
+
+- [Setting up VS Code](learn/vscode-plugin/)
+- [Setting up IntelliJ](learn/intellij-plugin/)

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -124,5 +124,5 @@ To get help when you work with Ballerina, see [Community](/community).
 
 Once you have successfully installed Ballerina, click the below links to set up your IDE.
 
-- [Setting up VS Code](/learn/tools-ides/vscode-plugin/)
-- [Setting up IntelliJ](/learn/tools-ides/intellij-plugin/)
+- [Setting up VS Code](/learn/vscode-plugin/)
+- [Setting up IntelliJ](/learn/intellij-plugin/)

--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -124,5 +124,5 @@ To get help when you work with Ballerina, see [Community](/community).
 
 Once you have successfully installed Ballerina, click the below links to set up your IDE.
 
-- [Setting up VS Code](learn/vscode-plugin/)
-- [Setting up IntelliJ](learn/intellij-plugin/)
+- [Setting up VS Code](/learn/vscode-plugin/)
+- [Setting up IntelliJ](/learn/intellij-plugin/)

--- a/learn/tools-ides/intellij-plugin.md
+++ b/learn/tools-ides/intellij-plugin.md
@@ -31,9 +31,10 @@ You need [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) installed.
 **Plugin Version**|**Platform Version Compatibility**
 :-----:|:-----:
 0.8.0 - 0.8.2|IntelliJ IDEA 2016.3 - 2016.4
-0.8.3 - 0.981.0|IntelliJ IDEA 2016.3+
-0.982.0 - 0.991.0|IntelliJ IDEA 2017.3+
-0.991.1+ | IntelliJ IDEA 2018.3+
+0.8.3 - 0.981.0|IntelliJ IDEA 2016.3 - 2017.2
+0.982.0 - 0.991.0|IntelliJ IDEA 2017.3 - 2018.2
+0.991.1 - 1.2.1 | IntelliJ IDEA 2018.3 - 2019.3
+1.2.2+ | IntelliJ IDEA 2018.3+
 
 ## Installing the plugin
 


### PR DESCRIPTION
## Purpose
Update IntelliJ Docs after the Learn page redesign.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
