### PR TITLE
Change the Front Matter Layout for the Swan Lake Release

### DIFF
--- a/swan-lake/learn/ballerina-streaming-reference.md
+++ b/swan-lake/learn/ballerina-streaming-reference.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Ballerina Streaming Reference Guide
 permalink: /swan-lake/learn/ballerina-streaming-reference/
 active: ballerina-streaming-reference

--- a/swan-lake/learn/calling-java-code-from-ballerina.md
+++ b/swan-lake/learn/calling-java-code-from-ballerina.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Calling Java Code from Ballerina
 description: See how Ballerina offers a straightforward way to call existing Java code from Ballerina and a Java API to call Ballerina code from Java.
 keywords: ballerina, programming language, java api, interoperability

--- a/swan-lake/learn/coding-conventions.md
+++ b/swan-lake/learn/coding-conventions.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Coding Conventions
 description: The Ballerina Style Guide aims at maintaining a standard coding style among the Ballerina community. The Ballerina code formatting tools are based on this guide.
 keywords: ballerina, programming language, ballerina style guide

--- a/swan-lake/learn/coding-conventions/annotations_documentation_and_comments.md
+++ b/swan-lake/learn/coding-conventions/annotations_documentation_and_comments.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Annotations, Documentation and Comments
 permalink: /swan-lake/learn/coding-conventions/annotations_documentation_and_comments/
 active: annotations_documentation_and_comments

--- a/swan-lake/learn/coding-conventions/expressions.md
+++ b/swan-lake/learn/coding-conventions/expressions.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Expressions
 active: expressions
 permalink: /swan-lake/learn/coding-conventions/expressions/

--- a/swan-lake/learn/coding-conventions/operators_keywords_and_types.md
+++ b/swan-lake/learn/coding-conventions/operators_keywords_and_types.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Operators, keywords, and types
 active: operators_keywords_and_types
 permalink: /swan-lake/learn/coding-conventions/operators_keywords_and_types/

--- a/swan-lake/learn/coding-conventions/statements.md
+++ b/swan-lake/learn/coding-conventions/statements.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Statements
 active: statements
 permalink: /swan-lake/learn/coding-conventions/statements/

--- a/swan-lake/learn/coding-conventions/top-level-definitions.md
+++ b/swan-lake/learn/coding-conventions/top-level-definitions.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Top Level definitions
 active: definitions
 permalink: /swan-lake/learn/coding-conventions/top-level-definitions/

--- a/swan-lake/learn/deploying-ballerina-programs-in-the-cloud.md
+++ b/swan-lake/learn/deploying-ballerina-programs-in-the-cloud.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Deploying Ballerina Programs in the Cloud
 description: See how the Ballerina compiler generates the necessary artifacts to deploy to cloud platforms like Kubernetes, Docker, Moby or Cloud Foundry.
 keywords: ballerina, programming language, services, cloud

--- a/swan-lake/learn/documenting-ballerina-code.md
+++ b/swan-lake/learn/documenting-ballerina-code.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Documenting Ballerina Code
 description: Learn how to write unstructured documents with a bit of structure to enable HTML content generation as API documentation.
 keywords: ballerina, programming language, api documentation, api docs

--- a/swan-lake/learn/extending-with-compiler-extensions.md
+++ b/swan-lake/learn/extending-with-compiler-extensions.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Extending with Compiler Extensions
 description: Learn how to extend Ballerina using annotations, which can be used to provide structured metadata about a particular construct.
 keywords: ballerina, programming language, annotations, metadata, extend ballerina

--- a/swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
+++ b/swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Generating Ballerina Code for Protocol Buffer Definitions
 description: The Protocol Buffers to Ballerina tool provides capabilities to generate Ballerina source code for the Protocol Buffer definition.
 keywords: ballerina, protocol buffers, programming language

--- a/swan-lake/learn/keeping-ballerina-up-to-date.md
+++ b/swan-lake/learn/keeping-ballerina-up-to-date.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Keeping Ballerina Up to Date
 description: Learn how to maintain your Ballerina programming language installation and keep it up to date with the latest patch and minor releases.
 keywords: ballerina, programming language, release, update

--- a/swan-lake/learn/observing-ballerina-code.md
+++ b/swan-lake/learn/observing-ballerina-code.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Observing Ballerina Code
 description: See how Ballerina supports observability by exposing itself via metrics, tracing and logs to external systems.
 keywords: ballerina, observability, metrics, tracing, logs

