### PR TITLE
Fix the "Appendix C" Broken Link in a Released Spec Version

### DIFF
--- a/spec/lang/draft/v2020-06-18/index.html
+++ b/spec/lang/draft/v2020-06-18/index.html
@@ -506,7 +506,7 @@ unusual aspects that make it particularly suitable for its intended purpose.
 First, it provides language constructs specifically for consuming and providing
 network services. Future versions of Ballerina will add language constructs for
 other middleware functionality such as event stream processing, distributed
-transactions and reliable messaging; this is described in more detail in <a href="planned_future_functionality">Appendix C</a>.
+transactions and reliable messaging; this is described in more detail in <a href="#planned_future_functionality">Appendix C</a>.
 </p>
 <p>
 Second, its abstractions and syntax for concurrency and network interaction have


### PR DESCRIPTION
## Purpose
Fix the "Appendix C" broken link in a released spec version.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
