### PR TITLE
Fix the Update Tool info on the Downloads Page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -160,11 +160,11 @@ redirect_from:
                 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
                     <div class="cFeaturedVersion">
                         <h2>Preview release: Swan Lake (preview version) </span></h2>
-                        <p>If you already have jBallerina version 1.2.0 or above installed, you need to update the update tool to latest in order to get the swan lake channel. This can be done by executing following command.</p>
+                        <p>If you already have jBallerina version 1.2.0 or above installed, you can use the Ballerina Update Tool to update it to the Swan Lake channel. To do this, first, execute the command below to get the Update Toole updated to its latest version. </p>
                         <pre>ballerina update</pre>
-                        <p>Then you can get swan lake preview 1 by executing following command</p>
+                        <p>Next, execute the command below to update to Swan Lake Preview 1.</p>
                         <pre>ballerina dist pull slp1</pre>
-                        <p>For further details, see the <a href="https://ballerina.io/downloads/release-notes/">Release Note</a>. </p>
+                        <p>For further details, see the <a href="https://ballerina.io/downloads/release-notes/">Release Note</a>. </p><br></div>
                     </div>
                 </div>
             

--- a/downloads.html
+++ b/downloads.html
@@ -25,11 +25,14 @@ redirect_from:
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
                 <div class="cFeaturedVersion">
                     <h2>Current version: <span id="versionInfo">{{ site.data.stable-latest.metadata.version }} ({{ site.data.stable-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2>
+                    <div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;" >
+                    
                     <p>
-                        If you already have jBallerina version 1.2.0 or above installed, you can use the Ballerina Update Tool to directly update to jBallerina 1.2.4 by executing the command below. 
-                        For further details, see the <a href="https://ballerina.io/downloads/release-notes/">Release Note</a>.<pre>ballerina dist update</pre> </p>
+                        If you already have jBallerina version 1.2.0 or above installed, you can use the <a href="/learn/keeping-ballerina-up-to-date/">Ballerina Update Tool</a> to directly update to jBallerina 1.2.4 by executing the command below. </p>
+                        <pre>ballerina dist update</pre> 
+                        <p>For further details, see the <a href="/downloads/release-notes/">Release Note</a>.</p>
                 </div>
-            </div>
+            </div></div>
             <div class="row">
                 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
             
@@ -160,13 +163,14 @@ redirect_from:
                 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
                     <div class="cFeaturedVersion">
                         <h2>Preview release: Swan Lake (preview version) </span></h2>
-                        <p>If you already have jBallerina version 1.2.0 or above installed, you can use the Ballerina Update Tool to update it to the Swan Lake channel. To do this, first, execute the command below to get the Update Toole updated to its latest version. </p>
+                        <div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;" >
+                        <p>If you already have jBallerina installed, you can use the <a href="/swan-lake/learn/keeping-ballerina-up-to-date/">Ballerina Update Tool</a> to update it to the Swan Lake channel. To do this, first, execute the command below to get the Update Toole updated to its latest version. </p>
                         <pre>ballerina update</pre>
                         <p>Next, execute the command below to update to Swan Lake Preview 1.</p>
                         <pre>ballerina dist pull slp1</pre>
-                        <p>For further details, see the <a href="https://ballerina.io/downloads/release-notes/">Release Note</a>. </p><br></div>
+                        <p>For further details, see the <a href="/downloads/swan-lake-release-notes">Release Note</a>. </p><br></div>
                     </div>
-                </div>
+                </div></div>
             
                     <!--<div class="cStandaloneInstallers">
                         <h2>Preview release: Swan Lake (preview version)</h2>-->

--- a/downloads/swan-lake-release-notes/swan-lake-preview1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview1/RELEASE_NOTE.md
@@ -4,6 +4,24 @@ title: Swan Lake Preview 1 Release note
 ---
 # Overview of Ballerina Swan Lake - Preview 1
 This release is the first preview version of Ballerina Swan Lake. This release includes a new set of Language features and significant improvements to the compiler, runtime, standard libraries, and developer tooling.
+
+You can use the update tool to update to jBallerina 1.2.4 as follows.
+
+**For existing users:**
+
+If you are already using jBallerina, you can directly update your distribution to the Swan Lake channel using the [Ballerina Update Tool](swan-lake/learn/keeping-ballerina-up-to-date/). To do this, first, execute the command below to get the Update Tool updated to its latest version. 
+                        
+> `ballerina update`
+                        
+ Next, execute the command below to update to Swan Lake Preview 1.
+
+ > `ballerina dist pull slp1`                  
+
+However, if you are using a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/).
+
+**For new users:**
+
+If you have not installed jBallerina, then download the [installers](https://ballerina.io/downloads/) to install.
  
 # Highlights
 


### PR DESCRIPTION
## Purpose
Fix the Update Tool info on the downloads page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
