### PR TITLE
Generate and Add API Docs of the Deployment Modules in 1.2.x

### DIFF
--- a/learn/api-docs/ballerina/awslambda/annotations.html
+++ b/learn/api-docs/ballerina/awslambda/annotations.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers the capabilities of creating AWS Lambda functions using ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,awslambda">
+
+    <title>API Docs - Annotations : awslambda</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Annotations</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#Function" onclick="menuLinkClick()">Function</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../awslambda/index.html" onclick="menuLinkClick()">
+            <h3>awslambda</h3>
+        </a>
+    
+    <ul>
+        
+        
+            <li>
+                <a  data="objects" href="../awslambda/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../awslambda/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../awslambda/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../awslambda/index.html">awslambda</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Annotations - </span>
+                 
+                     <a href="../awslambda/index.html">awslambda</a>
+                 
+            </h1>
+            <div class="annotations">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Function</b>
+                                    <span class="type"></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        function</li>
+                                <li>
+                                    
+                                    <p>@awslambda:Function annotation</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/awslambda/functions.html
+++ b/learn/api-docs/ballerina/awslambda/functions.html
@@ -1,0 +1,330 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers the capabilities of creating AWS Lambda functions using ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,awslambda">
+
+    <title>API Docs - Functions : awslambda</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Functions</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#__process" onclick="menuLinkClick()">__process</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#__register" onclick="menuLinkClick()">__register</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../awslambda/index.html" onclick="menuLinkClick()">
+            <h3>awslambda</h3>
+        </a>
+    
+    <ul>
+        
+        
+            <li>
+                <a  data="objects" href="../awslambda/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../awslambda/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../awslambda/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../awslambda/index.html">awslambda</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1>
+                <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Functions - </span>
+                
+                    <a href="../awslambda/index.html">awslambda</a>
+                
+            </h1>
+            <div class="constants">
+                <table class="ui table row-border details-table">
+                    <tbody>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#__process">__process</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#__register">__register</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                    </tbody>
+                </table>
+                <div>
+                    
+                        <div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="__process" title="__process">
+             <a class="url-link" href="#__process">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > __process </h2>
+        <span class="method-types">
+            <p>()</p>
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        
+    </div>
+    
+
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="__register" title="__register">
+             <a class="url-link" href="#__register">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > __register </h2>
+        <span class="method-types">
+            <p>(<span class="builtin-type">string</span> handler, <code> <span>function(</span><a href="../awslambda/objects/Context.html">Context</a>, <span class="builtin-type">json</span><span>) </span><span>returns (</span><span class="builtin-type">json</span> | <span class="builtin-type">error</span><span>)</span> </code> func)</p>
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >handler</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >func</span>
+                        <span class="type">  <code> <span>function(</span><a href="../awslambda/objects/Context.html">Context</a>, <span class="builtin-type">json</span><span>) </span><span>returns (</span><span class="builtin-type">json</span> | <span class="builtin-type">error</span><span>)</span> </code> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+</div>
+                            
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/awslambda/index.html
+++ b/learn/api-docs/ballerina/awslambda/index.html
@@ -1,0 +1,353 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers the capabilities of creating AWS Lambda functions using ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,awslambda">
+
+    <title>API Docs - ballerinax/awslambda</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../awslambda/index.html" onclick="menuLinkClick()">
+            <h3>awslambda</h3>
+        </a>
+    
+    <ul>
+        
+        
+            <li>
+                <a  data="objects" href="../awslambda/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../awslambda/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../awslambda/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../awslambda/index.html">awslambda</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper module-wrapper">
+                <h1>
+                    <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                    
+                        Module : <span class="modules">awslambda</span>
+                    
+                </h1>
+                    <h2>Module Overview</h2>
+<p>This module offers the capabilities of creating AWS Lambda functions using ballerina.</p>
+<ul>
+<li>For information on the operations, which you can perform with this module, see <a href="https://ballerina.io/learn/api-docs/ballerina/awslambda/index.html#objects">Objects</a>.</li>
+<li>For information on the deployment, see the <a href="https://ballerina.io/learn/deployment/aws-lambda/">AWS Lambda Deployment Guide</a>.</li>
+<li>For examples on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/aws-lambda-deployment.html">AWS Lambda Deployment Example</a>.</li>
+</ul>
+<h3>Annotation Usage Sample:</h3>
+<pre><code class="language-ballerina">import ballerinax/awslambda;
+import ballerina/system;
+
+@awslambda:Function
+public function echo(awslambda:Context ctx, json input) returns json|error {
+   return input;
+}
+
+@awslambda:Function
+public function uuid(awslambda:Context ctx, json input) returns json|error {
+   return system:uuid();
+}
+
+@awslambda:Function
+public function ctxinfo(awslambda:Context ctx, json input) returns json|error {
+   json result = { RequestID: ctx.getRequestId(),
+                   DeadlineMS: ctx.getDeadlineMs(),
+                   InvokedFunctionArn: ctx.getInvokedFunctionArn(),
+                   TraceID: ctx.getTraceId(),
+                   RemainingExecTime: ctx.getRemainingExecutionTime() };
+   return result;
+}
+</code></pre>
+<p>The output of the Ballerina build is as follows:</p>
+<pre><code class="language-bash">$ ballerina build functions.bal 
+Compiling source
+    functions.bal
+
+Generating executable
+    functions.jar
+	@awslambda:Function: echo, uuid, ctxinfo
+
+	Run the following command to deploy each Ballerina AWS Lambda function:
+	aws lambda create-function --function-name &lt;FUNCTION_NAME&gt; --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.&lt;FUNCTION_NAME&gt; --runtime provided --role &lt;LAMBDA_ROLE_ARN&gt; --layers &lt;BALLERINA_LAYER_ARN&gt;
+
+	Run the following command to re-deploy an updated Ballerina AWS Lambda function:
+	aws lambda update-function-code --function-name &lt;FUNCTION_NAME&gt; --zip-file fileb://aws-ballerina-lambda-functions.zip
+</code></pre>
+
+
+            
+
+            
+            
+            <section class="method-content" id="objects">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#objects">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Objects </h2>
+                </div>
+                <table>
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate objects" id="Context" title="Context">
+                                <a class="objects " href="objects/Context.html">Context</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Object to represent an AWS Lambda function execution context.
+                            </td>
+                        </tr>
+                    
+                    
+                </table>
+             </section>
+            
+            
+
+            
+
+            
+           
+
+            
+            <section class="method-content" id="functions">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#functions">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                    <h2> Functions </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="__process" title="__process">
+                                <a class="functions " href="functions.html#__process">__process</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="__register" title="__register">
+                                <a class="functions " href="functions.html#__register">__register</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+
+            
+
+
+            
+            <section class="method-content" id="annotations">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#annotations">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Annotations </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Function" title="Function">
+                                <a class="annotations " href="annotations.html#Function">Function</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@awslambda:Function annotation</p>
+
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+            
+
+            
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/awslambda/objects/Context.html
+++ b/learn/api-docs/ballerina/awslambda/objects/Context.html
@@ -1,0 +1,470 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers the capabilities of creating AWS Lambda functions using ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,awslambda">
+
+    <title>API Docs - Object : Context</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Objects</h3>
+                <ul>
+                    
+                        <li class="active">
+                            <a href="Context.html" onclick="menuLinkClick()">Context</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../awslambda/index.html" onclick="menuLinkClick()">
+            <h3>awslambda</h3>
+        </a>
+    
+    <ul>
+        
+        
+            <li>
+                <a  data="objects" href="../../awslambda/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../awslambda/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../awslambda/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../awslambda/index.html">awslambda</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+
+        <div class="main-wrapper">
+            <h1>
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Object - </span>
+                
+                    <a href="../../awslambda/index.html">awslambda</a>
+                 :
+                <span class="objects ">Context</span>
+            </h1>
+            <p>
+                
+                <p>Object to represent an AWS Lambda function execution context.</p>
+
+            </p>
+
+            <div class="constants">
+                <div class="method-sum">
+                    
+
+                
+                    
+                        <h2>Methods</h2>
+                        <div class="method-list">
+                            
+                                
+<div class="param-sum">
+    <div class="param-name " title="getRequestId">
+        <a href="#getRequestId">getRequestId </a>
+    </div>
+    <div class="param-details"> 
+            
+        <p>Returns the unique id for this request.
+    </div>
+</div>
+
+                            
+                                
+<div class="param-sum">
+    <div class="param-name " title="getDeadlineMs">
+        <a href="#getDeadlineMs">getDeadlineMs </a>
+    </div>
+    <div class="param-details"> 
+            
+        <p>Returns the request execution deadline in milliseconds from the epoch.
+    </div>
+</div>
+
+                            
+                                
+<div class="param-sum">
+    <div class="param-name " title="getInvokedFunctionArn">
+        <a href="#getInvokedFunctionArn">getInvokedFunctionArn </a>
+    </div>
+    <div class="param-details"> 
+            
+        <p>Returns the ARN of the function being invoked.
+    </div>
+</div>
+
+                            
+                                
+<div class="param-sum">
+    <div class="param-name " title="getTraceId">
+        <a href="#getTraceId">getTraceId </a>
+    </div>
+    <div class="param-details"> 
+            
+        <p>Returns the trace id for this request</p>
+
+    </div>
+</div>
+
+                            
+                                
+<div class="param-sum">
+    <div class="param-name " title="getRemainingExecutionTime">
+        <a href="#getRemainingExecutionTime">getRemainingExecutionTime </a>
+    </div>
+    <div class="param-details"> 
+            
+        <p>Returns the remaining execution time for this request in milliseconds</p>
+
+    </div>
+</div>
+
+                            
+                        </div>
+                    
+
+                    
+                </div>
+
+                
+                    
+                        <div class="method-content">
+    <div class="main-method-title here" id="getRequestId" title="getRequestId">
+             <a class="url-link" href="#getRequestId">
+                <img class="url-link-img" src="../../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getRequestId </h2>
+        <span class="method-types">
+            <p>()</p>
+            
+                <b> returns </b><span class="builtin-type">string</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>Returns the unique id for this request.</p>
+
+    </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">string</span></span>)</li>
+                <li><p>the request id</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                    
+                        <div class="method-content">
+    <div class="main-method-title here" id="getDeadlineMs" title="getDeadlineMs">
+             <a class="url-link" href="#getDeadlineMs">
+                <img class="url-link-img" src="../../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getDeadlineMs </h2>
+        <span class="method-types">
+            <p>()</p>
+            
+                <b> returns </b><span class="builtin-type">int</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>Returns the request execution deadline in milliseconds from the epoch.</p>
+
+    </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">int</span></span>)</li>
+                <li><p>the request execution deadline</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                    
+                        <div class="method-content">
+    <div class="main-method-title here" id="getInvokedFunctionArn" title="getInvokedFunctionArn">
+             <a class="url-link" href="#getInvokedFunctionArn">
+                <img class="url-link-img" src="../../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getInvokedFunctionArn </h2>
+        <span class="method-types">
+            <p>()</p>
+            
+                <b> returns </b><span class="builtin-type">string</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>Returns the ARN of the function being invoked.</p>
+
+    </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">string</span></span>)</li>
+                <li><p>the invoked function ARN</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                    
+                        <div class="method-content">
+    <div class="main-method-title here" id="getTraceId" title="getTraceId">
+             <a class="url-link" href="#getTraceId">
+                <img class="url-link-img" src="../../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getTraceId </h2>
+        <span class="method-types">
+            <p>()</p>
+            
+                <b> returns </b><span class="builtin-type">string</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>Returns the trace id for this request</p>
+
+    </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">string</span></span>)</li>
+                <li><p>the trace id</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                    
+                        <div class="method-content">
+    <div class="main-method-title here" id="getRemainingExecutionTime" title="getRemainingExecutionTime">
+             <a class="url-link" href="#getRemainingExecutionTime">
+                <img class="url-link-img" src="../../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getRemainingExecutionTime </h2>
+        <span class="method-types">
+            <p>()</p>
+            
+                <b> returns </b><span class="builtin-type">int</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>Returns the remaining execution time for this request in milliseconds</p>
+
+    </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">int</span></span>)</li>
+                <li><p>the remaining execution time</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                    
+                
+            </div>
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/annotations.html
+++ b/learn/api-docs/ballerina/azure.functions/annotations.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Annotations : azure.functions</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Annotations</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#BindingName" onclick="menuLinkClick()">BindingName</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#BlobInput" onclick="menuLinkClick()">BlobInput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#BlobOutput" onclick="menuLinkClick()">BlobOutput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#BlobTrigger" onclick="menuLinkClick()">BlobTrigger</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#CosmosDBInput" onclick="menuLinkClick()">CosmosDBInput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#CosmosDBOutput" onclick="menuLinkClick()">CosmosDBOutput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#CosmosDBTrigger" onclick="menuLinkClick()">CosmosDBTrigger</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#Function" onclick="menuLinkClick()">Function</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#HTTPOutput" onclick="menuLinkClick()">HTTPOutput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#HTTPTrigger" onclick="menuLinkClick()">HTTPTrigger</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#QueueOutput" onclick="menuLinkClick()">QueueOutput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#QueueTrigger" onclick="menuLinkClick()">QueueTrigger</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#TimerTrigger" onclick="menuLinkClick()">TimerTrigger</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#TwilioSmsOutput" onclick="menuLinkClick()">TwilioSmsOutput</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Annotations - </span>
+                 
+                     <a href="../azure.functions/index.html">azure.functions</a>
+                 
+            </h1>
+            <div class="annotations">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >BindingName</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/BindingNameConfiguration.html">BindingNameConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:BindingName annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >BlobInput</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/BlobConfiguration.html">BlobConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:BlobInput annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >BlobOutput</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/BlobConfiguration.html">BlobConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:BlobOutput annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >BlobTrigger</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/BlobConfiguration.html">BlobConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:BlobTrigger annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >CosmosDBInput</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/CosmosDBInputConfiguration.html">CosmosDBInputConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:CosmosDBInput annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >CosmosDBOutput</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/CosmosDBOutputConfiguration.html">CosmosDBOutputConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        return</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:CosmosDBOutput annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >CosmosDBTrigger</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/CosmosDBTriggerConfiguration.html">CosmosDBTriggerConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:CosmosDBTrigger annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Function</b>
+                                    <span class="type"></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        function</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:Function annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >HTTPOutput</b>
+                                    <span class="type"></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        return, parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:HTTPOutput annotation</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >HTTPTrigger</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/HTTPTriggerConfiguration.html">HTTPTriggerConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:HTTPTrigger annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >QueueOutput</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/QueueConfiguration.html">QueueConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        return, parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:QueueOutput annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >QueueTrigger</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/QueueConfiguration.html">QueueConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:QueueOutput annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >TimerTrigger</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/TimerTriggerConfiguration.html">TimerTriggerConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:TimerTrigger annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >TwilioSmsOutput</b>
+                                    <span class="type"> <span ><a href="../azure.functions/records/TwilioSmsConfiguration.html">TwilioSmsConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        parameter</li>
+                                <li>
+                                    
+                                    <p>@azurefunctions:TwilioSmsOutput annotation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/functions.html
+++ b/learn/api-docs/ballerina/azure.functions/functions.html
@@ -1,0 +1,3089 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Functions : azure.functions</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Functions</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#__register" onclick="menuLinkClick()">__register</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#createContext" onclick="menuLinkClick()">createContext</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getBallerinaValueFromInputData" onclick="menuLinkClick()">getBallerinaValueFromInputData</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getBallerinaValueFromInputDataDoubleEscape" onclick="menuLinkClick()">getBallerinaValueFromInputDataDoubleEscape</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getBinaryFromHTTPReq" onclick="menuLinkClick()">getBinaryFromHTTPReq</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getBodyFromHTTPInputData" onclick="menuLinkClick()">getBodyFromHTTPInputData</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getBytesFromInputData" onclick="menuLinkClick()">getBytesFromInputData</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getHTTPRequestFromInputData" onclick="menuLinkClick()">getHTTPRequestFromInputData</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getHTTPRequestFromParams" onclick="menuLinkClick()">getHTTPRequestFromParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getJsonFromHTTPReq" onclick="menuLinkClick()">getJsonFromHTTPReq</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getJsonFromInputData" onclick="menuLinkClick()">getJsonFromInputData</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getJsonFromInputDataDoubleEscaped" onclick="menuLinkClick()">getJsonFromInputDataDoubleEscaped</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getJsonFromMetadata" onclick="menuLinkClick()">getJsonFromMetadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getMetadata" onclick="menuLinkClick()">getMetadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getOptionalBallerinaValueFromInputDataDoubleEscape" onclick="menuLinkClick()">getOptionalBallerinaValueFromInputDataDoubleEscape</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getOptionalBytesFromInputData" onclick="menuLinkClick()">getOptionalBytesFromInputData</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getOptionalStringConvertedBytesFromInputData" onclick="menuLinkClick()">getOptionalStringConvertedBytesFromInputData</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getOptionalStringFromInputData" onclick="menuLinkClick()">getOptionalStringFromInputData</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getStringConvertedBytesFromInputData" onclick="menuLinkClick()">getStringConvertedBytesFromInputData</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getStringFromHTTPReq" onclick="menuLinkClick()">getStringFromHTTPReq</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getStringFromInputData" onclick="menuLinkClick()">getStringFromInputData</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#getStringFromMetadata" onclick="menuLinkClick()">getStringFromMetadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setBallerinaValueAsJsonReturn" onclick="menuLinkClick()">setBallerinaValueAsJsonReturn</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setBlobOutput" onclick="menuLinkClick()">setBlobOutput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setHTTPOutput" onclick="menuLinkClick()">setHTTPOutput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setHTTPReturn" onclick="menuLinkClick()">setHTTPReturn</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setJsonReturn" onclick="menuLinkClick()">setJsonReturn</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setPureHTTPOutput" onclick="menuLinkClick()">setPureHTTPOutput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setPureJsonOutput" onclick="menuLinkClick()">setPureJsonOutput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setPureStringOutput" onclick="menuLinkClick()">setPureStringOutput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setStringOutput" onclick="menuLinkClick()">setStringOutput</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setStringReturn" onclick="menuLinkClick()">setStringReturn</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#setTwilioSmsOutput" onclick="menuLinkClick()">setTwilioSmsOutput</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1>
+                <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Functions - </span>
+                
+                    <a href="../azure.functions/index.html">azure.functions</a>
+                
+            </h1>
+            <div class="constants">
+                <table class="ui table row-border details-table">
+                    <tbody>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#__register">__register</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - registers a handler function.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#createContext">createContext</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - creates function context.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getBallerinaValueFromInputData">getBallerinaValueFromInputData</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns a converted Ballerina value from input data.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getBallerinaValueFromInputDataDoubleEscape">getBallerinaValueFromInputDataDoubleEscape</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the converted Ballerina value from input data - double escape.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getBinaryFromHTTPReq">getBinaryFromHTTPReq</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the binary payload from the HTTP request.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getBodyFromHTTPInputData">getBodyFromHTTPInputData</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the HTTP body value from input data.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getBytesFromInputData">getBytesFromInputData</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the binary value from input data.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getHTTPRequestFromInputData">getHTTPRequestFromInputData</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Populates the HTTP request structure from an input data entry.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getHTTPRequestFromParams">getHTTPRequestFromParams</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the HTTP request data.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getJsonFromHTTPReq">getJsonFromHTTPReq</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the JSON payload from the HTTP request.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getJsonFromInputData">getJsonFromInputData</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the JSON value from input data.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getJsonFromInputDataDoubleEscaped">getJsonFromInputDataDoubleEscaped</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the JSON value from input data - double escape.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getJsonFromMetadata">getJsonFromMetadata</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns a json value from metadata.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getMetadata">getMetadata</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - extracts the metadata.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getOptionalBallerinaValueFromInputDataDoubleEscape">getOptionalBallerinaValueFromInputDataDoubleEscape</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the optional converted Ballerina value from input data - double escape.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getOptionalBytesFromInputData">getOptionalBytesFromInputData</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the optional binary value from input data.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getOptionalStringConvertedBytesFromInputData">getOptionalStringConvertedBytesFromInputData</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the optional string value converted from input binary data.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getOptionalStringFromInputData">getOptionalStringFromInputData</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the optional string value from input data.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getStringConvertedBytesFromInputData">getStringConvertedBytesFromInputData</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the string value converted from input binary data.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getStringFromHTTPReq">getStringFromHTTPReq</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the string payload from the HTTP request.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getStringFromInputData">getStringFromInputData</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns the string value from input data.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#getStringFromMetadata">getStringFromMetadata</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Returns a string value from metadata.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setBallerinaValueAsJsonReturn">setBallerinaValueAsJsonReturn</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Converts a Ballerina value to a JSON and set the return value.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setBlobOutput">setBlobOutput</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Sets the Blob output.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setHTTPOutput">setHTTPOutput</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Sets the HTTP output.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setHTTPReturn">setHTTPReturn</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Sets the HTTP binding return value.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setJsonReturn">setJsonReturn</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Sets the JSON return value.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setPureHTTPOutput">setPureHTTPOutput</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Sets the pure HTTP output.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setPureJsonOutput">setPureJsonOutput</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Sets the pure JSON output.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setPureStringOutput">setPureStringOutput</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Sets the pure string output.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setStringOutput">setStringOutput</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Sets the string output.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setStringReturn">setStringReturn</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Sets the string return value.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                            <tr>
+                                <td width="30%"><a class="functions " href="#setTwilioSmsOutput">setTwilioSmsOutput</a></td>
+                                <td width="70%">
+                                    <div class="function-desc">
+                                        
+                                        <p>INTERNAL usage - Sets the Twilio output.
+                                    </div>
+                                </td>
+                            </tr>
+                        
+                    </tbody>
+                </table>
+                <div>
+                    
+                        <div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="__register" title="__register">
+             <a class="url-link" href="#__register">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > __register </h2>
+        <span class="method-types">
+            <p>(<span class="builtin-type">string</span> name, <span class="builtin-type">FunctionHandler</span> funcHandler)</p>
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - registers a handler function.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The name of the function</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >funcHandler</span>
+                        <span class="type">  <span class="builtin-type">FunctionHandler</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The function handler</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="createContext" title="createContext">
+             <a class="url-link" href="#createContext">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > createContext </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> hparams, <span class="builtin-type">boolean</span> populateMetadata)</p>
+            
+                <b> returns </b><a href="../azure.functions/objects/Context.html">Context</a> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - creates function context.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >hparams</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >populateMetadata</span>
+                        <span class="type">  <span class="builtin-type">boolean</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The flag to populate metadata</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><a href="../azure.functions/objects/Context.html">Context</a> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The function context</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getBallerinaValueFromInputData" title="getBallerinaValueFromInputData">
+             <a class="url-link" href="#getBallerinaValueFromInputData">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getBallerinaValueFromInputData </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name, <span class="builtin-type">typedesc</span> recordType)</p>
+            
+                <b> returns </b><span class="builtin-type">anydata</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns a converted Ballerina value from input data.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >recordType</span>
+                        <span class="type">  <span class="builtin-type">typedesc</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The record type descriptor</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">anydata</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The JSON value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getBallerinaValueFromInputDataDoubleEscape" title="getBallerinaValueFromInputDataDoubleEscape">
+             <a class="url-link" href="#getBallerinaValueFromInputDataDoubleEscape">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getBallerinaValueFromInputDataDoubleEscape </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name, <span class="builtin-type">typedesc</span> recordType)</p>
+            
+                <b> returns </b><span class="builtin-type">anydata</span> | <span class="builtin-type">()</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the converted Ballerina value from input data - double escape.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >recordType</span>
+                        <span class="type">  <span class="builtin-type">typedesc</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The record type descriptor</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">anydata</span> | <span class="builtin-type">()</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The JSON value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getBinaryFromHTTPReq" title="getBinaryFromHTTPReq">
+             <a class="url-link" href="#getBinaryFromHTTPReq">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getBinaryFromHTTPReq </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params)</p>
+            
+                <b> returns </b><span class="array-type"><span class="builtin-type">byte</span>[]</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the binary payload from the HTTP request.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="array-type"><span class="builtin-type">byte</span>[]</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The binary payload</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getBodyFromHTTPInputData" title="getBodyFromHTTPInputData">
+             <a class="url-link" href="#getBodyFromHTTPInputData">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getBodyFromHTTPInputData </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="builtin-type">string</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the HTTP body value from input data.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">string</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The HTTP body</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getBytesFromInputData" title="getBytesFromInputData">
+             <a class="url-link" href="#getBytesFromInputData">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getBytesFromInputData </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="array-type"><span class="builtin-type">byte</span>[]</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the binary value from input data.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="array-type"><span class="builtin-type">byte</span>[]</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The binary value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getHTTPRequestFromInputData" title="getHTTPRequestFromInputData">
+             <a class="url-link" href="#getHTTPRequestFromInputData">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getHTTPRequestFromInputData </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><a href="../azure.functions/records/HTTPRequest.html">HTTPRequest</a> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Populates the HTTP request structure from an input data entry.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><a href="../azure.functions/records/HTTPRequest.html">HTTPRequest</a> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The HTTP request</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getHTTPRequestFromParams" title="getHTTPRequestFromParams">
+             <a class="url-link" href="#getHTTPRequestFromParams">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getHTTPRequestFromParams </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params)</p>
+            
+                <b> returns </b><a href="../http/objects/Request.html">Request</a> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the HTTP request data.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><a href="../http/objects/Request.html">Request</a> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The HTTP request</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getJsonFromHTTPReq" title="getJsonFromHTTPReq">
+             <a class="url-link" href="#getJsonFromHTTPReq">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getJsonFromHTTPReq </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params)</p>
+            
+                <b> returns </b><span class="builtin-type">json</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the JSON payload from the HTTP request.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">json</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The JSON payload</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getJsonFromInputData" title="getJsonFromInputData">
+             <a class="url-link" href="#getJsonFromInputData">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getJsonFromInputData </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="builtin-type">json</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the JSON value from input data.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">json</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The JSON value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getJsonFromInputDataDoubleEscaped" title="getJsonFromInputDataDoubleEscaped">
+             <a class="url-link" href="#getJsonFromInputDataDoubleEscaped">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getJsonFromInputDataDoubleEscaped </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="builtin-type">json</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the JSON value from input data - double escape.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">json</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The JSON value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getJsonFromMetadata" title="getJsonFromMetadata">
+             <a class="url-link" href="#getJsonFromMetadata">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getJsonFromMetadata </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="builtin-type">json</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns a json value from metadata.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The metadata entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">json</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The metadata entry value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getMetadata" title="getMetadata">
+             <a class="url-link" href="#getMetadata">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getMetadata </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> hparams)</p>
+            
+                <b> returns </b><span class="builtin-type">json</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - extracts the metadata.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >hparams</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">json</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The metadata JSON</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getOptionalBallerinaValueFromInputDataDoubleEscape" title="getOptionalBallerinaValueFromInputDataDoubleEscape">
+             <a class="url-link" href="#getOptionalBallerinaValueFromInputDataDoubleEscape">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getOptionalBallerinaValueFromInputDataDoubleEscape </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name, <span class="builtin-type">typedesc</span> recordType)</p>
+            
+                <b> returns </b><span class="builtin-type">anydata</span> | <span class="builtin-type">()</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the optional converted Ballerina value from input data - double escape.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >recordType</span>
+                        <span class="type">  <span class="builtin-type">typedesc</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The record type descriptor</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">anydata</span> | <span class="builtin-type">()</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The JSON value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getOptionalBytesFromInputData" title="getOptionalBytesFromInputData">
+             <a class="url-link" href="#getOptionalBytesFromInputData">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getOptionalBytesFromInputData </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="array-type"><span class="builtin-type">byte</span>[]</span> | <span class="builtin-type">()</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the optional binary value from input data.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="array-type"><span class="builtin-type">byte</span>[]</span> | <span class="builtin-type">()</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The optional string value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getOptionalStringConvertedBytesFromInputData" title="getOptionalStringConvertedBytesFromInputData">
+             <a class="url-link" href="#getOptionalStringConvertedBytesFromInputData">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getOptionalStringConvertedBytesFromInputData </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="builtin-type">string</span> | <span class="builtin-type">()</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the optional string value converted from input binary data.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">string</span> | <span class="builtin-type">()</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The optional binary value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getOptionalStringFromInputData" title="getOptionalStringFromInputData">
+             <a class="url-link" href="#getOptionalStringFromInputData">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getOptionalStringFromInputData </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="builtin-type">string</span> | <span class="builtin-type">()</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the optional string value from input data.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">string</span> | <span class="builtin-type">()</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The optional string value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getStringConvertedBytesFromInputData" title="getStringConvertedBytesFromInputData">
+             <a class="url-link" href="#getStringConvertedBytesFromInputData">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getStringConvertedBytesFromInputData </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="builtin-type">string</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the string value converted from input binary data.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">string</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The string value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getStringFromHTTPReq" title="getStringFromHTTPReq">
+             <a class="url-link" href="#getStringFromHTTPReq">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getStringFromHTTPReq </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params)</p>
+            
+                <b> returns </b><span class="builtin-type">string</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the string payload from the HTTP request.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">string</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The string payload</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getStringFromInputData" title="getStringFromInputData">
+             <a class="url-link" href="#getStringFromInputData">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getStringFromInputData </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="builtin-type">string</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns the string value from input data.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The input data entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">string</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The string value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="getStringFromMetadata" title="getStringFromMetadata">
+             <a class="url-link" href="#getStringFromMetadata">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > getStringFromMetadata </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name)</p>
+            
+                <b> returns </b><span class="builtin-type">string</span> | <span class="builtin-type">error</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Returns a string value from metadata.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The metadata entry name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">string</span> | <span class="builtin-type">error</span></span>)</li>
+                <li><p>The metadata entry value</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setBallerinaValueAsJsonReturn" title="setBallerinaValueAsJsonReturn">
+             <a class="url-link" href="#setBallerinaValueAsJsonReturn">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setBallerinaValueAsJsonReturn </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">anydata</span> value)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Converts a Ballerina value to a JSON and set the return value.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >value</span>
+                        <span class="type">  <span class="builtin-type">anydata</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The value</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setBlobOutput" title="setBlobOutput">
+             <a class="url-link" href="#setBlobOutput">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setBlobOutput </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name, <span class="builtin-type">any</span> binding)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Sets the Blob output.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The parameter name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >binding</span>
+                        <span class="type">  <span class="builtin-type">any</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The binding data</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setHTTPOutput" title="setHTTPOutput">
+             <a class="url-link" href="#setHTTPOutput">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setHTTPOutput </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name, <a href="../azure.functions/records/HTTPBinding.html">HTTPBinding</a> binding)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Sets the HTTP output.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The parameter name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >binding</span>
+                        <span class="type">  <a href="../azure.functions/records/HTTPBinding.html">HTTPBinding</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The binding data</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setHTTPReturn" title="setHTTPReturn">
+             <a class="url-link" href="#setHTTPReturn">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setHTTPReturn </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <a href="../azure.functions/records/HTTPBinding.html">HTTPBinding</a> binding)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Sets the HTTP binding return value.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >binding</span>
+                        <span class="type">  <a href="../azure.functions/records/HTTPBinding.html">HTTPBinding</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The HTTP binding return value</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setJsonReturn" title="setJsonReturn">
+             <a class="url-link" href="#setJsonReturn">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setJsonReturn </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">json</span> value)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Sets the JSON return value.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >value</span>
+                        <span class="type">  <span class="builtin-type">json</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The JSON return value</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setPureHTTPOutput" title="setPureHTTPOutput">
+             <a class="url-link" href="#setPureHTTPOutput">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setPureHTTPOutput </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <a href="../azure.functions/records/HTTPBinding.html">HTTPBinding</a> binding)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Sets the pure HTTP output.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >binding</span>
+                        <span class="type">  <a href="../azure.functions/records/HTTPBinding.html">HTTPBinding</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The binding data</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setPureJsonOutput" title="setPureJsonOutput">
+             <a class="url-link" href="#setPureJsonOutput">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setPureJsonOutput </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">json</span> value)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Sets the pure JSON output.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >value</span>
+                        <span class="type">  <span class="builtin-type">json</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The value</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setPureStringOutput" title="setPureStringOutput">
+             <a class="url-link" href="#setPureStringOutput">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setPureStringOutput </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> value)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Sets the pure string output.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >value</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The value</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setStringOutput" title="setStringOutput">
+             <a class="url-link" href="#setStringOutput">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setStringOutput </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name, <a href="../azure.functions/records/StringOutputBinding.html">StringOutputBinding</a> binding)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Sets the string output.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The parameter name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >binding</span>
+                        <span class="type">  <a href="../azure.functions/records/StringOutputBinding.html">StringOutputBinding</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The binding data</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setStringReturn" title="setStringReturn">
+             <a class="url-link" href="#setStringReturn">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setStringReturn </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> value)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Sets the string return value.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >value</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The string return value</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                                <div class="method-content">
+    <div class="main-method-title here" id="setTwilioSmsOutput" title="setTwilioSmsOutput">
+             <a class="url-link" href="#setTwilioSmsOutput">
+                <img class="url-link-img" src="../html-template-resources/images/link.svg">
+            </a>
+            <h2 > setTwilioSmsOutput </h2>
+        <span class="method-types">
+            <p>(<a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> params, <span class="builtin-type">string</span> name, <a href="../azure.functions/records/TwilioSmsOutputBinding.html">TwilioSmsOutputBinding</a> binding)</p>
+            
+                <b> returns </b><span class="builtin-type">error?</span> 
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>INTERNAL usage - Sets the Twilio output.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >params</span>
+                        <span class="type">  <a href="../azure.functions/records/HandlerParams.html">HandlerParams</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The handler parameters</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >name</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The parameter name</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >binding</span>
+                        <span class="type">  <a href="../azure.functions/records/TwilioSmsOutputBinding.html">TwilioSmsOutputBinding</a> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The binding data</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+        
+        <div class="returns-listing">
+            <ul>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><span class="builtin-type">error?</span></span>)</li>
+                <li><p>An error in failure</p>
+</li>
+            </ul>
+        </div>
+        
+    
+</div>
+                            
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/index.html
+++ b/learn/api-docs/ballerina/azure.functions/index.html
@@ -1,0 +1,1149 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - ballerinax/azure.functions</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper module-wrapper">
+                <h1>
+                    <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                    
+                        Module : <span class="modules">azure.functions</span>
+                    
+                </h1>
+                    <h1>Module Overview</h1>
+<p>Annotation based Azure Functions extension implementation for Ballerina.</p>
+<ul>
+<li>For information on the operations, which you can perform with this module, see <a href="https://ballerina.io/learn/api-docs/ballerina/azure.functions/index.html#objects">Objects</a>.</li>
+<li>For more information on the deployment, see the <a href="https://ballerina.io/learn/deployment/azure-functions/">Azure Functions Deployment Guide</a>.</li>
+<li>For examples on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/azure-functions-deployment.html">Azure Functions Deployment Example</a>.</li>
+</ul>
+<h2>Azure Setup</h2>
+<ul>
+<li>An Azure &quot;Function App&quot; needs to be created in a given resource group with the following requirements
+<ul>
+<li>Runtime stack - &quot;Java 8&quot;</li>
+<li>Hosting operating system - &quot;Windows&quot; (default; Linux is not supported in Azure for custom handlers at the moment)</li>
+</ul>
+</li>
+</ul>
+<h2>Supported Annotations:</h2>
+<h3>@azure.functions:Function</h3>
+<h4>Custom 'host.json'</h4>
+<p>A custom <a href="https://docs.microsoft.com/en-us/azure/azure-functions/functions-host-json">host.json</a> file for the functions deployment can be optionally provided by placing a 'host.json' file in the current working directory where the Ballerina build is done. The required host.json properties are provided/overridden by the values derived from the source code by the compiler extension.</p>
+<h4>Usage Sample:</h4>
+<pre><code class="language-ballerina">import ballerina/http;
+import ballerina/system;
+import ballerinax/azure.functions as af;
+
+// HTTP request/response with no authentication
+@af:Function
+public function hello(@af:HTTPTrigger { authLevel: &quot;anonymous&quot; } http:Request req) 
+                      returns @af:HTTPOutput string|error {
+    return &quot;Hello, &quot; + check &lt;@untainted&gt; req.getTextPayload() + &quot;!&quot;;
+}
+
+// HTTP request to add data to a queue
+@af:Function
+public function fromHttpToQueue(af:Context ctx, 
+            @af:HTTPTrigger {} af:HTTPRequest req, 
+            @af:QueueOutput { queueName: &quot;queue1&quot; } af:StringOutputBinding msg) 
+            returns @af:HTTPOutput af:HTTPBinding {
+    msg.value = req.body;
+    return { statusCode: 200, payload: &quot;Request: &quot; + req.toString() };
+}
+
+// A message put to a queue is copied to another queue
+@af:Function
+public function fromQueueToQueue(af:Context ctx, 
+        @af:QueueTrigger { queueName: &quot;queue2&quot; } string inMsg,
+        @af:QueueOutput { queueName: &quot;queue3&quot; } af:StringOutputBinding outMsg) {
+    ctx.log(&quot;In Message: &quot; + inMsg);
+    ctx.log(&quot;Metadata: &quot; + ctx.metadata.toString());
+    outMsg.value = inMsg;
+}
+
+// A blob added to a container is copied to a queue
+@af:Function
+public function fromBlobToQueue(af:Context ctx, 
+        @af:BlobTrigger { path: &quot;bpath1/{name}&quot; } byte[] blobIn,
+        @af:BindingName { } string name,
+        @af:QueueOutput { queueName: &quot;queue3&quot; } af:StringOutputBinding outMsg) 
+        returns error? {
+    outMsg.value = &quot;Name: &quot; + name + &quot; Content: &quot; + blobIn.toString();
+}
+
+// HTTP request to read a blob value
+@af:Function
+public function httpTriggerBlobInput(@af:HTTPTrigger { } af:HTTPRequest req, 
+                    @af:BlobInput { path: &quot;bpath1/{Query.name}&quot; } byte[]? blobIn)
+                    returns @af:HTTPOutput string {
+    int length = 0;
+    if blobIn is byte[] {
+        length = blobIn.length();
+    }
+    return &quot;Blob: &quot; + req.query[&quot;name&quot;].toString() + &quot; Length: &quot; + 
+            length.toString() + &quot; Content: &quot; + blobIn.toString();
+}
+
+// HTTP request to add a new blob
+@af:Function
+public function httpTriggerBlobOutput(@af:HTTPTrigger { } af:HTTPRequest req, 
+        @af:BlobOutput { path: &quot;bpath1/{Query.name}&quot; } af:StringOutputBinding bb)
+        returns @af:HTTPOutput string|error {
+    bb.value = req.body;
+    return &quot;Blob: &quot; + req.query[&quot;name&quot;].toString() + &quot; Content: &quot; + 
+            bb?.value.toString();
+}
+
+// Sending an SMS
+@af:Function
+public function sendSMS(@af:HTTPTrigger { } af:HTTPRequest req, 
+                        @af:TwilioSmsOutput { fromNumber: &quot;+12069845840&quot; } 
+                                              af:TwilioSmsOutputBinding tb)
+                        returns @af:HTTPOutput string {
+    tb.to = req.query[&quot;to&quot;].toString();
+    tb.body = req.body.toString();
+    return &quot;Message - to: &quot; + tb?.to.toString() + &quot; body: &quot; + tb?.body.toString();
+}
+
+public type Person record {
+    string id;
+    string name;
+    string country;
+};
+
+// CosmosDB record trigger
+@af:Function
+public function cosmosDBToQueue1(@af:CosmosDBTrigger { 
+        connectionStringSetting: &quot;CosmosDBConnection&quot;, databaseName: &quot;db1&quot;,
+        collectionName: &quot;c1&quot; } Person[] req, 
+        @af:QueueOutput { queueName: &quot;queue3&quot; } af:StringOutputBinding outMsg) {
+    outMsg.value = req.toString();
+}
+
+@af:Function
+public function cosmosDBToQueue2(@af:CosmosDBTrigger { 
+        connectionStringSetting: &quot;CosmosDBConnection&quot;, databaseName: &quot;db1&quot;, 
+        collectionName: &quot;c2&quot; } json req,
+        @af:QueueOutput { queueName: &quot;queue3&quot; } af:StringOutputBinding outMsg) {
+    outMsg.value = req.toString();
+}
+
+// HTTP request to read CosmosDB records
+@af:Function
+public function httpTriggerCosmosDBInput1(
+            @af:HTTPTrigger { } af:HTTPRequest httpReq, 
+            @af:CosmosDBInput { connectionStringSetting: &quot;CosmosDBConnection&quot;, 
+                databaseName: &quot;db1&quot;, collectionName: &quot;c1&quot;, 
+                id: &quot;{Query.id}&quot;, partitionKey: &quot;{Query.country}&quot; } json dbReq)
+                returns @af:HTTPOutput string|error {
+    return dbReq.toString();
+}
+
+@af:Function
+public function httpTriggerCosmosDBInput2(
+            @af:HTTPTrigger { } af:HTTPRequest httpReq, 
+            @af:CosmosDBInput { connectionStringSetting: &quot;CosmosDBConnection&quot;, 
+                databaseName: &quot;db1&quot;, collectionName: &quot;c1&quot;, 
+                id: &quot;{Query.id}&quot;, partitionKey: &quot;{Query.country}&quot; } Person? dbReq)
+                returns @af:HTTPOutput string|error {
+    return dbReq.toString();
+}
+
+@af:Function
+public function httpTriggerCosmosDBInput3(
+        @af:HTTPTrigger { route: &quot;c1/{country}&quot; } af:HTTPRequest httpReq, 
+        @af:CosmosDBInput { connectionStringSetting: &quot;CosmosDBConnection&quot;, 
+        databaseName: &quot;db1&quot;, collectionName: &quot;c1&quot;, 
+        sqlQuery: &quot;select * from c1 where c1.country = {country}&quot; } 
+        Person[] dbReq)
+        returns @af:HTTPOutput string|error {
+    return dbReq.toString();
+}
+
+// HTTP request to write records to CosmosDB
+@af:Function
+public function httpTriggerCosmosDBOutput1(
+    @af:HTTPTrigger { } af:HTTPRequest httpReq, @af:HTTPOutput af:HTTPBinding hb) 
+    returns @af:CosmosDBOutput { connectionStringSetting: &quot;CosmosDBConnection&quot;, 
+                                databaseName: &quot;db1&quot;, collectionName: &quot;c1&quot; } json {
+    json entry = { id: system:uuid(), name: &quot;Saman&quot;, country: &quot;Sri Lanka&quot; };
+    hb.payload = &quot;Adding entry: &quot; + entry.toString();
+    return entry;
+}
+
+@af:Function
+public function httpTriggerCosmosDBOutput2(
+        @af:HTTPTrigger { } af:HTTPRequest httpReq, 
+        @af:HTTPOutput af:HTTPBinding hb) 
+        returns @af:CosmosDBOutput { 
+            connectionStringSetting: &quot;CosmosDBConnection&quot;, 
+            databaseName: &quot;db1&quot;, collectionName: &quot;c1&quot; } json {
+    json entry = [{ id: system:uuid(), name: &quot;John Doe A&quot;, country: &quot;USA&quot; }, 
+                  { id: system:uuid(), name: &quot;John Doe B&quot;, country: &quot;USA&quot; }];
+    hb.payload = &quot;Adding entries: &quot; + entry.toString();
+    return entry;
+}
+
+@af:Function
+public function httpTriggerCosmosDBOutput3(
+                    @af:HTTPTrigger { } af:HTTPRequest httpReq) 
+                    returns @af:CosmosDBOutput { 
+                        connectionStringSetting: &quot;CosmosDBConnection&quot;, 
+                        databaseName: &quot;db1&quot;, collectionName: &quot;c1&quot; } Person[] {
+    Person[] persons = [];
+    persons.push({id: system:uuid(), name: &quot;Jack&quot;, country: &quot;UK&quot;});
+    persons.push({id: system:uuid(), name: &quot;Will&quot;, country: &quot;UK&quot;});
+    return persons;
+}
+
+// A timer function which is executed every 10 seconds.
+@af:Function
+public function queuePopulationTimer(
+            @af:TimerTrigger { schedule: &quot;*/10 * * * * *&quot; } json triggerInfo, 
+            @af:QueueOutput { queueName: &quot;queue4&quot; } af:StringOutputBinding msg) {
+    msg.value = triggerInfo.toString();
+}
+</code></pre>
+<p>The output of the Ballerina build is as follows:</p>
+<pre><code class="language-bash">$ ballerina build azure_functions_deployment.bal 
+Compiling source
+        azure_functions_deployment.bal
+
+Generating executables
+        azure_functions_deployment.jar
+        @azure.functions:Function: hello, fromHttpToQueue, fromQueueToQueue, fromBlobToQueue, httpTriggerBlobInput, httpTriggerBlobOutput, sendSMS, cosmosDBToQueue1, cosmosDBToQueue2, httpTriggerCosmosDBInput1, httpTriggerCosmosDBInput2, httpTriggerCosmosDBInput3, httpTriggerCosmosDBOutput1, httpTriggerCosmosDBOutput2, httpTriggerCosmosDBOutput3, queuePopulationTimer
+</code></pre>
+
+
+            
+            
+            <section class="method-content" id="records">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#records">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Records </h2>
+                </div>
+                <table>
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="BindingNameConfiguration" title="BindingNameConfiguration">
+                                <a class="records " href="records/BindingNameConfiguration.html">BindingNameConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>BindingName annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="BlobConfiguration" title="BlobConfiguration">
+                                <a class="records " href="records/BlobConfiguration.html">BlobConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Blob annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="BytesOutputBinding" title="BytesOutputBinding">
+                                <a class="records " href="records/BytesOutputBinding.html">BytesOutputBinding</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Byte array output binding data.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="CosmosDBInputConfiguration" title="CosmosDBInputConfiguration">
+                                <a class="records " href="records/CosmosDBInputConfiguration.html">CosmosDBInputConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>CosmosDB input annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="CosmosDBOutputConfiguration" title="CosmosDBOutputConfiguration">
+                                <a class="records " href="records/CosmosDBOutputConfiguration.html">CosmosDBOutputConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>CosmosDB output annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="CosmosDBTriggerConfiguration" title="CosmosDBTriggerConfiguration">
+                                <a class="records " href="records/CosmosDBTriggerConfiguration.html">CosmosDBTriggerConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>CosmosDB trigger annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="HTTPBinding" title="HTTPBinding">
+                                <a class="records " href="records/HTTPBinding.html">HTTPBinding</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>HTTP binding data.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="HTTPRequest" title="HTTPRequest">
+                                <a class="records " href="records/HTTPRequest.html">HTTPRequest</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>HTTP request binding data.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="HTTPTriggerConfiguration" title="HTTPTriggerConfiguration">
+                                <a class="records " href="records/HTTPTriggerConfiguration.html">HTTPTriggerConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>HTTPTrigger annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="HandlerParams" title="HandlerParams">
+                                <a class="records " href="records/HandlerParams.html">HandlerParams</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL stucture - the request handler parameter data.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="QueueConfiguration" title="QueueConfiguration">
+                                <a class="records " href="records/QueueConfiguration.html">QueueConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Queue annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="StringOutputBinding" title="StringOutputBinding">
+                                <a class="records " href="records/StringOutputBinding.html">StringOutputBinding</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>String output binding data.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="TimerTriggerConfiguration" title="TimerTriggerConfiguration">
+                                <a class="records " href="records/TimerTriggerConfiguration.html">TimerTriggerConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>TimerTrigger annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="TwilioSmsConfiguration" title="TwilioSmsConfiguration">
+                                <a class="records " href="records/TwilioSmsConfiguration.html">TwilioSmsConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Twilio annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="TwilioSmsOutputBinding" title="TwilioSmsOutputBinding">
+                                <a class="records " href="records/TwilioSmsOutputBinding.html">TwilioSmsOutputBinding</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Twilion SMS output binding data.
+                            </td>
+                        </tr>
+                    
+                    
+                </table>
+            </section>
+            
+            
+
+            
+            
+            <section class="method-content" id="objects">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#objects">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Objects </h2>
+                </div>
+                <table>
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate objects" id="Context" title="Context">
+                                <a class="objects " href="objects/Context.html">Context</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>The request context holder.
+                            </td>
+                        </tr>
+                    
+                    
+                </table>
+             </section>
+            
+            
+
+            
+
+            
+           
+
+            
+            <section class="method-content" id="functions">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#functions">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                    <h2> Functions </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="__register" title="__register">
+                                <a class="functions " href="functions.html#__register">__register</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - registers a handler function.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="createContext" title="createContext">
+                                <a class="functions " href="functions.html#createContext">createContext</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - creates function context.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getBallerinaValueFromInputData" title="getBallerinaValueFromInputData">
+                                <a class="functions " href="functions.html#getBallerinaValueFromInputData">getBallerinaValueFromInputData</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns a converted Ballerina value from input data.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getBallerinaValueFromInputDataDoubleEscape" title="getBallerinaValueFromInputDataDoubleEscape">
+                                <a class="functions " href="functions.html#getBallerinaValueFromInputDataDoubleEscape">getBallerinaValueFromInputDataDoubleEscape</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the converted Ballerina value from input data - double escape.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getBinaryFromHTTPReq" title="getBinaryFromHTTPReq">
+                                <a class="functions " href="functions.html#getBinaryFromHTTPReq">getBinaryFromHTTPReq</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the binary payload from the HTTP request.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getBodyFromHTTPInputData" title="getBodyFromHTTPInputData">
+                                <a class="functions " href="functions.html#getBodyFromHTTPInputData">getBodyFromHTTPInputData</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the HTTP body value from input data.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getBytesFromInputData" title="getBytesFromInputData">
+                                <a class="functions " href="functions.html#getBytesFromInputData">getBytesFromInputData</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the binary value from input data.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getHTTPRequestFromInputData" title="getHTTPRequestFromInputData">
+                                <a class="functions " href="functions.html#getHTTPRequestFromInputData">getHTTPRequestFromInputData</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Populates the HTTP request structure from an input data entry.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getHTTPRequestFromParams" title="getHTTPRequestFromParams">
+                                <a class="functions " href="functions.html#getHTTPRequestFromParams">getHTTPRequestFromParams</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the HTTP request data.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getJsonFromHTTPReq" title="getJsonFromHTTPReq">
+                                <a class="functions " href="functions.html#getJsonFromHTTPReq">getJsonFromHTTPReq</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the JSON payload from the HTTP request.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getJsonFromInputData" title="getJsonFromInputData">
+                                <a class="functions " href="functions.html#getJsonFromInputData">getJsonFromInputData</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the JSON value from input data.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getJsonFromInputDataDoubleEscaped" title="getJsonFromInputDataDoubleEscaped">
+                                <a class="functions " href="functions.html#getJsonFromInputDataDoubleEscaped">getJsonFromInputDataDoubleEscaped</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the JSON value from input data - double escape.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getJsonFromMetadata" title="getJsonFromMetadata">
+                                <a class="functions " href="functions.html#getJsonFromMetadata">getJsonFromMetadata</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns a json value from metadata.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getMetadata" title="getMetadata">
+                                <a class="functions " href="functions.html#getMetadata">getMetadata</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - extracts the metadata.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getOptionalBallerinaValueFromInputDataDoubleEscape" title="getOptionalBallerinaValueFromInputDataDoubleEscape">
+                                <a class="functions " href="functions.html#getOptionalBallerinaValueFromInputDataDoubleEscape">getOptionalBallerinaValueFromInputDataDoubleEscape</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the optional converted Ballerina value from input data - double escape.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getOptionalBytesFromInputData" title="getOptionalBytesFromInputData">
+                                <a class="functions " href="functions.html#getOptionalBytesFromInputData">getOptionalBytesFromInputData</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the optional binary value from input data.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getOptionalStringConvertedBytesFromInputData" title="getOptionalStringConvertedBytesFromInputData">
+                                <a class="functions " href="functions.html#getOptionalStringConvertedBytesFromInputData">getOptionalStringConvertedBytesFromInputData</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the optional string value converted from input binary data.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getOptionalStringFromInputData" title="getOptionalStringFromInputData">
+                                <a class="functions " href="functions.html#getOptionalStringFromInputData">getOptionalStringFromInputData</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the optional string value from input data.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getStringConvertedBytesFromInputData" title="getStringConvertedBytesFromInputData">
+                                <a class="functions " href="functions.html#getStringConvertedBytesFromInputData">getStringConvertedBytesFromInputData</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the string value converted from input binary data.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getStringFromHTTPReq" title="getStringFromHTTPReq">
+                                <a class="functions " href="functions.html#getStringFromHTTPReq">getStringFromHTTPReq</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the string payload from the HTTP request.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getStringFromInputData" title="getStringFromInputData">
+                                <a class="functions " href="functions.html#getStringFromInputData">getStringFromInputData</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns the string value from input data.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="getStringFromMetadata" title="getStringFromMetadata">
+                                <a class="functions " href="functions.html#getStringFromMetadata">getStringFromMetadata</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Returns a string value from metadata.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setBallerinaValueAsJsonReturn" title="setBallerinaValueAsJsonReturn">
+                                <a class="functions " href="functions.html#setBallerinaValueAsJsonReturn">setBallerinaValueAsJsonReturn</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Converts a Ballerina value to a JSON and set the return value.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setBlobOutput" title="setBlobOutput">
+                                <a class="functions " href="functions.html#setBlobOutput">setBlobOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Sets the Blob output.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setHTTPOutput" title="setHTTPOutput">
+                                <a class="functions " href="functions.html#setHTTPOutput">setHTTPOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Sets the HTTP output.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setHTTPReturn" title="setHTTPReturn">
+                                <a class="functions " href="functions.html#setHTTPReturn">setHTTPReturn</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Sets the HTTP binding return value.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setJsonReturn" title="setJsonReturn">
+                                <a class="functions " href="functions.html#setJsonReturn">setJsonReturn</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Sets the JSON return value.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setPureHTTPOutput" title="setPureHTTPOutput">
+                                <a class="functions " href="functions.html#setPureHTTPOutput">setPureHTTPOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Sets the pure HTTP output.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setPureJsonOutput" title="setPureJsonOutput">
+                                <a class="functions " href="functions.html#setPureJsonOutput">setPureJsonOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Sets the pure JSON output.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setPureStringOutput" title="setPureStringOutput">
+                                <a class="functions " href="functions.html#setPureStringOutput">setPureStringOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Sets the pure string output.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setStringOutput" title="setStringOutput">
+                                <a class="functions " href="functions.html#setStringOutput">setStringOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Sets the string output.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setStringReturn" title="setStringReturn">
+                                <a class="functions " href="functions.html#setStringReturn">setStringReturn</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Sets the string return value.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate functions" id="setTwilioSmsOutput" title="setTwilioSmsOutput">
+                                <a class="functions " href="functions.html#setTwilioSmsOutput">setTwilioSmsOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>INTERNAL usage - Sets the Twilio output.
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+
+            
+
+
+            
+            <section class="method-content" id="annotations">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#annotations">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Annotations </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="BindingName" title="BindingName">
+                                <a class="annotations " href="annotations.html#BindingName">BindingName</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:BindingName annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="BlobInput" title="BlobInput">
+                                <a class="annotations " href="annotations.html#BlobInput">BlobInput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:BlobInput annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="BlobOutput" title="BlobOutput">
+                                <a class="annotations " href="annotations.html#BlobOutput">BlobOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:BlobOutput annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="BlobTrigger" title="BlobTrigger">
+                                <a class="annotations " href="annotations.html#BlobTrigger">BlobTrigger</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:BlobTrigger annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="CosmosDBInput" title="CosmosDBInput">
+                                <a class="annotations " href="annotations.html#CosmosDBInput">CosmosDBInput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:CosmosDBInput annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="CosmosDBOutput" title="CosmosDBOutput">
+                                <a class="annotations " href="annotations.html#CosmosDBOutput">CosmosDBOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:CosmosDBOutput annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="CosmosDBTrigger" title="CosmosDBTrigger">
+                                <a class="annotations " href="annotations.html#CosmosDBTrigger">CosmosDBTrigger</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:CosmosDBTrigger annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Function" title="Function">
+                                <a class="annotations " href="annotations.html#Function">Function</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:Function annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="HTTPOutput" title="HTTPOutput">
+                                <a class="annotations " href="annotations.html#HTTPOutput">HTTPOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:HTTPOutput annotation</p>
+
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="HTTPTrigger" title="HTTPTrigger">
+                                <a class="annotations " href="annotations.html#HTTPTrigger">HTTPTrigger</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:HTTPTrigger annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="QueueOutput" title="QueueOutput">
+                                <a class="annotations " href="annotations.html#QueueOutput">QueueOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:QueueOutput annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="QueueTrigger" title="QueueTrigger">
+                                <a class="annotations " href="annotations.html#QueueTrigger">QueueTrigger</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:QueueOutput annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="TimerTrigger" title="TimerTrigger">
+                                <a class="annotations " href="annotations.html#TimerTrigger">TimerTrigger</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:TimerTrigger annotation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="TwilioSmsOutput" title="TwilioSmsOutput">
+                                <a class="annotations " href="annotations.html#TwilioSmsOutput">TwilioSmsOutput</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@azurefunctions:TwilioSmsOutput annotation.
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+            
+
+            
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/objects/Context.html
+++ b/learn/api-docs/ballerina/azure.functions/objects/Context.html
@@ -1,0 +1,422 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Object : Context</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Objects</h3>
+                <ul>
+                    
+                        <li class="active">
+                            <a href="Context.html" onclick="menuLinkClick()">Context</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+
+        <div class="main-wrapper">
+            <h1>
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Object - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                 :
+                <span class="objects ">Context</span>
+            </h1>
+            <p>
+                
+                <p>The request context holder.</p>
+
+            </p>
+
+            <div class="constants">
+                <div class="method-sum">
+                    
+                        
+                        <h2>Constructor</h2>
+<h3 >__init</h3><p>(<a href="../../azure.functions/records/HandlerParams.html">HandlerParams</a> hparams, <span class="builtin-type">boolean</span> populateMetadata)</p>
+<div class="data-wrapper">
+    
+        <div class="params-listing">
+            <ul>
+                <li> <b>hparams</b><span class="type">  <a href="../../azure.functions/records/HandlerParams.html">HandlerParams</a></span> </li>
+                <li>
+                    
+                </li>
+            </ul>
+        </div>
+    
+        <div class="params-listing">
+            <ul>
+                <li> <b>populateMetadata</b><span class="type">  <span class="builtin-type">boolean</span></span> </li>
+                <li>
+                    
+                </li>
+            </ul>
+        </div>
+    
+</div>
+                        
+                    
+
+                
+                    
+                        <h2>Methods</h2>
+                        <div class="method-list">
+                            
+                                
+<div class="param-sum">
+    <div class="param-name " title="log">
+        <a href="#log">log </a>
+    </div>
+    <div class="param-details"> 
+            
+        <p>Enters to function invocation logs.
+    </div>
+</div>
+
+                            
+                        </div>
+                    
+
+                    
+                        
+                            <h2>Fields</h2>
+                                <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >metadata</span>
+                <span class="type">  <span class="builtin-type">json</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The context metadata</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                        
+                    
+                </div>
+
+                
+                    
+                        <div class="method-content">
+    <div class="main-method-title here" id="log" title="log">
+             <a class="url-link" href="#log">
+                <img class="url-link-img" src="../../html-template-resources/images/link.svg">
+            </a>
+            <h2 > log </h2>
+        <span class="method-types">
+            <p>(<span class="builtin-type">string</span> msg)</p>
+            
+        </span>
+    </div>
+    <div class="function-desc">
+        
+        <p>Enters to function invocation logs.</p>
+
+    </div>
+    
+        <div class="data-wrapper">
+            <h3 class="param-title">Parameters</h3>
+                
+            <div class="params-listing">
+                <ul>
+                    <li>
+                        <span >msg</span>
+                        <span class="type">  <span class="builtin-type">string</span> </span>
+                        
+                    </li>
+                    <li>
+                        <p>
+                            
+                            <p>The log message</p>
+
+                        </p>
+                    </li>
+                </ul>
+            </div>
+            
+        </div>
+    
+
+    
+</div>
+                    
+                
+            </div>
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/BindingNameConfiguration.html
+++ b/learn/api-docs/ballerina/azure.functions/records/BindingNameConfiguration.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : BindingNameConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li class="active">
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">BindingNameConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>BindingName annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The binding name</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/BlobConfiguration.html
+++ b/learn/api-docs/ballerina/azure.functions/records/BlobConfiguration.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : BlobConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">BlobConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Blob annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >path</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The blob container path</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >connection</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                 <span class="default">(default AzureWebJobsStorage)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The name of the app setting which contains the Storage connection string</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/BytesOutputBinding.html
+++ b/learn/api-docs/ballerina/azure.functions/records/BytesOutputBinding.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : BytesOutputBinding</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">BytesOutputBinding</span>
+            </h1>
+            <p>
+                
+                <p>Byte array output binding data.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >value</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">byte</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The byte[] value</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/CosmosDBInputConfiguration.html
+++ b/learn/api-docs/ballerina/azure.functions/records/CosmosDBInputConfiguration.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : CosmosDBInputConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">CosmosDBInputConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>CosmosDB input annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >connectionStringSetting</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The name of the app setting which contains the connection string for CosmosDB account</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >databaseName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The database name</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >collectionName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The collection name</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >id</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The id of the document to retrieve</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >sqlQuery</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>An Azure Cosmos DB SQL query used to retrieve multiple documents</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >partitionKey</span>
+                <span class="type">  <span class="builtin-type">string</span> | <span class="builtin-type">int</span> | <span class="builtin-type">float</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The partition key value for lookups</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >preferredLocations</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>A comma-seperated list of regions as preferred locations for geo-replicated database accounts</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/CosmosDBOutputConfiguration.html
+++ b/learn/api-docs/ballerina/azure.functions/records/CosmosDBOutputConfiguration.html
@@ -1,0 +1,497 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : CosmosDBOutputConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">CosmosDBOutputConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>CosmosDB output annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >connectionStringSetting</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The name of the app setting which contains the connection string for CosmosDB account</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >databaseName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The database name</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >collectionName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The collection name</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >createIfNotExists</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Creates the collection is it does not exist</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >collectionThroughput</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The throughput of a newly created collection</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >partitionKey</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The partition key name</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >preferredLocations</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>A comma-seperated list of regions as preferred locations for geo-replicated database accounts</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >useMultipleWriteLocations</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>If true, uses multi-region writes</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/CosmosDBTriggerConfiguration.html
+++ b/learn/api-docs/ballerina/azure.functions/records/CosmosDBTriggerConfiguration.html
@@ -1,0 +1,650 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : CosmosDBTriggerConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">CosmosDBTriggerConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>CosmosDB trigger annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >connectionStringSetting</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The name of the app setting which contains the connection string for CosmosDB account</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >databaseName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The database name</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >collectionName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The collection name</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >leaseConnectionStringSetting</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The name of the app setting which contains the lease connection string</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >leaseDatabaseName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The name of the lease database</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >leaseCollectionName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The name of the collection used to store leases</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >createLeaseCollectionIfNotExists</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The lease collection is automatically created when this is set to true</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >leasesCollectionThroughput</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The request throughput of the lease collection</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >leaseCollectionPrefix</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The prefix of the leases created</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >feedPollDelay</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The time delay (in milliseconds) in polling a partition for new changes in the feed</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >leaseAcquireInterval</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The time (in milliseconds) the interval to create a task to check if partitions are distributed evenly</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >leaseExpirationInterval</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The lease expiration interval in milliseconds</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >leaseRenewInterval</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The lease renewal interval in milliseconds</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >checkpointFrequency</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The interval (in milliseconds) between lease checkpoints</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >maxItemsPerInvocation</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The maximum number of items received per function call</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >startFromBeginning</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Tells the trigger to read changes from the beginning of the collection's change history</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >preferredLocations</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>A comma-seperated list of regions as preferred locations for geo-replicated database accounts</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/HTTPBinding.html
+++ b/learn/api-docs/ballerina/azure.functions/records/HTTPBinding.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : HTTPBinding</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">HTTPBinding</span>
+            </h1>
+            <p>
+                
+                <p>HTTP binding data.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >statusCode</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 200)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The HTTP response status code</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >payload</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The HTTP response payload</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/HTTPRequest.html
+++ b/learn/api-docs/ballerina/azure.functions/records/HTTPRequest.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : HTTPRequest</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">HTTPRequest</span>
+            </h1>
+            <p>
+                
+                <p>HTTP request binding data.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >url</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The request URL</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >method</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The request HTTP method</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >query</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The request query parameter map</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >headers</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="array-type"><span class="builtin-type">string</span>[]</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The request HTTP header map</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >params</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The request parameters</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >identities</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">json</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The request identities</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >body</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The request body</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/HTTPTriggerConfiguration.html
+++ b/learn/api-docs/ballerina/azure.functions/records/HTTPTriggerConfiguration.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : HTTPTriggerConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">HTTPTriggerConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>HTTPTrigger annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >authLevel</span>
+                <span class="type">  <a href="../../azure.functions/types.html#AUTH_LEVEL">AUTH_LEVEL</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The authentication level of the function</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >route</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The route template</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/HandlerParams.html
+++ b/learn/api-docs/ballerina/azure.functions/records/HandlerParams.html
@@ -1,0 +1,429 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : HandlerParams</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">HandlerParams</span>
+            </h1>
+            <p>
+                
+                <p>INTERNAL stucture - the request handler parameter data.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >request</span>
+                <span class="type">  <a href="../../http/objects/Request.html">Request</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The HTTP request</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >response</span>
+                <span class="type">  <a href="../../http/objects/Response.html">Response</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The HTTP response</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >pure</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The flag to mention if it's a pure HTTP request</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >result</span>
+                <span class="type">  <span class="builtin-type">json</span></span>
+                 <span class="default">(default  {Outputs:  {},Logs: []})</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The result JSON</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/QueueConfiguration.html
+++ b/learn/api-docs/ballerina/azure.functions/records/QueueConfiguration.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : QueueConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">QueueConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Queue annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >queueName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The queue name</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >connection</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                 <span class="default">(default AzureWebJobsStorage)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The name of the app setting which contains the Storage connection string</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/StringOutputBinding.html
+++ b/learn/api-docs/ballerina/azure.functions/records/StringOutputBinding.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : StringOutputBinding</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">StringOutputBinding</span>
+            </h1>
+            <p>
+                
+                <p>String output binding data.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >value</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The string value</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/TimerTriggerConfiguration.html
+++ b/learn/api-docs/ballerina/azure.functions/records/TimerTriggerConfiguration.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : TimerTriggerConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">TimerTriggerConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>TimerTrigger annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >schedule</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The CRON expression representing the timer schedule.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >runOnStartup</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The flag to state if the timer should be started on a runtime restart</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/TwilioSmsConfiguration.html
+++ b/learn/api-docs/ballerina/azure.functions/records/TwilioSmsConfiguration.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : TwilioSmsConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">TwilioSmsConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Twilio annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >accountSidSetting</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                 <span class="default">(default AzureWebJobsTwilioAccountSid)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The app setting which holds the Twilio Account Sid</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >authTokenSetting</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                 <span class="default">(default AzureWebJobsTwilioAuthToken)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The app setting which holds the Twilio authentication token</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >fromNumber</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The phone number the SMS is sent from</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/records/TwilioSmsOutputBinding.html
+++ b/learn/api-docs/ballerina/azure.functions/records/TwilioSmsOutputBinding.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Record : TwilioSmsOutputBinding</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BindingNameConfiguration.html" onclick="menuLinkClick()">BindingNameConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BlobConfiguration.html" onclick="menuLinkClick()">BlobConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="BytesOutputBinding.html" onclick="menuLinkClick()">BytesOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBInputConfiguration.html" onclick="menuLinkClick()">CosmosDBInputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBOutputConfiguration.html" onclick="menuLinkClick()">CosmosDBOutputConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="CosmosDBTriggerConfiguration.html" onclick="menuLinkClick()">CosmosDBTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPBinding.html" onclick="menuLinkClick()">HTTPBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRequest.html" onclick="menuLinkClick()">HTTPRequest</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPTriggerConfiguration.html" onclick="menuLinkClick()">HTTPTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HandlerParams.html" onclick="menuLinkClick()">HandlerParams</a>
+                        </li>
+                    
+                        <li >
+                            <a href="QueueConfiguration.html" onclick="menuLinkClick()">QueueConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="StringOutputBinding.html" onclick="menuLinkClick()">StringOutputBinding</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TimerTriggerConfiguration.html" onclick="menuLinkClick()">TimerTriggerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TwilioSmsConfiguration.html" onclick="menuLinkClick()">TwilioSmsConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="TwilioSmsOutputBinding.html" onclick="menuLinkClick()">TwilioSmsOutputBinding</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../azure.functions/index.html">azure.functions</a>
+                
+                 : <span class="records ">TwilioSmsOutputBinding</span>
+            </h1>
+            <p>
+                
+                <p>Twilion SMS output binding data.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >to</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The SMS recipient phone number</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >body</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The message body</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/azure.functions/types.html
+++ b/learn/api-docs/ballerina/azure.functions/types.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="Annotation based Azure Functions extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,azure.functions">
+
+    <title>API Docs - Types : azure.functions</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Types</h3>
+                <ul>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+        <div class="version">v0.0.0</div>
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../azure.functions/index.html" onclick="menuLinkClick()">
+            <h3>azure.functions</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../azure.functions/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+            <li>
+                <a  data="objects" href="../azure.functions/index.html#objects" onclick="menuLinkClick()">Objects</a>
+            </li>
+        
+        
+        
+        
+            <li>
+                <a data="functions" href="../azure.functions/index.html#functions" onclick="menuLinkClick()">Functions</a>
+            </li>
+        
+        
+        
+            <li>
+                <a data="annotations" href="../azure.functions/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../azure.functions/index.html">azure.functions</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Types - </span>
+                 
+                     <a href="../azure.functions/index.html">azure.functions</a>
+                 
+            </h1>
+            <div class="types">
+                <div class="data-wrapper">
+                    
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="AUTH_LEVEL">
+                                    <b >AUTH_LEVEL</b>
+                                    <span class="type">anonymous | function | admin</span></li>
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/docker/annotations.html
+++ b/learn/api-docs/ballerina/docker/annotations.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based docker extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,docker">
+
+    <title>API Docs - Annotations : docker</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Annotations</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#Config" onclick="menuLinkClick()">Config</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#CopyFiles" onclick="menuLinkClick()">CopyFiles</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#Expose" onclick="menuLinkClick()">Expose</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../docker/index.html" onclick="menuLinkClick()">
+            <h3>docker</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../docker/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../docker/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../docker/index.html">docker</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Annotations - </span>
+                 
+                     <a href="../docker/index.html">docker</a>
+                 
+            </h1>
+            <div class="annotations">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Config</b>
+                                    <span class="type"> <span ><a href="../docker/records/DockerConfiguration.html">DockerConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        service, function, listener</li>
+                                <li>
+                                    
+                                    <p>@docker:Config annotation to configure docker artifact generation.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >CopyFiles</b>
+                                    <span class="type"> <span ><a href="../docker/records/FileConfigs.html">FileConfigs</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        function, service, listener</li>
+                                <li>
+                                    
+                                    <p>@docker:CopyFile annotation to copy external files to docker image.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Expose</b>
+                                    <span class="type"> <span ><a href="../docker/records/ExposeConfig.html">ExposeConfig</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        listener</li>
+                                <li>
+                                    
+                                    <p>@docker:Expose annotation to expose ballerina ports.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/docker/index.html
+++ b/learn/api-docs/ballerina/docker/index.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based docker extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,docker">
+
+    <title>API Docs - ballerina/docker</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../docker/index.html" onclick="menuLinkClick()">
+            <h3>docker</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../docker/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../docker/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../docker/index.html">docker</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper module-wrapper">
+                <h1>
+                    <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                    
+                        Module : <span class="modules">docker</span>
+                    
+                </h1>
+                    <h2>Module Overview</h2>
+<p>This module offers an annotation based docker extension implementation for Ballerina.</p>
+<ul>
+<li>For information on the operations, which you can perform with this module, see <a href="https://ballerina.io/learn/api-docs/ballerina/docker/index.html#records">Records</a>.</li>
+<li>For information on the Deployment, see the<a href="https://ballerina.io/learn/deployment/docker/">Docker Deployment Guide</a>.</li>
+<li>For examples on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/docker-deployment.html">Docker Deployment Example</a>.</li>
+</ul>
+<h3>Annotation Usage Sample:</h3>
+<pre><code class="language-ballerina">import ballerina/http;
+import ballerina/log;
+import ballerina/docker;
+
+@docker:Expose{}
+listener http:Listener helloWorldEP = new(9090);
+
+@http:ServiceConfig {
+      basePath: &quot;/helloWorld&quot;
+}
+@docker:Config {
+    registry: &quot;docker.abc.com&quot;,
+    name: &quot;helloworld&quot;,
+    tag: &quot;v1.0&quot;
+}
+service helloWorld on helloWorldEP {
+    resource function sayHello(http:Caller caller, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload(&quot;Hello, World from service helloWorld ! \n&quot;);
+        var responseResult = caller-&gt;respond(response);
+        if (responseResult is error) {
+            log:printError(&quot;error responding back to client.&quot;, err = responseResult);
+        }
+    }
+}
+</code></pre>
+
+
+            
+            
+            <section class="method-content" id="records">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#records">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Records </h2>
+                </div>
+                <table>
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="DockerConfiguration" title="DockerConfiguration">
+                                <a class="records " href="records/DockerConfiguration.html">DockerConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Docker annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="FileConfig" title="FileConfig">
+                                <a class="records " href="records/FileConfig.html">FileConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>External file type for docker.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="FileConfigs" title="FileConfigs">
+                                <a class="records " href="records/FileConfigs.html">FileConfigs</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>External File configurations for docker.
+                            </td>
+                        </tr>
+                    
+                    
+                </table>
+            </section>
+            
+            
+
+            
+
+            
+
+            
+           
+
+            
+
+
+            
+
+
+            
+            <section class="method-content" id="annotations">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#annotations">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Annotations </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Config" title="Config">
+                                <a class="annotations " href="annotations.html#Config">Config</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@docker:Config annotation to configure docker artifact generation.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="CopyFiles" title="CopyFiles">
+                                <a class="annotations " href="annotations.html#CopyFiles">CopyFiles</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@docker:CopyFile annotation to copy external files to docker image.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Expose" title="Expose">
+                                <a class="annotations " href="annotations.html#Expose">Expose</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@docker:Expose annotation to expose ballerina ports.
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+            
+
+            
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/docker/records/DockerConfiguration.html
+++ b/learn/api-docs/ballerina/docker/records/DockerConfiguration.html
@@ -1,0 +1,577 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based docker extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,docker">
+
+    <title>API Docs - Record : DockerConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li class="active">
+                            <a href="DockerConfiguration.html" onclick="menuLinkClick()">DockerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfigs.html" onclick="menuLinkClick()">FileConfigs</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../docker/index.html" onclick="menuLinkClick()">
+            <h3>docker</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../docker/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../docker/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../docker/index.html">docker</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../docker/index.html">docker</a>
+                
+                 : <span class="records ">DockerConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Docker annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >registry</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker registry url.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name of the docker image. Default value is the file name of the executable .jar file.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >tag</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker image tag. Default value is <code>&quot;latest&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >username</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Username for docker registry.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >password</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Password for docker registry.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >baseImage</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Base image to create the docker image. Default value is <code>&quot;openjdk:8-jre-alpine&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >buildImage</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable building docker image. Default value is <code>true</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >push</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable pushing docker image to registry. Field <code>buildImage</code> must be set to <code>true</code> to be effective. Default value is <code>false</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >cmd</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Value for CMD for the generated Dockerfile. Default is <code>CMD java -jar ${APP} [--b7a.config.file=${CONFIG_FILE}] [--debug]</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >enableDebug</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable ballerina debug. Default is <code>false</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >debugPort</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 5005)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Ballerina remote debug port. Default is <code>5005</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dockerAPIVersion</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker API version.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dockerHost</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker host IP and docker PORT. (e.g minikube IP and docker PORT).
+Default is to use DOCKER_HOST environment variable.
+If DOCKER_HOST is unavailable, use <code>&quot;unix:///var/run/docker.sock&quot;</code> for Unix or use <code>&quot;tcp://localhost:2375&quot;</code> for Windows.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dockerCertPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker certificate path. Default is to use <code>&quot;DOCKER_CERT_PATH&quot;</code> environment variable.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >env</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">boolean</span> | <span class="builtin-type">int</span> | <span class="builtin-type">float</span> | <span class="builtin-type">decimal</span> | <span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Environment variables for container.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dockerConfigPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker config file path.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/docker/records/FileConfig.html
+++ b/learn/api-docs/ballerina/docker/records/FileConfig.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based docker extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,docker">
+
+    <title>API Docs - Record : FileConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="DockerConfiguration.html" onclick="menuLinkClick()">DockerConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfigs.html" onclick="menuLinkClick()">FileConfigs</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../docker/index.html" onclick="menuLinkClick()">
+            <h3>docker</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../docker/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../docker/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../docker/index.html">docker</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../docker/index.html">docker</a>
+                
+                 : <span class="records ">FileConfig</span>
+            </h1>
+            <p>
+                
+                <p>External file type for docker.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >sourceFile</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Source path of the file (in your machine).</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >target</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Target path (inside container).</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >isBallerinaConf</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Flag to specify ballerina config file. When true, the config is passed as a command argument to the Dockerfile CMD.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/docker/records/FileConfigs.html
+++ b/learn/api-docs/ballerina/docker/records/FileConfigs.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based docker extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,docker">
+
+    <title>API Docs - Record : FileConfigs</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="DockerConfiguration.html" onclick="menuLinkClick()">DockerConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="FileConfigs.html" onclick="menuLinkClick()">FileConfigs</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../docker/index.html" onclick="menuLinkClick()">
+            <h3>docker</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../docker/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../docker/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../docker/index.html">docker</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../docker/index.html">docker</a>
+                
+                 : <span class="records ">FileConfigs</span>
+            </h1>
+            <p>
+                
+                <p>External File configurations for docker.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >files</span>
+                <span class="type">  <span class="array-type"><a href="../../docker/records/FileConfig.html">FileConfig</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Array of <a href="docker.html#FileConfig">FileConfig</a></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/annotations.html
+++ b/learn/api-docs/ballerina/istio/annotations.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - Annotations : istio</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Annotations</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#Gateway" onclick="menuLinkClick()">Gateway</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#VirtualService" onclick="menuLinkClick()">VirtualService</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Annotations - </span>
+                 
+                     <a href="../istio/index.html">istio</a>
+                 
+            </h1>
+            <div class="annotations">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Gateway</b>
+                                    <span class="type"> <span ><a href="../istio/records/GatewayConfig.html">GatewayConfig</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        listener, service</li>
+                                <li>
+                                    
+                                    <p>@istio:Gateway annotation to generate istio gateways.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >VirtualService</b>
+                                    <span class="type"> <span ><a href="../istio/records/VirtualServiceConfig.html">VirtualServiceConfig</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        listener, service</li>
+                                <li>
+                                    
+                                    <p>@istio:VirtualService annotation to generate istio virtual service.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/index.html
+++ b/learn/api-docs/ballerina/istio/index.html
@@ -1,0 +1,377 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - ballerina/istio</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper module-wrapper">
+                <h1>
+                    <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                    
+                        Module : <span class="modules">istio</span>
+                    
+                </h1>
+                    <h2>Module Overview</h2>
+<p>This module offers an annotation based Istio extension implementation for Ballerina.</p>
+<p>For information on the operations, which you can perform with this module, see <a href="https://ballerina.io/learn/api-docs/ballerina/istio/index.html#records">Records</a>.</p>
+
+
+            
+            
+            <section class="method-content" id="records">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#records">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Records </h2>
+                </div>
+                <table>
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="DestinationConfig" title="DestinationConfig">
+                                <a class="records " href="records/DestinationConfig.html">DestinationConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Configuration to a network addressable service.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="DestinationWeightConfig" title="DestinationWeightConfig">
+                                <a class="records " href="records/DestinationWeightConfig.html">DestinationWeightConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Configuration for weight for destination to traffic route.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="GatewayConfig" title="GatewayConfig">
+                                <a class="records " href="records/GatewayConfig.html">GatewayConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Istio gateway annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="HTTPRouteConfig" title="HTTPRouteConfig">
+                                <a class="records " href="records/HTTPRouteConfig.html">HTTPRouteConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Configurations for conditions and actions for routing HTTP.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="PortConfig" title="PortConfig">
+                                <a class="records " href="records/PortConfig.html">PortConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Port of a service.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ServerConfig" title="ServerConfig">
+                                <a class="records " href="records/ServerConfig.html">ServerConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Istio gateway server configuration to describe the properties of the proxy on a given load balancer.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="TLSOptionConfig" title="TLSOptionConfig">
+                                <a class="records " href="records/TLSOptionConfig.html">TLSOptionConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Istio gateway server tls option configurations.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="VirtualServiceConfig" title="VirtualServiceConfig">
+                                <a class="records " href="records/VirtualServiceConfig.html">VirtualServiceConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Virtual service configuration for @istio:VirtualService annotation.
+                            </td>
+                        </tr>
+                    
+                    
+                </table>
+            </section>
+            
+            
+
+            
+
+            
+
+            
+           
+
+            
+
+
+            
+
+
+            
+            <section class="method-content" id="annotations">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#annotations">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Annotations </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Gateway" title="Gateway">
+                                <a class="annotations " href="annotations.html#Gateway">Gateway</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@istio:Gateway annotation to generate istio gateways.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="VirtualService" title="VirtualService">
+                                <a class="annotations " href="annotations.html#VirtualService">VirtualService</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@istio:VirtualService annotation to generate istio virtual service.
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+            
+
+            
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/records/DestinationConfig.html
+++ b/learn/api-docs/ballerina/istio/records/DestinationConfig.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - Record : DestinationConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li class="active">
+                            <a href="DestinationConfig.html" onclick="menuLinkClick()">DestinationConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DestinationWeightConfig.html" onclick="menuLinkClick()">DestinationWeightConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="GatewayConfig.html" onclick="menuLinkClick()">GatewayConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRouteConfig.html" onclick="menuLinkClick()">HTTPRouteConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PortConfig.html" onclick="menuLinkClick()">PortConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServerConfig.html" onclick="menuLinkClick()">ServerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TLSOptionConfig.html" onclick="menuLinkClick()">TLSOptionConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="VirtualServiceConfig.html" onclick="menuLinkClick()">VirtualServiceConfig</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../istio/index.html">istio</a>
+                
+                 : <span class="records ">DestinationConfig</span>
+            </h1>
+            <p>
+                
+                <p>Configuration to a network addressable service.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >host</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Host of a service.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >subset</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Subset within the service.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >port</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The port on the host that is being addressed.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/records/DestinationWeightConfig.html
+++ b/learn/api-docs/ballerina/istio/records/DestinationWeightConfig.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - Record : DestinationWeightConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="DestinationConfig.html" onclick="menuLinkClick()">DestinationConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="DestinationWeightConfig.html" onclick="menuLinkClick()">DestinationWeightConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="GatewayConfig.html" onclick="menuLinkClick()">GatewayConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRouteConfig.html" onclick="menuLinkClick()">HTTPRouteConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PortConfig.html" onclick="menuLinkClick()">PortConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServerConfig.html" onclick="menuLinkClick()">ServerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TLSOptionConfig.html" onclick="menuLinkClick()">TLSOptionConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="VirtualServiceConfig.html" onclick="menuLinkClick()">VirtualServiceConfig</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../istio/index.html">istio</a>
+                
+                 : <span class="records ">DestinationWeightConfig</span>
+            </h1>
+            <p>
+                
+                <p>Configuration for weight for destination to traffic route.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >destination</span>
+                <span class="type">  <a href="../../istio/records/DestinationConfig.html">DestinationConfig</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Destination to forward to.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >weight</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Weight for the destination.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/records/GatewayConfig.html
+++ b/learn/api-docs/ballerina/istio/records/GatewayConfig.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - Record : GatewayConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="DestinationConfig.html" onclick="menuLinkClick()">DestinationConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DestinationWeightConfig.html" onclick="menuLinkClick()">DestinationWeightConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="GatewayConfig.html" onclick="menuLinkClick()">GatewayConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRouteConfig.html" onclick="menuLinkClick()">HTTPRouteConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PortConfig.html" onclick="menuLinkClick()">PortConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServerConfig.html" onclick="menuLinkClick()">ServerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TLSOptionConfig.html" onclick="menuLinkClick()">TLSOptionConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="VirtualServiceConfig.html" onclick="menuLinkClick()">VirtualServiceConfig</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../istio/index.html">istio</a>
+                
+                 : <span class="records ">GatewayConfig</span>
+            </h1>
+            <p>
+                
+                <p>Istio gateway annotation configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name of the resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >labels</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of labels for the resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >annotations</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of annotations for resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >selector</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Specific set of pods/VMs on which this gateway configuration should be applied.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >servers</span>
+                <span class="type">  <span class="array-type"><a href="../../istio/records/ServerConfig.html">ServerConfig</a>?[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>List of servers to pass.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/records/HTTPRouteConfig.html
+++ b/learn/api-docs/ballerina/istio/records/HTTPRouteConfig.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - Record : HTTPRouteConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="DestinationConfig.html" onclick="menuLinkClick()">DestinationConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DestinationWeightConfig.html" onclick="menuLinkClick()">DestinationWeightConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="GatewayConfig.html" onclick="menuLinkClick()">GatewayConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="HTTPRouteConfig.html" onclick="menuLinkClick()">HTTPRouteConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PortConfig.html" onclick="menuLinkClick()">PortConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServerConfig.html" onclick="menuLinkClick()">ServerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TLSOptionConfig.html" onclick="menuLinkClick()">TLSOptionConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="VirtualServiceConfig.html" onclick="menuLinkClick()">VirtualServiceConfig</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../istio/index.html">istio</a>
+                
+                 : <span class="records ">HTTPRouteConfig</span>
+            </h1>
+            <p>
+                
+                <p>Configurations for conditions and actions for routing HTTP.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >route</span>
+                <span class="type">  <span class="array-type"><a href="../../istio/records/DestinationWeightConfig.html">DestinationWeightConfig</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Route destination.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >timeout</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Timeout for requests in seconds.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >appendHeaders</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Additional header to add before forwarding/directing.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/records/PortConfig.html
+++ b/learn/api-docs/ballerina/istio/records/PortConfig.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - Record : PortConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="DestinationConfig.html" onclick="menuLinkClick()">DestinationConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DestinationWeightConfig.html" onclick="menuLinkClick()">DestinationWeightConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="GatewayConfig.html" onclick="menuLinkClick()">GatewayConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRouteConfig.html" onclick="menuLinkClick()">HTTPRouteConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="PortConfig.html" onclick="menuLinkClick()">PortConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServerConfig.html" onclick="menuLinkClick()">ServerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TLSOptionConfig.html" onclick="menuLinkClick()">TLSOptionConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="VirtualServiceConfig.html" onclick="menuLinkClick()">VirtualServiceConfig</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../istio/index.html">istio</a>
+                
+                 : <span class="records ">PortConfig</span>
+            </h1>
+            <p>
+                
+                <p>Port of a service.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >number</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The port number.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >protocol</span>
+                <span class="type">  <a href="../../istio/types.html#PortProtocol">PortProtocol</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The protocol exposed by the port.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Label for the port.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/records/ServerConfig.html
+++ b/learn/api-docs/ballerina/istio/records/ServerConfig.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - Record : ServerConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="DestinationConfig.html" onclick="menuLinkClick()">DestinationConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DestinationWeightConfig.html" onclick="menuLinkClick()">DestinationWeightConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="GatewayConfig.html" onclick="menuLinkClick()">GatewayConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRouteConfig.html" onclick="menuLinkClick()">HTTPRouteConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PortConfig.html" onclick="menuLinkClick()">PortConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ServerConfig.html" onclick="menuLinkClick()">ServerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TLSOptionConfig.html" onclick="menuLinkClick()">TLSOptionConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="VirtualServiceConfig.html" onclick="menuLinkClick()">VirtualServiceConfig</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../istio/index.html">istio</a>
+                
+                 : <span class="records ">ServerConfig</span>
+            </h1>
+            <p>
+                
+                <p>Istio gateway server configuration to describe the properties of the proxy on a given load balancer.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >port</span>
+                <span class="type">  <a href="../../istio/records/PortConfig.html">PortConfig</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The port of the proxy.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >hosts</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>List of hosts exposed by the gateway.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >tls</span>
+                <span class="type">  <a href="../../istio/records/TLSOptionConfig.html">TLSOptionConfig</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>TLS options.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/records/TLSOptionConfig.html
+++ b/learn/api-docs/ballerina/istio/records/TLSOptionConfig.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - Record : TLSOptionConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="DestinationConfig.html" onclick="menuLinkClick()">DestinationConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DestinationWeightConfig.html" onclick="menuLinkClick()">DestinationWeightConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="GatewayConfig.html" onclick="menuLinkClick()">GatewayConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRouteConfig.html" onclick="menuLinkClick()">HTTPRouteConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PortConfig.html" onclick="menuLinkClick()">PortConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServerConfig.html" onclick="menuLinkClick()">ServerConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="TLSOptionConfig.html" onclick="menuLinkClick()">TLSOptionConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="VirtualServiceConfig.html" onclick="menuLinkClick()">VirtualServiceConfig</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../istio/index.html">istio</a>
+                
+                 : <span class="records ">TLSOptionConfig</span>
+            </h1>
+            <p>
+                
+                <p>Istio gateway server tls option configurations.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >httpsRedirect</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>If set to true, the load balancer will send a 301 redirect for all http connections, asking the clients to use HTTPS. Default is <code>false</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >mode</span>
+                <span class="type">  <a href="../../istio/types.html#TLSOptionMode">TLSOptionMode</a></span>
+                 <span class="default">(default PASSTHROUGH)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Indicates whether connections to this port should be secured using TLS. The value of this field determines how TLS is enforced. Default is <code>&quot;PASSTHROUGH&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >serverCertificate</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>REQUIRED if mode is SIMPLE or MUTUAL. The path to the file holding the server-side TLS certificate to use.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >privateKey</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>REQUIRED if mode is SIMPLE or MUTUAL. The path to the file holding the server’s private key.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >caCertificates</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>REQUIRED if mode is MUTUAL. The path to a file containing certificate authority certificates to use in verifying a presented client side certificate.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >subjectAltNames</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>A list of alternate names to verify the subject identity in the certificate presented by the client.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/records/VirtualServiceConfig.html
+++ b/learn/api-docs/ballerina/istio/records/VirtualServiceConfig.html
@@ -1,0 +1,437 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - Record : VirtualServiceConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="DestinationConfig.html" onclick="menuLinkClick()">DestinationConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DestinationWeightConfig.html" onclick="menuLinkClick()">DestinationWeightConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="GatewayConfig.html" onclick="menuLinkClick()">GatewayConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="HTTPRouteConfig.html" onclick="menuLinkClick()">HTTPRouteConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PortConfig.html" onclick="menuLinkClick()">PortConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServerConfig.html" onclick="menuLinkClick()">ServerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="TLSOptionConfig.html" onclick="menuLinkClick()">TLSOptionConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="VirtualServiceConfig.html" onclick="menuLinkClick()">VirtualServiceConfig</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../istio/index.html">istio</a>
+                
+                 : <span class="records ">VirtualServiceConfig</span>
+            </h1>
+            <p>
+                
+                <p>Virtual service configuration for @istio:VirtualService annotation.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name of the resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >labels</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of labels for the resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >annotations</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of annotations for resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >hosts</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Destination which traffic should be sent.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >gateways</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Names of the gateways which the service should listen to.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >http</span>
+                <span class="type">  <span class="array-type"><a href="../../istio/records/HTTPRouteConfig.html">HTTPRouteConfig</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Route rules for HTTP traffic.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/istio/types.html
+++ b/learn/api-docs/ballerina/istio/types.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Istio extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
+
+    <title>API Docs - Types : istio</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Types</h3>
+                <ul>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../istio/index.html" onclick="menuLinkClick()">
+            <h3>istio</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../istio/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="annotations" href="../istio/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Types - </span>
+                 
+                     <a href="../istio/index.html">istio</a>
+                 
+            </h1>
+            <div class="types">
+                <div class="data-wrapper">
+                    
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="PortProtocol">
+                                    <b >PortProtocol</b>
+                                    <span class="type">HTTP | HTTPS | GRPC | HTTP2 | MONGO | TCP | TLS</span></li>
+                                <li>
+                                    
+                                    <p>Types of protocols of a port.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="TLSOptionMode">
+                                    <b >TLSOptionMode</b>
+                                    <span class="type">PASSTHROUGH | SIMPLE | MUTUAL</span></li>
+                                <li>
+                                    
+                                    <p>TLS mode enforced by the proxy.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/annotations.html
+++ b/learn/api-docs/ballerina/knative/annotations.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Annotations : knative</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Annotations</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#ConfigMap" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#HPA" onclick="menuLinkClick()">HPA</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#Secret" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#Service" onclick="menuLinkClick()">Service</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Annotations - </span>
+                 
+                     <a href="../knative/index.html">knative</a>
+                 
+            </h1>
+            <div class="annotations">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >ConfigMap</b>
+                                    <span class="type"> <span ><a href="../knative/records/ConfigMapMount.html">ConfigMapMount</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        service, function</li>
+                                <li>
+                                    
+                                    <p>@knative:ConfigMap annotation to configure config maps.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >HPA</b>
+                                    <span class="type"> <span ><a href="../knative/records/PodAutoscalerConfig.html">PodAutoscalerConfig</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        service, function</li>
+                                <li>
+                                    
+                                    <p>@knative:HPA annotation to configure horizontal pod autoscaler yaml.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Secret</b>
+                                    <span class="type"> <span ><a href="../knative/records/SecretMount.html">SecretMount</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        function, service</li>
+                                <li>
+                                    
+                                    <p>@knative:Secret annotation to configure secrets.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Service</b>
+                                    <span class="type"> <span ><a href="../knative/records/ServiceConfiguration.html">ServiceConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        function, listener, service</li>
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/constants.html
+++ b/learn/api-docs/ballerina/knative/constants.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Constants : knative</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1>
+                <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Constants - </span> 
+                <a href="../knative/index.html">knative</a> 
+            </h1>
+            <div class="constants">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="IMAGE_PULL_POLICY_IF_NOT_PRESENT">
+                                    <b >IMAGE_PULL_POLICY_IF_NOT_PRESENT</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> IfNotPresent
+                                </li>
+                                <li>
+                                    
+                                    <p>Pull image if it is not present for knative service.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="IMAGE_PULL_POLICY_ALWAYS">
+                                    <b >IMAGE_PULL_POLICY_ALWAYS</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> Always
+                                </li>
+                                <li>
+                                    
+                                    <p>Always pull the image for knative service.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="IMAGE_PULL_POLICY_NEVER">
+                                    <b >IMAGE_PULL_POLICY_NEVER</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> Never
+                                </li>
+                                <li>
+                                    
+                                    <p>Never pull the image for knative service.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="EXISTS_OPERATION">
+                                    <b >EXISTS_OPERATION</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> Exists
+                                </li>
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="EQUAL_OPERATION">
+                                    <b >EQUAL_OPERATION</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> Equal
+                                </li>
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="TOLERATION_EFFECT_NO_SCHEDULE">
+                                    <b >TOLERATION_EFFECT_NO_SCHEDULE</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> NoSchedule
+                                </li>
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="TOLERATION_EFFECT_PREFER_NO_SCHEDULE">
+                                    <b >TOLERATION_EFFECT_PREFER_NO_SCHEDULE</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> PreferNoSchedule
+                                </li>
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="TOLERATION_EFFECT_NO_EXECUTE">
+                                    <b >TOLERATION_EFFECT_NO_EXECUTE</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> NoExecute
+                                </li>
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/index.html
+++ b/learn/api-docs/ballerina/knative/index.html
@@ -1,0 +1,684 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - ballerina/knative</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper module-wrapper">
+                <h1>
+                    <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                    
+                        Module : <span class="modules">knative</span>
+                    
+                </h1>
+                    <h2>Module Overview</h2>
+<p>This module offers an annotation based Knative extension implementation for Ballerina.</p>
+<ul>
+<li>For information on the operations, which you can perform with this module, see <a href="https://ballerina.io/learn/api-docs/ballerina/knative/index.html#objects">Objects</a>.</li>
+<li>For examples on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/knative-deployment.html">Knative Deployment Example</a>.</li>
+</ul>
+<h3>Annotation Usage Sample:</h3>
+<pre><code class="language-ballerina">import ballerina/http;
+import ballerina/log;
+import ballerina/knative;
+
+@knative:Service {
+    name:&quot;hello&quot;
+}
+listener http:Listener helloEP = new(9090);
+
+@http:ServiceConfig {
+    basePath: &quot;/helloWorld&quot;
+}
+service helloWorld on helloEP {
+    resource function sayHello(http:Caller caller, http:Request request) {
+        var responseResult = caller-&gt;respond(&quot;Hello, World from service helloWorld ! &quot;);
+        if (responseResult is error) {
+            log:printError(&quot;error responding&quot;, responseResult);
+        }
+    }
+}
+</code></pre>
+
+
+            
+            
+            <section class="method-content" id="records">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#records">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Records </h2>
+                </div>
+                <table>
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ConfigMap" title="ConfigMap">
+                                <a class="records " href="records/ConfigMap.html">ConfigMap</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Knative Config Map volume mount.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ConfigMapKeyRef" title="ConfigMapKeyRef">
+                                <a class="records " href="records/ConfigMapKeyRef.html">ConfigMapKeyRef</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value from config map key.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ConfigMapKeyValue" title="ConfigMapKeyValue">
+                                <a class="records " href="records/ConfigMapKeyValue.html">ConfigMapKeyValue</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value for config map key.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ConfigMapMount" title="ConfigMapMount">
+                                <a class="records " href="records/ConfigMapMount.html">ConfigMapMount</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Secret volume mount configurations for knative.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="FieldRef" title="FieldRef">
+                                <a class="records " href="records/FieldRef.html">FieldRef</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value from field.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="FieldValue" title="FieldValue">
+                                <a class="records " href="records/FieldValue.html">FieldValue</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value for a field.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="FileConfig" title="FileConfig">
+                                <a class="records " href="records/FileConfig.html">FileConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>External file type for docker.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="Metadata" title="Metadata">
+                                <a class="records " href="records/Metadata.html">Metadata</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Knative annotation configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="PodAutoscalerConfig" title="PodAutoscalerConfig">
+                                <a class="records " href="records/PodAutoscalerConfig.html">PodAutoscalerConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Knative Horizontal Pod Autoscaler configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="PodTolerationConfiguration" title="PodTolerationConfiguration">
+                                <a class="records " href="records/PodTolerationConfiguration.html">PodTolerationConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Pod toleration configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ProbeConfiguration" title="ProbeConfiguration">
+                                <a class="records " href="records/ProbeConfiguration.html">ProbeConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Probing configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ResourceFieldRef" title="ResourceFieldRef">
+                                <a class="records " href="records/ResourceFieldRef.html">ResourceFieldRef</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value from resource field.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ResourceFieldValue" title="ResourceFieldValue">
+                                <a class="records " href="records/ResourceFieldValue.html">ResourceFieldValue</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value for resource field.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="Secret" title="Secret">
+                                <a class="records " href="records/Secret.html">Secret</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Knative secret volume mount.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="SecretKeyRef" title="SecretKeyRef">
+                                <a class="records " href="records/SecretKeyRef.html">SecretKeyRef</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value from secret key.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="SecretKeyValue" title="SecretKeyValue">
+                                <a class="records " href="records/SecretKeyValue.html">SecretKeyValue</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value for a secret key.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="SecretMount" title="SecretMount">
+                                <a class="records " href="records/SecretMount.html">SecretMount</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Secret volume mount configurations for knative.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ServiceConfiguration" title="ServiceConfiguration">
+                                <a class="records " href="records/ServiceConfiguration.html">ServiceConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Knative service configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                </table>
+            </section>
+            
+            
+
+            
+
+            
+
+            
+           
+
+            
+
+
+            
+            <section class="method-content" id="constants">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#constants">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Constants </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="IMAGE_PULL_POLICY_IF_NOT_PRESENT" title="IMAGE_PULL_POLICY_IF_NOT_PRESENT">
+                                <a class="constant " href="constants.html#IMAGE_PULL_POLICY_IF_NOT_PRESENT">IMAGE_PULL_POLICY_IF_NOT_PRESENT</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Pull image if it is not present for knative service.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="IMAGE_PULL_POLICY_ALWAYS" title="IMAGE_PULL_POLICY_ALWAYS">
+                                <a class="constant " href="constants.html#IMAGE_PULL_POLICY_ALWAYS">IMAGE_PULL_POLICY_ALWAYS</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Always pull the image for knative service.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="IMAGE_PULL_POLICY_NEVER" title="IMAGE_PULL_POLICY_NEVER">
+                                <a class="constant " href="constants.html#IMAGE_PULL_POLICY_NEVER">IMAGE_PULL_POLICY_NEVER</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Never pull the image for knative service.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="EXISTS_OPERATION" title="EXISTS_OPERATION">
+                                <a class="constant " href="constants.html#EXISTS_OPERATION">EXISTS_OPERATION</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="EQUAL_OPERATION" title="EQUAL_OPERATION">
+                                <a class="constant " href="constants.html#EQUAL_OPERATION">EQUAL_OPERATION</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="TOLERATION_EFFECT_NO_SCHEDULE" title="TOLERATION_EFFECT_NO_SCHEDULE">
+                                <a class="constant " href="constants.html#TOLERATION_EFFECT_NO_SCHEDULE">TOLERATION_EFFECT_NO_SCHEDULE</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="TOLERATION_EFFECT_PREFER_NO_SCHEDULE" title="TOLERATION_EFFECT_PREFER_NO_SCHEDULE">
+                                <a class="constant " href="constants.html#TOLERATION_EFFECT_PREFER_NO_SCHEDULE">TOLERATION_EFFECT_PREFER_NO_SCHEDULE</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="TOLERATION_EFFECT_NO_EXECUTE" title="TOLERATION_EFFECT_NO_EXECUTE">
+                                <a class="constant " href="constants.html#TOLERATION_EFFECT_NO_EXECUTE">TOLERATION_EFFECT_NO_EXECUTE</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+
+            
+            <section class="method-content" id="annotations">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#annotations">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Annotations </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="ConfigMap" title="ConfigMap">
+                                <a class="annotations " href="annotations.html#ConfigMap">ConfigMap</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@knative:ConfigMap annotation to configure config maps.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="HPA" title="HPA">
+                                <a class="annotations " href="annotations.html#HPA">HPA</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@knative:HPA annotation to configure horizontal pod autoscaler yaml.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Secret" title="Secret">
+                                <a class="annotations " href="annotations.html#Secret">Secret</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@knative:Secret annotation to configure secrets.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Service" title="Service">
+                                <a class="annotations " href="annotations.html#Service">Service</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+            
+            <section class="method-content" id="types">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#types">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Types </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate types" id="ImagePullPolicy" title="ImagePullPolicy">
+                                <a class="types " href="types.html#ImagePullPolicy">ImagePullPolicy</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Image pull policy type field for kubernetes deployment and jobs.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate types" id="TolerationEffect" title="TolerationEffect">
+                                <a class="types " href="types.html#TolerationEffect">TolerationEffect</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Types of toleration effects for pods.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate types" id="TolerationOperator" title="TolerationOperator">
+                                <a class="types " href="types.html#TolerationOperator">TolerationOperator</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Type of operations between key and value of a toleration.
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+            
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/ConfigMap.html
+++ b/learn/api-docs/ballerina/knative/records/ConfigMap.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : ConfigMap</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li class="active">
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">ConfigMap</span>
+            </h1>
+            <p>
+                
+                <p>Knative Config Map volume mount.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >mountPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Mount path</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >readOnly</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Is mount read only. Default is <code>true</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >data</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Paths to data files.+ port - port value for the containerPort</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/ConfigMapKeyRef.html
+++ b/learn/api-docs/ballerina/knative/records/ConfigMapKeyRef.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : ConfigMapKeyRef</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">ConfigMapKeyRef</span>
+            </h1>
+            <p>
+                
+                <p>Value from config map key.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >configMapKeyRef</span>
+                <span class="type">  <a href="../../knative/records/ConfigMapKeyValue.html">ConfigMapKeyValue</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Reference for config map key</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/ConfigMapKeyValue.html
+++ b/learn/api-docs/ballerina/knative/records/ConfigMapKeyValue.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : ConfigMapKeyValue</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">ConfigMapKeyValue</span>
+            </h1>
+            <p>
+                
+                <p>Value for config map key.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>name of the config</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >key</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>key of the config</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/ConfigMapMount.html
+++ b/learn/api-docs/ballerina/knative/records/ConfigMapMount.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : ConfigMapMount</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">ConfigMapMount</span>
+            </h1>
+            <p>
+                
+                <p>Secret volume mount configurations for knative.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >conf</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>path to ballerina configuration file</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >configMaps</span>
+                <span class="type">  <span class="array-type"><a href="../../knative/records/ConfigMap.html">ConfigMap</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Array of <a href="kubernetes.html#ConfigMap">ConfigMap</a></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/FieldRef.html
+++ b/learn/api-docs/ballerina/knative/records/FieldRef.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : FieldRef</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">FieldRef</span>
+            </h1>
+            <p>
+                
+                <p>Value from field.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >fieldRef</span>
+                <span class="type">  <a href="../../knative/records/FieldValue.html">FieldValue</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Reference for a field</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/FieldValue.html
+++ b/learn/api-docs/ballerina/knative/records/FieldValue.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : FieldValue</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">FieldValue</span>
+            </h1>
+            <p>
+                
+                <p>Value for a field.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >fieldPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Path of the field</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/FileConfig.html
+++ b/learn/api-docs/ballerina/knative/records/FileConfig.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : FileConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">FileConfig</span>
+            </h1>
+            <p>
+                
+                <p>External file type for docker.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >sourceFile</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>source path of the file (in your machine)</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >target</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>target path (inside container)</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/Metadata.html
+++ b/learn/api-docs/ballerina/knative/records/Metadata.html
@@ -1,0 +1,435 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : Metadata</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">Metadata</span>
+            </h1>
+            <p>
+                
+                <p>Knative annotation configuration.
+Metadata for artifacts.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name of the resource. Default is <code>&quot;&lt;OUPUT_FILE_NAME&gt;-&lt;RESOURCE_TYPE&gt;&quot;</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >labels</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of labels for the resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >annotations</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of annotations for resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/PodAutoscalerConfig.html
+++ b/learn/api-docs/ballerina/knative/records/PodAutoscalerConfig.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : PodAutoscalerConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">PodAutoscalerConfig</span>
+            </h1>
+            <p>
+                
+                <p>Knative Horizontal Pod Autoscaler configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >minReplicas</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Minimum number of replicas</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >maxReplicas</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Maximum number of replicas</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/PodTolerationConfiguration.html
+++ b/learn/api-docs/ballerina/knative/records/PodTolerationConfiguration.html
@@ -1,0 +1,468 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : PodTolerationConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">PodTolerationConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Pod toleration configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >key</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Taint key of the toleration</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >operator</span>
+                <span class="type">  <a href="../../knative/types.html#TolerationOperator">TolerationOperator</a></span>
+                 <span class="default">(default Equal)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Operator between the key and value. Default is <code>&quot;Equal&quot;</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >value</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Taint value of the toleration</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >effect</span>
+                <span class="type">  <a href="../../knative/types.html#TolerationEffect">TolerationEffect</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The taint effect</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >tolerationSeconds</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 0)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Time period of toleration in seconds. Default is <code>0</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/ProbeConfiguration.html
+++ b/learn/api-docs/ballerina/knative/records/ProbeConfiguration.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : ProbeConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">ProbeConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Probing configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >port</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Port to check for tcp connection</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >initialDelayInSeconds</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Initial delay for pobing in seconds</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >periodSeconds</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Interval between probes in seconds</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/ResourceFieldRef.html
+++ b/learn/api-docs/ballerina/knative/records/ResourceFieldRef.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : ResourceFieldRef</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">ResourceFieldRef</span>
+            </h1>
+            <p>
+                
+                <p>Value from resource field.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >resourceFieldRef</span>
+                <span class="type">  <a href="../../knative/records/ResourceFieldValue.html">ResourceFieldValue</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Reference for resource field</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/ResourceFieldValue.html
+++ b/learn/api-docs/ballerina/knative/records/ResourceFieldValue.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : ResourceFieldValue</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">ResourceFieldValue</span>
+            </h1>
+            <p>
+                
+                <p>Value for resource field.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >containerName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name of the container</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >resource</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Resource field</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/Secret.html
+++ b/learn/api-docs/ballerina/knative/records/Secret.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : Secret</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">Secret</span>
+            </h1>
+            <p>
+                
+                <p>Knative secret volume mount.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >mountPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Mount path</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >readOnly</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Is mount read only. Default is <code>true</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >data</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Paths to data files as an array</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/SecretKeyRef.html
+++ b/learn/api-docs/ballerina/knative/records/SecretKeyRef.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : SecretKeyRef</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">SecretKeyRef</span>
+            </h1>
+            <p>
+                
+                <p>Value from secret key.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >secretKeyRef</span>
+                <span class="type">  <a href="../../knative/records/SecretKeyValue.html">SecretKeyValue</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Reference for secret key</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/SecretKeyValue.html
+++ b/learn/api-docs/ballerina/knative/records/SecretKeyValue.html
@@ -1,0 +1,417 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : SecretKeyValue</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">SecretKeyValue</span>
+            </h1>
+            <p>
+                
+                <p>Value for a secret key.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name of the secret</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >key</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Key of the secret</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/SecretMount.html
+++ b/learn/api-docs/ballerina/knative/records/SecretMount.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : SecretMount</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">SecretMount</span>
+            </h1>
+            <p>
+                
+                <p>Secret volume mount configurations for knative.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >secrets</span>
+                <span class="type">  <span class="array-type"><a href="../../knative/records/Secret.html">Secret</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Array of <a href="knative.html#Secret">Secret</a></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/records/ServiceConfiguration.html
+++ b/learn/api-docs/ballerina/knative/records/ServiceConfiguration.html
@@ -1,0 +1,796 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Record : ServiceConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../knative/index.html">knative</a>
+                
+                 : <span class="records ">ServiceConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Knative service configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dockerHost</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker host IP and docker PORT. ( e.g minikube IP and docker PORT)
+Default is to use DOCKER_HOST environment variable
+If DOCKER_HOST is unavailable, use <code>&quot;unix:///var/run/docker.sock&quot;</code> for Unix or
+use <code>&quot;npipe:////./pipe/docker_engine&quot;</code> for Windows 10 or use <code>&quot;localhost:2375&quot;</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dockerCertPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker certificate path. Default is &quot;DOCKER_CERT_PATH&quot; environment variable</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >registry</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker registry url</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >username</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Username for docker registry</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >password</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Password for docker registry</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >baseImage</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Base image for docker image building. Default value is <code>&quot;ballerina/ballerina-runtime:&lt;BALLERINA_VERSION&gt;&quot;</code>
+Use <code>&quot;ballerina/ballerina-runtime:latest&quot;</code> to use the latest stable ballerina runtime docker image</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >image</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker image name with tag. Default is <code>&quot;&lt;OUTPUT_FILE_NAME&gt;:latest&quot;</code>. If field <code>registry</code> is set then
+it will be prepended to the docker image name as <code>&lt;registry&gt;/&lt;OUTPUT_FILE_NAME&gt;:latest</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >buildImage</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker image to be build or not. Default is <code>true</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >push</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable pushing docker image to registry. Field <code>buildImage</code> must be set to <code>true</code> to be effective. Default value is <code>false</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >copyFiles</span>
+                <span class="type">  <span class="array-type"><a href="../../knative/records/FileConfig.html">FileConfig</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Array of <a href="kubernetes#FileConfig">External files</a> for docker image</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >singleYAML</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Generate a single yaml file with all kubernetes artifacts (services, deployment, ingress and etc). Default is <code>true</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >namespace</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Kubernetes namespace to be used on all artifacts</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >replicas</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 1)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Number of replicas. Default is <code>1</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >livenessProbe</span>
+                <span class="type">  <span class="builtin-type">boolean</span> | <a href="../../knative/records/ProbeConfiguration.html">ProbeConfiguration</a></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable/Disable liveness probe and configure it. Default is <code>false</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >readinessProbe</span>
+                <span class="type">  <span class="builtin-type">boolean</span> | <a href="../../knative/records/ProbeConfiguration.html">ProbeConfiguration</a></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable/Disable readiness probe and configure it. Default is <code>false</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >imagePullPolicy</span>
+                <span class="type">  <a href="../../knative/types.html#ImagePullPolicy">ImagePullPolicy</a></span>
+                 <span class="default">(default IMAGE_PULL_POLICY_IF_NOT_PRESENT)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Image pull policy. Default is <code>&quot;IfNotPresent&quot;</code></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >env</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span> | <a href="../../knative/records/FieldRef.html">FieldRef</a> | <a href="../../knative/records/SecretKeyRef.html">SecretKeyRef</a> | <a href="../../knative/records/ResourceFieldRef.html">ResourceFieldRef</a> | <a href="../../knative/records/ConfigMapKeyRef.html">ConfigMapKeyRef</a>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Environment variable map for containers</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >podAnnotations</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of annotations for pods</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >podTolerations</span>
+                <span class="type">  <span class="array-type"><a href="../../knative/records/PodTolerationConfiguration.html">PodTolerationConfiguration</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Toleration for pods</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dependsOn</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Services this deployment depends on</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >imagePullSecrets</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Image pull secrets</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >containerConcurrency</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 100)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>concurent request handle by one container instance</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >timeoutSeconds</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 60)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>max time the instance is allowed for responding to a request</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >port</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 8080)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>containerPort value for Knative service</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/knative/types.html
+++ b/learn/api-docs/ballerina/knative/types.html
@@ -1,0 +1,289 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Knative extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,knative">
+
+    <title>API Docs - Types : knative</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Types</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#ImagePullPolicy" onclick="menuLinkClick()">ImagePullPolicy</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#TolerationEffect" onclick="menuLinkClick()">TolerationEffect</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#TolerationOperator" onclick="menuLinkClick()">TolerationOperator</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../knative/index.html" onclick="menuLinkClick()">
+            <h3>knative</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../knative/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../knative/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../knative/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../knative/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Types - </span>
+                 
+                     <a href="../knative/index.html">knative</a>
+                 
+            </h1>
+            <div class="types">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="ImagePullPolicy">
+                                    <b >ImagePullPolicy</b>
+                                    
+                                    <span class="type">  <a href="../knative/constants.html#IMAGE_PULL_POLICY_IF_NOT_PRESENT">IMAGE_PULL_POLICY_IF_NOT_PRESENT</a> | <a href="../knative/constants.html#IMAGE_PULL_POLICY_ALWAYS">IMAGE_PULL_POLICY_ALWAYS</a> | <a href="../knative/constants.html#IMAGE_PULL_POLICY_NEVER">IMAGE_PULL_POLICY_NEVER</a></span></li>
+                                    
+                                <li>
+                                    
+                                    <p>Image pull policy type field for kubernetes deployment and jobs.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="TolerationEffect">
+                                    <b >TolerationEffect</b>
+                                    
+                                    <span class="type">  <a href="../knative/constants.html#TOLERATION_EFFECT_NO_SCHEDULE">TOLERATION_EFFECT_NO_SCHEDULE</a> | <a href="../knative/constants.html#TOLERATION_EFFECT_PREFER_NO_SCHEDULE">TOLERATION_EFFECT_PREFER_NO_SCHEDULE</a> | <a href="../knative/constants.html#TOLERATION_EFFECT_NO_EXECUTE">TOLERATION_EFFECT_NO_EXECUTE</a></span></li>
+                                    
+                                <li>
+                                    
+                                    <p>Types of toleration effects for pods.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="TolerationOperator">
+                                    <b >TolerationOperator</b>
+                                    
+                                    <span class="type">  <a href="../knative/constants.html#EXISTS_OPERATION">EXISTS_OPERATION</a> | <a href="../knative/constants.html#EQUAL_OPERATION">EQUAL_OPERATION</a></span></li>
+                                    
+                                <li>
+                                    
+                                    <p>Type of operations between key and value of a toleration.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/annotations.html
+++ b/learn/api-docs/ballerina/kubernetes/annotations.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Annotations : kubernetes</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Annotations</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#ConfigMap" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#Deployment" onclick="menuLinkClick()">Deployment</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#HPA" onclick="menuLinkClick()">HPA</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#Ingress" onclick="menuLinkClick()">Ingress</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#Job" onclick="menuLinkClick()">Job</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#PersistentVolumeClaim" onclick="menuLinkClick()">PersistentVolumeClaim</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#ResourceQuota" onclick="menuLinkClick()">ResourceQuota</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#Secret" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#Service" onclick="menuLinkClick()">Service</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Annotations - </span>
+                 
+                     <a href="../kubernetes/index.html">kubernetes</a>
+                 
+            </h1>
+            <div class="annotations">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >ConfigMap</b>
+                                    <span class="type"> <span ><a href="../kubernetes/records/ConfigMapMount.html">ConfigMapMount</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        service, function</li>
+                                <li>
+                                    
+                                    <p>@kubernetes:ConfigMap annotation to configure config maps.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Deployment</b>
+                                    <span class="type"> <span ><a href="../kubernetes/records/DeploymentConfiguration.html">DeploymentConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        service, listener, function</li>
+                                <li>
+                                    
+                                    <p>@kubernetes:Deployment annotation to configure deplyoment yaml.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >HPA</b>
+                                    <span class="type"> <span ><a href="../kubernetes/records/PodAutoscalerConfig.html">PodAutoscalerConfig</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        function, service</li>
+                                <li>
+                                    
+                                    <p>@kubernetes:HPA annotation to configure horizontal pod autoscaler yaml.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Ingress</b>
+                                    <span class="type"> <span ><a href="../kubernetes/records/IngressConfiguration.html">IngressConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        listener, service</li>
+                                <li>
+                                    
+                                    <p>@kubernetes:Ingress annotation to configure ingress yaml.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Job</b>
+                                    <span class="type"> <span ><a href="../kubernetes/records/JobConfig.html">JobConfig</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        function</li>
+                                <li>
+                                    
+                                    <p>@kubernetes:Job annotation to configure kubernetes jobs.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >PersistentVolumeClaim</b>
+                                    <span class="type"> <span ><a href="../kubernetes/records/PersistentVolumeClaims.html">PersistentVolumeClaims</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        service, function</li>
+                                <li>
+                                    
+                                    <p>@kubernetes:PersistentVolumeClaim annotation to configure Persistent Volume Claims.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >ResourceQuota</b>
+                                    <span class="type"> <span ><a href="../kubernetes/records/ResourceQuotas.html">ResourceQuotas</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        function, service</li>
+                                <li>
+                                    
+                                    <p>@kubernetes:ResourcesQuotas annotation to configure Resource Quotas.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Secret</b>
+                                    <span class="type"> <span ><a href="../kubernetes/records/SecretMount.html">SecretMount</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        service, function</li>
+                                <li>
+                                    
+                                    <p>@kubernetes:Secret annotation to configure secrets.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Service</b>
+                                    <span class="type"> <span ><a href="../kubernetes/records/ServiceConfiguration.html">ServiceConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        listener, service</li>
+                                <li>
+                                    
+                                    <p>@kubernetes:Service annotation to configure service yaml.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/constants.html
+++ b/learn/api-docs/ballerina/kubernetes/constants.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Constants : kubernetes</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1>
+                <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Constants - </span> 
+                <a href="../kubernetes/index.html">kubernetes</a> 
+            </h1>
+            <div class="constants">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="IMAGE_PULL_POLICY_IF_NOT_PRESENT">
+                                    <b >IMAGE_PULL_POLICY_IF_NOT_PRESENT</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> IfNotPresent
+                                </li>
+                                <li>
+                                    
+                                    <p>Pull image if it is not present for deployment or job.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="IMAGE_PULL_POLICY_ALWAYS">
+                                    <b >IMAGE_PULL_POLICY_ALWAYS</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> Always
+                                </li>
+                                <li>
+                                    
+                                    <p>Always pull the image for knative service for deployment or job.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="IMAGE_PULL_POLICY_NEVER">
+                                    <b >IMAGE_PULL_POLICY_NEVER</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> Never
+                                </li>
+                                <li>
+                                    
+                                    <p>Never pull the image for deployment or job.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="STRATEGY_RECREATE">
+                                    <b >STRATEGY_RECREATE</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> Recreate
+                                </li>
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="STRATEGY_ROLLING_UPDATE">
+                                    <b >STRATEGY_ROLLING_UPDATE</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> RollingUpdate
+                                </li>
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="SESSION_AFFINITY_NONE">
+                                    <b >SESSION_AFFINITY_NONE</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> None
+                                </li>
+                                <li>
+                                    
+                                    <p>Disable session affinity on pods.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="SESSION_AFFINITY_CLIENT_IP">
+                                    <b >SESSION_AFFINITY_CLIENT_IP</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> ClientIP
+                                </li>
+                                <li>
+                                    
+                                    <p>Enable session affinity on pods.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="SERVICE_TYPE_NORD_PORT">
+                                    <b >SERVICE_TYPE_NORD_PORT</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> NodePort
+                                </li>
+                                <li>
+                                    
+                                    <p>Node port type service.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="SERVICE_TYPE_CLUSTER_IP">
+                                    <b >SERVICE_TYPE_CLUSTER_IP</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> ClusterIP
+                                </li>
+                                <li>
+                                    
+                                    <p>Cluster IP type service.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="SERVICE_TYPE_LOAD_BALANCER">
+                                    <b >SERVICE_TYPE_LOAD_BALANCER</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> LoadBalancer
+                                </li>
+                                <li>
+                                    
+                                    <p>Load balancer type service.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="RESTART_POLICY_ON_FAILURE">
+                                    <b >RESTART_POLICY_ON_FAILURE</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> OnFailure
+                                </li>
+                                <li>
+                                    
+                                    <p>Restart on failure policy for jobs.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="RESTART_POLICY_ALWAYS">
+                                    <b >RESTART_POLICY_ALWAYS</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> Always
+                                </li>
+                                <li>
+                                    
+                                    <p>Always restart policy when job is finished.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="RESTART_POLICY_NEVER">
+                                    <b >RESTART_POLICY_NEVER</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> Never
+                                </li>
+                                <li>
+                                    
+                                    <p>Never restart policy for jobs.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/index.html
+++ b/learn/api-docs/ballerina/kubernetes/index.html
@@ -1,0 +1,942 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - ballerina/kubernetes</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper module-wrapper">
+                <h1>
+                    <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                    
+                        Module : <span class="modules">kubernetes</span>
+                    
+                </h1>
+                    <h2>Module Overview</h2>
+<p>This module offers an annotation based Kubernetes extension implementation for Ballerina.</p>
+<ul>
+<li>For information on the operations, which you can perform with this module, see <a href="https://ballerina.io/learn/api-docs/ballerina/kubernetes/index.html#objects">Objects</a>.</li>
+<li>For more information on the deployment, see <a href="https://ballerina.io/learn/deployment/kubernetes/">Kubernetes Deployment Guide</a>.</li>
+<li>For examples on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/kubernetes-deployment.html">Kubernetes Deployment Example</a>.</li>
+</ul>
+<h3>Annotation Usage Sample:</h3>
+<pre><code class="language-ballerina">import ballerina/http;
+import ballerina/log;
+import ballerinax/kubernetes;
+
+@kubernetes:Ingress{
+    hostname: &quot;abc.com&quot;
+}
+@kubernetes:Service {
+    name:&quot;hello&quot;
+}
+listener http:Listener helloEP = new(9090);
+
+@kubernetes:Deployment {
+    livenessProbe: true
+}
+@http:ServiceConfig {
+    basePath: &quot;/helloWorld&quot;
+}
+service helloWorld on helloEP {
+    resource function sayHello(http:Caller caller, http:Request request) {
+        http:Response response = new;
+        response.setTextPayload(&quot;Hello, World from service helloWorld ! &quot;);
+        var responseResult = caller-&gt;respond(response);
+        if (responseResult is error) {
+            log:printError(&quot;error responding back to client.&quot;, err = responseResult);
+        }
+    }
+}
+</code></pre>
+
+
+            
+            
+            <section class="method-content" id="records">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#records">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Records </h2>
+                </div>
+                <table>
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="BuildExtension" title="BuildExtension">
+                                <a class="records " href="records/BuildExtension.html">BuildExtension</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Extend building of the docker image.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ConfigMap" title="ConfigMap">
+                                <a class="records " href="records/ConfigMap.html">ConfigMap</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Kubernetes Config Map volume mount.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ConfigMapKeyRef" title="ConfigMapKeyRef">
+                                <a class="records " href="records/ConfigMapKeyRef.html">ConfigMapKeyRef</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value from config map key.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ConfigMapKeyValue" title="ConfigMapKeyValue">
+                                <a class="records " href="records/ConfigMapKeyValue.html">ConfigMapKeyValue</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value for config map key.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ConfigMapMount" title="ConfigMapMount">
+                                <a class="records " href="records/ConfigMapMount.html">ConfigMapMount</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>ConfigMap volume mount configurations for kubernetes.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="DeploymentConfiguration" title="DeploymentConfiguration">
+                                <a class="records " href="records/DeploymentConfiguration.html">DeploymentConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Kubernetes deployment configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="FieldRef" title="FieldRef">
+                                <a class="records " href="records/FieldRef.html">FieldRef</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value from field.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="FieldValue" title="FieldValue">
+                                <a class="records " href="records/FieldValue.html">FieldValue</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value for a field.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="FileConfig" title="FileConfig">
+                                <a class="records " href="records/FileConfig.html">FileConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>External file type for docker.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="IngressConfiguration" title="IngressConfiguration">
+                                <a class="records " href="records/IngressConfiguration.html">IngressConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Kubernetes ingress configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="JobConfig" title="JobConfig">
+                                <a class="records " href="records/JobConfig.html">JobConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Kubernetes job configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="Metadata" title="Metadata">
+                                <a class="records " href="records/Metadata.html">Metadata</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Metadata for artifacts</p>
+
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="OpenShiftBuildConfigConfiguration" title="OpenShiftBuildConfigConfiguration">
+                                <a class="records " href="records/OpenShiftBuildConfigConfiguration.html">OpenShiftBuildConfigConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Build Config configuration for OpenShift.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="PersistentVolumeClaimConfig" title="PersistentVolumeClaimConfig">
+                                <a class="records " href="records/PersistentVolumeClaimConfig.html">PersistentVolumeClaimConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Kubernetes Persistent Volume Claim.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="PersistentVolumeClaims" title="PersistentVolumeClaims">
+                                <a class="records " href="records/PersistentVolumeClaims.html">PersistentVolumeClaims</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Persistent Volume Claims configurations for kubernetes.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="PodAutoscalerConfig" title="PodAutoscalerConfig">
+                                <a class="records " href="records/PodAutoscalerConfig.html">PodAutoscalerConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Kubernetes Horizontal Pod Autoscaler configuration</p>
+
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="PodTolerationConfiguration" title="PodTolerationConfiguration">
+                                <a class="records " href="records/PodTolerationConfiguration.html">PodTolerationConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Pod toleration configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ProbeConfiguration" title="ProbeConfiguration">
+                                <a class="records " href="records/ProbeConfiguration.html">ProbeConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Probing configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ProjectedVolumeMount" title="ProjectedVolumeMount">
+                                <a class="records " href="records/ProjectedVolumeMount.html">ProjectedVolumeMount</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Projected volume mount configurations for kubernetes.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="PrometheusConfig" title="PrometheusConfig">
+                                <a class="records " href="records/PrometheusConfig.html">PrometheusConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Prometheus port configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ResourceFieldRef" title="ResourceFieldRef">
+                                <a class="records " href="records/ResourceFieldRef.html">ResourceFieldRef</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value from resource field.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ResourceFieldValue" title="ResourceFieldValue">
+                                <a class="records " href="records/ResourceFieldValue.html">ResourceFieldValue</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value for resource field.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ResourceQuotaConfig" title="ResourceQuotaConfig">
+                                <a class="records " href="records/ResourceQuotaConfig.html">ResourceQuotaConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Kubernetes Resource Quota</p>
+
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ResourceQuotas" title="ResourceQuotas">
+                                <a class="records " href="records/ResourceQuotas.html">ResourceQuotas</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Resource Quota configuration for kubernetes.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="RollingUpdateConfig" title="RollingUpdateConfig">
+                                <a class="records " href="records/RollingUpdateConfig.html">RollingUpdateConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Rolling Update config type field for deployment.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="Secret" title="Secret">
+                                <a class="records " href="records/Secret.html">Secret</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Kubernetes secret volume mount.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="SecretKeyRef" title="SecretKeyRef">
+                                <a class="records " href="records/SecretKeyRef.html">SecretKeyRef</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value from secret key.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="SecretKeyValue" title="SecretKeyValue">
+                                <a class="records " href="records/SecretKeyValue.html">SecretKeyValue</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Value for a secret key.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="SecretMount" title="SecretMount">
+                                <a class="records " href="records/SecretMount.html">SecretMount</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Secret volume mount configurations for kubernetes.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ServiceAccountToken" title="ServiceAccountToken">
+                                <a class="records " href="records/ServiceAccountToken.html">ServiceAccountToken</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Service account token configurations for kubernetes.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="ServiceConfiguration" title="ServiceConfiguration">
+                                <a class="records " href="records/ServiceConfiguration.html">ServiceConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Kubernetes service configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                </table>
+            </section>
+            
+            
+
+            
+
+            
+
+            
+           
+
+            
+
+
+            
+            <section class="method-content" id="constants">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#constants">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Constants </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="IMAGE_PULL_POLICY_IF_NOT_PRESENT" title="IMAGE_PULL_POLICY_IF_NOT_PRESENT">
+                                <a class="constant " href="constants.html#IMAGE_PULL_POLICY_IF_NOT_PRESENT">IMAGE_PULL_POLICY_IF_NOT_PRESENT</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Pull image if it is not present for deployment or job.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="IMAGE_PULL_POLICY_ALWAYS" title="IMAGE_PULL_POLICY_ALWAYS">
+                                <a class="constant " href="constants.html#IMAGE_PULL_POLICY_ALWAYS">IMAGE_PULL_POLICY_ALWAYS</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Always pull the image for knative service for deployment or job.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="IMAGE_PULL_POLICY_NEVER" title="IMAGE_PULL_POLICY_NEVER">
+                                <a class="constant " href="constants.html#IMAGE_PULL_POLICY_NEVER">IMAGE_PULL_POLICY_NEVER</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Never pull the image for deployment or job.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="STRATEGY_RECREATE" title="STRATEGY_RECREATE">
+                                <a class="constant " href="constants.html#STRATEGY_RECREATE">STRATEGY_RECREATE</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="STRATEGY_ROLLING_UPDATE" title="STRATEGY_ROLLING_UPDATE">
+                                <a class="constant " href="constants.html#STRATEGY_ROLLING_UPDATE">STRATEGY_ROLLING_UPDATE</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="SESSION_AFFINITY_NONE" title="SESSION_AFFINITY_NONE">
+                                <a class="constant " href="constants.html#SESSION_AFFINITY_NONE">SESSION_AFFINITY_NONE</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Disable session affinity on pods.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="SESSION_AFFINITY_CLIENT_IP" title="SESSION_AFFINITY_CLIENT_IP">
+                                <a class="constant " href="constants.html#SESSION_AFFINITY_CLIENT_IP">SESSION_AFFINITY_CLIENT_IP</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Enable session affinity on pods.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="SERVICE_TYPE_NORD_PORT" title="SERVICE_TYPE_NORD_PORT">
+                                <a class="constant " href="constants.html#SERVICE_TYPE_NORD_PORT">SERVICE_TYPE_NORD_PORT</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Node port type service.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="SERVICE_TYPE_CLUSTER_IP" title="SERVICE_TYPE_CLUSTER_IP">
+                                <a class="constant " href="constants.html#SERVICE_TYPE_CLUSTER_IP">SERVICE_TYPE_CLUSTER_IP</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Cluster IP type service.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="SERVICE_TYPE_LOAD_BALANCER" title="SERVICE_TYPE_LOAD_BALANCER">
+                                <a class="constant " href="constants.html#SERVICE_TYPE_LOAD_BALANCER">SERVICE_TYPE_LOAD_BALANCER</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Load balancer type service.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="RESTART_POLICY_ON_FAILURE" title="RESTART_POLICY_ON_FAILURE">
+                                <a class="constant " href="constants.html#RESTART_POLICY_ON_FAILURE">RESTART_POLICY_ON_FAILURE</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Restart on failure policy for jobs.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="RESTART_POLICY_ALWAYS" title="RESTART_POLICY_ALWAYS">
+                                <a class="constant " href="constants.html#RESTART_POLICY_ALWAYS">RESTART_POLICY_ALWAYS</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Always restart policy when job is finished.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="RESTART_POLICY_NEVER" title="RESTART_POLICY_NEVER">
+                                <a class="constant " href="constants.html#RESTART_POLICY_NEVER">RESTART_POLICY_NEVER</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Never restart policy for jobs.
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+
+            
+            <section class="method-content" id="annotations">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#annotations">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Annotations </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="ConfigMap" title="ConfigMap">
+                                <a class="annotations " href="annotations.html#ConfigMap">ConfigMap</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@kubernetes:ConfigMap annotation to configure config maps.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Deployment" title="Deployment">
+                                <a class="annotations " href="annotations.html#Deployment">Deployment</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@kubernetes:Deployment annotation to configure deplyoment yaml.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="HPA" title="HPA">
+                                <a class="annotations " href="annotations.html#HPA">HPA</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@kubernetes:HPA annotation to configure horizontal pod autoscaler yaml.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Ingress" title="Ingress">
+                                <a class="annotations " href="annotations.html#Ingress">Ingress</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@kubernetes:Ingress annotation to configure ingress yaml.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Job" title="Job">
+                                <a class="annotations " href="annotations.html#Job">Job</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@kubernetes:Job annotation to configure kubernetes jobs.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="PersistentVolumeClaim" title="PersistentVolumeClaim">
+                                <a class="annotations " href="annotations.html#PersistentVolumeClaim">PersistentVolumeClaim</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@kubernetes:PersistentVolumeClaim annotation to configure Persistent Volume Claims.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="ResourceQuota" title="ResourceQuota">
+                                <a class="annotations " href="annotations.html#ResourceQuota">ResourceQuota</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@kubernetes:ResourcesQuotas annotation to configure Resource Quotas.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Secret" title="Secret">
+                                <a class="annotations " href="annotations.html#Secret">Secret</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@kubernetes:Secret annotation to configure secrets.
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Service" title="Service">
+                                <a class="annotations " href="annotations.html#Service">Service</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@kubernetes:Service annotation to configure service yaml.
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+            
+            <section class="method-content" id="types">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#types">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Types </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate types" id="StrategyRollingType" title="StrategyRollingType">
+                                <a class="types " href="types.html#StrategyRollingType">StrategyRollingType</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                        <tr>
+                            <td class="module-title truncate types" id="StrategyType" title="StrategyType">
+                                <a class="types " href="types.html#StrategyType">StrategyType</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+            
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/BuildExtension.html
+++ b/learn/api-docs/ballerina/kubernetes/records/BuildExtension.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : BuildExtension</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li class="active">
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">BuildExtension</span>
+            </h1>
+            <p>
+                
+                <p>Extend building of the docker image.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >openshift</span>
+                <span class="type">  <a href="../../kubernetes/records/OpenShiftBuildConfigConfiguration.html">OpenShiftBuildConfigConfiguration</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Openshift build config.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ConfigMap.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ConfigMap.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ConfigMap</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ConfigMap</span>
+            </h1>
+            <p>
+                
+                <p>Kubernetes Config Map volume mount.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >mountPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Mount path.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >readOnly</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Is mount read only. Default is <code>true</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >defaultMode</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Default permission mode.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >data</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Paths to data files.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyRef.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyRef.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ConfigMapKeyRef</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ConfigMapKeyRef</span>
+            </h1>
+            <p>
+                
+                <p>Value from config map key.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >configMapKeyRef</span>
+                <span class="type">  <a href="../../kubernetes/records/ConfigMapKeyValue.html">ConfigMapKeyValue</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Reference for config map key.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyValue.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyValue.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ConfigMapKeyValue</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ConfigMapKeyValue</span>
+            </h1>
+            <p>
+                
+                <p>Value for config map key.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>name of the config.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >key</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>key of the config.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ConfigMapMount</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ConfigMapMount</span>
+            </h1>
+            <p>
+                
+                <p>ConfigMap volume mount configurations for kubernetes.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >conf</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>path to ballerina configuration file</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >configMaps</span>
+                <span class="type">  <span class="array-type"><a href="../../kubernetes/records/ConfigMap.html">ConfigMap</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Array of <a href="kubernetes.html#ConfigMap">ConfigMap</a></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
+++ b/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
@@ -1,0 +1,913 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : DeploymentConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">DeploymentConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Kubernetes deployment configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dockerHost</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker host IP and docker PORT. (e.g minikube IP and docker PORT).
+Default is to use DOCKER_HOST environment variable.
+If DOCKER_HOST is unavailable, use <code>&quot;unix:///var/run/docker.sock&quot;</code> for Unix or use <code>&quot;npipe:////./pipe/docker_engine&quot;</code> for Windows 10 or use <code>&quot;localhost:2375&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dockerCertPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker certificate path. Default is &quot;DOCKER_CERT_PATH&quot; environment variable.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >registry</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker registry url.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >username</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Username for docker registry.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >password</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Password for docker registry.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >baseImage</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Base image to create the docker image. Default value is <code>&quot;openjdk:8-jre-alpine&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >image</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker image name with tag. Default is <code>&quot;&lt;OUTPUT_FILE_NAME&gt;:latest&quot;</code>. If field <code>registry</code> is set then it will be prepended to the docker image name as <code>&lt;registry&gt;/&lt;OUTPUT_FILE_NAME&gt;:latest</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >buildImage</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker image to be build or not. Default is <code>true</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >push</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable pushing docker image to registry. Field <code>buildImage</code> must be set to <code>true</code> to be effective. Default value is <code>false</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >cmd</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Value for CMD for the generated Dockerfile. Default is <code>CMD java -jar ${APP} [--b7a.config.file=${CONFIG_FILE}] [--debug]</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >updateStrategy</span>
+                <span class="type">  <a href="../../kubernetes/types.html#StrategyType">StrategyType</a> | <a href="../../kubernetes/records/RollingUpdateConfig.html">RollingUpdateConfig</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Deployment strategy.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >copyFiles</span>
+                <span class="type">  <span class="array-type"><a href="../../kubernetes/records/FileConfig.html">FileConfig</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Array of <a href="kubernetes#FileConfig">External files</a> for docker image.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >singleYAML</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Generate a single yaml file with all kubernetes artifacts (services, deployment, ingress and etc). Default is <code>true</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >namespace</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Kubernetes namespace to be used on all artifacts.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >replicas</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 1)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Number of replicas. Default is <code>1</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >livenessProbe</span>
+                <span class="type">  <span class="builtin-type">boolean</span> | <a href="../../kubernetes/records/ProbeConfiguration.html">ProbeConfiguration</a></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable/Disable liveness probe and configure it. Default is <code>false</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >readinessProbe</span>
+                <span class="type">  <span class="builtin-type">boolean</span> | <a href="../../kubernetes/records/ProbeConfiguration.html">ProbeConfiguration</a></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable/Disable readiness probe and configure it. Default is <code>false</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >imagePullPolicy</span>
+                <span class="type">  <a href="../../kubernetes/types.html#ImagePullPolicy">ImagePullPolicy</a></span>
+                 <span class="default">(default IMAGE_PULL_POLICY_IF_NOT_PRESENT)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Image pull policy. Default is <code>&quot;IfNotPresent&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >env</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span> | <a href="../../kubernetes/records/FieldRef.html">FieldRef</a> | <a href="../../kubernetes/records/SecretKeyRef.html">SecretKeyRef</a> | <a href="../../kubernetes/records/ResourceFieldRef.html">ResourceFieldRef</a> | <a href="../../kubernetes/records/ConfigMapKeyRef.html">ConfigMapKeyRef</a>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Environment variable map for containers.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >podAnnotations</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of annotations for pods.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >podTolerations</span>
+                <span class="type">  <span class="array-type"><a href="../../kubernetes/records/PodTolerationConfiguration.html">PodTolerationConfiguration</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Toleration for pods.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >buildExtension</span>
+                <span class="type">  <a href="../../kubernetes/records/BuildExtension.html">BuildExtension</a> | <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker image build extensions.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dependsOn</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Services this deployment depends on.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >imagePullSecrets</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Image pull secrets.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >nodeSelector</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Node selector labels.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >serviceAccountName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Service Account Name.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >projectedVolumeMount</span>
+                <span class="type">  <a href="../../kubernetes/records/ProjectedVolumeMount.html">ProjectedVolumeMount</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Projected Volume Mount config.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >prometheus</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable Prometheus.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/FieldRef.html
+++ b/learn/api-docs/ballerina/kubernetes/records/FieldRef.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : FieldRef</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">FieldRef</span>
+            </h1>
+            <p>
+                
+                <p>Value from field.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >fieldRef</span>
+                <span class="type">  <a href="../../kubernetes/records/FieldValue.html">FieldValue</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Reference for a field.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/FieldValue.html
+++ b/learn/api-docs/ballerina/kubernetes/records/FieldValue.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : FieldValue</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">FieldValue</span>
+            </h1>
+            <p>
+                
+                <p>Value for a field.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >fieldPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Path of the field</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/FileConfig.html
+++ b/learn/api-docs/ballerina/kubernetes/records/FileConfig.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : FileConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">FileConfig</span>
+            </h1>
+            <p>
+                
+                <p>External file type for docker.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >sourceFile</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>source path of the file (in your machine)</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >target</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>target path (inside container)</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/IngressConfiguration.html
+++ b/learn/api-docs/ballerina/kubernetes/records/IngressConfiguration.html
@@ -1,0 +1,520 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : IngressConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">IngressConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Kubernetes ingress configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >hostname</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Host name of the ingress. Default is <code>&quot;&lt;BALLERINA_SERVICE_NAME&gt;.com&quot;</code> or <code>&quot;&lt;BALLERINA_SERVICE_LISTENER_NAME&gt;.com&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >path</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                 <span class="default">(default /)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Resource path. Default is <code>&quot;/&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >targetPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Target path for url rewrite.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >ingressClass</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                 <span class="default">(default nginx)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Ingress class. Default is <code>&quot;nginx&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >enableTLS</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable/Disable ingress TLS. Default is <code>false</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
+++ b/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
@@ -1,0 +1,794 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : JobConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">JobConfig</span>
+            </h1>
+            <p>
+                
+                <p>Kubernetes job configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dockerHost</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker host IP and docker PORT. (e.g minikube IP and docker PORT).
+Default is to use DOCKER_HOST environment variable.
+If DOCKER_HOST is unavailable, use <code>&quot;unix:///var/run/docker.sock&quot;</code> for Unix or use <code>&quot;npipe:////./pipe/docker_engine&quot;</code> for Windows 10 or use <code>&quot;localhost:2375&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >dockerCertPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker certificate path. Default is &quot;DOCKER_CERT_PATH&quot; environment variable.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >registry</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker registry url.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >username</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Username for docker registry.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >password</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Password for docker registry.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >baseImage</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Base image to create the docker image. Default value is <code>&quot;openjdk:8-jre-alpine&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >image</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker image name with tag. Default is <code>&quot;&lt;OUTPUT_FILE_NAME&gt;:latest&quot;</code>. If field <code>registry</code> is set then it will be prepended to the docker image name as <code>&lt;registry&gt;/&lt;OUTPUT_FILE_NAME&gt;:latest</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >buildImage</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Docker image to be build or not. Default is <code>true</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >push</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Enable pushing docker image to registry. Field <code>buildImage</code> must be set to <code>true</code>. Default value is <code>false</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >cmd</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Value for CMD for the generated Dockerfile. Default is <code>CMD java -jar ${APP} [--b7a.config.file=${CONFIG_FILE}] [--debug]</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >copyFiles</span>
+                <span class="type">  <span class="array-type"><a href="../../kubernetes/records/FileConfig.html">FileConfig</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Array of <a href="kubernetes#FileConfig">External files</a> for docker image.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >singleYAML</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Generate a single yaml file with all kubernetes artifacts (ingress, configmaps, secrets and etc). Default is <code>true</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >namespace</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Kubernetes namespace to be used on all artifacts.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >imagePullPolicy</span>
+                <span class="type">  <a href="../../kubernetes/types.html#ImagePullPolicy">ImagePullPolicy</a></span>
+                 <span class="default">(default IMAGE_PULL_POLICY_IF_NOT_PRESENT)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Image pull policy. Default is <code>&quot;IfNotPresent&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >env</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span> | <a href="../../kubernetes/records/FieldRef.html">FieldRef</a> | <a href="../../kubernetes/records/SecretKeyRef.html">SecretKeyRef</a> | <a href="../../kubernetes/records/ResourceFieldRef.html">ResourceFieldRef</a> | <a href="../../kubernetes/records/ConfigMapKeyRef.html">ConfigMapKeyRef</a>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Environment varialbes for container.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >restartPolicy</span>
+                <span class="type">  <a href="../../kubernetes/types.html#RestartPolicy">RestartPolicy</a></span>
+                 <span class="default">(default RESTART_POLICY_NEVER)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Restart policy. Default is <code>&quot;Never&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >backoffLimit</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Backoff limit.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >activeDeadlineSeconds</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 20)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Active deadline seconds. Default is <code>20</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >schedule</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Schedule for cron jobs.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >imagePullSecrets</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Image pull secrets.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >nodeSelector</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Node selector labels.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/Metadata.html
+++ b/learn/api-docs/ballerina/kubernetes/records/Metadata.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : Metadata</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">Metadata</span>
+            </h1>
+            <p>
+                
+                <p>Metadata for artifacts</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name of the resource. Default is <code>&quot;&lt;OUPUT_FILE_NAME&gt;-&lt;RESOURCE_TYPE&gt;&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >labels</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of labels for the resource.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >annotations</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of annotations for resource.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/OpenShiftBuildConfigConfiguration.html
+++ b/learn/api-docs/ballerina/kubernetes/records/OpenShiftBuildConfigConfiguration.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : OpenShiftBuildConfigConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">OpenShiftBuildConfigConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Build Config configuration for OpenShift.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >forcePullDockerImage</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Set force pull images when building docker image.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >buildDockerWithNoCache</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default false)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Build docker image with no cache enabled.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaimConfig.html
+++ b/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaimConfig.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : PersistentVolumeClaimConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">PersistentVolumeClaimConfig</span>
+            </h1>
+            <p>
+                
+                <p>Kubernetes Persistent Volume Claim.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >mountPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Mount Path.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >accessMode</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                 <span class="default">(default ReadWriteOnce)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Access mode. Default is <code>&quot;ReadWriteOnce&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >volumeClaimSize</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Size of the volume claim.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >readOnly</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Is mount read only.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
+++ b/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : PersistentVolumeClaims</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">PersistentVolumeClaims</span>
+            </h1>
+            <p>
+                
+                <p>Persistent Volume Claims configurations for kubernetes.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >volumeClaims</span>
+                <span class="type">  <span class="array-type"><a href="../../kubernetes/records/PersistentVolumeClaimConfig.html">PersistentVolumeClaimConfig</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Array of <a href="kubernetes.html#PersistentVolumeClaimConfig">PersistentVolumeClaimConfig</a></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/PodAutoscalerConfig.html
+++ b/learn/api-docs/ballerina/kubernetes/records/PodAutoscalerConfig.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : PodAutoscalerConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">PodAutoscalerConfig</span>
+            </h1>
+            <p>
+                
+                <p>Kubernetes Horizontal Pod Autoscaler configuration</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >minReplicas</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Minimum number of replicas.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >maxReplicas</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Maximum number of replicas.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >cpuPercentage</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 50)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>CPU percentage to start scaling. Default is <code>50</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/PodTolerationConfiguration.html
+++ b/learn/api-docs/ballerina/kubernetes/records/PodTolerationConfiguration.html
@@ -1,0 +1,520 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : PodTolerationConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">PodTolerationConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Pod toleration configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >key</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Taint key of the toleration.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >operator</span>
+                <span class="type">  <a href="../../kubernetes/types.html#TolerationOperator">TolerationOperator</a></span>
+                 <span class="default">(default Equal)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Operator between the key and value. Default is <code>&quot;Equal&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >value</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Taint value of the toleration.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >effect</span>
+                <span class="type">  <a href="../../kubernetes/types.html#TolerationEffect">TolerationEffect</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The taint effect</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >tolerationSeconds</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 0)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Time period of toleration in seconds. Default is <code>0</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ProbeConfiguration.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ProbeConfiguration.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ProbeConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ProbeConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Probing configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >port</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Port to check for tcp connection.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >initialDelaySeconds</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Initial delay for pobing in seconds.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >periodSeconds</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Interval between probes in seconds.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ProjectedVolumeMount.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ProjectedVolumeMount.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ProjectedVolumeMount</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ProjectedVolumeMount</span>
+            </h1>
+            <p>
+                
+                <p>Projected volume mount configurations for kubernetes.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >sources</span>
+                <span class="type">  <span class="array-type"><a href="../../kubernetes/records/ServiceAccountToken.html">ServiceAccountToken</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>projected Sources</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/PrometheusConfig.html
+++ b/learn/api-docs/ballerina/kubernetes/records/PrometheusConfig.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : PrometheusConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">PrometheusConfig</span>
+            </h1>
+            <p>
+                
+                <p>Prometheus port configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >port</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                 <span class="default">(default 9797)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Prometheus port. Default is 9797.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >serviceType</span>
+                <span class="type">  <a href="../../kubernetes/types.html#ServiceType">ServiceType</a></span>
+                 <span class="default">(default SERVICE_TYPE_CLUSTER_IP)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Service type of the service. Default is <code>&quot;ClusterIP&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >nodePort</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>NodePort for the pods. Default is not set.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ResourceFieldRef.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ResourceFieldRef.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ResourceFieldRef</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ResourceFieldRef</span>
+            </h1>
+            <p>
+                
+                <p>Value from resource field.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >resourceFieldRef</span>
+                <span class="type">  <a href="../../kubernetes/records/ResourceFieldValue.html">ResourceFieldValue</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Reference for resource field.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ResourceFieldValue.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ResourceFieldValue.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ResourceFieldValue</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ResourceFieldValue</span>
+            </h1>
+            <p>
+                
+                <p>Value for resource field.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >containerName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name of the container.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >resource</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Resource field</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ResourceQuotaConfig.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ResourceQuotaConfig.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ResourceQuotaConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ResourceQuotaConfig</span>
+            </h1>
+            <p>
+                
+                <p>Kubernetes Resource Quota</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >hard</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Quotas for the resources</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >scopes</span>
+                <span class="type">  <span class="array-type"><a href="../../kubernetes/types.html#ResourceQuotaScope">ResourceQuotaScope</a>?[]</span></span>
+                 <span class="default">(default [])</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Scopes of the quota</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ResourceQuotas</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ResourceQuotas</span>
+            </h1>
+            <p>
+                
+                <p>Resource Quota configuration for kubernetes.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >resourceQuotas</span>
+                <span class="type">  <span class="array-type"><a href="../../kubernetes/records/ResourceQuotaConfig.html">ResourceQuotaConfig</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Array of <a href="kubernetes.html#ResourceQuotaConfig">ResourceQuotaConfig</a></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/RollingUpdateConfig.html
+++ b/learn/api-docs/ballerina/kubernetes/records/RollingUpdateConfig.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : RollingUpdateConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">RollingUpdateConfig</span>
+            </h1>
+            <p>
+                
+                <p>Rolling Update config type field for deployment.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >strategyType</span>
+                <span class="type">  <a href="../../kubernetes/constants.html#StrategyRollingType">StrategyRollingType</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>strategy type rolling update</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >maxUnavailable</span>
+                <span class="type">  <span class="builtin-type">string</span> | <span class="builtin-type">int</span></span>
+                 <span class="default">(default 25%)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>max unavailable pods</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >maxSurge</span>
+                <span class="type">  <span class="builtin-type">string</span> | <span class="builtin-type">int</span></span>
+                 <span class="default">(default 25%)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>desired number of Pods are up</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/Secret.html
+++ b/learn/api-docs/ballerina/kubernetes/records/Secret.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : Secret</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">Secret</span>
+            </h1>
+            <p>
+                
+                <p>Kubernetes secret volume mount.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >mountPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Mount path.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >readOnly</span>
+                <span class="type">  <span class="builtin-type">boolean</span></span>
+                 <span class="default">(default true)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Is mount read only. Default is <code>true</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >defaultMode</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Default permission mode.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >data</span>
+                <span class="type">  <span class="array-type"><span class="builtin-type">string</span>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Paths to data files as an array.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/SecretKeyRef.html
+++ b/learn/api-docs/ballerina/kubernetes/records/SecretKeyRef.html
@@ -1,0 +1,452 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : SecretKeyRef</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">SecretKeyRef</span>
+            </h1>
+            <p>
+                
+                <p>Value from secret key.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >secretKeyRef</span>
+                <span class="type">  <a href="../../kubernetes/records/SecretKeyValue.html">SecretKeyValue</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Reference for secret key.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/SecretKeyValue.html
+++ b/learn/api-docs/ballerina/kubernetes/records/SecretKeyValue.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : SecretKeyValue</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">SecretKeyValue</span>
+            </h1>
+            <p>
+                
+                <p>Value for a secret key.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name of the secret.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >key</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Key of the secret.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
+++ b/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : SecretMount</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">SecretMount</span>
+            </h1>
+            <p>
+                
+                <p>Secret volume mount configurations for kubernetes.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >conf</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>path to ballerina configuration file</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >secrets</span>
+                <span class="type">  <span class="array-type"><a href="../../kubernetes/records/Secret.html">Secret</a>[]</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Array of <a href="kubernetes.html#Secret">Secret</a></p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ServiceAccountToken.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ServiceAccountToken.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ServiceAccountToken</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ServiceAccountToken</span>
+            </h1>
+            <p>
+                
+                <p>Service account token configurations for kubernetes.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>ServiceAccountToken Name</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >mountPath</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>volume mount path</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >expirationSeconds</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>token expirations seconds</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >audience</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>token audience</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/records/ServiceConfiguration.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ServiceConfiguration.html
@@ -1,0 +1,554 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Record : ServiceConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="BuildExtension.html" onclick="menuLinkClick()">BuildExtension</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMap.html" onclick="menuLinkClick()">ConfigMap</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyRef.html" onclick="menuLinkClick()">ConfigMapKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapKeyValue.html" onclick="menuLinkClick()">ConfigMapKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ConfigMapMount.html" onclick="menuLinkClick()">ConfigMapMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="DeploymentConfiguration.html" onclick="menuLinkClick()">DeploymentConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldRef.html" onclick="menuLinkClick()">FieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FieldValue.html" onclick="menuLinkClick()">FieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="FileConfig.html" onclick="menuLinkClick()">FileConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="IngressConfiguration.html" onclick="menuLinkClick()">IngressConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="JobConfig.html" onclick="menuLinkClick()">JobConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Metadata.html" onclick="menuLinkClick()">Metadata</a>
+                        </li>
+                    
+                        <li >
+                            <a href="OpenShiftBuildConfigConfiguration.html" onclick="menuLinkClick()">OpenShiftBuildConfigConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaimConfig.html" onclick="menuLinkClick()">PersistentVolumeClaimConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PersistentVolumeClaims.html" onclick="menuLinkClick()">PersistentVolumeClaims</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodAutoscalerConfig.html" onclick="menuLinkClick()">PodAutoscalerConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PodTolerationConfiguration.html" onclick="menuLinkClick()">PodTolerationConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProbeConfiguration.html" onclick="menuLinkClick()">ProbeConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ProjectedVolumeMount.html" onclick="menuLinkClick()">ProjectedVolumeMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="PrometheusConfig.html" onclick="menuLinkClick()">PrometheusConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldRef.html" onclick="menuLinkClick()">ResourceFieldRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceFieldValue.html" onclick="menuLinkClick()">ResourceFieldValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotaConfig.html" onclick="menuLinkClick()">ResourceQuotaConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ResourceQuotas.html" onclick="menuLinkClick()">ResourceQuotas</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RollingUpdateConfig.html" onclick="menuLinkClick()">RollingUpdateConfig</a>
+                        </li>
+                    
+                        <li >
+                            <a href="Secret.html" onclick="menuLinkClick()">Secret</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyRef.html" onclick="menuLinkClick()">SecretKeyRef</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretKeyValue.html" onclick="menuLinkClick()">SecretKeyValue</a>
+                        </li>
+                    
+                        <li >
+                            <a href="SecretMount.html" onclick="menuLinkClick()">SecretMount</a>
+                        </li>
+                    
+                        <li >
+                            <a href="ServiceAccountToken.html" onclick="menuLinkClick()">ServiceAccountToken</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="ServiceConfiguration.html" onclick="menuLinkClick()">ServiceConfiguration</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                
+                 : <span class="records ">ServiceConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Kubernetes service configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >portName</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name for the port. Default value is the protocol of the listener.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >port</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Service port. Default is the Ballerina service port.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >targetPort</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Port of the pods. Default is the Ballerina service port.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >nodePort</span>
+                <span class="type">  <span class="builtin-type">int</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>NodePort for the pods. Default is not set.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >sessionAffinity</span>
+                <span class="type">  <a href="../../kubernetes/types.html#SessionAffinity">SessionAffinity</a></span>
+                 <span class="default">(default SESSION_AFFINITY_NONE)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Session affinity for pods. Default is <code>&quot;None&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >serviceType</span>
+                <span class="type">  <a href="../../kubernetes/types.html#ServiceType">ServiceType</a></span>
+                 <span class="default">(default SERVICE_TYPE_CLUSTER_IP)</span> 
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Service type of the service. Default is <code>&quot;ClusterIP&quot;</code>.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >prometheus</span>
+                <span class="type">  <a href="../../kubernetes/records/PrometheusConfig.html">PrometheusConfig</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Prometheus port configurations.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/kubernetes/types.html
+++ b/learn/api-docs/ballerina/kubernetes/types.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based Kubernetes extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,kubernetes">
+
+    <title>API Docs - Types : kubernetes</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Types</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#StrategyRollingType" onclick="menuLinkClick()">StrategyRollingType</a>
+                        </li>
+                    
+                        <li >
+                            <a href="#StrategyType" onclick="menuLinkClick()">StrategyType</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../kubernetes/index.html" onclick="menuLinkClick()">
+            <h3>kubernetes</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../kubernetes/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../kubernetes/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../kubernetes/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+            <li>
+                <a data="types" href="../kubernetes/index.html#types" onclick="menuLinkClick()">Types</a>
+            </li>
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Types - </span>
+                 
+                     <a href="../kubernetes/index.html">kubernetes</a>
+                 
+            </h1>
+            <div class="types">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="StrategyRollingType">
+                                    <b >StrategyRollingType</b>
+                                    
+                                    <span class="type">  <a href="../kubernetes/constants.html#STRATEGY_ROLLING_UPDATE">STRATEGY_ROLLING_UPDATE</a></span></li>
+                                    
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="StrategyType">
+                                    <b >StrategyType</b>
+                                    
+                                    <span class="type">  <a href="../kubernetes/constants.html#STRATEGY_RECREATE">STRATEGY_RECREATE</a> | <a href="../kubernetes/constants.html#STRATEGY_ROLLING_UPDATE">STRATEGY_ROLLING_UPDATE</a></span></li>
+                                    
+                                <li>
+                                    
+                                    
+                                </li>
+                            </ul>
+                        </div>
+                    
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="ImagePullPolicy">
+                                    <b >ImagePullPolicy</b>
+                                    <span class="type">IfNotPresent | Always | Never</span></li>
+                                <li>
+                                    
+                                    <p>Image pull policy type field for kubernetes deployment and jobs.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="ResourceQuotaScope">
+                                    <b >ResourceQuotaScope</b>
+                                    <span class="type">Terminating | NotTerminating | BestEffort | NotBestEffort</span></li>
+                                <li>
+                                    
+                                    <p>Scopes for kubernetes resource quotas</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="RestartPolicy">
+                                    <b >RestartPolicy</b>
+                                    <span class="type">OnFailure | Always | Never</span></li>
+                                <li>
+                                    
+                                    <p>Restart policy type field for kubernetes jobs.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="ServiceType">
+                                    <b >ServiceType</b>
+                                    <span class="type">NodePort | ClusterIP | LoadBalancer</span></li>
+                                <li>
+                                    
+                                    <p>Service type field for kubernetes services.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="SessionAffinity">
+                                    <b >SessionAffinity</b>
+                                    <span class="type">None | ClientIP</span></li>
+                                <li>
+                                    
+                                    <p>Session affinity field for kubernetes services.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="TolerationEffect">
+                                    <b >TolerationEffect</b>
+                                    <span class="type">NoSchedule | PreferNoSchedule | NoExecute</span></li>
+                                <li>
+                                    
+                                    <p>Types of toleration effects for pods.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="TolerationOperator">
+                                    <b >TolerationOperator</b>
+                                    <span class="type">Exists | Equal</span></li>
+                                <li>
+                                    
+                                    <p>Type of operations between key and value of a toleration.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/openshift/annotations.html
+++ b/learn/api-docs/ballerina/openshift/annotations.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based OpenShift extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,openshift">
+
+    <title>API Docs - Annotations : openshift</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Annotations</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="#Route" onclick="menuLinkClick()">Route</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../openshift/index.html" onclick="menuLinkClick()">
+            <h3>openshift</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../openshift/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../openshift/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../openshift/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+             <h1>
+                 <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                 <span class="title-type">Annotations - </span>
+                 
+                     <a href="../openshift/index.html">openshift</a>
+                 
+            </h1>
+            <div class="annotations">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li>
+                                    <b >Route</b>
+                                    <span class="type"> <span ><a href="../openshift/records/RouteConfiguration.html">RouteConfiguration</a></span></span>
+                                    <img class="attach-icon" src="../html-template-resources/images/attach.svg">
+                                        listener, service</li>
+                                <li>
+                                    
+                                    <p>@kubernetes:OpenShiftRoute annotation to generate openshift routes.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/openshift/constants.html
+++ b/learn/api-docs/ballerina/openshift/constants.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based OpenShift extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,openshift">
+
+    <title>API Docs - Constants : openshift</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../openshift/index.html" onclick="menuLinkClick()">
+            <h3>openshift</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../openshift/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../openshift/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../openshift/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1>
+                <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Constants - </span> 
+                <a href="../openshift/index.html">openshift</a> 
+            </h1>
+            <div class="constants">
+                <div class="data-wrapper">
+                    
+                        <div class="params-listing">
+                            <ul>
+                                <li id="BUILD_EXTENSION_OPENSHIFT">
+                                    <b >BUILD_EXTENSION_OPENSHIFT</b>
+                                    <span class="type">  <span class="builtin-type">string</span></span> openshift
+                                </li>
+                                <li>
+                                    
+                                    <p>Configuration to use the OpenShift Build Configs.</p>
+
+                                </li>
+                            </ul>
+                        </div>
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/openshift/index.html
+++ b/learn/api-docs/ballerina/openshift/index.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based OpenShift extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,openshift">
+
+    <title>API Docs - ballerina/openshift</title>
+    <script src="../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../html-template-resources/styles/css/font.css">
+    <script src="../html-template-resources/semantic.min.js"></script>
+    <script src="../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../index.html">
+    <img class="logo" src="../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../openshift/index.html" onclick="menuLinkClick()">
+            <h3>openshift</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../openshift/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../openshift/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../openshift/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+    <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper module-wrapper">
+                <h1>
+                    <a class="breadcrumb-home" href="
+    ../index.html">
+    <img class="breadcrumb-home-icon" src="../html-template-resources/images/home.svg">
+</a>
+                    
+                        Module : <span class="modules">openshift</span>
+                    
+                </h1>
+                    <h2>Module Overview</h2>
+<p>This module offers an annotation based OpenShift extension implementation for Ballerina.</p>
+<ul>
+<li>For information on the operations, which you can perform with this module, see <a href="https://ballerina.io/learn/api-docs/ballerina/openshift/index.html#objects">Objects</a>.</li>
+<li>For examples on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/openshift-deployment.html">OpenShift Deployment Example</a>.</li>
+</ul>
+<h3>Annotation Usage Sample:</h3>
+<pre><code class="language-ballerina">import ballerina/http;
+import ballerina/log;
+import ballerina/kubernetes;
+import ballerina/openshift;
+
+@kubernetes:Service {}
+@openshift:Route {
+    host: &quot;www.oc-example.com&quot;
+}
+listener http:Listener helloEP = new(9090);
+
+@kubernetes:Deployment {
+    namespace: &quot;hello-api&quot;,
+    registry: &quot;172.30.1.1:5000&quot;,
+    image: &quot;hello-service:v1.0&quot;,
+    buildImage: false,
+    buildExtension: openshift:BUILD_EXTENSION_OPENSHIFT
+}
+@http:ServiceConfig {
+    basePath: &quot;/hello&quot;
+}
+service hello on helloEP {
+    @http:ResourceConfig {
+        methods: [&quot;GET&quot;],
+        path: &quot;/{user}&quot;
+    }
+    resource function sayHello(http:Caller caller, http:Request request, string user) {
+        string payload = string `Hello ${&lt;@untainted string&gt; user}!`;
+        var responseResult = caller-&gt;respond(payload);
+        if (responseResult is error) {
+            error err = responseResult;
+            log:printError(&quot;Error sending response&quot;, err);
+        }
+    }
+}
+</code></pre>
+
+
+            
+            
+            <section class="method-content" id="records">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#records">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Records </h2>
+                </div>
+                <table>
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="RouteConfiguration" title="RouteConfiguration">
+                                <a class="records " href="records/RouteConfiguration.html">RouteConfiguration</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Route configuration for @kubernetes:OpenShiftRoute.
+                            </td>
+                        </tr>
+                    
+                    
+                    
+                        <tr>
+                            <td class="module-title truncate records" id="RouteDomainConfig" title="RouteDomainConfig">
+                                <a class="records " href="records/RouteDomainConfig.html">RouteDomainConfig</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Domain for OpenShift Route configuration.
+                            </td>
+                        </tr>
+                    
+                    
+                </table>
+            </section>
+            
+            
+
+            
+
+            
+
+            
+           
+
+            
+
+
+            
+            <section class="method-content" id="constants">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#constants">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Constants </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate constant" id="BUILD_EXTENSION_OPENSHIFT" title="BUILD_EXTENSION_OPENSHIFT">
+                                <a class="constant " href="constants.html#BUILD_EXTENSION_OPENSHIFT">BUILD_EXTENSION_OPENSHIFT</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>Configuration to use the OpenShift Build Configs.
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+
+            
+            <section class="method-content" id="annotations">
+                <div class="main-method-title here">
+                    <a class="url-link" href="#annotations">
+                        <img class="url-link-img" src="../html-template-resources/images/link.svg">
+                    </a>
+                <h2> Annotations </h2>
+                </div>
+                <table>
+                    
+                        <tr>
+                            <td class="module-title truncate annotations" id="Route" title="Route">
+                                <a class="annotations " href="annotations.html#Route">Route</a>
+                            </td>
+                            <td class="module-desc">
+                                
+                                <p>@kubernetes:OpenShiftRoute annotation to generate openshift routes.
+                            </td>
+                        </tr>
+                    
+                </table>
+            </section>
+            
+
+            
+
+            
+        </div>
+    </div>
+
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/openshift/records/RouteConfiguration.html
+++ b/learn/api-docs/ballerina/openshift/records/RouteConfiguration.html
@@ -1,0 +1,383 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based OpenShift extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,openshift">
+
+    <title>API Docs - Record : RouteConfiguration</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li class="active">
+                            <a href="RouteConfiguration.html" onclick="menuLinkClick()">RouteConfiguration</a>
+                        </li>
+                    
+                        <li >
+                            <a href="RouteDomainConfig.html" onclick="menuLinkClick()">RouteDomainConfig</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../openshift/index.html" onclick="menuLinkClick()">
+            <h3>openshift</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../openshift/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../openshift/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../openshift/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../openshift/index.html">openshift</a>
+                
+                 : <span class="records ">RouteConfiguration</span>
+            </h1>
+            <p>
+                
+                <p>Route configuration for @kubernetes:OpenShiftRoute.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >name</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Name of the resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >labels</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of labels for the resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >annotations</span>
+                <span class="type">  <span class="builtin-type">map</span><<span class="builtin-type">string</span>></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>Map of annotations for resource</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >host</span>
+                <span class="type">  <span class="builtin-type">string</span> | <a href="../../openshift/records/RouteDomainConfig.html">RouteDomainConfig</a></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The host of the route.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+

