### PR TITLE
Improve publish_json.py to remove and update

### DIFF
--- a/.github/scripts/publish_json.py
+++ b/.github/scripts/publish_json.py
@@ -23,9 +23,10 @@ with open(path_latest, 'r') as content_file:
     temp = content_file.read() 
     latest_realease = json.loads(temp)
 
+# remove the already committed change
 for release in data:
     if release['version'] == latest_realease['version']:
-        sys.exit("This version already exist in release_notes_versions.json")
+        data.remove(release)
 
 # append both json
 data.append(latest_realease)
@@ -37,4 +38,4 @@ os.makedirs(os.path.dirname(outputFile_rel), exist_ok=True)
 with open(outputFile_rel, "w") as f:
     json.dump(data, f, indent=3)
 
-print ("Check .../target/output/")
+print ("Check ./target/release_notes_versions.json")

--- a/.github/workflows/sw_update_release__note_versions.yml
+++ b/.github/workflows/sw_update_release__note_versions.yml
@@ -28,7 +28,7 @@ jobs:
       run: python3 .github/scripts/publish_json.py _data/swanlake_release_notes_versions.json _data/swanlake-latest/metadata.json
 
     - name: Copy newly generated release-notes-json file
-      run: cp .github/scripts/target/swanlake_release_notes_versions.json _data/swanlake_release_notes_versions.json
+      run: cp .github/scripts/target/release_notes_versions.json.json _data/swanlake_release_notes_versions.json
 
     - name: Commit release-notes-versions json file
       run: |


### PR DESCRIPTION
## Purpose
> For a given release metadata.json file can be updated few times due to blockers in the pack. In such cases, we this script now remove the old entry and add the new one.