### PR TITLE
Fix the Google Group Link in Spec Versions

### DIFF
--- a/spec/lang/2019R1/index.html
+++ b/spec/lang/2019R1/index.html
@@ -66,7 +66,7 @@ Comments on this document are welcome and should be made by creating an issue in
 >https://github.com/ballerina-platform/ballerina-spec</a></code>, which is the
 GitHub repository where this specification is maintained. The design of the
 language may also be discussed in the <a
-href="mailto:ballerina-dec@googlegroups.com">ballerina-dev@googlegroups.com</a>
+href="mailto:ballerina-dev@googlegroups.com">ballerina-dev@googlegroups.com</a>
 mailing list.
 </p>
 <h2 class="toc">Table of Contents</h2>

--- a/spec/lang/2019R2/index.html
+++ b/spec/lang/2019R2/index.html
@@ -68,7 +68,7 @@ Comments on this document are welcome and should be made by creating an issue in
 >https://github.com/ballerina-platform/ballerina-spec</a></code>, which is the
 GitHub repository where this specification is maintained. The design of the
 language may also be discussed in the <a
-href="mailto:ballerina-dec@googlegroups.com">ballerina-dev@googlegroups.com</a>
+href="mailto:ballerina-dev@googlegroups.com">ballerina-dev@googlegroups.com</a>
 mailing list.
 </p>
 <h2 class="toc">Table of Contents</h2>

--- a/spec/lang/2019R3/index.html
+++ b/spec/lang/2019R3/index.html
@@ -66,7 +66,7 @@ moved into a separate <a href="experimental.html">document</a>.
 Comments on this document are welcome and should be made by creating an issue in
 <code><a href="https://github.com/ballerina-platform/ballerina-spec">https://github.com/ballerina-platform/ballerina-spec</a></code>, which is the
 GitHub repository where this specification is maintained. The design of the
-language may also be discussed in the <a href="mailto:ballerina-dec@googlegroups.com">ballerina-dev@googlegroups.com</a>
+language may also be discussed in the <a href="mailto:ballerina-dev@googlegroups.com">ballerina-dev@googlegroups.com</a>
 mailing list.
 </p>
 <section class="toc"><h2>Table of contents</h2>

--- a/spec/lang/2020R1/index.html
+++ b/spec/lang/2020R1/index.html
@@ -62,7 +62,7 @@ design to be updated to the final design.
 Comments on this document are welcome and should be made by creating an issue in
 <code><a href="https://github.com/ballerina-platform/ballerina-spec">https://github.com/ballerina-platform/ballerina-spec</a></code>, which is the
 GitHub repository where this specification is maintained. The design of the
-language may also be discussed in the <a href="mailto:ballerina-dec@googlegroups.com">ballerina-dev@googlegroups.com</a>
+language may also be discussed in the <a href="mailto:ballerina-dev@googlegroups.com">ballerina-dev@googlegroups.com</a>
 mailing list.
 </p>
 <section class="toc"><h2>Table of contents</h2>

--- a/spec/lang/draft/v2020-06-18/index.html
+++ b/spec/lang/draft/v2020-06-18/index.html
@@ -57,7 +57,7 @@ the current design to be updated to the final design.
 Comments on this document are welcome and should be made by creating an issue in
 <code><a href="https://github.com/ballerina-platform/ballerina-spec">https://github.com/ballerina-platform/ballerina-spec</a></code>, which is the
 GitHub repository where this specification is maintained. The design of the
-language may also be discussed in the <a href="mailto:ballerina-dec@googlegroups.com">ballerina-dev@googlegroups.com</a>
+language may also be discussed in the <a href="mailto:ballerina-dev@googlegroups.com">ballerina-dev@googlegroups.com</a>
 mailing list.
 </p>
 <section class="toc"><h2>Table of contents</h2>

--- a/spec/lang/master/index.html
+++ b/spec/lang/master/index.html
@@ -57,7 +57,7 @@ the current design to be updated to the final design.
 Comments on this document are welcome and should be made by creating an issue in
 <code><a href="https://github.com/ballerina-platform/ballerina-spec">https://github.com/ballerina-platform/ballerina-spec</a></code>, which is the
 GitHub repository where this specification is maintained. The design of the
-language may also be discussed in the <a href="mailto:ballerina-dec@googlegroups.com">ballerina-dev@googlegroups.com</a>
+language may also be discussed in the <a href="mailto:ballerina-dev@googlegroups.com">ballerina-dev@googlegroups.com</a>
 mailing list.
 </p>
 <section class="toc"><h2>Table of contents</h2>

--- a/spec/lang/master/spec.xml
+++ b/spec/lang/master/spec.xml
@@ -53,7 +53,7 @@ Comments on this document are welcome and should be made by creating an issue in
 >https://github.com/ballerina-platform/ballerina-spec</a></code>, which is the
 GitHub repository where this specification is maintained. The design of the
 language may also be discussed in the <a
-href="mailto:ballerina-dec@googlegroups.com">ballerina-dev@googlegroups.com</a>
+href="mailto:ballerina-dev@googlegroups.com">ballerina-dev@googlegroups.com</a>
 mailing list.
 </p>
 <section class="toc">


### PR DESCRIPTION
## Purpose
Fix the Google Group link in spec versions.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
