### PR TITLE
Add a Link to the Learn Section in the "Page Not Available" Error Page

### DIFF
--- a/1.0/page-not-available.html
+++ b/1.0/page-not-available.html
@@ -36,5 +36,5 @@ layout: ballerina-inner-page
   <h1>Oops, we are sorry.</h1>
 
   <p><strong>The page you are looking for is not available for this Ballerina version.</strong></p>
-  <p>Please try using other keywords or contact the Ballerina Team via the <a href="https://groups.google.com/forum/#!forum/ballerina-dev">Ballerina Dev Google Group</a>.</p>
+  <p>Please try using other keywords to search in <a href="/1.0/learn/">Learn</a> or contact the Ballerina Team via the <a href="https://groups.google.com/forum/#!forum/ballerina-dev">Ballerina Dev Google Group</a>.</p>
 </div>

--- a/1.1/page-not-available.html
+++ b/1.1/page-not-available.html
@@ -36,5 +36,5 @@ layout: ballerina-inner-page
   <h1>Oops, we are sorry.</h1>
 
   <p><strong>The page you are looking for is not available for this Ballerina version.</strong></p>
-  <p>Please try using other keywords or contact the Ballerina Team via the <a href="https://groups.google.com/forum/#!forum/ballerina-dev">Ballerina Dev Google Group</a>.</p>
+  <p>Please try using other keywords to search in <a href="/1.1/learn/">Learn</a> or contact the Ballerina Team via the <a href="https://groups.google.com/forum/#!forum/ballerina-dev">Ballerina Dev Google Group</a>.</p>
 </div>

--- a/page-not-available.html
+++ b/page-not-available.html
@@ -36,5 +36,5 @@ layout: ballerina-inner-page
   <h1>Oops, we are sorry.</h1>
 
   <p><strong>The page you are looking for is not available for this Ballerina version.</strong></p>
-  <p>Please try using other keywords or contact the Ballerina Team via the <a href="https://groups.google.com/forum/#!forum/ballerina-dev">Ballerina Dev Google Group</a>.</p>
+  <p>Please try using other keywords to search in <a href="/learn/">Learn</a> or contact the Ballerina Team via the <a href="https://groups.google.com/forum/#!forum/ballerina-dev">Ballerina Dev Google Group</a>.</p>
 </div>

--- a/swan-lake/page-not-available.html
+++ b/swan-lake/page-not-available.html
@@ -36,5 +36,5 @@ layout: ballerina-inner-page
   <h1>Oops, we are sorry.</h1>
 
   <p><strong>The page you are looking for is not available for this Ballerina version.</strong></p>
-  <p>Please try using other keywords or contact the Ballerina Team via the <a href="https://groups.google.com/forum/#!forum/ballerina-dev">Ballerina Dev Google Group</a>.</p>
+  <p>Please try using other keywords to search in <a href="/swan-lake/learn/">Learn</a> or contact the Ballerina Team via the <a href="https://groups.google.com/forum/#!forum/ballerina-dev">Ballerina Dev Google Group</a>.</p>
 </div>


### PR DESCRIPTION
## Purpose
Add a Link to the "Learn" section in the "page not available" error page.
> Fixes https://github.com/ballerina-platform/ballerina-dev-website/issues/733

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
