### PR TITLE
Remove the What's Next Section in the Downloads Page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -148,20 +148,26 @@ redirect_from:
                         After downloading a Ballerina distribution based on your operating system, follow the <a href="https://ballerina.io/learn/installing-ballerina">installation instructions</a>. If you want to build Ballerina from source, see <a href="https://ballerina.io/learn/installing-ballerina/#building-from-source">Building from source</a>.
                     </p>
                         </div> -->
-                    </div>
-                </div></div>
+                    
 
-                <div class="row">
+                <!--<div class="row">
                     <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
                         <div class="cFeaturedVersion">
-                        <p style="margin-top: 30px;">For downloading the VSCode and IntelliJ Ballerina extensions, see <a href="/learn/setting-up-visual-studio-code/">Setting up Visual Studio Code</a> and <a href="/learn/setting-up-intellij-idea/">Setting up IntelliJ IDEA</a>.</p>
-                 </div></div></div>   
-                
-                
-
+    
+                 </div></div></div>-->  
+                </div>
+            </div></div> 
+            
             <div class="row">
                 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
                     <div class="cFeaturedVersion">
+                        <div class="row">
+                <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
+                            
+                        <p style="margin-top: 30px;"></p><p>For downloading the VSCode and IntelliJ Ballerina extensions, see <a href="/learn/setting-up-visual-studio-code/">Setting up Visual Studio Code</a> and <a href="/learn/setting-up-intellij-idea/">Setting up IntelliJ IDEA</a>
+                             and for installation instructions, see <a href="/learn/installing-ballerina/">Installing Ballerina</a>.
+                        </p></p>
+                    
                         <h2>Preview release: Swan Lake (preview version) </span></h2>
                         <div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;" >
                         <p>If you already have jBallerina installed, you can use the <a href="/swan-lake/learn/keeping-ballerina-up-to-date/">Ballerina Update Tool</a> to update it to the Swan Lake channel. To do this, first, execute the command below to get the Update Toole updated to its latest version. </p>
@@ -174,7 +180,7 @@ redirect_from:
 
                     </div>
                     <br>
-                </div></div>
+                </div></div></div>
             
                     <!--<div class="cStandaloneInstallers">
                         <h2>Preview release: Swan Lake (preview version)</h2>-->
@@ -220,7 +226,7 @@ redirect_from:
             <div class="row">
                 <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
                     <div class="cFeaturedVersion">
-                    <p style="margin-top: 30px;">For setting up the VSCode Ballerina extension, see <a href="/swan-lake/learn/setting-up-visual-studio-code/">Setting up Visual Studio Code</a>.</p>
+                    <!--<p style="margin-top: 30px;">For setting up the VSCode Ballerina extension, see <a href="/swan-lake/learn/setting-up-visual-studio-code/">Setting up Visual Studio Code</a>.</p>-->
              </div></div></div>  
 
             <div class="row">
@@ -236,30 +242,25 @@ redirect_from:
                                     <tr><td style="width: 50%">Install via the ZIP archive <a href="/swan-lake/learn/installing-ballerina/#installing-via-the-ballerina-language-zip-file" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td></tr>
                                     <tr><td style="width: 50%">Install from source <a href="/swan-lake/learn/installing-ballerina/#building-from-source" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td></tr>   
                                 </table>
+                                <p style="margin-top: 30px;">For setting up the VSCode Ballerina extension, see <a href="/swan-lake/learn/setting-up-visual-studio-code/">Setting up Visual Studio Code</a>.
+                                    and for installation instructions, see <a href="/swan-lake/learn/installing-ballerina/">Installing Ballerina</a>.</p></p>
                             </div></div></div>
-
-
-
 
                     <div class="row">
                         <div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">
-                            <div class="cInstallers">
-
-                              
-
-                               
+                            <div class="cInstallers">                             
                 
                 <div class=" cDownloadsHeader">
                 <div class="cInstallers">
+                    <div class="row">
+                        <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
 
-                   
-
-                    <h2>What's Next?</h2>
+                    <!--<h2>What's Next?</h2>-->
                     
-                    <p style="margin-bottom: 100px;">For installation instructions, see <a href="/swan-lake/learn/installing-ballerina/">Installing Ballerina</a>.</p>
+                   
                     
                     </div>
-                    </ul>
+                    
                 </div>
             </div>
             </div></div>


### PR DESCRIPTION
## Purpose
Remove the What's Next section in the Downloads page.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
