### PR TITLE
Added data-pack attribute to download links

### DIFF
--- a/hbs/archived_list.hbs
+++ b/hbs/archived_list.hbs
@@ -5,7 +5,7 @@
             {{#each lefttable}}
             <tr>
                 <td style="width: 96%">{{this}}</td>
-                <td style="width: 1%; white-space: nowrap;"><a href="{{{basedownloadurl ../version this null}}}" class="cDownloadLinkIcon {{{isjson this}}}" name="{{this}}" target="{{settarget this}}" ><img src="{{downloadimgurl this "../../img/download-bg-green-fill.svg" "../../img/right-bg-green-fill.svg"}}"></a></td>
+                <td style="width: 1%; white-space: nowrap;"><a href="{{{basedownloadurl ../version this null}}}" class="cDownloadLinkIcon {{{isjson this}}}" name="{{this}}" data-pack="{{this}}" target="{{settarget this}}" ><img src="{{downloadimgurl this "../../img/download-bg-green-fill.svg" "../../img/right-bg-green-fill.svg"}}"></a></td>
                 <td style="width: 1%; white-space: nowrap;"><a href="{{{basedownloadurl ../version this ".md5"}}}">{{checksome  this "md5"}}</a></td>
                 <td style="width: 1%; white-space: nowrap;"><a href="{{{basedownloadurl ../version this ".sha1"}}}">{{checksome this "SHA-1"}}</a></td>
                 <td style="width: 1%; white-space: nowrap;"><a href="{{{basedownloadurl ../version this ".asc"}}}">{{checksome this "asc"}}</a></td>
@@ -19,7 +19,7 @@
             {{#each righttable}}
             <tr>
                 <td style="width: 96%">{{this}}</td>
-                <td style="width: 1%; white-space: nowrap;"><a href="{{{basedownloadurl ../version this null}}}" class="cDownloadLinkIcon {{{isjson this}}}" name="{{this}}" target="{{settarget this}}" ><img src="{{downloadimgurl this "../../img/download-bg-green-fill.svg" "../../img/right-bg-green-fill.svg"}}"></a></td>
+                <td style="width: 1%; white-space: nowrap;"><a href="{{{basedownloadurl ../version this null}}}" class="cDownloadLinkIcon {{{isjson this}}}" name="{{this}}" data-pack="{{this}}" target="{{settarget this}}" ><img src="{{downloadimgurl this "../../img/download-bg-green-fill.svg" "../../img/right-bg-green-fill.svg"}}"></a></td>
                 <td style="width: 1%; white-space: nowrap;"><a href="{{{basedownloadurl ../version this ".md5"}}}">{{checksome  this "md5"}}</a></td>
                 <td style="width: 1%; white-space: nowrap;"><a href="{{{basedownloadurl ../version this ".sha1"}}}">{{checksome this "SHA-1"}}</a></td>
                 <td style="width: 1%; white-space: nowrap;"><a href="{{{basedownloadurl ../version this ".asc"}}}">{{checksome this "asc"}}</a></td>


### PR DESCRIPTION


## Purpose
> Added data-pack attribute to download links to proper grouping in download stats

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
