### PR TITLE
Fix the "Seek Help" Title in the Community page

### DIFF
--- a/community.md
+++ b/community.md
@@ -22,7 +22,7 @@ We warmly welcome all contributors to the community to help establish Ballerina 
 
 [Learn Ballerina](https://ballerina.io/learn) and try out writing Ballerina code on your own.
 
-## Seek for help
+## Seek help
 
 We are happy to help! Come engage with us on any channel that works for you.
 


### PR DESCRIPTION
## Purpose
This is to fix the "Seek Help" title in the Community page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
