### PR TITLE
Fix the Line Break in the Downloads Page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -170,9 +170,10 @@ redirect_from:
                         <pre>ballerina dist pull slp1</pre>
                        
                         <p>For further details, see the <a href="/downloads/swan-lake-release-notes">Release Note</a>. </p>
-                        <br>
+                        
 
                     </div>
+                    <br>
                 </div></div>
             
                     <!--<div class="cStandaloneInstallers">


### PR DESCRIPTION
## Purpose
Fix the line break in the Downloads page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
