### PR TITLE
Add Formatting for Code Snippets in the OpenAPI Guide

### DIFF
--- a/1.0/learn/how-to-use-openapi-tools/index.html
+++ b/1.0/learn/how-to-use-openapi-tools/index.html
@@ -230,28 +230,28 @@ Code generation from OpenAPI to Ballerina can produce <code class="highlighter-r
 <p>For build time client stub generation, annotation support is provided.</p>
 
 <h3 id="mock-service-from-openapi">Mock service from OpenAPI</h3>
-<p><code class="highlighter-rouge ballerina">ballerina openapi gen-service &lt;moduleName&gt;:&lt;serivceName&gt; 
+<pre><code class="highlighter-rouge">ballerina openapi gen-service &lt;moduleName&gt;:&lt;serivceName&gt; 
                                &lt;openapi_contract&gt;
                                [-c: copy-contract] 
-                               [-o: outputFile]</code></p>
+                               [-o: outputFile]</code></pre>
 
 <p>Generates a Ballerina service for the OpenAPI file.</p>
 
 <p>This generated service is a mock version of the actual Ballerina service. Generated sources contain the service definition in <code class="highlighter-rouge">src/&lt;module-name&gt;/</code> and the OpenAPI contract that used to generate will be copied to <code class="highlighter-rouge">src/&lt;module-name&gt;/resources</code>.</p>
 
 <h3 id="client-stub-from-openapi">Client stub from OpenAPI</h3>
-<p><code class="highlighter-rouge ballerina">ballerina openapi gen-client [&lt;moduleName&gt;]:&lt;clientName&gt; 
-                   &lt;openapi-contract&gt; [-o &lt;dir-path&gt; | --output &lt;dir-path&gt;]</code></p>
+<pre><code class="highlighter-rouge">ballerina openapi gen-client [&lt;moduleName&gt;]:&lt;clientName&gt; 
+                   &lt;openapi-contract&gt; [-o &lt;dir-path&gt; | --output &lt;dir-path&gt;]</code></pre>
 
 <p>Generates a Ballerina client stub for the service defined in a OpenAPI file.</p>
 
 <p>This client can be used in client applications to call the service defined in the OpenAPI file.</p>
 
 <h3 id="service-to-openapi-export">Service to OpenAPI export</h3>
-<p><code class="highlighter-rouge ballerina">ballerina openapi gen-contract [&lt;moduleName&gt;:]&lt;serviceName&gt; 
+<pre><code class="highlighter-rouge">ballerina openapi gen-contract [&lt;moduleName&gt;:]&lt;serviceName&gt; 
                                 [-i: &lt;ballerinaFile&gt; | --ballerina-file &lt;ballerina-file&gt;] 
                                 [-o: &lt;openapi-contract&gt; | --output &lt;openapi-contract&gt;] 
-                                [-s | --skip-bind]</code></p>
+                                [-s | --skip-bind]</code></pre>
 
 <p>Export the Ballerina service to a definition of OpenApi Specification 3.0.
 For the export to work properly, the input Ballerina service should be defined using basic service and resource level HTTP annotations.</p>
@@ -260,22 +260,22 @@ For the export to work properly, the input Ballerina service should be defined u
 <p>Generates a Ballerina client stub to communicate with a Ballerina service.</p>
 
 <p>All endpoint(s) that are used for client stub generation should be marked with the <code class="highlighter-rouge">@openapi:ClientEndpoint</code> annotation. If not, there might be errors during client stub generation. Endpoints that are not marked with this annotation are not picked for client stub generation.
-The <code class="highlighter-rouge ballerina">@openapi:ClientConfig { generate: true }</code> annotation is used to enable or disable client stub generation per service.</p>
+The <code class="highlighter-rouge">@openapi:ClientConfig { generate: true }</code> annotation is used to enable or disable client stub generation per service.</p>
 
 <h2 id="samples">Samples</h2>
 
 <h3 id="mock-service-from-openapi-1">Mock service from OpenAPI</h3>
