### PR TITLE
Open Links in the Spec Page in New Tabs

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -38,12 +38,14 @@ The below are the most stable versions of the lanuguage specification, which are
 
 ### Working drafts 
 
-- For working draft language specifications of a Ballerina release, see the [draft language specification](https://ballerina.io/spec/lang/draft/).
-- For the latest working draft language specification of a Ballerina release, see the [latest draft language specification](https://ballerina.io/spec/lang/draft/latest/).
+- For working draft language specifications of a Ballerina release, see the <a target="_blank" href="https://ballerina.io/spec/lang/draft/">draft language specification</a>.
+- For the latest working draft language specification of a Ballerina release, see the <a target="_blank" href="https://ballerina.io/spec/lang/draft/latest/">latest draft language specification</a>.
+
 
 ### GitHub master 
 
-For a current repo snapshot of the language specification including all changes, see the [master language specification](https://ballerina.io/spec/lang/master/). 
+For a current repo snapshot of the language specification including all changes, see the<a target="_blank" href="https://ballerina.io/spec/lang/master/">master language specification</a>.
+
 
 ## Proposals for improvements/enhancements
 


### PR DESCRIPTION
## Purpose
Open Links in the Spec page[1] in new tabs.

[1] https://ballerina.io/spec/
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
