### PR TITLE
Fix the Term "VS Code" and Breadcrumbs of the VS Code Plugin Pages

### DIFF
--- a/1.0/learn/vscode-plugin/index.html
+++ b/1.0/learn/vscode-plugin/index.html
@@ -276,7 +276,7 @@
 <h2 id="using-the-extension">Using the extension</h2>
 
 <blockquote>
-  <p><strong>Tip:</strong> Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VSCode Extension, enable the Allow Experimental option in user settings.</p>
+  <p><strong>Tip:</strong> Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VS Code Extension, enable the Allow Experimental option in user settings.</p>
 </blockquote>
 
 <blockquote>

--- a/1.1/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/1.1/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-inner-page
-title: Using the features of the IntelliJ plugin
+title: Using the Features of the IntelliJ Plugin
 permalink: /1.1/learn/intellij-plugin/using-intellij-plugin-features
 redirect_from:
   - /1.1/learn/tools-ides/intellij-plugin/using-intellij-plugin-features
@@ -11,7 +11,7 @@ redirect_from:
   - /v1-1/learn/intellij-plugin/using-intellij-plugin-features/
 ---
 
-# Using the features of the IntelliJ plugin
+# Using the Features of the IntelliJ Plugin
 
 The below sections include information on the various capabilities that are facilitated by the IntelliJ Ballerina plugin for the development process.
 

--- a/1.1/learn/tools-ides/vscode-plugin.md
+++ b/1.1/learn/tools-ides/vscode-plugin.md
@@ -65,7 +65,7 @@ $ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 
 ## Using the extension
 
-> **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VSCode Extension, enable the Allow Experimental option in user settings.
+> **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VS Code Extension, enable the Allow Experimental option in user settings.
 
 > **Troubleshooting**: If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
 

--- a/1.1/learn/tools-ides/vscode-plugin/language-intelligence.md
+++ b/1.1/learn/tools-ides/vscode-plugin/language-intelligence.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-inner-page
-title: Language intelligence
+title: Language Intelligence
 permalink: /1.1/learn/vscode-plugin/language-intelligence
 redirect_from:
   - /1.1/learn/tools-ides/vscode-plugin/language-intelligence
@@ -11,7 +11,7 @@ redirect_from:
   - /v1-1/learn/vscode-plugin/language-intelligence
 ---
 
-# Language intelligence
+# Language Intelligence
 
 The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency.
 

--- a/1.1/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/1.1/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -1,6 +1,6 @@
 Lea---
 layout: ballerina-inner-page
-title: Run all tests
+title: Run all Tests
 permalink: /1.1/learn/vscode-plugin/run-all-tests
 redirect_from:
   - /1.1/learn/tools-ides/vscode-plugin/run-all-tests
@@ -11,7 +11,7 @@ redirect_from:
   - /v1-1/learn/vscode-plugin/run-all-tests
 ---
 
-# Run all tests
+# Run all Tests
 
 This option allows you to run all the tests that belong to multiple modules of your project. Follow the steps below to do this.
 

--- a/1.1/learn/tools-ides/vscode-plugin/run-and-debug.md
+++ b/1.1/learn/tools-ides/vscode-plugin/run-and-debug.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-inner-page
-title: Run and debug
+title: Run and Debug
 permalink: /1.1/learn/vscode-plugin/run-and-debug
 redirect_from:
   - /1.1/learn/tools-ides/vscode-plugin/run-and-debug
@@ -11,7 +11,7 @@ redirect_from:
   - /v1-1/learn/vscode-plugin/run-and-debug/
 ---
 
-# Run and debug
+# Run and Debug
 
 The VS Code Ballerina extension gives you the  same debugging experience as the conventional VS Code Debugger.
 

--- a/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
+++ b/learn/tools-ides/intellij-plugin/using-intellij-plugin-features.md
@@ -12,7 +12,7 @@ redirect_from:
   - /v1-2/learn/intellij-plugin/using-intellij-plugin-features
 ---
 
-# Using the features of the IntelliJ plugin
+# Using the Features of the IntelliJ Plugin
 
 The below sections include information on the various capabilities that are facilitated by the IntelliJ Ballerina plugin for the development process.
 

--- a/learn/tools-ides/vscode-plugin.md
+++ b/learn/tools-ides/vscode-plugin.md
@@ -67,7 +67,7 @@ $ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 
 ## Using the extension
 
-> **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VSCode Extension, enable the Allow Experimental option in user settings.
+> **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VS Code Extension, enable the Allow Experimental option in user settings.
 
 > **Troubleshooting**: If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
 

--- a/learn/tools-ides/vscode-plugin/language-intelligence.md
+++ b/learn/tools-ides/vscode-plugin/language-intelligence.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-left-nav-pages
-title: Language intelligence
+title: Language Intelligence
 permalink: /learn/vscode-plugin/language-intelligence/
 active: language-intelligence
 redirect_from:
@@ -11,7 +11,7 @@ redirect_from:
   - /v1-2/learn/vscode-plugin/language-intelligence
 ---
 
-# Language intelligence
+# Language Intelligence
 
 The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency.
 

--- a/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-left-nav-pages
-title: Run all tests
+title: Run all Tests
 permalink: /learn/vscode-plugin/run-all-tests/
 active: run-all-tests
 redirect_from:
@@ -11,7 +11,7 @@ redirect_from:
   - /v1-2/learn/vscode-plugin/run-all-tests
 ---
 
-# Run all tests
+# Run all Tests
 
 This option allows you to run all the tests that belong to multiple modules of your project. Follow the steps below to do this.
 

--- a/learn/tools-ides/vscode-plugin/run-and-debug.md
+++ b/learn/tools-ides/vscode-plugin/run-and-debug.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-left-nav-pages
-title: Run and debug
+title: Run and Debug
 permalink: /learn/vscode-plugin/run-and-debug/
 active: run-and-debug
 redirect_from:
@@ -12,7 +12,7 @@ redirect_from:
   - /v1-2/learn/vscode-plugin/run-and-debug
 ---
 
-# Run and debug
+# Run and Debug
 
 The VS Code Ballerina extension gives you the  same debugging experience as the conventional VS Code Debugger.
 


### PR DESCRIPTION
## Purpose
Fix the term "VS Code" and the breadcrumbs of the VS Code Plugin pages.

> Fixes #586 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