-<p><code class="highlighter-rouge ballerina">ballerina openapi gen-service helloworld:helloService hello_service.yaml</code></p>
+<pre><code class="highlighter-rouge">ballerina openapi gen-service helloworld:helloService hello_service.yaml</code></pre>
 
 <p>This will generate a Ballerina service, for <code class="highlighter-rouge">hello_service.yaml</code> OpenAPI contract, named <code class="highlighter-rouge">helloService</code> in the module named <code class="highlighter-rouge">helloworld</code>.
 This command should be executed inside a Ballerina project.</p>
 <h3 id="client-stub-from-openapi-1">Client stub from OpenAPI</h3>
-<p><code class="highlighter-rouge ballerina">ballerina openapi gen-client hello_client hello_service.yaml</code></p>
+<pre><code class="highlighter-rouge">ballerina openapi gen-client hello_client hello_service.yaml</code></pre>
 
 <p>This will generate a Client named <code class="highlighter-rouge">hello_client</code> in a module named <code class="highlighter-rouge">client</code> for the service documented in <code class="highlighter-rouge">hello_service.yaml</code>.
 This command should be executed inside a Ballerina project.</p>
 <h3 id="openapi-from-service">OpenAPI from service</h3>
-<p><code class="highlighter-rouge ballerina">ballerina openapi gen-contract hello -i src/helloS/hello.bal</code></p>
+<pre><code class="highlighter-rouge">ballerina openapi gen-contract hello -i src/helloS/hello.bal</code></pre>
 
 <p>This will generate the OpenAPI contract for the Ballerina service <code class="highlighter-rouge">hello</code> which is in <code class="highlighter-rouge">hello.bal</code> Ballerina file.</p>
 <h3 id="client-stub-from-service">Client stub from service</h3>

--- a/1.0/learn/how-to-use-openapi-tools/index.html
+++ b/1.0/learn/how-to-use-openapi-tools/index.html
@@ -230,7 +230,7 @@ Code generation from OpenAPI to Ballerina can produce <code class="highlighter-r
 <p>For build time client stub generation, annotation support is provided.</p>
 
 <h3 id="mock-service-from-openapi">Mock service from OpenAPI</h3>
-<p><code class="highlighter-rouge">ballerina openapi gen-service &lt;moduleName&gt;:&lt;serivceName&gt; 
+<p><code class="highlighter-rouge ballerina">ballerina openapi gen-service &lt;moduleName&gt;:&lt;serivceName&gt; 
                                &lt;openapi_contract&gt;
                                [-c: copy-contract] 
                                [-o: outputFile]</code></p>
@@ -240,7 +240,7 @@ Code generation from OpenAPI to Ballerina can produce <code class="highlighter-r
 <p>This generated service is a mock version of the actual Ballerina service. Generated sources contain the service definition in <code class="highlighter-rouge">src/&lt;module-name&gt;/</code> and the OpenAPI contract that used to generate will be copied to <code class="highlighter-rouge">src/&lt;module-name&gt;/resources</code>.</p>
 
 <h3 id="client-stub-from-openapi">Client stub from OpenAPI</h3>
-<p><code class="highlighter-rouge">ballerina openapi gen-client [&lt;moduleName&gt;]:&lt;clientName&gt; 
+<p><code class="highlighter-rouge ballerina">ballerina openapi gen-client [&lt;moduleName&gt;]:&lt;clientName&gt; 
                    &lt;openapi-contract&gt; [-o &lt;dir-path&gt; | --output &lt;dir-path&gt;]</code></p>
 
 <p>Generates a Ballerina client stub for the service defined in a OpenAPI file.</p>
@@ -248,7 +248,7 @@ Code generation from OpenAPI to Ballerina can produce <code class="highlighter-r
 <p>This client can be used in client applications to call the service defined in the OpenAPI file.</p>
 
 <h3 id="service-to-openapi-export">Service to OpenAPI export</h3>