--- a/swan-lake/learn/publishing-modules-to-ballerina-central.md
+++ b/swan-lake/learn/publishing-modules-to-ballerina-central.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Publishing Modules to Ballerina Central
 description: Learn how to use the CLI tool in the Ballerina programming language to push modules to Ballerina Central.
 keywords: ballerina, programming language, ballerina central, ballerina modules

--- a/swan-lake/learn/quick-tour.md
+++ b/swan-lake/learn/quick-tour.md
@@ -1,6 +1,6 @@
 ---
-layout: ballerina-inner-page
-title: Ballerina Quick Tour
+layout: ballerina-left-nav-pages-swanlake
+title: Quick Tour
 description: A quick tour of the Ballerina programming language, including writing, running and invoking an HTTP service and using a client to interact with a service.
 keywords: ballerina, quick tour, programming language, http service
 permalink: /swan-lake/learn/quick-tour/

--- a/swan-lake/learn/running-ballerina-code.md
+++ b/swan-lake/learn/running-ballerina-code.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Running Ballerina Code
 description: Learn how to run Ballerina programs and services using the CLI tool.
 keywords: ballerina, programming language, services

--- a/swan-lake/learn/set-up-ballerina-sdk.md
+++ b/swan-lake/learn/set-up-ballerina-sdk.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Setting up Ballerina SDK
 permalink: /swan-lake/learn/set-up-ballerina-sdk/
 active: set-up-ballerina-sdk

--- a/swan-lake/learn/structuring-ballerina-code.md
+++ b/swan-lake/learn/structuring-ballerina-code.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Structuring Ballerina Code
 description: Learn how to develop a Ballerina project, structure code, and use the Ballerina Tool to fetch, build, and install Ballerina modules.
 keywords: ballerina, programming language, ballerina modules, structure code

--- a/swan-lake/learn/testing-ballerina-code.md
+++ b/swan-lake/learn/testing-ballerina-code.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Testing Ballerina Code
 description: Learn how to use Ballerina's built-in test framework to write testable code. The test framework provides a set of building blocks to help write and run tests.
 keywords: ballerina, programming language, testing

--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Setting up IntelliJ IDEA
 permalink: /swan-lake/learn/setting-up-intellij-idea/
 active: setting-up-intellij-idea

--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Using the features of the IntelliJ plugin
 permalink: /swan-lake/setting-up-intellij-idea/using-intellij-plugin-features/
 active: using-intellij-plugin-features

--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Using the IntelliJ Ballerina Plugin
 permalink: /swan-lake/learn/setting-up-intellij-idea/using-the-intellij-plugin/
 active: using-the-intellij-plugin

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Setting up Visual Studio Code
 permalink: /swan-lake/learn/setting-up-visual-studio-code/
 active: setting-up-visual-studio-code

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Documentation Viewer
 permalink: /swan-lake/learn/setting-up-visual-studio-code/documentation-viewer/
 active: documentation-viewer

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Graphical View
 permalink: /swan-lake/learn/setting-up-visual-studio-code/graphical-editor/
 active: graphical-editor

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Language Intelligence
 permalink: /swan-lake/learn/setting-up-visual-studio-code/language-intelligence/
 active: language-intelligence

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Run all Tests
 permalink: /swan-lake/learn/setting-up-visual-studio-code/run-all-tests/
 active: run-all-tests

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Run and Debug
 permalink: /swan-lake/learn/setting-up-visual-studio-code/run-and-debug/
 active: run-and-debug

--- a/swan-lake/learn/using-the-cli-tools.md
+++ b/swan-lake/learn/using-the-cli-tools.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Using the CLI Tools
 description: Learn all the command line interface (CLI) commands need to get started, build, test and run programs, work with Ballerina Central, and manage projects.
 keywords: ballerina, cli, command line interface, programming language

--- a/swan-lake/learn/using-the-openapi-tools.md
+++ b/swan-lake/learn/using-the-openapi-tools.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Using the OpenAPI Tools
 description: Check out how the Ballerina OpenAPI tooling makes it easy for users to start developing a service documented in the OpenAPI contract.
 keywords: ballerina, programming language, openapi, open api, restful api

--- a/swan-lake/learn/writing-secure-ballerina-code.md
+++ b/swan-lake/learn/writing-secure-ballerina-code.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Writing Secure Ballerina Code
 description: Check out the different security features and controls available within the Ballerina programming language and follow the guidelines on writing secure Ballerina programs.
 keywords: ballerina, programming language, security, secure ballerina code


### PR DESCRIPTION
## Purpose
Change the front matter layout for the Swan Lake release.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
