### PR TITLE
Add Trailing Slashes in the Permalinks of Tooling Pages

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -51,7 +51,7 @@ redirect_from:
     <li><a href="/learn/calling-java-code-from-ballerina" class="cGreenLinkArrow">Interoperability</a></li>
     <li><a href="/learn/writing-secure-ballerina-code" class="cGreenLinkArrow">Security</a></li>
     <li><a href="/learn/testing-ballerina-code" class="cGreenLinkArrow">Testing</a></li>
-    <li><a href="/learn/eextending-with-compiler-extensions" class="cGreenLinkArrow">Extending Ballerina</a></li>
+    <li><a href="/learn/extending-with-compiler-extensions" class="cGreenLinkArrow">Extending Ballerina</a></li>
    </ul>
 
 </div>

--- a/learn/calling-java-code-from-ballerina.md
+++ b/learn/calling-java-code-from-ballerina.md
@@ -3,7 +3,7 @@ layout: ballerina-left-nav-pages
 title: Calling Java Code from Ballerina
 description: See how Ballerina offers a straightforward way to call existing Java code from Ballerina and a Java API to call Ballerina code from Java.
 keywords: ballerina, programming language, java api, interoperability
-permalink: /learn/calling-java-code-from-ballerina
+permalink: /learn/calling-java-code-from-ballerina/
 active: how-to-use-calling-java-code-from-ballerina
 redirect_from:
   - /learn/how-to-use-java-interoperability
@@ -12,7 +12,7 @@ redirect_from:
   - /v1-2/learn/how-to-use-java-interoperability/
   - /learn/how-to-call-java-code-from-ballerina/
   - /learn/how-to-call-java-code-from-ballerina
-  - /learn/calling-java-code-from-ballerina/
+  - /learn/calling-java-code-from-ballerina
 ---
 
 # Calling Java Code from Ballerina

--- a/learn/coding-conventions.md
+++ b/learn/coding-conventions.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Coding Conventions
 description: The Ballerina Style Guide aims at maintaining a standard coding style among the Ballerina community. The Ballerina code formatting tools are based on this guide.
 keywords: ballerina, programming language, ballerina style guide
-permalink: /learn/coding-conventions
+permalink: /learn/coding-conventions/
 active: coding-conventions
 redirect_from:
   - /learn/style-guide
   - /learn/style-guide/
   - /v1-2/learn/style-guide
   - /v1-2/learn/style-guide/
-  - /learn/coding-conventions/
+  - /learn/coding-conventions
 ---
 
 # Coding Conventions

--- a/learn/deploying-ballerina-programs-in-the-cloud.md
+++ b/learn/deploying-ballerina-programs-in-the-cloud.md
@@ -3,7 +3,7 @@ layout: ballerina-left-nav-pages
 title: Deploying Ballerina Programs in the Cloud
 description: See how the Ballerina compiler generates the necessary artifacts to deploy to cloud platforms like Kubernetes, Docker, Moby or Cloud Foundry.
 keywords: ballerina, programming language, services, cloud
-permalink: /learn/deploying-ballerina-programs-in-the-cloud
+permalink: /learn/deploying-ballerina-programs-in-the-cloud/
 active: deploying-ballerina-programs-in-the-cloud
 redirect_from:
   - /learn/how-to-deploy-and-run-ballerina-programs/
@@ -12,7 +12,7 @@ redirect_from:
   - /learn/how-to-deploy-ballerina-programs-in-cloud
   - /v1-2/learn/how-to-deploy-and-run-ballerina-programs/
   - /v1-2/learn/how-to-deploy-and-run-ballerina-programs
-  - /learn/deploying-ballerina-programs-in-the-cloud/
+  - /learn/deploying-ballerina-programs-in-the-cloud
 
 ---
 

--- a/learn/documenting-ballerina-code.md
+++ b/learn/documenting-ballerina-code.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Documenting Ballerina Code
 description: Learn how to write unstructured documents with a bit of structure to enable HTML content generation as API documentation.
 keywords: ballerina, programming language, api documentation, api docs
-permalink: /learn/documenting-ballerina-code
+permalink: /learn/documenting-ballerina-code/
 active: documenting-ballerina-code
 redirect_from:
   - /learn/how-to-document-ballerina-code
   - /learn/how-to-document-ballerina-code/
   - /v1-2/learn/how-to-document-ballerina-code
   - /v1-2/learn/how-to-document-ballerina-code/