-<p><code class="highlighter-rouge">ballerina openapi gen-contract [&lt;moduleName&gt;:]&lt;serviceName&gt; 
+<p><code class="highlighter-rouge ballerina">ballerina openapi gen-contract [&lt;moduleName&gt;:]&lt;serviceName&gt; 
                                 [-i: &lt;ballerinaFile&gt; | --ballerina-file &lt;ballerina-file&gt;] 
                                 [-o: &lt;openapi-contract&gt; | --output &lt;openapi-contract&gt;] 
                                 [-s | --skip-bind]</code></p>
@@ -260,28 +260,28 @@ For the export to work properly, the input Ballerina service should be defined u
 <p>Generates a Ballerina client stub to communicate with a Ballerina service.</p>
 
 <p>All endpoint(s) that are used for client stub generation should be marked with the <code class="highlighter-rouge">@openapi:ClientEndpoint</code> annotation. If not, there might be errors during client stub generation. Endpoints that are not marked with this annotation are not picked for client stub generation.
-The <code class="highlighter-rouge">@openapi:ClientConfig { generate: true }</code> annotation is used to enable or disable client stub generation per service.</p>
+The <code class="highlighter-rouge ballerina">@openapi:ClientConfig { generate: true }</code> annotation is used to enable or disable client stub generation per service.</p>
 
 <h2 id="samples">Samples</h2>
 
 <h3 id="mock-service-from-openapi-1">Mock service from OpenAPI</h3>
-<p><code class="highlighter-rouge">ballerina openapi gen-service helloworld:helloService hello_service.yaml</code></p>
+<p><code class="highlighter-rouge ballerina">ballerina openapi gen-service helloworld:helloService hello_service.yaml</code></p>
 
 <p>This will generate a Ballerina service, for <code class="highlighter-rouge">hello_service.yaml</code> OpenAPI contract, named <code class="highlighter-rouge">helloService</code> in the module named <code class="highlighter-rouge">helloworld</code>.
 This command should be executed inside a Ballerina project.</p>
 <h3 id="client-stub-from-openapi-1">Client stub from OpenAPI</h3>
-<p><code class="highlighter-rouge">ballerina openapi gen-client hello_client hello_service.yaml</code></p>
+<p><code class="highlighter-rouge ballerina">ballerina openapi gen-client hello_client hello_service.yaml</code></p>
 
 <p>This will generate a Client named <code class="highlighter-rouge">hello_client</code> in a module named <code class="highlighter-rouge">client</code> for the service documented in <code class="highlighter-rouge">hello_service.yaml</code>.
 This command should be executed inside a Ballerina project.</p>
 <h3 id="openapi-from-service">OpenAPI from service</h3>
-<p><code class="highlighter-rouge">ballerina openapi gen-contract hello -i src/helloS/hello.bal</code></p>
+<p><code class="highlighter-rouge ballerina">ballerina openapi gen-contract hello -i src/helloS/hello.bal</code></p>
 
 <p>This will generate the OpenAPI contract for the Ballerina service <code class="highlighter-rouge">hello</code> which is in <code class="highlighter-rouge">hello.bal</code> Ballerina file.</p>
 <h3 id="client-stub-from-service">Client stub from service</h3>
 <p>Apply annotation to say that client generation is enabled by adding <code class="highlighter-rouge">@openapi:ClientConfig { generate: true }</code>
 and point the client endpoint to be applied on generation by adding <code class="highlighter-rouge">@openapi:ClientEndpoint</code> annotation to the client endpoint.</p>
-<pre><code class="language-ballerina">import ballerina/http;
+<pre><code class="highlighter-rouge ballerina">import ballerina/http;
 import ballerina/log;
 import ballerina/openapi;
 

--- a/1.1/learn/how-to-use-openapi-tools.md
+++ b/1.1/learn/how-to-use-openapi-tools.md
@@ -27,33 +27,43 @@ Code generation from OpenAPI to Ballerina can produce `ballerina mock services` 
 For build time client stub generation, annotation support is provided.
 
 ### Mock service from OpenAPI
-`ballerina openapi gen-service <moduleName>:<serivceName> 
+
+```ballerina
+ballerina openapi gen-service <moduleName>:<serivceName> 
                                <openapi_contract>
                                [-c: copy-contract] 
