### PR TITLE
Fix the Linux MD5 Links in Downloads

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -63,7 +63,7 @@ redirect_from:
                   <div class="cSize">deb  <span id="packLinuxName">{{ site.data.stable-latest.metadata.linux-installer-size }}</span></div>
                </a>
                <ul class="cDiwnloadSubLinks">
-                  <li><a id="packLinuxMd5" href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }} /{{ site.data.stable-latest.metadata.linux-installer }}.md5">md5</a></li>
+                  <li><a id="packLinuxMd5" href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/{{ site.data.stable-latest.metadata.linux-installer }}.md5">md5</a></li>
                   <li><a id="packLinuxSha1" href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/{{ site.data.stable-latest.metadata.linux-installer }}.sha1">SHA-1</a></li>
                   <li><a id="packLinuxAsc" href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/{{ site.data.stable-latest.metadata.linux-installer }}.asc">asc</a></li>
                </ul>
@@ -73,7 +73,7 @@ redirect_from:
                   <div class="cSize">rpm  <span id="packLinuxName">{{ site.data.stable-latest.metadata.rpm-installer-size }}</span></div>
                </a>
                <ul class="cDiwnloadSubLinks">
-                  <li><a id="packLinuxMd5" href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }} /{{ site.data.stable-latest.metadata.rpm-installer }}.md5">md5</a></li>
+                  <li><a id="packLinuxMd5" href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/{{ site.data.stable-latest.metadata.rpm-installer }}.md5">md5</a></li>
                   <li><a id="packLinuxSha1" href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/{{ site.data.stable-latest.metadata.rpm-installer }}.sha1">SHA-1</a></li>
                   <li><a id="packLinuxAsc" href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/{{ site.data.stable-latest.metadata.rpm-installer }}.asc">asc</a></li>
                </ul>


### PR DESCRIPTION
## Purpose
Fix the Linux md5 links in the Downloads page.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
