### PR TITLE
Fix the Inconsistencies in the Tooling Pages in Learn

### DIFF
--- a/1.0/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/1.0/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -168,5 +168,5 @@ You expand/collapse the following Ballerina code segments using the icons in the
 
 ## What's next?
 
-- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Plugin](/v1-0/learn/intellij-plugin).
+- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Ballerina Plugin](/v1-0/learn/intellij-plugin).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-0/learn).

--- a/1.0/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/1.0/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -168,5 +168,5 @@ You expand/collapse the following Ballerina code segments using the icons in the
 
 ## What's next?
 
-- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Ballerina Plugin](/v1-0/learn/intellij-plugin).
-- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-0/learn).
+- For more information on the IntelliJ IDEA Ballerina plugin, see [IntelliJ IDEA Ballerina Plugin](/1.0/learn/intellij-plugin).
+- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/1.0/learn/).

--- a/1.0/learn/tools-ides/vscode-plugin.md
+++ b/1.0/learn/tools-ides/vscode-plugin.md
@@ -7,7 +7,7 @@ redirect_from:
   - /v1-0/learn/tools-ides/vscode-plugin/
 ---
 
-# The Visual Studio Code Extension
+# The Visual Studio Code Ballerina Extension
 
 The VS Code Ballerina extension provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code extension.
 

--- a/1.0/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/1.0/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -21,6 +21,6 @@ The Documentation Viewer represents the documented entities in a file in an orga
 ## What's next?
 
 - For information on the next capability of the VS Code Ballerina plugin, see [Run All tests](/1.0//learn/vscode-plugin/run-all-tests).
-- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/1.0/learn/vscode-plugin).
+- For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/1.0/learn/vscode-plugin).
 
 

--- a/1.0/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/1.0/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -20,6 +20,7 @@ The Documentation Viewer represents the documented entities in a file in an orga
 
 ## What's next?
 
-- For information on the Ballerina VSCode extension, see [VSCode Extension](/v1-0/learn/vscode-plugin)
-- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-0/learn).
+- For information on the next capability of the VS Code Ballerina plugin, see [Run All tests](/1.0//learn/vscode-plugin/run-all-tests).
+- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/1.0/learn/vscode-plugin).
+
 

--- a/1.0/learn/tools-ides/vscode-plugin/graphical-editor.md
+++ b/1.0/learn/tools-ides/vscode-plugin/graphical-editor.md
@@ -60,4 +60,4 @@ You can expand the Diagram View to show not only the control flow but also to sh
 ## What's next?
 
  - For information on the next capability of the VS Code Ballerina plugin, see [Documentation Viewer](/v1-0/learn/vscode-plugin/documentation-viewer).
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/v1-0/learn/vscode-plugin).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/v1-0/learn/vscode-plugin).

--- a/1.0/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/1.0/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -18,5 +18,5 @@ This option allows you to run all the tests that belong to multiple modules of y
 
 ## What's next?
 
-- For information on the Ballerina VSCode extension, see [The Visual Studio Code Extension](/1.0/learn/vscode-plugin/vscode-plugin).
+- For information on the Ballerina VSCode extension, see [The Visual Studio Code Ballerina Extension](/1.0/learn/vscode-plugin/vscode-plugin).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/1.0/learn/).

--- a/1.0/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/1.0/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -18,5 +18,5 @@ This option allows you to run all the tests that belong to multiple modules of y
 
 ## What's next?
 
-- For information on the next capability of the VS Code Ballerina extension, see [Graphical Editor](/v1-0/learn/vscode-plugin/graphical-editor.md).
-- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/v1-0/learn/vscode-plugin.md).
+- For information on the Ballerina VSCode extension, see [The Visual Studio Code Extension](/1.0/learn/vscode-plugin/vscode-plugin).
+- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/1.0/learn/).

--- a/1.0/learn/tools-ides/vscode-plugin/run-and-debug.md
+++ b/1.0/learn/tools-ides/vscode-plugin/run-and-debug.md
@@ -38,5 +38,5 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
 ## What's next?
 
  - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/v1-0/learn/vscode-plugin/graphical-editor).
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/v1-0/learn/vscode-plugin).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/v1-0/learn/vscode-plugin).
 

--- a/1.1/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/1.1/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -172,5 +172,5 @@ You expand/collapse the following Ballerina code segments using the icons in the
 
 ## What's next?
 
-- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Ballerina Plugin](/1.1/learn/intellij-plugin).
-- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-1/learn).
+- For more information on the IntelliJ IDEA Ballerina plugin, see [IntelliJ IDEA Ballerina Plugin](/1.1/learn/intellij-plugin).
+- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/1.1/learn/).

--- a/1.1/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/1.1/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -172,5 +172,5 @@ You expand/collapse the following Ballerina code segments using the icons in the
 
 ## What's next?
 
-- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Plugin](/1.1/learn/intellij-plugin).
+- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Ballerina Plugin](/1.1/learn/intellij-plugin).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-1/learn).

--- a/1.1/learn/tools-ides/vscode-plugin.md
+++ b/1.1/learn/tools-ides/vscode-plugin.md
@@ -11,7 +11,7 @@ redirect_from:
   - /v1-1/learn/vscode-plugin
 ---
 
-# The Visual Studio Code Extension
+# The Visual Studio Code Ballerina Extension
 
 The VS Code Ballerina extension provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code extension.
 

--- a/1.1/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/1.1/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -24,6 +24,7 @@ The Documentation Viewer represents the documented entities in a file in an orga
 
 ## What's next?
 
-- For information on the Ballerina VSCode extension, see [VSCode Extension](/1.1/learn/vscode-plugin)
-- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-1/learn).
+- For information on the next capability of the VS Code Ballerina plugin, see [Run All tests](/1.0/learn/vscode-plugin/run-all-tests).
+- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/1.0/learn/vscode-plugin).
+
 

--- a/1.1/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/1.1/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -24,7 +24,7 @@ The Documentation Viewer represents the documented entities in a file in an orga
 
 ## What's next?
 
-- For information on the next capability of the VS Code Ballerina plugin, see [Run All tests](/1.0/learn/vscode-plugin/run-all-tests).
-- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/1.0/learn/vscode-plugin).
+- For information on the next capability of the VS Code Ballerina plugin, see [Run All tests](/1.1/learn/vscode-plugin/run-all-tests).
+- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/1.1/learn/vscode-plugin).
 
 

--- a/1.1/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/1.1/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -25,6 +25,6 @@ The Documentation Viewer represents the documented entities in a file in an orga
 ## What's next?
 
 - For information on the next capability of the VS Code Ballerina plugin, see [Run All tests](/1.1/learn/vscode-plugin/run-all-tests).
-- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/1.1/learn/vscode-plugin).
+- For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/1.1/learn/vscode-plugin).
 
 

--- a/1.1/learn/tools-ides/vscode-plugin/graphical-editor.md
+++ b/1.1/learn/tools-ides/vscode-plugin/graphical-editor.md
@@ -64,4 +64,4 @@ You can expand the Diagram View to show not only the control flow but also to sh
 ## What's next?
 
  - For information on the next capability of the VS Code Ballerina plugin, see [Documentation Viewer](/1.1/learn/vscode-plugin/documentation-viewer).
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/1.1/learn/vscode-plugin).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/1.1/learn/vscode-plugin).

--- a/1.1/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/1.1/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -22,5 +22,5 @@ This option allows you to run all the tests that belong to multiple modules of y
 
 ## What's next?
 
-- For information on the next capability of the VS Code Ballerina extension, see [Graphical Editor](/1.1/learn/vscode-plugin/graphical-editor.md).
-- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/1.1/learn/vscode-plugin/vscode-plugin.md)
+- For information on the Ballerina VSCode extension, see [The Visual Studio Code Extension](/1.1/learn/vscode-plugin/vscode-plugin).
+- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/1.1/learn/).

--- a/1.1/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/1.1/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -22,5 +22,5 @@ This option allows you to run all the tests that belong to multiple modules of y
 
 ## What's next?
 
-- For information on the Ballerina VSCode extension, see [The Visual Studio Code Extension](/1.1/learn/vscode-plugin/vscode-plugin).
+- For information on the Ballerina VSCode extension, see [The Visual Studio Code Ballerina Extension](/1.1/learn/vscode-plugin/vscode-plugin).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/1.1/learn/).

--- a/1.1/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/1.1/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -1,4 +1,4 @@
----
+Lea---
 layout: ballerina-inner-page
 title: Run all tests
 permalink: /1.1/learn/vscode-plugin/run-all-tests

--- a/1.1/learn/tools-ides/vscode-plugin/run-and-debug.md
+++ b/1.1/learn/tools-ides/vscode-plugin/run-and-debug.md
@@ -42,4 +42,4 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
 ## What's next?
 
  - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/1.1/learn/vscode-plugin/graphical-editor).
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/1.1/learn/vscode-plugin).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/1.1/learn/vscode-plugin).