-                               [-o: outputFile]`
+                               [-o: outputFile]
+```
 
 Generates a Ballerina service for the OpenAPI file.
 
 This generated service is a mock version of the actual Ballerina service. Generated sources contain the service definition in `src/<module-name>/` and the OpenAPI contract that used to generate will be copied to `src/<module-name>/resources`. 
 
 ### Client stub from OpenAPI
-`ballerina openapi gen-client [<moduleName>]:<clientName> 
-                   <openapi-contract> [-o <dir-path> | --output <dir-path>]`
+
+```ballerina
+ballerina openapi gen-client [<moduleName>]:<clientName> 
+                   <openapi-contract> [-o <dir-path> | --output <dir-path>]
+```
     
 Generates a Ballerina client stub for the service defined in a OpenAPI file.
 
 This client can be used in client applications to call the service defined in the OpenAPI file.
 
 ### Service to OpenAPI export
-`ballerina openapi gen-contract [<moduleName>:]<serviceName> 
+
+```ballerina
+ballerina openapi gen-contract [<moduleName>:]<serviceName> 
                                 [-i: <ballerinaFile> | --ballerina-file <ballerina-file>] 
                                 [-o: <openapi-contract> | --output <openapi-contract>] 
-                                [-s | --skip-bind]`
+                                [-s | --skip-bind]
+```
 
 Export the Ballerina service to a definition of OpenApi Specification 3.0.
 For the export to work properly, the input Ballerina service should be defined using basic service and resource level HTTP annotations.
 
 ### Client stub for service
+
 Generates a Ballerina client stub to communicate with a Ballerina service.
 
 All endpoint(s) that are used for client stub generation should be marked with the `@openapi:ClientEndpoint` annotation. If not, there might be errors during client stub generation. Endpoints that are not marked with this annotation are not picked for client stub generation.
@@ -62,22 +72,36 @@ The `@openapi:ClientConfig { generate: true }` annotation is used to enable or d
 ## Samples
 
 ### Mock service from OpenAPI
-`ballerina openapi gen-service helloworld:helloService hello_service.yaml`
+
+```ballerina
+ballerina openapi gen-service helloworld:helloService hello_service.yaml
+```
 
 This will generate a Ballerina service, for `hello_service.yaml` OpenAPI contract, named `helloService` in the module named `helloworld`.
 This command should be executed inside a Ballerina project. 
+
 ### Client stub from OpenAPI
-`ballerina openapi gen-client hello_client hello_service.yaml`
+
+```ballerina
+ballerina openapi gen-client hello_client hello_service.yaml
+```
 
 This will generate a Client named `hello_client` in a module named `client` for the service documented in `hello_service.yaml`.
 This command should be executed inside a Ballerina project. 
+
 ### OpenAPI from service
-`ballerina openapi gen-contract hello -i src/helloS/hello.bal`
+
+```ballerina
+ballerina openapi gen-contract hello -i src/helloS/hello.bal
+```
 
 This will generate the OpenAPI contract for the Ballerina service `hello` which is in `hello.bal` Ballerina file.
+
 ### Client stub from service
+
 Apply annotation to say that client generation is enabled by adding `@openapi:ClientConfig { generate: true }`
 and point the client endpoint to be applied on generation by adding `@openapi:ClientEndpoint` annotation to the client endpoint.
+
 ```ballerina
 import ballerina/http;
 import ballerina/log;

--- a/1.1/learn/how-to-use-openapi-tools.md
+++ b/1.1/learn/how-to-use-openapi-tools.md
@@ -28,7 +28,7 @@ For build time client stub generation, annotation support is provided.
 
 ### Mock service from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-service <moduleName>:<serivceName> 
                                <openapi_contract>
                                [-c: copy-contract] 
@@ -41,7 +41,7 @@ This generated service is a mock version of the actual Ballerina service. Genera
 
 ### Client stub from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-client [<moduleName>]:<clientName> 
                    <openapi-contract> [-o <dir-path> | --output <dir-path>]
 ```
@@ -52,7 +52,7 @@ This client can be used in client applications to call the service defined in th
 
 ### Service to OpenAPI export
 
