### PR TITLE
Fix the New Lines Formatting in Java JDBC API Docs

### DIFF
--- a/learn/api-docs/ballerina/java.jdbc/types.html
+++ b/learn/api-docs/ballerina/java.jdbc/types.html
@@ -387,8 +387,8 @@ that is accessible via Java Database Connectivity (JDBC).
                                 <li>
                                     
                                     <p>The direction of the parameter.</p>
-<p><code>IN</code> - IN parameters are used to send values to stored procedures
-<code>OUT</code> - OUT parameters are used to get values from stored procedures
+<p><code>IN</code> - IN parameters are used to send values to stored procedures <br><br>
+<code>OUT</code> - OUT parameters are used to get values from stored procedures <br><br>
 <code>INOUT</code> - INOUT parameters are used to send values and get values from stored procedures</p>
 
                                 </li>


### PR DESCRIPTION
## Purpose
Fix the new lines formatting in the java.jdbc module API Docs in 1.2.x.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
