### PR TITLE
Add a Missing Hyphen in the Istio Module.md File

### DIFF
--- a/learn/api-docs/ballerina/istio/index.html
+++ b/learn/api-docs/ballerina/istio/index.html
@@ -135,7 +135,7 @@
                     
                 </h1>
                     <h2>Module Overview</h2>
-<p>This module offers an annotation based Istio extension implementation for Ballerina. For information on the operations, which you can perform with this module, see <a href="/learn/api-docs/ballerina/istio/index.html#records">Records</a>.</p>
+<p>This module offers an annotation-based Istio extension implementation for Ballerina. For information on the operations, which you can perform with this module, see <a href="/learn/api-docs/ballerina/istio/index.html#records">Records</a>.</p>
 
 
             

--- a/swan-lake/learn/api-docs/ballerina/istio/index.html
+++ b/swan-lake/learn/api-docs/ballerina/istio/index.html
@@ -125,7 +125,7 @@
     <div>Version : 1.0.0</div>
     
     <h2>Module Overview</h2>
-<p>This module offers an annotation based Istio extension implementation for Ballerina. For information on the operations, which you can perform with this module, see <a href="/swan-lake/learn/api-docs/ballerina/istio/index.html#objects">Objects</a>.</p>
+<p>This module offers an annotation-based Istio extension implementation for Ballerina. For information on the operations, which you can perform with this module, see <a href="/swan-lake/learn/api-docs/ballerina/istio/index.html#objects">Objects</a>.</p>
 
 
     


### PR DESCRIPTION
## Purpose
Add a Missing Hyphen in the Istio Module.md file.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