-```ballerina
+```
 ballerina openapi gen-contract [<moduleName>:]<serviceName> 
                                 [-i: <ballerinaFile> | --ballerina-file <ballerina-file>] 
                                 [-o: <openapi-contract> | --output <openapi-contract>] 
@@ -73,7 +73,7 @@ The `@openapi:ClientConfig { generate: true }` annotation is used to enable or d
 
 ### Mock service from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-service helloworld:helloService hello_service.yaml
 ```
 
@@ -82,7 +82,7 @@ This command should be executed inside a Ballerina project.
 
 ### Client stub from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-client hello_client hello_service.yaml
 ```
 
@@ -91,7 +91,7 @@ This command should be executed inside a Ballerina project.
 
 ### OpenAPI from service
 
-```ballerina
+```
 ballerina openapi gen-contract hello -i src/helloS/hello.bal
 ```
 

--- a/learn/using-the-openapi-tools.md
+++ b/learn/using-the-openapi-tools.md
@@ -30,7 +30,7 @@ For build time client stub generation, annotation support is provided.
 
 ### Mock service from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-service <moduleName>:<serviceName> 
                                <openapi_contract>
                                [-c: copy-contract] 
@@ -43,7 +43,7 @@ This generated service is a mock version of the actual Ballerina service. Genera
 
 ### Client stub from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-client [<moduleName>]:<clientName> 
                    <openapi-contract> [-o <dir-path> | --output <dir-path>]
 ```
@@ -54,7 +54,7 @@ This client can be used in client applications to call the service defined in th
 
 ### Service to OpenAPI export
 
-```ballerina
+```
 ballerina openapi gen-contract [<moduleName>:]<serviceName> 
                                 [-i: <ballerinaFile> | --ballerina-file <ballerina-file>] 
                                 [-o: <openapi-contract> | --output <openapi-contract>] 
@@ -75,7 +75,7 @@ The `@openapi:ClientConfig { generate: true }` annotation is used to enable or d
 
 ### Mock service from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-service helloworld:helloService hello_service.yaml
 ```
 
@@ -84,7 +84,7 @@ This command should be executed inside a Ballerina project.
 
 ### Client stub from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-client hello_client hello_service.yaml
 ```
 
@@ -93,7 +93,7 @@ This command should be executed inside a Ballerina project.
 
 ### OpenAPI from service
 
