### PR TITLE
Resolve a Conflict in the Downloads Page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -168,14 +168,10 @@ redirect_from:
                         <pre>ballerina update</pre>
                         <p>Next, execute the command below to update to Swan Lake Preview 1.</p>
                         <pre>ballerina dist pull slp1</pre>
-<<<<<<< HEAD
-                        <p>For further details, see the <a href="/downloads/swan-lake-release-notes">Release Note</a>. </p><br></div>
-=======
                        
-                        <p>For further details, see the <a href="https://ballerina.io/downloads/release-notes/">Release Note</a>. </p>
+                        <p>For further details, see the <a href="/downloads/swan-lake-release-notes">Release Note</a>. </p>
                         <br>
 
->>>>>>> 58b130e0dc37786c6bba854d1c4a4217f23a7f72
                     </div>
                 </div></div>
             


### PR DESCRIPTION
## Purpose
Resolve a conflict in the Downloads page.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
