### PR TITLE
Fix the Breadcrumbs of the BBE Index Page in 1.0 and 1.1 versions

### DIFF
--- a/1.0/learn/by-example/index.html
+++ b/1.0/learn/by-example/index.html
@@ -16,7 +16,7 @@
 <meta name="keywords" content="ballerinalang, integration, microservices, programming language, cloud native, ballerina language" />
 
 <link rel="shortcut icon" href="/img/favicon.ico">
-<title>Ballerina-by-Example - Ballerina.io</title>
+<title>Ballerina by Example</title>
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-92163714-2"></script>
 <!--FB-->

--- a/1.1/learn/by-example/index.html
+++ b/1.1/learn/by-example/index.html
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-inner-page
-title: Ballerina-by-Example - Ballerina.io
+title: Ballerina by Example 
 description: Ballerina by Example enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
 ---
 <div class="row cBallerina-io-Gray-row">


### PR DESCRIPTION
## Purpose
Fix the breadcrumbs of the BBE index page in 1.0 and 1.1 versions.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
