### PR TITLE
Fix the Swan Lake Testing Guide Link

### DIFF
--- a/swan-lake/learn.md
+++ b/swan-lake/learn.md
@@ -51,7 +51,7 @@ redirect_from:
     <li><a href="/swan-lake/learn/observing-ballerina-code" class="cGreenLinkArrow">Observability</a></li>
     <li><a href="/swan-lake/learn/calling-java-code-from-ballerina" class="cGreenLinkArrow">Interoperability</a></li>
     <li><a href="/swan-lake/learn/writing-secure-ballerina-code" class="cGreenLinkArrow">Security</a></li>
-    <li><a href="/swan-lake/learn/testing-quick-start" class="cGreenLinkArrow">Testing Ballerina Code</a></li>
+    <li><a href="/swan-lake/learn/testing-ballerina-code/testing-quick-start" class="cGreenLinkArrow">Testing Ballerina Code</a></li>
     <li><a href="/swan-lake/learn/extending-with-compiler-extensions" class="cGreenLinkArrow">Extending Ballerina</a></li>
    </ul>
 


### PR DESCRIPTION
## Purpose
Fix the Swan Lake testing guide link.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
