### PR TITLE
Fix the "Edit on GitHub" Option of the Deployment Modules for 1.1.x & 1.0.x

### DIFF
--- a/1.0/learn/by-example/docker-deployment.html
+++ b/1.0/learn/by-example/docker-deployment.html
@@ -292,7 +292,7 @@ Docker should be configured to run the sample.</p>
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/master/examples/docker-deployment/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/module-ballerina-docker/tree/ballerina-1.0.x/docker-extension-examples/examples/docker-deployment"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>

--- a/1.0/learn/by-example/kubernetes-deployment.html
+++ b/1.0/learn/by-example/kubernetes-deployment.html
@@ -335,7 +335,7 @@ to the security folder.</p>
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/master/examples/kubernetes-deployment/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/module-ballerina-kubernetes/tree/ballerina-1.0.x/kubernetes-extension-examples/examples/kubernetes-deployment"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>

--- a/1.0/learn/by-example/openshift-deployment.html
+++ b/1.0/learn/by-example/openshift-deployment.html
@@ -303,7 +303,7 @@ This example deploys an HTTP service, which responses &ldquo;Hello&rdquo; follow
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/master/examples/openshift-deployment/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/module-ballerina-kubernetes/tree/ballerina-1.0.x/kubernetes-extension-examples/examples/openshift-deployment"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>

--- a/1.1/learn/by-example/docker-deployment.html
+++ b/1.1/learn/by-example/docker-deployment.html
@@ -81,7 +81,7 @@ Docker should be configured to run the sample.</p>
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/master/examples/docker-deployment/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/module-ballerina-docker/tree/ballerina-1.1.x/docker-extension-examples/examples/docker-deployment"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>

--- a/1.1/learn/by-example/kubernetes-deployment.html
+++ b/1.1/learn/by-example/kubernetes-deployment.html
@@ -124,7 +124,7 @@ to the security folder.</p>
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/master/examples/kubernetes-deployment/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/module-ballerina-kubernetes/tree/ballerina-1.1.x/kubernetes-extension-examples/examples/kubernetes-deployment"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>

--- a/1.1/learn/by-example/openshift-deployment.html
+++ b/1.1/learn/by-example/openshift-deployment.html
@@ -92,7 +92,7 @@ This example deploys an HTTP service, which responses &ldquo;Hello&rdquo; follow
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/master/examples/openshift-deployment/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/module-ballerina-kubernetes/tree/ballerina-1.1.x/kubernetes-extension-examples/examples/openshift-deployment"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>

--- a/js/redirections.js
+++ b/js/redirections.js
@@ -197,7 +197,11 @@ let redirections = {
     "/1.1/learn/by-example/jdbc-streaming-big-dataset.html":"/1.1/page-not-available.html",
     "/1.0/learn/by-example/jdbc-streaming-big-dataset.html":"/1.0/page-not-available.html",
     "/1.1/learn/by-example/knative-deployment.html": "/1.1/page-not-available.html",
-    "/1.0/learn/by-example/knative-deployment.html": "/1.0/page-not-available.html"
+    "/1.0/learn/by-example/knative-deployment.html": "/1.0/page-not-available.html",
+    "/1.1/learn/by-example/aws-lambda-deployment.html": "/1.1/page-not-available.html",
+    "/1.0/learn/by-example/aws-lambda-deployment.html": "/1.0/page-not-available.html",
+    "/1.1/learn/by-example/azure-functions-deployment.html": "/1.1/page-not-available.html",
+    "/1.0/learn/by-example/azure-functions-deployment": "/1.0/page-not-available.html"
 
 
     

--- a/js/redirections.js
+++ b/js/redirections.js
@@ -193,7 +193,9 @@ let redirections = {
     "/1.0/learn/faq/":"/1.0/learn/",
     "/1.0/learn/by-guide":"/1.0/learn/",
     "/1.0/learn/by-guide/":"/1.0/learn/",
-    "/swan-lake/learn/by-example/jdbc-streaming-big-dataset.html":"/swan-lake/page-not-available.html"
+    "/swan-lake/learn/by-example/jdbc-streaming-big-dataset.html":"/swan-lake/page-not-available.html",
+    "/1.1/learn/by-example/knative-deployment.html":"/1.1/page-not-available.html",
+    "/1.0/learn/by-example/knative-deployment.html":"/1.0/page-not-available.html"
 
 
     


### PR DESCRIPTION
## Purpose
Fix the "Edit on GitHub" Option of the Deployment Modules for 1.1.x & 1.0.x.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
