### PR TITLE
Fix the Capitalization in Topics of the Swan Lake Release Note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-preview1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview1/RELEASE_NOTE.md
@@ -13,7 +13,7 @@ This release is the first preview version of Ballerina Swan Lake. This release i
 - Improvements on Standard Library modules 
 - Improved mocking support in testing
 
-# What's New in Ballerina Swan Lake - Preview 1
+# What's new in Ballerina Swan Lake - Preview 1
 
 ## Language
 
@@ -28,11 +28,11 @@ Some of these new language features are revamped versions of the existing langua
  
 In addition to the new Language features, this release introduces a new parser implementation aiming to improve the performance and usability of the compiler. Now, the compiler has more control over syntax errors and it can provide a better diagnostic for syntax errors. Additionally, the new parser has tightened up the language parser rules with respect to the Ballerina specification. However, still it doesn’t cover the full set of the language features. This will be fixed in the upcoming preview versions.  
 
-### Introduction of `distinct` Types
+### Introduction of `distinct` types
 
 Ballerina `distinct` types provide functionalities similar to those provided by the nominal types but they work within the Ballerina's structural type system. With`distinct` types, it is possible to define unique types that are structurally similar. 
 
-##### The `distinct` Error Type
+##### The `distinct` error type
 
 The `error` types can be defined as `distinct` types so that Ballerina programmers can have more fine-grained control over error handling.
 
