### PR TITLE
Remove Bullets in the BBE Home Page

### DIFF
--- a/css/bbe-page.css
+++ b/css/bbe-page.css
@@ -62,9 +62,10 @@
 
 .rst-content .section ol li, .rst-content ol.arabic li, .wy-plain-list-decimal li, article ol li, .rst-content .section ul li, .rst-content .toctree-wrapper ul li, .wy-plain-list-disc li, article ul li {
     font-size: 14px;
+    list-style: none;
 }
 
 .cBBEtop img {
     width: 200px;
-    list-style: none;
+    
 }

--- a/css/bbe-page.css
+++ b/css/bbe-page.css
@@ -66,4 +66,5 @@
 
 .cBBEtop img {
     width: 200px;
+    list-style: none;
 }


### PR DESCRIPTION
## Purpose
Remove bullets in the BBE home page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
