### PR TITLE
Fix a Typo in the Spec Page

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -44,7 +44,7 @@ The below are the most stable versions of the lanuguage specification, which are
 
 ### GitHub master 
 
-For a current repo snapshot of the language specification including all changes, see the<a target="_blank" href="https://ballerina.io/spec/lang/master/">master language specification</a>.
+For a current repo snapshot of the language specification including all changes, see the <a target="_blank" href="https://ballerina.io/spec/lang/master/">master language specification</a>.
 
 
 ## Proposals for improvements/enhancements


### PR DESCRIPTION
## Purpose
Fix a typo in the Spec page[1].

[1] https://ballerina.io/spec/

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