-```ballerina
+```
 ballerina openapi gen-contract helloworld:helloService -i src/helloworld/helloService.bal
 ```
 

--- a/learn/using-the-openapi-tools.md
+++ b/learn/using-the-openapi-tools.md
@@ -29,33 +29,43 @@ Code generation from OpenAPI to Ballerina can produce `ballerina mock services` 
 For build time client stub generation, annotation support is provided.
 
 ### Mock service from OpenAPI
-`ballerina openapi gen-service <moduleName>:<serviceName> 
+
+```ballerina
+ballerina openapi gen-service <moduleName>:<serviceName> 
                                <openapi_contract>
                                [-c: copy-contract] 
-                               [-o: outputFile]`
+                               [-o: outputFile]
+```
 
 Generates a Ballerina service for the OpenAPI file.
 
 This generated service is a mock version of the actual Ballerina service. Generated sources contain the service definition in `src/<module-name>/` and the OpenAPI contract that used to generate will be copied to `src/<module-name>/resources`. 
 
 ### Client stub from OpenAPI
-`ballerina openapi gen-client [<moduleName>]:<clientName> 
-                   <openapi-contract> [-o <dir-path> | --output <dir-path>]`
+
+```ballerina
+ballerina openapi gen-client [<moduleName>]:<clientName> 
+                   <openapi-contract> [-o <dir-path> | --output <dir-path>]
+```
     
 Generates a Ballerina client stub for the service defined in a OpenAPI file.
 
 This client can be used in client applications to call the service defined in the OpenAPI file.
 
 ### Service to OpenAPI export
-`ballerina openapi gen-contract [<moduleName>:]<serviceName> 
+
+```ballerina
+ballerina openapi gen-contract [<moduleName>:]<serviceName> 
                                 [-i: <ballerinaFile> | --ballerina-file <ballerina-file>] 
                                 [-o: <openapi-contract> | --output <openapi-contract>] 
-                                [-s | --skip-bind]`
+                                [-s | --skip-bind]
+```
 
 Export the Ballerina service to a definition of OpenApi Specification 3.0.
 For the export to work properly, the input Ballerina service should be defined using basic service and resource level HTTP annotations.
 
 ### Client stub for service
+
 Generates a Ballerina client stub to communicate with a Ballerina service.
 
 All endpoint(s) that are used for client stub generation should be marked with the `@openapi:ClientEndpoint` annotation. If not, there might be errors during client stub generation. Endpoints that are not marked with this annotation are not picked for client stub generation.
@@ -64,22 +74,36 @@ The `@openapi:ClientConfig { generate: true }` annotation is used to enable or d
 ## Samples
 
 ### Mock service from OpenAPI
-`ballerina openapi gen-service helloworld:helloService hello_service.yaml`
+
+```ballerina
+ballerina openapi gen-service helloworld:helloService hello_service.yaml
+```
 
 This will generate a Ballerina service, for `hello_service.yaml` OpenAPI contract, named `helloService` in the module named `helloworld`.
 This command should be executed inside a Ballerina project. 
+
 ### Client stub from OpenAPI
-`ballerina openapi gen-client hello_client hello_service.yaml`
+
+```ballerina
+ballerina openapi gen-client hello_client hello_service.yaml
+```
 
 This will generate a Client named `hello_client` in a module named `client` for the service documented in `hello_service.yaml`.
 This command should be executed inside a Ballerina project. 
+
 ### OpenAPI from service
-`ballerina openapi gen-contract helloworld:helloService -i src/helloworld/helloService.bal`
+
+```ballerina
+ballerina openapi gen-contract helloworld:helloService -i src/helloworld/helloService.bal
+```
 
 This will generate the OpenAPI contract for the Ballerina service `hello` which is in `hello.bal` Ballerina file.
+
 ### Client stub from service
+
 Apply annotation to say that client generation is enabled by adding `@openapi:ClientConfig { generate: true }`
 and point the client endpoint to be applied on generation by adding `@openapi:ClientEndpoint` annotation to the client endpoint.
+
 ```ballerina
 import ballerina/http;
 import ballerina/log;

--- a/swan-lake/learn/using-the-openapi-tools.md
+++ b/swan-lake/learn/using-the-openapi-tools.md
@@ -27,28 +27,37 @@ Code generation from OpenAPI to Ballerina can produce `ballerina mock services` 
 For build time client stub generation, annotation support is provided.
 
 ### Mock service from OpenAPI
-`ballerina openapi gen-service <moduleName>:<serviceName> 
+
+```ballerina
+ballerina openapi gen-service <moduleName>:<serviceName> 
                                <openapi_contract>
                                [-c: copy-contract] 
-                               [-o: outputFile]`
+                               [-o: outputFile]
+```
 
 Generates a Ballerina service for the OpenAPI file.
 
 This generated service is a mock version of the actual Ballerina service. Generated sources contain the service definition in `src/<module-name>/` and the OpenAPI contract that used to generate will be copied to `src/<module-name>/resources`. 
 
 ### Client stub from OpenAPI
-`ballerina openapi gen-client [<moduleName>]:<clientName> 
-                   <openapi-contract> [-o <dir-path> | --output <dir-path>]`
+
+```ballerina
+ballerina openapi gen-client [<moduleName>]:<clientName> 
+                   <openapi-contract> [-o <dir-path> | --output <dir-path>]
+```
     
 Generates a Ballerina client stub for the service defined in a OpenAPI file.
 
 This client can be used in client applications to call the service defined in the OpenAPI file.
 
 ### Service to OpenAPI export
