### PR TITLE
Add Other Installation Options to the Downloads Page

### DIFF
--- a/1.1/learn/tools-ides/vscode-plugin/run-all-tests.md
+++ b/1.1/learn/tools-ides/vscode-plugin/run-all-tests.md
@@ -23,5 +23,5 @@ This option allows you to run all the tests that belong to multiple modules of y
 
 ## What's next?
 
-- For information on the Ballerina VSCode extension, see [The Visual Studio Code Ballerina Extension](/1.1/learn/vscode-plugin/vscode-plugin).
+- For information on the Ballerina VSCode extension, see [The Visual Studio Code Ballerina Extension](/1.1/learn/vscode-plugin/).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Learn](/1.1/learn/).

--- a/downloads.html
+++ b/downloads.html
@@ -17,9 +17,9 @@ redirect_from:
         <div class="row">
             <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cDownloadsHeader">
                 <h1>Downloads</h1>
-                <!--<p>
-                    After downloading a Ballerina distribution from below based on your system, follow the <a href="https://ballerina-platform.github.io/learn/installing-ballerina">installation instructions</a> or <a href="https://ballerina.io/learn/installing-ballerina/#installing-from-source">build instructions</a>.
-                </p>-->
+                <p>
+                    After downloading a Ballerina distribution from below based on your operating system, follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>. If you want to build Ballerina from source, see <a href="https://ballerina.io/learn/installing-ballerina/#building-from-source">Building from source</a>.
+                </p>
             </div>
         </div>
         <div class="row">
@@ -116,14 +116,14 @@ redirect_from:
                                 <tr><td style="width: 50%">Install using macOS Homebrew <a href="/learn/installing-ballerina/#installing-on-macos" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td></tr>
                             </table>
                         <!--</div>
-                    </div>-->
+                    </div>
                     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
 
                     <h2>What's Next?</h2>
                 <p>
                     After downloading a Ballerina distribution based on your operating system, follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>. If you want to build Ballerina from source, see <a href="https://ballerina.io/learn/installing-ballerina/#building-from-source">Building from source</a>.
                 </p>
-                    </div>
+                    </div>-->
                 </div>
             </div></div>
 

--- a/downloads.html
+++ b/downloads.html
@@ -58,7 +58,7 @@ redirect_from:
                     <div class="cSize">Package <span id="packLinuxName">{{ site.data.latest.metadata.linux-installer-size }}</span></div>
                 </a>
                 <ul class="cDiwnloadSubLinks">
-                    <li><a id="packLinuxMd5" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}	/{{ site.data.latest.metadata.linux-installer }}.md5">md5</a></li>
+                    <li><a id="packLinuxMd5" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }} /{{ site.data.latest.metadata.linux-installer }}.md5">md5</a></li>
                     <li><a id="packLinuxSha1" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.linux-installer }}.sha1">SHA-1</a></li>
                     <li><a id="packLinuxAsc" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.linux-installer }}.asc">asc</a></li>
                 </ul>
@@ -69,7 +69,7 @@ redirect_from:
                     <div class="cSize">Package <span id="packLinuxName">{{ site.data.latest.metadata.linux-installer-size }}</span></div>
                 </a>
                 <ul class="cDiwnloadSubLinks">
-                    <li><a id="packLinuxMd5" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}	/{{ site.data.latest.metadata.linux-installer }}.md5">md5</a></li>
+                    <li><a id="packLinuxMd5" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }} /{{ site.data.latest.metadata.linux-installer }}.md5">md5</a></li>
                     <li><a id="packLinuxSha1" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.linux-installer }}.sha1">SHA-1</a></li>
                     <li><a id="packLinuxAsc" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.linux-installer }}.asc">asc</a></li>
                 </ul>
@@ -98,21 +98,45 @@ redirect_from:
                 </ul>
             </div>
         </div>
-        <div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">
+        <!--<div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">-->
             <div class="cReleaseNotes">
                 <p><a href="/downloads/release-notes">RELEASE NOTES ></a></p>
             </div>
             <div class="cReleaseNotes">
                 <p><a href="/downloads/archived">ARCHIVED VERSIONS ></a></p>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
+            <div class="row">
+            <div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">
+                <div class="cInstallers">
+                    <h2>Other Installation Options</h2>
+                    <!--<div class="col-xs-12 col-sm-16 col-md-6 col-lg-6 cLeftTable">
+                        <div class="insPackages0container">-->
+                            <table id="insPackages0">
+                                <tr><td style="width: 50%">Install from source <a href="/learn/installing-ballerina/#building-from-source" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td></tr>
+                                <tr><td style="width: 50%">Install using macOS Homebrew <a href="/learn/installing-ballerina/#installing-on-macos" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td></tr>
+                            </table>
+                        <!--</div>
+                    </div>-->
+                    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
+
+                    <h2>What's Next?</h2>
+                <p>
+                    After downloading a Ballerina distribution based on your operating system, follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>. If you want to build Ballerina from source, see <a href="https://ballerina.io/learn/installing-ballerina/#building-from-source">Building from source</a>.
+                </p>
+                    </div>
+                </div>
+            </div></div>
+
+
+            <!--<div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
             <h2>What's Next?</h2>
                 <p>
                     After downloading a Ballerina distribution based on your operating system, follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>. If you want to build Ballerina from source, see <a href="https://ballerina.io/learn/installing-ballerina/#building-from-source">Building from source</a>.
                 </p>
             </div>
+
         </div>
-        <!--<div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">
+        <div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">
             <div class="cStandaloneInstallers">
 
                 <h2>What's Next?</h2>
@@ -186,5 +210,3 @@ a.cDownload.cLinuxPKGs {
         margin: 0 5px;
     }
 </style>
-
-   


### PR DESCRIPTION
## Purpose
Add other installation options to the Downloads page[1].

[1] http://ballerina.io/downloads/
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
