### PR TITLE
Fix Redirection Issues in the Setting up Tooling Pages

### DIFF
--- a/learn/tools-ides/setting-up-intellij-idea.md
+++ b/learn/tools-ides/setting-up-intellij-idea.md
@@ -14,7 +14,6 @@ redirect_from:
   - /v1-2/learn/intellij-plugin/
   - /learn/tools-ides/setting-up-intellij-idea
   - /learn/tools-ides/setting-up-intellij-idea/
-  - /learn/setting-up-intellij-idea/
   - /learn/setting-up-intellij-idea
 ---
 

--- a/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/learn/tools-ides/setting-up-visual-studio-code.md
@@ -14,7 +14,6 @@ redirect_from:
   - /learn/vscode-plugin
   - /learn/tools-ides/setting-up-visual-studio-code
   - /learn/tools-ides/setting-up-visual-studio-code/
-  - /learn/setting-up-visual-studio-code/
   - /learn/setting-up-visual-studio-code
 ---
 


### PR DESCRIPTION
## Purpose
Fix redirection issues in the setting up tooling pages
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
