### PR TITLE
Change the Heading Levels in the 1.2.7 Release Note

### DIFF
--- a/downloads/RELEASE_NOTE.md
+++ b/downloads/RELEASE_NOTE.md
@@ -2,7 +2,7 @@
 layout: release-note
 title: Release note
 ---
-# Overview of jBallerina {{ site.data.stable-latest.metadata.version }}
+### Overview of jBallerina {{ site.data.stable-latest.metadata.version }}
 The jBallerina {{ site.data.stable-latest.metadata.version }} patch release improves upon the {{ site.data.stable-latest.metadata.version }} release by introducing the features listed below and addressing a number of [bugs](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+{{ site.data.stable-latest.metadata.version }}%22+label%3AType%2FBug+is%3Aclosed) and [improvements](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+{{ site.data.stable-latest.metadata.version }}%22+is%3Aclosed+label%3AType%2FImprovement).
 
 You can use the update tool to update to jBallerina {{ site.data.stable-latest.metadata.version }} as follows.
@@ -22,9 +22,9 @@ However, you need to use the following commands instead of the above if you have
 
 If you have not installed jBallerina, then download the [installers](https://ballerina.io/downloads/) to install.
 
-## Standard Library
+#### Standard Library
 - 
 
-## Dev Tools
+#### Dev Tools
 - 
 

--- a/downloads/release-notes/1.2.7/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.7/RELEASE_NOTE.md
@@ -2,7 +2,7 @@
 layout: release-note
 title: Release note
 ---
-## Overview of jBallerina {{ site.data.stable-latest.metadata.version }}
+### Overview of jBallerina {{ site.data.stable-latest.metadata.version }}
 The jBallerina {{ site.data.stable-latest.metadata.version }} patch release improves upon the {{ site.data.stable-latest.metadata.version }} release by introducing the features listed below and addressing a number of [bugs](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+{{ site.data.stable-latest.metadata.version }}%22+label%3AType%2FBug+is%3Aclosed) and [improvements](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+{{ site.data.stable-latest.metadata.version }}%22+is%3Aclosed+label%3AType%2FImprovement).
 
 You can use the update tool to update to jBallerina {{ site.data.stable-latest.metadata.version }} as follows.
@@ -22,17 +22,17 @@ However, you need to use the following commands instead of the above if you have
 
 If you have not installed jBallerina, then download the [installers](https://ballerina.io/downloads/) to install.
 
-### Standard Library
+#### Standard Library
 
-#### I/O
+##### I/O
 
 - When a CSV file has an empty record, the previous implementation panicked. This is fixed with this release.
 
-### Developer Tools
+#### Developer Tools
 
-#### Test Framework
+##### Test Framework
 
-##### Object Mocking
+###### Object Mocking
 
 Object mocking enables controlling the values of member variables and the behavior of the member functions of an object. The following improvements are introduced with regard to this.
 
@@ -44,7 +44,7 @@ Object mocking is done by using the following functions.
 - The `test:mock()` and `test:prepare()` functions are used to initialize the mocking capability.
 - The `test:prepare()` function allows to use the associated mocking functions like `thenReturn()`, `thenReturnSequence()`, `doNothing()`, and `withArguments()`.
 
-##### Function Mocking
+###### Function Mocking
 
 - The `MockFunction` object is added to handle function mocking. `MockFunction` objects are defined by attaching the `@test:Mock` to the `MockFunction` object to specify the function to mock.
 - The mocking API also supports scoping and stubbing of mock functions that are declared for functions in imported modules.


### PR DESCRIPTION
## Purpose
Change the heading levels in the 1.2.7 release note.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
