### PR TITLE
Fix the Hyperlink Style in the Downloads Page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -259,6 +259,15 @@ redirect_from:
                                     <tr><td style="width: 50%">Install via the ZIP archive <a href="/swan-lake/learn/installing-ballerina/#installing-via-the-ballerina-language-zip-file" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td></tr>
                                     <tr><td style="width: 50%">Install from source <a href="/swan-lake/learn/installing-ballerina/#building-from-source" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td></tr>   
                                 </table>
+                                <div class="row">
+                                    <div class="container">
+                                    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">       
+                                        <div class="cFeaturedVersion">
+                                  
+                                    <div class="cDownloadsHeader">
+
+
+
                                 <p style="margin-top: 30px;">For setting up the VSCode Ballerina extension, see <a href="/swan-lake/learn/setting-up-visual-studio-code/">Setting up Visual Studio Code</a>
                                     and for installation instructions, see <a href="/swan-lake/learn/installing-ballerina/">Installing Ballerina</a>.</p></p>
                             </div>


### PR DESCRIPTION
## Purpose
Fix the hyperlink style in the downloads page.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