-  - /learn/documenting-ballerina-code/
+  - /learn/documenting-ballerina-code
 ---
 
 # Documenting Ballerina Code

--- a/learn/extending-with-compiler-extensions.md
+++ b/learn/extending-with-compiler-extensions.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Extending with Compiler Extensions
 description: Learn how to extend Ballerina using annotations, which can be used to provide structured metadata about a particular construct.
 keywords: ballerina, programming language, annotations, metadata, extend ballerina
-permalink: /learn/extending-with-compiler-extensions
+permalink: /learn/extending-with-compiler-extensions/
 active: extending-with-compiler-extensions
 redirect_from:
   - /learn/how-to-extend-ballerina
   - /learn/how-to-extend-ballerina/
   - /v1-2/learn/how-to-extend-ballerina
   - /v1-2/learn/how-to-extend-ballerina/
-  - /learn/extending-with-compiler-extensions/
+  - /learn/extending-with-compiler-extensions
 ---
 
 # Extending with Compiler Extensions 

--- a/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
+++ b/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Generating Ballerina Code for Protocol Buffer Definitions
 description: The Protocol Buffers to Ballerina tool provides capabilities to generate Ballerina source code for the Protocol Buffer definition.
 keywords: ballerina, protocol buffers, programming language
-permalink: /learn/generating-ballerina-code-for-protocol-buffer-definitions
+permalink: /learn/generating-ballerina-code-for-protocol-buffer-definitions/
 active: how-to-generating-ballerina-code-for-protocol-buffer-definitions
 redirect_from:
   - /learn/how-to-generate-code-for-protocol-buffers
   - /learn/how-to-generate-code-for-protocol-buffers/
   - /v1-2/learn/how-to-generate-code-for-protocol-buffers
   - /v1-2/learn/how-to-generate-code-for-protocol-buffers/
-  - /learn/generating-ballerina-code-for-protocol-buffer-definitions/
+  - /learn/generating-ballerina-code-for-protocol-buffer-definitions
   
 ---
 

--- a/learn/keeping-ballerina-up-to-date.md
+++ b/learn/keeping-ballerina-up-to-date.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Keeping Ballerina Up to Date
 description: Learn how to maintain your Ballerina programming language installation and keep it up to date with the latest patch and minor releases.
 keywords: ballerina, programming language, release, update
-permalink: /learn/keeping-ballerina-up-to-date
+permalink: /learn/keeping-ballerina-up-to-date/
 active: keeping-ballerina-up-to-date
 redirect_from:
   - /v1-2/learn/how-to-keep-ballerina-up-to-date
   - /v1-2/learn/how-to-keep-ballerina-up-to-date/
   - /learn/how-to-keep-ballerina-up-to-date/
   - /learn/how-to-keep-ballerina-up-to-date
-  - /learn/keeping-ballerina-up-to-date/
+  - /learn/keeping-ballerina-up-to-date
 ---
 
 # Keeping Ballerina Up to Date

--- a/learn/observing-ballerina-code.md
+++ b/learn/observing-ballerina-code.md
@@ -3,7 +3,7 @@ layout: ballerina-left-nav-pages
 title: Observing Ballerina Code
 description: See how Ballerina supports observability by exposing itself via metrics, tracing and logs to external systems.
 keywords: ballerina, observability, metrics, tracing, logs
-permalink: /learn/observing-ballerina-code
+permalink: /learn/observing-ballerina-code/
 active: how-to-observing-ballerina-code
 redirect_from:
   - /learn/how-to-observe-ballerina-code
@@ -12,7 +12,7 @@ redirect_from:
   - /v1-2/learn/how-to-observe-ballerina-code/
   - /learn/how-to-observe-ballerina-services/
   - /learn/how-to-observe-ballerina-services
-  - /learn/observing-ballerina-code/
+  - /learn/observing-ballerina-code
 ---
 
 # Observing Ballerina Code

--- a/learn/publishing-modules-to-ballerina-central.md
+++ b/learn/publishing-modules-to-ballerina-central.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Publishing Modules to Ballerina Central
 description: Learn how to use the CLI tool in the Ballerina programming language to push modules to Ballerina Central.
 keywords: ballerina, programming language, ballerina central, ballerina modules
-permalink: /learn/publishing-modules-to-ballerina-central
+permalink: /learn/publishing-modules-to-ballerina-central/
 active: publishing-modules-to-ballerina-central
 redirect_from:
   - /learn/how-to-publish-modules
   - /learn/how-to-publish-modules/
   - /v1-2/learn/how-to-publish-modules
   - /v1-2/learn/how-to-publish-modules/
