### PR TITLE
Add missing navigations in SwanLake learn page

### DIFF
--- a/_data/learnnavswanlake.yml
+++ b/_data/learnnavswanlake.yml
@@ -79,12 +79,21 @@
       url: /swan-lake/learn/writing-secure-ballerina-code
       active: writing-secure-ballerina-code
 
-- title: Testing
+- title: Testing Ballerina Code
   url: '#' 
   sublinks:
-    - title: Testing Ballerina Code
-      url: /swan-lake/learn/testing-ballerina-code
-      active: testing-ballerina-code
+    - title: Quick Start
+      url: /swan-lake/learn/testing-quick-start
+      active: testing-quick-start
+    - title: Writing Tests
+        url: /swan-lake/learn/writing-tests
+        active: writing-tests
+    - title: Mocking
+        url: /swan-lake/learn/mocking
+        active: mocking
+    - title: Executing Tests
+        url: /swan-lake/learn/writing-tests
+        active: writing-tests
 
 - title: Extending Ballerina
   url: '#' 


### PR DESCRIPTION
## Purpose
> Add missing testing guide navigations to swanlake yml

## Check List

- [ ] **Page Addition**
  - [x] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [x] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