-`ballerina openapi gen-contract [<moduleName>:]<serviceName> 
+
+```ballerina
+ballerina openapi gen-contract [<moduleName>:]<serviceName> 
                                 [-i: <ballerinaFile> | --ballerina-file <ballerina-file>] 
                                 [-o: <openapi-contract> | --output <openapi-contract>] 
-                                [-s | --skip-bind]`
+                                [-s | --skip-bind]
+```
 
 Export the Ballerina service to a definition of OpenApi Specification 3.0.
 For the export to work properly, the input Ballerina service should be defined using basic service and resource level HTTP annotations.
@@ -62,22 +71,35 @@ The `@openapi:ClientConfig { generate: true }` annotation is used to enable or d
 ## Samples
 
 ### Mock service from OpenAPI
-`ballerina openapi gen-service helloworld:helloService hello_service.yaml`
+```ballerina
+ballerina openapi gen-service helloworld:helloService hello_service.yaml
+```
 
 This will generate a Ballerina service, for `hello_service.yaml` OpenAPI contract, named `helloService` in the module named `helloworld`.
-This command should be executed inside a Ballerina project. 
+This command should be executed inside a Ballerina project.
+
 ### Client stub from OpenAPI
-`ballerina openapi gen-client hello_client hello_service.yaml`
+
+```ballerina
+ballerina openapi gen-client hello_client hello_service.yaml
+```
 
 This will generate a Client named `hello_client` in a module named `client` for the service documented in `hello_service.yaml`.
 This command should be executed inside a Ballerina project. 
+
 ### OpenAPI from service
-`ballerina openapi gen-contract helloworld:helloService -i src/helloworld/helloService.bal`
+
+```ballerina
+ballerina openapi gen-contract helloworld:helloService -i src/helloworld/helloService.bal
+```
 
 This will generate the OpenAPI contract for the Ballerina service `hello` which is in `hello.bal` Ballerina file.
+
 ### Client stub from service
+
 Apply annotation to say that client generation is enabled by adding `@openapi:ClientConfig { generate: true }`
 and point the client endpoint to be applied on generation by adding `@openapi:ClientEndpoint` annotation to the client endpoint.
+
 ```ballerina
 import ballerina/http;
 import ballerina/log;

--- a/swan-lake/learn/using-the-openapi-tools.md
+++ b/swan-lake/learn/using-the-openapi-tools.md
@@ -28,7 +28,7 @@ For build time client stub generation, annotation support is provided.
 
 ### Mock service from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-service <moduleName>:<serviceName> 
                                <openapi_contract>
                                [-c: copy-contract] 
@@ -41,7 +41,7 @@ This generated service is a mock version of the actual Ballerina service. Genera
 
 ### Client stub from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-client [<moduleName>]:<clientName> 
                    <openapi-contract> [-o <dir-path> | --output <dir-path>]
 ```
@@ -52,7 +52,7 @@ This client can be used in client applications to call the service defined in th
 
 ### Service to OpenAPI export
 
-```ballerina
+```
 ballerina openapi gen-contract [<moduleName>:]<serviceName> 
                                 [-i: <ballerinaFile> | --ballerina-file <ballerina-file>] 
                                 [-o: <openapi-contract> | --output <openapi-contract>] 
@@ -71,7 +71,7 @@ The `@openapi:ClientConfig { generate: true }` annotation is used to enable or d
 ## Samples
 
 ### Mock service from OpenAPI
-```ballerina
+```
 ballerina openapi gen-service helloworld:helloService hello_service.yaml
 ```
 
@@ -80,7 +80,7 @@ This command should be executed inside a Ballerina project.
 
 ### Client stub from OpenAPI
 
-```ballerina
+```
 ballerina openapi gen-client hello_client hello_service.yaml
 ```
 
@@ -89,7 +89,7 @@ This command should be executed inside a Ballerina project.
 
 ### OpenAPI from service
 
-```ballerina
+```
 ballerina openapi gen-contract helloworld:helloService -i src/helloworld/helloService.bal
 ```
 


### PR DESCRIPTION
## Purpose
Add formatting for code snippets in the OpenAPI guide[1] in all versions.

[1] https://ballerina.io/learn/using-the-openapi-tools/

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
