### PR TITLE
Fix error handling issue in github publish workflow

### DIFF
--- a/.github/workflows/publish_github_release.yml
+++ b/.github/workflows/publish_github_release.yml
@@ -27,4 +27,6 @@ jobs:
         #python script takes RN.md as the input and produces out.json as the output
         python3 .github/scripts/sanitize_rn.py
 
-        curl -v -H "Authorization: token $WEBSITE_TOKEN" -H "Content-Type: application/json" -d @out.json https://api.github.com/repos/ballerina-platform/ballerina-lang/releases
+        if ! curl -v -H "Authorization: token $WEBSITE_TOKEN" -H "Content-Type: application/json" -d @out.json https://api.github.com/repos/ballerina-platform/ballerina-lang/releases --fail; then
+          exit 1
+        fi


### PR DESCRIPTION
## Purpose
> Without the fix workflow doesn't fail if curl returns anything other than 200 OK.