### PR TITLE
Add More Front Matter Redirections in Tooling Pages

### DIFF
--- a/_data/learnnav.yml
+++ b/_data/learnnav.yml
@@ -6,10 +6,10 @@
       url: /learn/installing-ballerina/
       active: installing-ballerina
     - title: Setting up Visual Studio Code
-      url: /learn/tools-ides/setting-up-visual-studio-code/
+      url: /learn/setting-up-visual-studio-code/
       active: setting-up-visual-studio-code
     - title: Setting up IntelliJ IDEA
-      url: /learn/tools-ides/setting-up-intellij-idea/
+      url: /learn/setting-up-intellij-idea/
       active: setting-up-intellij-idea
 
 - title: Ballerina CLI Tools

--- a/learn/tools-ides/setting-up-intellij-idea.md
+++ b/learn/tools-ides/setting-up-intellij-idea.md
@@ -13,6 +13,8 @@ redirect_from:
   - /v1-2/learn/intellij-plugin
   - /v1-2/learn/intellij-plugin/
   - /learn/tools-ides/setting-up-intellij-idea/
+  - /learn/setting-up-intellij-idea/
+  - /learn/setting-up-intellij-idea
 ---
 
 # Setting up IntelliJ IDEA

--- a/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
+++ b/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features
   - /learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features/
   - /learn/setting-up-intellij-idea/using-intellij-plugin-features
+  - /learn/using-intellij-plugin-features
+  - /learn/using-intellij-plugin-features/
 ---
 
 # Using the Features of the IntelliJ Plugin

--- a/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
+++ b/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
@@ -17,6 +17,8 @@ redirect_from:
   - /learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin
   - /learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin/
   - /learn/setting-up-intellij-idea/using-the-intellij-plugin
+  - /learn/using-the-intellij-plugin
+  - - /learn/using-the-intellij-plugin/
 ---
 
 # Using the IntelliJ Ballerina Plugin

--- a/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/learn/tools-ides/setting-up-visual-studio-code.md
@@ -13,6 +13,8 @@ redirect_from:
   - /learn/vscode-plugin/
   - /learn/vscode-plugin
   - /learn/tools-ides/setting-up-visual-studio-code/
+  - /learn/setting-up-visual-studio-code/
+  - /learn/setting-up-visual-studio-code
 ---
 
 # Setting up Visual Studio Code 

--- a/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/tools-ides/setting-up-visual-studio-code/documentation-viewer
   - /learn/tools-ides/setting-up-visual-studio-code/documentation-viewer/
   - /learn/setting-up-visual-studio-code/documentation-viewer
+  - /learn/documentation-viewer
+  - /learn/documentation-viewer/
 ---
 
 # Documentation Viewer

--- a/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/tools-ides/setting-up-visual-studio-code/graphical-editor
   - /learn/tools-ides/setting-up-visual-studio-code/graphical-editor/
   - /learn/setting-up-visual-studio-code/graphical-editor
+  - /learn/graphical-editor
+  - /learn/graphical-editor/
 ---
 
 # Graphical View

--- a/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/tools-ides/setting-up-visual-studio-code/language-intelligence
   - /learn/tools-ides/setting-up-visual-studio-code/language-intelligence/
   - /learn/setting-up-visual-studio-code/language-intelligence
+  - /learn/language-intelligence
+  - /learn/language-intelligence/
 ---
 
 # Language Intelligence

--- a/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/tools-ides/setting-up-visual-studio-code/run-all-tests
   - /learn/tools-ides/setting-up-visual-studio-code/run-all-tests/
   - /learn/setting-up-visual-studio-code/run-all-tests
+  - /learn/run-all-tests
+  - /learn/run-all-tests/
 ---
 
 # Run all Tests

--- a/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/tools-ides/setting-up-visual-studio-code/run-and-debug
   - /learn/tools-ides/setting-up-visual-studio-code/run-and-debug/
   - /learn/setting-up-visual-studio-code/run-and-debug
+  - /learn/run-and-debug
+  - /learn/run-and-debug/
 ---
 
 # Run and Debug


### PR DESCRIPTION
## Purpose
Add more front matter redirections in all the Tooling pages. This is related to [1].

[1] https://github.com/ballerina-platform/ballerina-dev-website/issues/587
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
