### PR TITLE
Fix the Breadcrumbs of the BBE Index Page  in 1.0

### DIFF
--- a/1.0/learn/by-example/index.html
+++ b/1.0/learn/by-example/index.html
@@ -183,7 +183,7 @@
     
     
     
-    <li>/</li> Ballerina-by-Example - Ballerina.io
+    <li>/</li> Ballerina by Example 
     
     
 


### PR DESCRIPTION
## Purpose
Fix the breadcrumbs of the BBE index page in 1.0.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