-  - /learn/publishing-modules-to-ballerina-central/
+  - /learn/publishing-modules-to-ballerina-central
 ---
 
 # Publishing Modules to Ballerina Central

--- a/learn/running-ballerina-code.md
+++ b/learn/running-ballerina-code.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Running Ballerina Code
 description: Learn how to run Ballerina programs and services using the CLI tool.
 keywords: ballerina, programming language, services
-permalink: /learn/running-ballerina-code
+permalink: /learn/running-ballerina-code/
 active: running-ballerina-code
 redirect_from:
   - /learn/how-to-deploy-and-run-ballerina-programs
   - /learn/how-to-run-ballerina-programs/
   - /v1-2/learn/how-to-deploy-and-run-ballerina-programs
   - /v1-2/learn/how-to-deploy-and-run-ballerina-programs/
-  - /learn/running-ballerina-code/
+  - /learn/running-ballerina-code
 ---
 
 # Running Ballerina Code

--- a/learn/structuring-ballerina-code.md
+++ b/learn/structuring-ballerina-code.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Structuring Ballerina Code
 description: Learn how to develop a Ballerina project, structure code, and use the Ballerina Tool to fetch, build, and install Ballerina modules.
 keywords: ballerina, programming language, ballerina modules, structure code
-permalink: /learn/structuring-ballerina-code
+permalink: /learn/structuring-ballerina-code/
 active: structuring-ballerina-code
 redirect_from:
   - /learn/how-to-structure-ballerina-code
   - /learn/how-to-structure-ballerina-code/
   - /v1-2/learn/how-to-structure-ballerina-code
   - /v1-2/learn/how-to-structure-ballerina-code/
-  - /learn/structuring-ballerina-code/
+  - /learn/structuring-ballerina-code
 ---
 
 # Structuring Ballerina Code

--- a/learn/testing-ballerina-code.md
+++ b/learn/testing-ballerina-code.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Testing Ballerina Code
 description: Learn how to use Ballerina's built-in test framework to write testable code. The test framework provides a set of building blocks to help write and run tests.
 keywords: ballerina, programming language, testing
-permalink: /learn/testing-ballerina-code
+permalink: /learn/testing-ballerina-code/
 active: testing-ballerina-code
 redirect_from:
   - /learn/how-to-test-ballerina-code
   - /learn/how-to-test-ballerina-code/
   - /v1-2/learn/how-to-test-ballerina-code
   - /v1-2/learn/how-to-test-ballerina-code/
-  - /learn/testing-ballerina-code/
+  - /learn/testing-ballerina-code
 ---
 
 # Testing Ballerina Code

--- a/learn/tools-ides/setting-up-intellij-idea.md
+++ b/learn/tools-ides/setting-up-intellij-idea.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-left-nav-pages
 title: Setting up IntelliJ IDEA
-permalink: /learn/tools-ides/setting-up-intellij-idea/
+permalink: /learn/setting-up-intellij-idea/
 active: setting-up-intellij-idea
 redirect_from:
   - /v1-2/learn/tools-ides/intellij-plugin
@@ -13,6 +13,7 @@ redirect_from:
   - /v1-2/learn/intellij-plugin
   - /v1-2/learn/intellij-plugin/
   - /learn/tools-ides/setting-up-intellij-idea
+  - /learn/tools-ides/setting-up-intellij-idea/
   - /learn/setting-up-intellij-idea/
   - /learn/setting-up-intellij-idea
 ---

--- a/learn/tools-ides/setting-up-intellij-idea.md
+++ b/learn/tools-ides/setting-up-intellij-idea.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-left-nav-pages
 title: Setting up IntelliJ IDEA
-permalink: /learn/tools-ides/setting-up-intellij-idea
+permalink: /learn/tools-ides/setting-up-intellij-idea/
 active: setting-up-intellij-idea
 redirect_from:
   - /v1-2/learn/tools-ides/intellij-plugin
@@ -12,7 +12,7 @@ redirect_from:
   - /learn/intellij-plugin/
   - /v1-2/learn/intellij-plugin
   - /v1-2/learn/intellij-plugin/
-  - /learn/tools-ides/setting-up-intellij-idea/
+  - /learn/tools-ides/setting-up-intellij-idea
   - /learn/setting-up-intellij-idea/
   - /learn/setting-up-intellij-idea
 ---

