### PR TITLE
Add the ZIP Archive Under Other Installation Options

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -92,7 +92,7 @@ redirect_from:
                     <li><a id="packMacAsc" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.macos-installer }}.asc">asc</a></li>
                 </ul>
             </div>
-            <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cDownloadMiddle">
+            <!--<div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cDownloadMiddle">
                 <a id="packMac" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.zip-installer }}" class="cDownload" data-download="downloads" data-pack="{{ site.data.latest.metadata.macos-installer }}">
                     <div>ZIP Archive</div>
                     <div class="cSize">Installer zip <span id="packMacName">{{ site.data.latest.metadata.zip-installer-size }}</span></div>
@@ -102,7 +102,7 @@ redirect_from:
                     <li><a id="packMacSha1" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.zip-installer }}.sha1">SHA-1</a></li>
                     <li><a id="packMacAsc" href="{{ site.dist_server }}/downloads/{{ site.data.latest.metadata.version }}/{{ site.data.latest.metadata.zip-installer }}.asc">asc</a></li>
                 </ul>
-            </div>
+            </div>-->
         </div>
         <!--<div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">-->
             <div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">
@@ -123,6 +123,7 @@ redirect_from:
                             <table id="insPackages0">
                                 <tr><td style="width: 50%">Install from source <a href="/learn/installing-ballerina/#building-from-source" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td></tr>
                                 <tr><td style="width: 50%">Install in macOS using Homebrew <a href="/learn/installing-ballerina/#installing-on-macos" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td></tr>
+                                <tr><td style="width: 50%">Install via the ZIP archive <a href="/learn/installing-ballerina/#installing-via-the-ballerina-language-zip-file" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td></tr>
                             </table>
                         <!--</div>
                     </div>


### PR DESCRIPTION
## Purpose
Add the ZIP archive under the other installation options.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
