### PR TITLE
Change the "Current Version" Title in the Downloads Page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -24,7 +24,7 @@ redirect_from:
         <div class="row">
             <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
                 <div class="cFeaturedVersion">
-                    <h2>Current version: <span id="versionInfo">{{ site.data.stable-latest.metadata.version }} ({{ site.data.stable-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2>
+                    <h2>Stable release: <span id="versionInfo">{{ site.data.stable-latest.metadata.version }} ({{ site.data.stable-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2>
                     <div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;" >
                     
                     <p>


### PR DESCRIPTION
## Purpose
Change the "Current version" title in Downloads page to "Stable release".
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
