### PR TITLE
Add the Missing Title in the Downloads Page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -14,19 +14,19 @@ redirect_from:
 <script src="/js/download-page.js"></script>
 <div class="row cBallerina-io-Gray-row">
     <div class="container">
-        <!--<div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">-->
+        <div class="row">
+            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
                 <h1>Downloads</h1>
                 <!--<p>
-                    After downloading a Ballerina distribution from below based on your operating system, follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>.  
-            </div>-->
-        </div>-->
+                    After downloading a Ballerina distribution from below based on your operating system, follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>.</p>-->
+            </div>
+        </div>
         <div class="row">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
                 <div class="cFeaturedVersion">
                     <h2>Current version: <span id="versionInfo">{{ site.data.latest.metadata.version }} ({{ site.data.latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2>
                     <div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff; margin-bottom: 40px;" >
-                        <details style="border-style: none;"> <summary style="border-style: none;">If you already have a jBallerina distribution installed, </strong></summary></br>you can use the Ballerina Update Tool to directly update them to jBallerina {{ site.data.latest.metadata.version }} by executing the commands below.
+                        <p>If you already have a jBallerina distribution installed, you can use the Ballerina Update Tool to directly update them to jBallerina {{ site.data.latest.metadata.version }} by executing the commands below.</p>
                         </br>
                         <ul>
                             <li><p>For jBallerina version 1.2.0: <pre>ballerina dist update</pre></p></li>
@@ -40,7 +40,7 @@ redirect_from:
                 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
             
                     <p>
-                    <strong>If you are new to Ballerina,</strong> download a Ballerina distribution from below based on your operating system and follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>.  
+                    If you are new to Ballerina, download a Ballerina distribution from below based on your operating system and follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>.  
                 </div>
             </div>
         </div></br>

--- a/downloads.html
+++ b/downloads.html
@@ -15,24 +15,24 @@ redirect_from:
 <div class="row cBallerina-io-Gray-row">
     <div class="container">
         <!--<div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
+            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">-->
                 <h1>Downloads</h1>
-                <p>
+                <!--<p>
                     After downloading a Ballerina distribution from below based on your operating system, follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>.  
-            </div>
+            </div>-->
         </div>-->
         <div class="row">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
                 <div class="cFeaturedVersion">
                     <h2>Current version: <span id="versionInfo">{{ site.data.latest.metadata.version }} ({{ site.data.latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2>
                     <div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff; margin-bottom: 40px;" >
-                        <p>If you already have the jBallerina distributions below installed, you can use the Ballerina Update Tool to directly update them to jBallerina {{ site.data.latest.metadata.version }} by executing the commands below.</p>
-                        <br>
+                        <details style="border-style: none;"> <summary style="border-style: none;">If you already have a jBallerina distribution installed, </strong></summary></br>you can use the Ballerina Update Tool to directly update them to jBallerina {{ site.data.latest.metadata.version }} by executing the commands below.
+                        </br>
                         <ul>
                             <li><p>For jBallerina version 1.2.0: <pre>ballerina dist update</pre></p></li>
                                 <li><p>For jBallerina version 1.1.0 - 1.2.0: <pre>ballerina dist pull jballerina-{{ site.data.latest.metadata.version }}</pre></p>
                     </li></ul>
-                        <p>For further details, see the <a href="https://ballerina.io/downloads/release-notes/">Release Note</a>.</p>
+                        <p>For further details, see the <a href="https://ballerina.io/downloads/release-notes/">Release Note</a>.</p></details>
                     </div>
                 </div>
             </div>
@@ -40,7 +40,7 @@ redirect_from:
                 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
             
                     <p>
-                        If you are new to Ballerina, download a Ballerina distribution from below based on your operating system and follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>.  
+                    <strong>If you are new to Ballerina,</strong> download a Ballerina distribution from below based on your operating system and follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>.  
                 </div>
             </div>
         </div></br>


### PR DESCRIPTION
## Purpose
Add the missing title in the Downloads Page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
