### PR TITLE
Add Redirections for AWS Lambda and Azure in 1.0 & 1.1

### DIFF
--- a/_data/learnnav.yml
+++ b/_data/learnnav.yml
@@ -58,11 +58,11 @@
       url: /learn/deployment/kubernetes/
       active: kubernetes
     - title: AWS Lambda
-      url: /learn/deployment/awslambda/
-      active: awslambda
+      url: /learn/deployment/aws-lambda/
+      active: aws-lambda
     - title: Azure Functions
-      url: /learn/deployment/azure/
-      active: azure
+      url: /learn/deployment/azure-functions/
+      active: azure-functions
 
 - title: Observability
   url: '#' 

--- a/_data/learnnavswanlake.yml
+++ b/_data/learnnavswanlake.yml
@@ -58,8 +58,8 @@
       url: /swan-lake/learn/deployment/kubernetes/
       active: kubernetes
     - title: AWS Lambda
-      url: /swan-lake/learn/deployment/awslambda/
-      active: awslambda
+      url: /swan-lake/learn/deployment/aws-lambda/
+      active: aws-lambda
 
 - title: Observability
   url: '#' 

--- a/js/redirections.js
+++ b/js/redirections.js
@@ -174,8 +174,10 @@ let redirections = {
     "/0.991/learn/coding-conventions/statements/":"/0.991/learn/style-guide/statements",
     "/1.1/learn/deploymens/aws-lambda/":"/1.1/page-not-available.html",
     "/1.0/learn/deploymens/aws-lambda/":"/1.0/page-not-available.html",
+    "/swan-lake/learn/deploymens/azure-functions/":"/swan-lake/page-not-available.html",
     "/1.1/learn/deploymens/azure-functions/":"/1.1/page-not-available.html",
     "/1.0/learn/deploymens/azure-functions/":"/1.0/page-not-available.html"
+    
 
 
 };

