### PR TITLE
Update the Supported "Node.js" Version in the Installation Page

### DIFF
--- a/learn/installing-ballerina.md
+++ b/learn/installing-ballerina.md
@@ -99,7 +99,7 @@ You need to download and install the below to build the Ballerina modules.
     - [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
     - [OpenJDK](http://openjdk.java.net/install/index.html)
     >**Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
-2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
+2. [Node.js (version 8.9.x)](https://nodejs.org/en/download/)
 3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
 
 ### Obtaining the source code

--- a/swan-lake/learn/installing-ballerina.md
+++ b/swan-lake/learn/installing-ballerina.md
@@ -92,7 +92,7 @@ You need to download and install the below to build the Ballerina modules.
     - [Oracle](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
     - [OpenJDK](http://openjdk.java.net/install/index.html)
     >**Note:** Set the JAVA_HOME environment variable to the path name of the directory into which you installed JDK.
-2. [Node.js (version 8.9.x or the latest LTS release)](https://nodejs.org/en/download/)
+2. [Node.js (version 8.9.x)](https://nodejs.org/en/download/)
 3. [npm (version 5.6.0 or later)](https://www.npmjs.com/get-npm)
 
 ### Obtaining the source code


### PR DESCRIPTION
## Purpose
Update the supported Node.js version as "8.9.x" in the installation page.

> Fixes https://github.com/ballerina-platform/ballerina-dev-website/issues/1093

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
