### PR TITLE
Update the API Docs Home Page for 1.2.x

### DIFF
--- a/learn/api-docs/ballerina/index.html
+++ b/learn/api-docs/ballerina/index.html
@@ -85,6 +85,18 @@ redirect_from:
                 <td class="module-desc"><p>This module provides the default authentication provider configurations, which can be extended to create new authentication providers.</p>
 </td>
               </tr>
+
+              <tr>
+                <td class="module-title modules"><a href="awslambda/index.html">awslambda</a></td>
+                <td class="module-desc"><p>This module offers the capabilities of creating AWS Lambda functions using ballerina.</p>
+</td>
+              </tr>
+              
+              <tr>
+                <td class="module-title modules"><a href="azure.functions/index.html">azure.functions</a></td>
+                <td class="module-desc"><p>Annotation based Azure Functions extension implementation for Ballerina.</p>
+</td>
+              </tr>
               
               <tr>
                 <td class="module-title modules"><a href="cache/index.html">cache</a></td>
@@ -101,6 +113,12 @@ redirect_from:
               <tr>
                 <td class="module-title modules"><a href="crypto/index.html">crypto</a></td>
                 <td class="module-desc"><p>This module provides the necessary utilities that are required to hash content using different hashing mechanisms and algorithms.</p>
+</td>
+              </tr>
+
+              <tr>
+                <td class="module-title modules"><a href="docker/index.html">docker</a></td>
+                <td class="module-desc"><p>This module offers an annotation based docker extension implementation for Ballerina.</p>
 </td>
               </tr>
               
@@ -147,6 +165,12 @@ file/directory, and retrieve metadata of the file.</p>
 or non-blocking manner.</p>
 </td>
               </tr>
+
+              <tr>
+                <td class="module-title modules"><a href="istio/index.html">istio</a></td>
+                <td class="module-desc"><p>This module offers an annotation based Istio extension implementation for Ballerina.</p>
+</td>
+              </tr>
               
               <tr>
                 <td class="module-title modules"><a href="java/index.html">java</a></td>
@@ -185,6 +209,17 @@ that is accessible via Java Database Connectivity (JDBC).</p>
 This module supports Kafka 1.x.x and 2.0.0 versions.</p>
 </td>
               </tr>
+
+              <tr>
+                <td class="module-title modules"><a href="knative/index.html">knative</a></td>
+                <td class="module-desc"><p>This module offers an annotation based Knative extension implementation for Ballerina.</p>
+</td>
+              </tr>
+              
+              <tr>
+                <td class="module-title modules"><a href="kubernetes/index.html">kubernetes</a></td>
+                <td class="module-desc"><p>This module offers an annotation based Kubernetes extension implementation for Ballerina.</p>
+</td>
               
               <tr>
                 <td class="module-title modules"><a href="lang.array/index.html">lang.array</a></td>
@@ -325,6 +360,12 @@ Ballerina supports Observability out of the box. This module provides user api's
               <tr>
                 <td class="module-title modules"><a href="openapi/index.html">openapi</a></td>
                 <td class="module-desc"><p>This module provides the following code generation capabilities.</p>
+</td>
+              </tr>
+
+              <tr>
+                <td class="module-title modules"><a href="openshift/index.html">openshift</a></td>
+                <td class="module-desc"><p>This module offers an annotation based OpenShift extension implementation for Ballerina.</p>
 </td>
               </tr>
               


### PR DESCRIPTION
## Purpose
Update the API Docs home page for 1.2.x.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
