### PR TITLE
Improve the New Downloads Page Layout

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -14,14 +14,13 @@ redirect_from:
 <script src="/js/download-page.js"></script>
 <div class="row cBallerina-io-Gray-row">
     <div class="container">
-        <div class="row">
+        <!--<div class="row">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
                 <h1>Downloads</h1>
                 <p>
-                    After downloading a Ballerina distribution from below based on your operating system, follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>. If you want to build Ballerina from source, see <a href="https://ballerina.io/learn/installing-ballerina/#building-from-source">Building from source</a>.
-                </p>
+                    After downloading a Ballerina distribution from below based on your operating system, follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>.  
             </div>
-        </div>
+        </div>-->
         <div class="row">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
                 <div class="cFeaturedVersion">
@@ -37,7 +36,14 @@ redirect_from:
                     </div>
                 </div>
             </div>
-        </div>
+            <div class="row">
+                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
+            
+                    <p>
+                        If you are new to Ballerina, download a Ballerina distribution from below based on your operating system and follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>.  
+                </div>
+            </div>
+        </div></br>
         <div class="clearfix"></div>
         <div class="row cDownloads">
             <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cDownloadLeft">
@@ -107,6 +113,7 @@ redirect_from:
                 <p><a href="/downloads/archived">ARCHIVED VERSIONS ></a></p>
             </div>
             </div>
+        
             <div class="row">
             <div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">
                 <div class="cInstallers">


### PR DESCRIPTION
## Purpose
Improve the new Downloads page layout in [1].

[1] http://ballerina.io/downloads/
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
