### PR TITLE
Fix the "Edit on GitHub" Links of AWS Lambda

### DIFF
--- a/1.0/learn/by-example/awslambda-deployment.html
+++ b/1.0/learn/by-example/awslambda-deployment.html
@@ -207,9 +207,9 @@
                     </div>
                     <div class="col-md-12 col-lg-2 cBallerina-io-breadcrumbs">
                         <ul class="wy-breadcrumbs">
-                            <!-- <li class="wy-breadcrumbs-aside">
-                                <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-platform.github.io/blob/master/1.0/learn/by-example/awslambda-deployment.html">Edit on GitHub</a>
-                            </li> -->
+                            <li class="wy-breadcrumbs-aside">
+                                <a class="icon icon-github" target="_blank" href="https://github.com/ballerina-platform/module-ballerinax-aws.lambda/tree/ballerina-1.0.x/awslambda-examples/examples/aws-lambda-deployment">Edit on GitHub</a>
+                            </li> 
                         </ul>
                     </div>
                 </div>

--- a/1.1/learn/by-example/awslambda-deployment.html
+++ b/1.1/learn/by-example/awslambda-deployment.html
@@ -76,7 +76,7 @@ redirect_from:
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/master/examples/awslambda-deployment/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/module-ballerinax-aws.lambda/tree/ballerina-1.1.x/awslambda-examples/examples/aws-lambda-deployment"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>

--- a/js/redirections.js
+++ b/js/redirections.js
@@ -198,10 +198,10 @@ let redirections = {
     "/1.0/learn/by-example/jdbc-streaming-big-dataset.html":"/1.0/page-not-available.html",
     "/1.1/learn/by-example/knative-deployment.html": "/1.1/page-not-available.html",
     "/1.0/learn/by-example/knative-deployment.html": "/1.0/page-not-available.html",
-    "/1.1/learn/by-example/aws-lambda-deployment.html": "/1.1/page-not-available.html",
-    "/1.0/learn/by-example/aws-lambda-deployment.html": "/1.0/page-not-available.html",
     "/1.1/learn/by-example/azure-functions-deployment.html": "/1.1/page-not-available.html",
-    "/1.0/learn/by-example/azure-functions-deployment": "/1.0/page-not-available.html"
+    "/1.0/learn/by-example/azure-functions-deployment": "/1.0/page-not-available.html",
+    "/1.1/learn/by-example/aws-lambda-deployment.html": "/1.1/learn/by-example/awslambda-deployment.html",
+    "/1.0/learn/by-example/aws-lambda-deployment.html": "/1.0/learn/by-example/awslambda-deployment.html",
 
 
     


### PR DESCRIPTION
## Purpose
Fix the "Edit on GitHub" links of AWS Lambda.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
