### PR TITLE
Fix the IntelliJ Guide Broken Link

### DIFF
--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-left-nav-pages-swanlake
 title: Using the features of the IntelliJ plugin
-permalink: /swan-lake/setting-up-intellij-idea/using-intellij-plugin-features/
+permalink: /swan-lake/learn/setting-up-intellij-idea/using-intellij-plugin-features/
 active: using-intellij-plugin-features
 redirect_from:
   - /swan-lake/learn/tools-ides/intellij-plugin/using-intellij-plugin-features


### PR DESCRIPTION
## Purpose
Fix the IntelliJ Guide broken link.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