--- a/js/redirections.js
+++ b/js/redirections.js
@@ -172,11 +172,11 @@ let redirections = {
     "/1.1/learn/coding-conventions/statements":"/1.1/learn/style-guide/statements",
     "/1.0/learn/coding-conventions/statements/":"/1.0/learn/style-guide/statements",
     "/0.991/learn/coding-conventions/statements/":"/0.991/learn/style-guide/statements",
-    "/1.1/learn/deploymens/aws-lambda/":"/1.1/page-not-available.html",
-    "/1.0/learn/deploymens/aws-lambda/":"/1.0/page-not-available.html",
-    "/swan-lake/learn/deploymens/azure-functions/":"/swan-lake/page-not-available.html",
-    "/1.1/learn/deploymens/azure-functions/":"/1.1/page-not-available.html",
-    "/1.0/learn/deploymens/azure-functions/":"/1.0/page-not-available.html"
+    "/1.1/learn/deployment/aws-lambda/":"/1.1/page-not-available.html",
+    "/1.0/learn/deployment/aws-lambda/":"/1.0/page-not-available.html",
+    "/swan-lake/learn/deployment/azure-functions/":"/swan-lake/page-not-available.html",
+    "/1.1/learn/deployment/azure-functions/":"/1.1/page-not-available.html",
+    "/1.0/learn/deployment/azure-functions/":"/1.0/page-not-available.html"
     
 
 

--- a/js/redirections.js
+++ b/js/redirections.js
@@ -172,5 +172,10 @@ let redirections = {
     "/1.1/learn/coding-conventions/statements":"/1.1/learn/style-guide/statements",
     "/1.0/learn/coding-conventions/statements/":"/1.0/learn/style-guide/statements",
     "/0.991/learn/coding-conventions/statements/":"/0.991/learn/style-guide/statements",
+    "/1.1/learn/deploymens/aws-lambda/":"/1.1/page-not-available.html",
+    "/1.0/learn/deploymens/aws-lambda/":"/1.0/page-not-available.html",
+    "/1.1/learn/deploymens/azure-functions/":"/1.1/page-not-available.html",
+    "/1.0/learn/deploymens/azure-functions/":"/1.0/page-not-available.html"
+
 
 };

--- a/learn/deployment/aws-lambda.md
+++ b/learn/deployment/aws-lambda.md
@@ -3,10 +3,10 @@ layout: ballerina-left-nav-pages
 title: AWS Lambda
 description: See how the Ballerina deployment in AWS Lambda works
 keywords: ballerina, programming language, serverless, cloud, AWS, Lambda
-permalink: /swan-lake/learn/deployment/awslambda/
+permalink: /learn/deployment/aws-lambda/
 active: awslambda
 redirect_from:
-  - /swan-lake/learn/deployment/awslambda
+  - /learn/deployment/aws-lambda
 ---
 
 # AWS Lambda
@@ -25,7 +25,7 @@ public function hash(awslambda:Context ctx, json input) returns json|error {
 }
 ```
 
-The first parameter with the [awslambda:Context](https://ballerina.io/swan-lake/learn/api-docs/ballerinax/awslambda.html#Context) object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time. The second parameter with the `json` value contains the input request data. This input value format will vary depending on the source, which invoked the function e.g., an AWS S3 bucket update event. The return type of the function is `json|error`, which means in a successful scenario, the function can return a `json` value with the response or else in an error situation, the function will return an `error` value, which provides information on the error to the system.
+The first parameter with the [awslambda:Context](https://ballerina.io/learn/api-docs/ballerinax/awslambda.html#Context) object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time. The second parameter with the `json` value contains the input request data. This input value format will vary depending on the source, which invoked the function e.g., an AWS S3 bucket update event. The return type of the function is `json|error`, which means in a successful scenario, the function can return a `json` value with the response or else in an error situation, the function will return an `error` value, which provides information on the error to the system.
 
 The AWS Lambda functionality is implemented as a compiler extension. Thus, the artifact generation happens automatically when you build a Ballerina module. Let's see how this works by building the above code. 
 

--- a/learn/deployment/azure-functions.md
+++ b/learn/deployment/azure-functions.md
@@ -3,10 +3,10 @@ layout: ballerina-left-nav-pages
 title: Azure Functions
 description: See how the Ballerina deployment in Azure Functions works
 keywords: ballerina, programming language, serverless, cloud, Azure, Functions
-permalink: /learn/deployment/azure/
+permalink: /learn/deployment/azure-functions/
 active: azure
 redirect_from:
-  - /learn/deployment/azure
+  - /learn/deployment/azure-functions
 ---
 
 # Azure Functions

--- a/swan-lake/learn/deployment/aws-lambda.md
+++ b/swan-lake/learn/deployment/aws-lambda.md
@@ -3,10 +3,10 @@ layout: ballerina-left-nav-pages
 title: AWS Lambda
 description: See how the Ballerina deployment in AWS Lambda works
 keywords: ballerina, programming language, serverless, cloud, AWS, Lambda
-permalink: /learn/deployment/awslambda/
+permalink: /swan-lake/learn/deployment/aws-lambda/
 active: awslambda
 redirect_from:
-  - /learn/deployment/awslambda
+  - /swan-lake/learn/deployment/aws-lambda
 ---
 
 # AWS Lambda
@@ -25,7 +25,7 @@ public function hash(awslambda:Context ctx, json input) returns json|error {
 }
 ```
 
-The first parameter with the [awslambda:Context](https://ballerina.io/learn/api-docs/ballerinax/awslambda.html#Context) object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time. The second parameter with the `json` value contains the input request data. This input value format will vary depending on the source, which invoked the function e.g., an AWS S3 bucket update event. The return type of the function is `json|error`, which means in a successful scenario, the function can return a `json` value with the response or else in an error situation, the function will return an `error` value, which provides information on the error to the system.
+The first parameter with the [awslambda:Context](https://ballerina.io/swan-lake/learn/api-docs/ballerinax/awslambda.html#Context) object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time. The second parameter with the `json` value contains the input request data. This input value format will vary depending on the source, which invoked the function e.g., an AWS S3 bucket update event. The return type of the function is `json|error`, which means in a successful scenario, the function can return a `json` value with the response or else in an error situation, the function will return an `error` value, which provides information on the error to the system.
 
 The AWS Lambda functionality is implemented as a compiler extension. Thus, the artifact generation happens automatically when you build a Ballerina module. Let's see how this works by building the above code. 
 


### PR DESCRIPTION
## Purpose
Add redirections for AWS Lambda and Azure in 1.0 & 1.1.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