--- a/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -181,4 +181,4 @@ This option allows you to view the definition of a selected variable, function, 
 ## What's next?
 
 - For more information on the IntelliJ IDEA Ballerina plugin, see [IntelliJ IDEA Ballerina Plugin](/learn/intellij-plugin).
-- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-2/learn).
+- For information on all the tools and IDEs that are supported by Ballerina, see [Setting up Ballerina](/learn/installing-ballerina/).

--- a/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -180,5 +180,5 @@ This option allows you to view the definition of a selected variable, function, 
 
 ## What's next?
 
-- For more information on the Ballerina IntelliJ IDEA plugin, see [IntelliJ IDEA Plugin](/learn/intellij-plugin).
+- For more information on the IntelliJ IDEA Ballerina plugin, see [IntelliJ IDEA Plugin](/learn/intellij-plugin).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-2/learn).

--- a/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -180,5 +180,5 @@ This option allows you to view the definition of a selected variable, function, 
 
 ## What's next?
 
-- For more information on the IntelliJ IDEA Ballerina plugin, see [IntelliJ IDEA Plugin](/learn/intellij-plugin).
+- For more information on the IntelliJ IDEA Ballerina plugin, see [IntelliJ IDEA Ballerina Plugin](/learn/intellij-plugin).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-2/learn).

--- a/learn/tools-ides/vscode-plugin.md
+++ b/learn/tools-ides/vscode-plugin.md
@@ -13,7 +13,7 @@ redirect_from:
   - /v1-2/learn/vscode-plugin/
 ---
 
-# The Visual Studio Code Extension
+# The Visual Studio Code Ballerina Extension
 
 The VS Code Ballerina extension provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code extension.
 

--- a/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -24,5 +24,5 @@ The Documentation Viewer represents the documented entities in a file in an orga
 ## What's next?
 
  - For information on the next capability of the VS Code Ballerina plugin, see [Run All tests](/learn/vscode-plugin/run-all-tests).
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/vscode-plugin).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin).
 

--- a/learn/tools-ides/vscode-plugin/documentation-viewer.md
+++ b/learn/tools-ides/vscode-plugin/documentation-viewer.md
@@ -23,6 +23,6 @@ The Documentation Viewer represents the documented entities in a file in an orga
 
 ## What's next?
 
-- For information on the Ballerina VSCode extension, see [VSCode Extension](/learn/vscode-plugin)
-- For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/v1-2/learn).
+ - For information on the next capability of the VS Code Ballerina plugin, see [Run All tests](/learn/vscode-plugin/run-all-tests).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/vscode-plugin).
 

--- a/learn/tools-ides/vscode-plugin/graphical-editor.md
+++ b/learn/tools-ides/vscode-plugin/graphical-editor.md
@@ -64,4 +64,4 @@ You can expand the Diagram View to show not only the control flow but also to sh
 ## What's next?
 
  - For information on the next capability of the VS Code Ballerina plugin, see [Documentation Viewer](/learn/vscode-plugin/documentation-viewer).
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/vscode-plugin).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin).

--- a/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -22,5 +22,5 @@ This option allows you to run all the tests that belong to multiple modules of y
 
 ## What's next?
 
-- For information on the Ballerina VSCode extension, see [The Visual Studio Code Extension](/learn/vscode-plugin/).
+- For information on the Ballerina VSCode extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin/).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Setting up Ballerina](/learn/installing-ballerina/).

--- a/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -22,5 +22,5 @@ This option allows you to run all the tests that belong to multiple modules of y
 
 ## What's next?
 
-- For information on the next capability of the VS Code Ballerina extension, see [Graphical Editor](/learn/vscode-plugin/graphical-editor).
-- For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/vscode-plugin/)
+- For information on the Ballerina VSCode extension, see [The Visual Studio Code Extension](/learn/vscode-plugin/).
+- For information on all the tools and IDEs that are supported by Ballerina, see [Setting up Ballerina](/learn/installing-ballerina/).

--- a/learn/tools-ides/vscode-plugin/run-and-debug.md
+++ b/learn/tools-ides/vscode-plugin/run-and-debug.md
@@ -43,4 +43,4 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
 ## What's next?
 
  - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/learn/vscode-plugin/graphical-editor).
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Extension](/learn/vscode-plugin).
+ - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin).


### PR DESCRIPTION
## Purpose
Fix the inconsistencies in the Tooling Pages in Learn.
> Fixes #529 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
