### PR TITLE
Directly push changes instead of creating redundant PRs

### DIFF
--- a/.github/workflows/add_new_release_note.yml
+++ b/.github/workflows/add_new_release_note.yml
@@ -28,7 +28,6 @@ jobs:
 
     - name: Push changes for the new release note
       run: |
-        git checkout automate-release-folder-$GITHUB_SHA 2>/dev/null || git checkout -b automate-release-folder-$GITHUB_SHA
         git pull origin master
         
         git config --global user.email "ballerina-bot@ballerina.org"
@@ -36,15 +35,12 @@ jobs:
         
         VERSION="`jq -r '.version' _data/stable-latest/metadata.json`"
         git add downloads/release-notes/$VERSION
-        git commit --allow-empty -m 'Add releaste note template for the new release'
+        git commit --allow-empty -m '[Automated] Add releaste note template for the new release'
         
-        git push --set-upstream origin automate-release-folder-$GITHUB_SHA
-        echo 'Successfully pushed to automate-release-folder-$GITHUB_SHA branch'
-
-    - name: Create pull request for the new release note
+    - name: Push changes for the new release note
       shell: bash
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -m '[Automated] Add release note template for the new release'
+        bin/hub push
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/index_search.yml
+++ b/.github/workflows/index_search.yml
@@ -45,22 +45,18 @@ jobs:
 
     - name: Push changes for new API Docs
       run: |
-        git checkout automate-search-index-$GITHUB_SHA 2>/dev/null || git checkout -b automate-search-index-$GITHUB_SHA
         git pull origin master
         
         git config --global user.email "ballerina-bot@ballerina.org"
         git config --global user.name "ballerina-bot"
         
         git add js/searchIndex.js
-        git commit --allow-empty -m 'Update search index'
+        git commit --allow-empty -m '[Automated] Update search index'
         
-        git push --set-upstream origin automate-search-index-$GITHUB_SHA
-        echo 'Successfully pushed to automate-search-index-$GITHUB_SHA branch'
-
-    - name: Create pull request for new search index
+    - name: Push changes for new search index
       shell: bash
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -m '[Automated] Update search index for the new release'
+        bin/hub push
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prod_sync.yml
+++ b/.github/workflows/prod_sync.yml
@@ -17,7 +17,6 @@ jobs:
     - name: Sync production repo with prod-sync branch
       run: |
         cd ballerina-platform.github.io
-        git checkout automate-prod-sync-$GITHUB_SHA 2>/dev/null || git checkout -b automate-prod-sync-$GITHUB_SHA
         git pull origin master
 
         git config --global user.email "ballerina-bot@ballerina.org"
@@ -26,14 +25,11 @@ jobs:
         git remote add dev https://github.com/ballerina-platform/ballerina-dev-website.git
         git pull dev prod-sync -X theirs --no-edit
         
-        git push --set-upstream origin automate-prod-sync-$GITHUB_SHA
-        echo 'Successfully pushed to automate-prod-sync-$GITHUB_SHA branch'
-
-    - name: Create pull request for prod-sync
+    - name: Push changes to prod website
       shell: bash
       run: |
         cd ballerina-platform.github.io
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -m '[Automated] Sync production site with dev site'
+        bin/hub push
       env:
         GITHUB_TOKEN: ${{ secrets.WEBSITE_TOKEN }}

--- a/.github/workflows/sw_add_new_release_note.yml
+++ b/.github/workflows/sw_add_new_release_note.yml
@@ -28,7 +28,6 @@ jobs:
 
     - name: Push changes for the new release note
       run: |
-        git checkout automate-release-folder-$GITHUB_SHA 2>/dev/null || git checkout -b automate-release-folder-$GITHUB_SHA
         git pull origin master
         
         git config --global user.email "ballerina-bot@ballerina.org"
@@ -36,15 +35,12 @@ jobs:
         
         VERSION="`jq -r '.version' _data/swanlake-latest/metadata.json`"
         git add downloads/swan-lake-release-notes/$VERSION
-        git commit --allow-empty -m 'Add releaste note template for the new release'
+        git commit --allow-empty -m '[Automated] Add releaste note template for the new release'
         
-        git push --set-upstream origin automate-release-folder-$GITHUB_SHA
-        echo 'Successfully pushed to automate-release-folder-$GITHUB_SHA branch'
-
-    - name: Create pull request for the new release note
+    - name: Push changes for the new release note
       shell: bash
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -m '[Automated] Add release note template for the new release'
+        bin/hub push
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sw_update_release__note_versions.yml
+++ b/.github/workflows/sw_update_release__note_versions.yml
@@ -30,21 +30,17 @@ jobs:
 
     - name: Update release-notes-versions json file
       run: |
-        git checkout automate-release-notes-json-$GITHUB_SHA 2>/dev/null || git checkout -b automate-release-notes-json-$GITHUB_SHA
         git pull origin master
         
         git config --global user.email "ballerina-bot@ballerina.org"
         git config --global user.name "ballerina-bot"
         git add _data/swanlake_release_notes_versions.json
-        git commit --allow-empty -m 'Update release notes json'
+        git commit --allow-empty -m '[Automated] Update swan lake release notes json'
         
-        git push --set-upstream origin automate-release-notes-json-$GITHUB_SHA
-        echo 'Successfully pushed to automate-downloads-page-update branch'
-
-    - name: Create pull request for new Release-notes/Archive pages
+    - name: Push changes for new Release-notes/Archive pages
       shell: bash
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -m '[Automated] Update Release-notes/Archive pages for the new release'
+        bin/hub push
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_release_note_versions_json.yml
+++ b/.github/workflows/update_release_note_versions_json.yml
@@ -33,21 +33,18 @@ jobs:
 
     - name: Update release-notes-versions json file
       run: |
-        git checkout automate-release-notes-json-$GITHUB_SHA 2>/dev/null || git checkout -b automate-release-notes-json-$GITHUB_SHA
         git pull origin master
         
         git config --global user.email "ballerina-bot@ballerina.org"
         git config --global user.name "ballerina-bot"
-        git add _data/release_notes_versions.json
-        git commit --allow-empty -m 'Update release notes json'
-        
-        git push --set-upstream origin automate-release-notes-json-$GITHUB_SHA
-        echo 'Successfully pushed to automate-downloads-page-update branch'
 
-    - name: Create pull request for new BBEs
+        git add _data/release_notes_versions.json
+        git commit --allow-empty -m '[Automated] Update release notes json'
+        
+    - name: Push changes for new Release-notes/Archive pages
       shell: bash
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -m '[Automated] Update Release-notes/Archive pages for the new release'
+        bin/hub push
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose
> $subject. 

Previously we created PRs for,

- Syncing changes with prod site even though it is been verified at the time changes are merged to prod-sync branch
- Index search which is generated by a tool and no pointing reviewing it
- Updating Archive/Release note pages. This is also automatically done no point in reviewing. Hence no need for PR
- Creating a new release note location is also auto created no point in reviewing 

Now with the new changes these will be directly committed to master by ballerina-bot.