--- a/learn/api-docs/ballerina/openshift/records/RouteDomainConfig.html
+++ b/learn/api-docs/ballerina/openshift/records/RouteDomainConfig.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="description" content="This module offers an annotation based OpenShift extension implementation for Ballerina.
+">
+    <meta name="keywords" content="ballerina,ballerina lang,api docs,openshift">
+
+    <title>API Docs - Record : RouteDomainConfig</title>
+    <script src="../../html-template-resources/jquery.min.js"></script>
+
+    <!-- BIO THEME START -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+<!-- Optional theme -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+<!-- Latest compiled and minified JavaScript -->
+<script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+<script type="text/javascript" src="/js/api-doc-template.js"></script>
+<script type="text/javascript" src="/js/ballerina-common.js"></script>
+<link rel="stylesheet" href="/css/ballerina-io.css">
+<link rel="stylesheet" href="/css/ballerina-io-docs.css">
+<link rel="stylesheet" href="/css/ballerina-io-api-new.css">
+
+<style>
+    .line-numbers-wrap {
+        display: none;
+    }
+</style>
+<!-- BIO THEME END -->
+
+    <link rel="stylesheet" href="../../html-template-resources/semantic.min.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/styles.css">
+    <link rel="stylesheet" href="../../html-template-resources/styles/css/font.css">
+    <script src="../../html-template-resources/semantic.min.js"></script>
+    <script src="../../syntax-highlighter/highlighter.js"></script>
+
+</head>
+
+
+<body class="cBallerina-io">
+    <div class="row cBallerina-io-top-row">
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+    <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+        <div class="cTopLine"></div>
+    </div>
+</div>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
+<div class="clearfix"></div>
+    <div class="navi-wrapper">
+        <div class="navi-wrapper-content">
+            <a href="
+    ../../index.html">
+    <img class="logo" src="../../html-template-resources/images/ballerina-logo.png">
+</a>
+
+            <div class="primary-list">
+                <h3>Records</h3>
+                <ul>
+                    
+                        <li >
+                            <a href="RouteConfiguration.html" onclick="menuLinkClick()">RouteConfiguration</a>
+                        </li>
+                    
+                        <li class="active">
+                            <a href="RouteDomainConfig.html" onclick="menuLinkClick()">RouteDomainConfig</a>
+                        </li>
+                    
+                </ul>
+            </div>
+            <div class="ui divider"></div>
+            
+
+    
+
+
+<div class="primary-list module">
+    
+        <a href="../../openshift/index.html" onclick="menuLinkClick()">
+            <h3>openshift</h3>
+        </a>
+    
+    <ul>
+        
+        <li>
+            <a data="records" href="../../openshift/index.html#records" onclick="menuLinkClick()">Records</a>
+        </li>
+        
+        
+        
+        
+        
+        
+            <li>
+                <a data="constants" href="../../openshift/index.html#constants" onclick="menuLinkClick()">Constants</a>
+            </li>
+        
+        
+            <li>
+                <a data="annotations" href="../../openshift/index.html#annotations" onclick="menuLinkClick()">Annotations</a>
+            </li>
+        
+        
+        
+    </ul>
+    <div class="ui divider"></div>
+</div>
+
+            <div class="primary-list module-list">
+    
+        <h3>All Modules</h3>
+        <ul>
+            
+                <li>
+                    <a href="../../istio/index.html">istio</a>
+                </li>
+            
+                <li>
+                    <a href="../../knative/index.html">knative</a>
+                </li>
+            
+                <li>
+                    <a href="../../kubernetes/index.html">kubernetes</a>
+                </li>
+            
+                <li>
+                    <a href="../../openshift/index.html">openshift</a>
+                </li>
+            
+        </ul>
+        <div class="ui divider"></div>
+    
+</div>
+        </div>
+    </div>
+      <div class="content-wrapper pusher">
+        <div>
+    <a id="toc" class="toc item" onclick="displayMenu()">
+        <img src="../../html-template-resources/images/menu.svg">
+    </a>
+</div>
+        <div class="main-wrapper">
+            <h1> 
+                <a class="breadcrumb-home" href="
+    ../../index.html">
+    <img class="breadcrumb-home-icon" src="../../html-template-resources/images/home.svg">
+</a>
+                <span class="title-type">Record - </span>
+                
+                    <a href="../../openshift/index.html">openshift</a>
+                
+                 : <span class="records ">RouteDomainConfig</span>
+            </h1>
+            <p>
+                
+                <p>Domain for OpenShift Route configuration.</p>
+
+            </p>
+            <div class="constants">
+                
+                    
+                        <h2>Fields</h2>
+                            <div class="data-wrapper">
+        
+    <div class="params-listing">
+        <ul>
+            <li> 
+                <span >domain</span>
+                <span class="type">  <span class="builtin-type">string</span></span>
+                
+            </li>
+            <li>
+                <p>
+                    
+                    <p>The domain of the hostname.</p>
+
+                </p>
+            </li>
+        </ul>
+    </div>
+    
+</div>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+
+                    
+                
+            </div>
+        </div>
+    </div>
+</body>
+
+<script>
+let mainNavLinks = document.querySelectorAll(".primary-list.module ul li a");
+let mainSections = document.querySelectorAll(".main-wrapper section.method-content");
+
+let lastId;
+let cur = [];
+
+let contentWrapper = document.querySelector(".content-wrapper");
+contentWrapper.addEventListener("scroll", event => {
+  let fromTop = contentWrapper.scrollTop;
+
+  mainNavLinks.forEach(link => {
+    let section = document.querySelector("#" + link.attributes.getNamedItem("data").textContent);
+
+    if (
+      section.offsetTop <= fromTop &&
+      section.offsetTop + section.offsetHeight > fromTop
+    ) {
+      link.classList.add("current");
+    } else {
+      link.classList.remove("current");
+    }
+  });
+});
+
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+<script>
+function menuLinkClick() {
+  if(window.matchMedia("(max-width: 600px)").matches) {
+    document.getElementsByClassName("navi-wrapper")[0].style.display = "none";
+  }
+}
+function displayMenu() {
+  var nav = document.getElementsByClassName("navi-wrapper")[0];
+  var content = document.getElementsByClassName("content-wrapper")[0];
+  if (nav.style.display === "none" || nav.style.display === "") {
+    nav.style.display = "block";
+    content.style.marginLeft = "210px";
+  } else {
+    nav.style.display = "none";
+    content.style.marginLeft = "0px";
+  }
+}
+</script>
+
+<script>
+    window.onload = (event) => {
+        ballerinaHighlighter.highlightSnippets();
+    };
+</script>
+


### PR DESCRIPTION
## Purpose
Generate and add API Docs of the deployment modules in 1.2.x after the 1.2.7 release.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
