### PR TITLE
Fix the Download Links of the ZIP Archive

### DIFF
--- a/_data/latest/metadata.json
+++ b/_data/latest/metadata.json
@@ -3,6 +3,8 @@
 	"release-date":"2020-05-15",
 	"windows-installer":"ballerina-windows-installer-x64-1.2.4.msi",
 	"windows-installer-size":"131mb",
+	"zip-installer":"ballerina-windows-installer-x64-1.2.4.zip",
+	"zip-installer-size":"105mb",
 	"linux-installer":"ballerina-linux-installer-x64-1.2.4.deb",
 	"linux-installer-size":"127mb",
 	"macos-installer":"ballerina-macos-installer-x64-1.2.4.pkg",

--- a/downloads.html
+++ b/downloads.html
@@ -74,14 +74,14 @@ redirect_from:
                 </ul>
             </div>
             <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 cDownloadMiddle">
-                <a id="packMac" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.macos-installer }}" class="cDownload" data-download="downloads" data-pack="{{ site.data.latest.metadata.macos-installer }}">
+                <a id="packMac" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.zip-installer }}" class="cDownload" data-download="downloads" data-pack="{{ site.data.latest.metadata.macos-installer }}">
                     <div>ZIP Archive</div>
                     <div class="cSize">Installer zip <span id="packMacName">{{ site.data.latest.metadata.macos-installer-size }}</span></div>
                 </a>
                 <ul class="cDiwnloadSubLinks">
-                    <li><a id="packMacMd5" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.macos-installer }}.md5">md5</a></li> 
-                    <li><a id="packMacSha1" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.macos-installer }}.sha1">SHA-1</a></li>
-                    <li><a id="packMacAsc" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.macos-installer }}.asc">asc</a></li>
+                    <li><a id="packMacMd5" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.zip-installer }}.md5">md5</a></li> 
+                    <li><a id="packMacSha1" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.zip-installer }}.sha1">SHA-1</a></li>
+                    <li><a id="packMacAsc" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.zip-installer }}.asc">asc</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Purpose
Fix the download links of the ZIP Archive.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
