### PR TITLE
Fix the Update Guide Links in the Swan Lake Release Notes

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-preview1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview1/RELEASE_NOTE.md
@@ -11,7 +11,7 @@ You can use the update tool to update to Ballerina Swan Lake Preview 1 as follow
 
 **For existing users:**
 
-If you are already using jBallerina, you can directly update your distribution to the Swan Lake channel using the [Ballerina Update Tool](swan-lake/learn/keeping-ballerina-up-to-date/). To do this, first, execute the command below to get the Update Tool updated to its latest version. 
+If you are already using jBallerina, you can directly update your distribution to the Swan Lake channel using the [Ballerina Update Tool](/swan-lake/learn/keeping-ballerina-up-to-date/). To do this, first, execute the command below to get the Update Tool updated to its latest version. 
                         
 > `ballerina update`
 

--- a/downloads/swan-lake-release-notes/swan-lake-preview2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview2/RELEASE_NOTE.md
@@ -9,7 +9,7 @@ You can use the update tool to update to Ballerina Swan Lake Preview 2 as follow
 
 **For existing users:**
 
-If you are already using jBallerina, you can directly update your distribution to the Swan Lake channel using the [Ballerina Update Tool](swan-lake/learn/keeping-ballerina-up-to-date/). To do this, first, execute the command below to get the Update Tool updated to its latest version. 
+If you are already using jBallerina, you can directly update your distribution to the Swan Lake channel using the [Ballerina Update Tool](/swan-lake/learn/keeping-ballerina-up-to-date/). To do this, first, execute the command below to get the Update Tool updated to its latest version. 
                         
 > `ballerina update`
 


### PR DESCRIPTION
## Purpose
Fix the update guide links in the Swan Lake release notes.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