--- a/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
+++ b/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
@@ -18,7 +18,7 @@ redirect_from:
   - /learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin/
   - /learn/setting-up-intellij-idea/using-the-intellij-plugin
   - /learn/using-the-intellij-plugin
-  - - /learn/using-the-intellij-plugin/
+  - /learn/using-the-intellij-plugin/
 ---
 
 # Using the IntelliJ Ballerina Plugin

--- a/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/learn/tools-ides/setting-up-visual-studio-code.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-left-nav-pages
 title: Setting up Visual Studio Code
-permalink: /learn/tools-ides/setting-up-visual-studio-code/
+permalink: /learn/setting-up-visual-studio-code/
 active: setting-up-visual-studio-code
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin
@@ -13,6 +13,7 @@ redirect_from:
   - /learn/vscode-plugin/
   - /learn/vscode-plugin
   - /learn/tools-ides/setting-up-visual-studio-code
+  - /learn/tools-ides/setting-up-visual-studio-code/
   - /learn/setting-up-visual-studio-code/
   - /learn/setting-up-visual-studio-code
 ---

--- a/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/learn/tools-ides/setting-up-visual-studio-code.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-left-nav-pages
 title: Setting up Visual Studio Code
-permalink: /learn/tools-ides/setting-up-visual-studio-code
+permalink: /learn/tools-ides/setting-up-visual-studio-code/
 active: setting-up-visual-studio-code
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin
@@ -12,7 +12,7 @@ redirect_from:
   - /v1-2/learn/vscode-plugin/
   - /learn/vscode-plugin/
   - /learn/vscode-plugin
-  - /learn/tools-ides/setting-up-visual-studio-code/
+  - /learn/tools-ides/setting-up-visual-studio-code
   - /learn/setting-up-visual-studio-code/
   - /learn/setting-up-visual-studio-code
 ---

--- a/learn/using-the-cli-tools.md
+++ b/learn/using-the-cli-tools.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Using the CLI Tools
 description: Learn all the command line interface (CLI) commands need to get started, build, test and run programs, work with Ballerina Central, and manage projects.
 keywords: ballerina, cli, command line interface, programming language
-permalink: /learn/using-the-cli-tools
+permalink: /learn/using-the-cli-tools/
 active: using-the-cli-tools
 redirect_from:
   - /v1-2/learn/cli-commands
   - /v1-2/learn/cli-commands/
   - /learn/cli-commands/
   - /learn/cli-commands
-  - /learn/using-the-cli-tools/
+  - /learn/using-the-cli-tools
 ---
 
 # Using the CLI Tools

--- a/learn/using-the-openapi-tools.md
+++ b/learn/using-the-openapi-tools.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Using the OpenAPI Tools
 description: Check out how the Ballerina OpenAPI tooling makes it easy for users to start developing a service documented in the OpenAPI contract.
 keywords: ballerina, programming language, openapi, open api, restful api
-permalink: /learn/using-the-openapi-tools
+permalink: /learn/using-the-openapi-tools/
 active: using-the-openapi-tools
 redirect_from:
   - /v1-2/learn/how-to-use-openapi-tools
   - /v1-2/learn/how-to-use-openapi-tools/
   - /learn/how-to-use-openapi-tools/
   - /learn/how-to-use-openapi-tools
-  - /learn/using-the-openapi-tools/
+  - /learn/using-the-openapi-tools
 ---
 
 # Using the OpenAPI Tools

--- a/learn/writing-secure-ballerina-code.md
+++ b/learn/writing-secure-ballerina-code.md
@@ -3,14 +3,14 @@ layout: ballerina-left-nav-pages
 title: Writing Secure Ballerina Code
 description: Check out the different security features and controls available within the Ballerina programming language and follow the guidelines on writing secure Ballerina programs.
 keywords: ballerina, programming language, security, secure ballerina code
-permalink: /learn/writing-secure-ballerina-code
+permalink: /learn/writing-secure-ballerina-code/
 active: writing-secure-ballerina-code
 redirect_from:
   - /learn/how-to-write-secure-ballerina-code
   - /learn/how-to-write-secure-ballerina-code/
   - /v1-2/learn/how-to-write-secure-ballerina-code
   - /v1-2/learn/how-to-write-secure-ballerina-code/
-  - /learn/writing-secure-ballerina-code/
+  - /learn/writing-secure-ballerina-code
 ---
 
 # Writing Secure Ballerina Code


### PR DESCRIPTION
## Purpose
Add Trailing Slashes in the Permalinks of Tooling Pages
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