@@ -71,7 +71,7 @@ Type-guards can be used to identify values of each distinct error at runtime.
 
 With the introduction of the `distinct` error type, the error reason is removed from the error type. For more information, see [error type changes](#the-error-type-changes).
 
-### The `error` Type Changes
+### The `error` type changes
 Previous error type was `error<reasonType, detailType>` in which the `reasonType` is a subtype of string and `detailType` is a subtype of `record {| string message?; error cause; (anydata|error)... |}`. With the error type change, the reason type parameter is removed and the detail type parameter is a subtype of `map<anydata|readonly>`.
 
 ```ballerina
@@ -86,7 +86,7 @@ type Error1 error<map<string>>;
 type Error2 error<record {| int code; |}>;
 ```
 
-#### Revised Error Constructor
+#### Revised error constructor
 
 Error-values of user-defined types are created using the error constructor of that type. The first mandatory positional augment of the error constructor is the error message and it must be a subtype of string. The second optional positional argument can be provided to pass an `error` cause. Error details are provided as named arguments in the error constructor.
 
@@ -96,7 +96,7 @@ type AppError error<record {| string buildNo; string userId; |};
 AppError appError = AppError("Failed to delete order line", buildNo=getBuildNo(), userId=userId);
 ```
 
-#### Error Type Infer 
+#### Error type infer 
 
 A type of `error<*>` means that the type is a subtype of error in which the precise subtype is to be inferred from the context.
 
@@ -113,11 +113,11 @@ TrxError e = TrxError("IAmAInferedErr");
 error<*> err = e;
 ```
 
-### Introduction of the `readonly` Type and Improved support for Immutability
+### Introduction of the `readonly` type and improved support for immutability
 
 This release introduces improved support for immutability. With the introduction of the `readonly` type, values that are known to be immutable can now be defined at compile-time. 
 
-#### The `readonly` Type
+#### The `readonly` type
 
 A value belongs to the `readonly` type if its read-only flag is set. A value belonging to one of the following inherently-immutable basic types will always have it’s read-only bit set and will always belong to the `readonly` type.
 
@@ -169,7 +169,7 @@ public function main() {
 
 Attempting to create an immutable value with incompatible mutable values as members will result in compilation errors.Read-only intersections for objects are only allowed with abstract objects. In order to represent a non-abstract object type as a read-only type, the object would have to be defined as a `readonly object`. For more information, see [Read-only objects](#read-only-objects).
 
-#### Read-only Fields
+#### Read-only fields
 A record or an object can now have `readonly` fields. A `readonly` field cannot be updated once the record or the object value is created and the value provided for the particular field should be an immutable value. If the field is of type `T`, the contextually-expected type for a value provided for a field would be `T & readonly`.
 
 Thus, a `readonly` field guarantees that the field will not change and also that the value set for the field itself will not be updated.
@@ -235,7 +235,7 @@ public function main() {
 }
 ```
 
-#### Read-only Objects
+#### Read-only objects
 An object type can also be defined as a `readonly object` type and any value belonging to this type will be immutable. Similar to `readonly` fields, each value provided for a field of a `readonly object` is expected to be immutable and the field itself cannot be updated once set.
 
 ```ballerina
@@ -264,7 +264,7 @@ public function main() {
 }
 ```
 
-### The `never` Type
+### The `never` type
 
 The `never` type provides a way to describe the type that contains no shapes. 
 
@@ -298,11 +298,11 @@ For `xml`, the `never` type can be used to describe the `xml` type that has no c
 xml<never> xmlValue = <xml<never>> 'xml:concat();
 ```
 
-### Object and Module Init Changes
+### Object and module init changes
 
 Module level variables can be initialized inside the module init function. Now, this is the same as initializing the fields inside an object.
 
-### Type Inclusion
+### Type inclusion
 
 Object type inclusion can now include non-abstract objects. Type reference expressions can also override fields and function declarations of the same name. Including type overrides fields of the included type provided that overriding field type is a subtype of the overridden field.
 
@@ -390,7 +390,7 @@ public enum Direction {
 
 The expression following `=` must be a constant expression with a static type that is a subtype of string.
 
-### Raw Templates
+### Raw templates
 Similar to string template literals, a raw template literal allows interpolating expressions into a string literal. However, for a raw template, the resulting value is an object whose type is a subtype of `lang.object:RawTemplate`.
 
 ```ballerina
@@ -407,7 +407,7 @@ public function main() {
 
 ```
 
-### Dependently-typed Function Signatures
+### Dependently-typed function signatures
 A function's return type descriptor can now refer to a name of a parameter of the function if the type of the parameter is a subtype of `typedesc`. The actual return type of such a function then depends on the value the user specifies for the referenced `typedesc` parameter when calling the function.
 
 Note that currently this is only supported for external functions.
@@ -427,7 +427,7 @@ public function main() {
 }
 ```
 
-### Backward-incompatible Improvements and Bug Fixes
+### Backward-incompatible improvements and bug fixes
 
 Parameter defaults are not added if a rest argument is provided when calling a function.
 
@@ -515,7 +515,7 @@ public function main() {
 }
 ```
 
-### Query Improvements 
+### Query improvements 
 
 Ballerina query action/expression provides a language-integrated query feature using SQL-like syntax. A Ballerina query is a comprehension, which can be used with a value that is iterable with any error type. A query consists of a sequence of clauses (i.e., `from`, `join`, `let`, `on`, `where`, `select`, `do`, and `limit`). The first clause must be a `from` clause and must consist of either a `select` or a `do` clause as well. When a query is evaluated, its clauses are executed in a pipeline by making the sequence of frames emitted by one clause being the input to the next clause. Each clause in the pipeline is executed lazily pulling input from its preceding clause. The result of such a query can either be a list, stream, table, string, XML, or termination value of the iterator which is ().
 
@@ -565,7 +565,7 @@ public function main() {
 
 ## Standard Library
 
-### Introduced New SQL Module
+### Introduced new SQL module
 
 The newly-introduced `sql` module provides a common interface and functionality to interact with a database. The corresponding database clients can be created by using specific database modules such as MySQL or using the Java Database Connectivity module JDBC. 
 
@@ -590,7 +590,7 @@ public function main() returns sql:Error? {
 }
 ```
 
-### Enhanced Log API Module
+### Enhanced log API module
 
 Revamped log API to support `anydata` and improved performance.
 
@@ -622,7 +622,7 @@ public type Fruit object {
 };
 ```
 
-### Enhanced gRPC Module
+### Enhanced gRPC module
 
 The client/bidirectional streaming service implementation is revamped to support multiple service resources.
 
@@ -651,7 +651,7 @@ service HelloWorld on new grpc:Listener(9090) {
 
 ```
 
-### Enhanced Auth Module
+### Enhanced Auth module
 
 The capability to validate the JWT signature with JWKs is extended now. With that, the JWT signature can be validated either from the TrustStore configuration or JWKs configuration.
 
@@ -671,7 +671,7 @@ jwt:JwtValidatorConfig validatorConfig = {
 };
 ```
 
-### Enhanced Email Module
+### Enhanced Email module
 
 The Email Connector clients are given the capability to add custom SMTP properties, custom POP properties, and custom IMAP properties via the configuration of each of the clients.
 
@@ -710,14 +710,14 @@ service emailObserver on emailListener {
 ```
 
 
-### Adding the Socket Module to Ballerina Central
+### Adding the Socket module to Ballerina Central
 
 Previously, the Socket module was available only in the Ballerina distribution. From this release onwards, it is available in both the
  released Ballerina distribution and Ballerina Central. This will allow us to release the module independently.
 
-## Build Tools
+## Build tools
 
-### Native Dependency Manager
+### Native dependency manager
 
 This brings the Maven dependency resolving support. Now, you can specify Maven dependencies by specifying the Group ID, Artifact ID, and version as below. 
 
@@ -732,7 +732,7 @@ version = "0.7.2"
 The Maven resolver will fetch those dependencies from the Maven Central.
 
 
-### Scoping Support
+### Scoping support
 
 Added an additional attribute called “scope” for platform libraries. Based on the scope, dependencies will be included to different phases. The values of this will be as follows
 
@@ -752,7 +752,7 @@ path = "path/to/sap_client_1.2.3.jar"
 scope = "provided" 
 ```
 
-### The Bindgen Tool
+### The Bindgen tool
 
 - Java Subtyping support is added to the generated bindings.
 - Maven dependency resolving is integrated into the tool and a new `-mvn|--maven` command option is introduced to facilitate this.
@@ -773,9 +773,9 @@ ballerina bindgen [(-cp|--classpath) <classpath>...]
                   (<class-name>...)
 ```
 
-### Test Framework
+### Test framework
 
-#### Introduction of the Mocking API in the Test Module
+#### Introduction of the Mocking API in the Test module
 
 The new mocking API simplifies function and object mocking in unit tests via the ***when-then*** convention. 
 
@@ -784,7 +784,7 @@ The mocking features can be used to control the behavior of functions and object
 from other modules and external endpoints. For the complete list of available mocking features, see 
 [API Documentation of the test module](https://ballerina.io/learn/api-docs/ballerina/test/index.html).
 
-#### Function Mocking
+#### Function mocking
 
 The `MockFunction` object is added to handle function mocking. The `MockFunction` objects are defined by attaching the `@test:MockFn` annotation to the `MockFunction` to specify the function to mock.
 
@@ -799,14 +799,14 @@ Function mocking is done by using the following functions:
 - The `test:when(mockObj)` is used to initialize the mocking capability within a particular test case
 - This allows you to use the associated mocking functions like `call()`, `thenReturn()` and `withArguments()`
 
-#### Object Mocking
+#### Object mocking
 
 Object mocking enables controlling the values of member variables and the behavior of the member functions of an object
 
 - Introduced the ability to create a `test double`, which provides an equivalent mock in place of the real object
 - Introduced the capability of stubbing the member function or member variable
 
-### API Documentation
+### API documentation
 
 - The search capability is added into the API Documentation
 - A feature is added to combine documentation from multiple projects


### PR DESCRIPTION
## Purpose
Fix the capitalization in the topics of the Swan Lake release note.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
