### PR TITLE
Add Interoperability to the Learn Left Nav

### DIFF
--- a/_data/learnnav.yml
+++ b/_data/learnnav.yml
@@ -62,6 +62,13 @@
       url: /learn/how-to-observe-ballerina-code
       active: how-to-observe-ballerina-code
 
+- title: Interoperability
+  url: '#' 
+  sublinks:
+    - title: Calling Java Code from Ballerina
+      url: /learn/how-to-call-java-code-from-ballerina/
+      active: how-to-call-java-code-from-ballerina
+
 - title: Security
   url: '#' 
   sublinks:
@@ -82,9 +89,7 @@
     - title: Extending with Compiler Extensions 
       url: /learn/how-to-extend-ballerina
       active: how-to-extend-ballerina
-    - title: Calling Java code from Ballerina
-      url: /learn/how-to-call-java-code-from-ballerina/
-      active: how-to-call-java-code-from-ballerina
+      
  
 
 

--- a/learn.md
+++ b/learn.md
@@ -48,6 +48,7 @@ redirect_from:
    <li><a href="/learn/how-to-structure-ballerina-code/" class="cGreenLinkArrow">Code Organization</a></li>
     <li><a href="/learn/how-to-deploy-ballerina-programs-in-cloud/" class="cGreenLinkArrow">Cloud Development</a></li>
     <li><a href="/learn/how-to-observe-ballerina-code" class="cGreenLinkArrow">Observability</a></li>
+    <li><a href="/learn/how-to-call-java-code-from-ballerina" class="cGreenLinkArrow">Interoperability</a></li>
     <li><a href="/learn/how-to-write-secure-ballerina-code" class="cGreenLinkArrow">Security</a></li>
     <li><a href="/learn/how-to-test-ballerina-code" class="cGreenLinkArrow">Testing</a></li>
     <li><a href="/learn/how-to-extend-ballerina" class="cGreenLinkArrow">Extending Ballerina</a></li>


### PR DESCRIPTION
## Purpose
Add interoperability as a new section in the left navigation of the Learn page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
