### PR TITLE
Fix Homebrew publish new line char issue

### DIFF
--- a/.github/scripts/publish_homebrew.py
+++ b/.github/scripts/publish_homebrew.py
@@ -1,5 +1,6 @@
 import sys
 from github import Github
+from os import linesep
 
 # Getting the command line arguments as inputs
 token = sys.argv[1]
@@ -34,6 +35,7 @@ for line in ballerina_rb_file.decoded_content.decode("utf-8").split("\n"):
     ballerina_rb_file_contents += updated_line+"\n"
 
 ballerina_rb_file_contents = ballerina_rb_file_contents.rstrip()
+ballerina_rb_file_contents += linesep
 commit_msg_title = " ".join(["ballerina", version])
 
 current_user = github_instance.get_user()

--- a/.github/workflows/publish_homebrew.yml
+++ b/.github/workflows/publish_homebrew.yml
@@ -9,7 +9,7 @@ on:
       - '_data/stable-latest/**'
 
 jobs:
-  publish:
+  publish-homebrew:
     runs-on: ubuntu-latest
     env:
         GITHUB_TOKEN: ${{ secrets.WEBSITE_TOKEN }}
@@ -58,5 +58,5 @@ jobs:
             exit 1
           fi
 
-          python3 ./.github/scripts/homebrew_publish.py ${{ secrets.WEBSITE_TOKEN }} "$VERSION" "$checksum" "$dist_url"
+          python3 ./.github/scripts/publish_homebrew.py ${{ secrets.WEBSITE_TOKEN }} "$VERSION" "$checksum" "$dist_url"
       


### PR DESCRIPTION
## Purpose
> Add the OS-dependent [end-of-the-line character](https://github.com/Homebrew/homebrew-core/blob/629f078633500a0c5462276e66f4061192039dad/Formula/ballerina.rb#L32) which is required by the `ballerina.rb Formula`. 
## Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)