### PR TITLE
Change the Preview Release Title in the Downloads Page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -177,7 +177,7 @@ redirect_from:
                              and for installation instructions, see <a href="/learn/installing-ballerina/">Installing Ballerina</a>.
                         </p></p>
                     
-                        <h2>Preview release: Swan Lake Preview 1 </span></h2>
+                        <h2>Preview release: Swan Lake Preview 1 <span id="versionInfo">({{ site.data.stable-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2>
                         <div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;" >
                         <p>If you already have jBallerina installed, you can use the <a href="/swan-lake/learn/keeping-ballerina-up-to-date/">Ballerina Update Tool</a> to update it to the Swan Lake channel. To do this, first, execute the command below to get the Update Toole updated to its latest version. </p>
                         <pre>ballerina update</pre>

--- a/downloads.html
+++ b/downloads.html
@@ -177,7 +177,7 @@ redirect_from:
                              and for installation instructions, see <a href="/learn/installing-ballerina/">Installing Ballerina</a>.
                         </p></p>
                     
-                        <h2>Preview release: Swan Lake (preview version) </span></h2>
+                        <h2>Preview release: Swan Lake Preview 1 </span></h2>
                         <div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;" >
                         <p>If you already have jBallerina installed, you can use the <a href="/swan-lake/learn/keeping-ballerina-up-to-date/">Ballerina Update Tool</a> to update it to the Swan Lake channel. To do this, first, execute the command below to get the Update Toole updated to its latest version. </p>
                         <pre>ballerina update</pre>

--- a/downloads.html
+++ b/downloads.html
@@ -177,7 +177,7 @@ redirect_from:
                              and for installation instructions, see <a href="/learn/installing-ballerina/">Installing Ballerina</a>.
                         </p></p>
                     
-                        <h2>Preview release: Swan Lake Preview 1 <span id="versionInfo">({{ site.data.stable-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2>
+                        <h2>Preview release: Swan Lake Preview 1 <span id="versionInfo">({{ site.data.swanlake-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2>
                         <div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;" >
                         <p>If you already have jBallerina installed, you can use the <a href="/swan-lake/learn/keeping-ballerina-up-to-date/">Ballerina Update Tool</a> to update it to the Swan Lake channel. To do this, first, execute the command below to get the Update Toole updated to its latest version. </p>
                         <pre>ballerina update</pre>


### PR DESCRIPTION
## Purpose
Change the preview release title in the Downloads page.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
