### PR TITLE
Fix Broken Links of the Deployment Modules

### DIFF
--- a/learn/api-docs/ballerina/docker/records/FileConfigs.html
+++ b/learn/api-docs/ballerina/docker/records/FileConfigs.html
@@ -164,7 +164,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="docker.html#FileConfig">FileConfig</a></p>
+                    <p>Array of FileConfig</p>
 
                 </p>
             </li>

--- a/learn/api-docs/ballerina/knative/records/ConfigMapMount.html
+++ b/learn/api-docs/ballerina/knative/records/ConfigMapMount.html
@@ -261,7 +261,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes.html#ConfigMap">ConfigMap</a></p>
+                    <p>Array of ConfigMap</p>
 
                 </p>
             </li>

--- a/learn/api-docs/ballerina/knative/records/SecretMount.html
+++ b/learn/api-docs/ballerina/knative/records/SecretMount.html
@@ -244,7 +244,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="knative.html#Secret">Secret</a></p>
+                    <p>Array of Secret</p>
 
                 </p>
             </li>

--- a/learn/api-docs/ballerina/knative/records/ServiceConfiguration.html
+++ b/learn/api-docs/ballerina/knative/records/ServiceConfiguration.html
@@ -402,7 +402,7 @@ it will be prepended to the docker image name as <code>&lt;registry&gt;/&lt;OUTP
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes#FileConfig">External files</a> for docker image</p>
+                    <p>Array of External files for the Docker image</p>
 
                 </p>
             </li>

--- a/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
@@ -313,7 +313,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes.html#ConfigMap">ConfigMap</a></p>
+                    <p>Array of ConfigMap</p>
 
                 </p>
             </li>

--- a/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
+++ b/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
@@ -485,7 +485,7 @@ If DOCKER_HOST is unavailable, use <code>&quot;unix:///var/run/docker.sock&quot;
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes#FileConfig">External files</a> for docker image.</p>
+                    <p>Array of External files for the Docker image.</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/docker/records/FileConfigs.html
+++ b/swan-lake/learn/api-docs/ballerina/docker/records/FileConfigs.html
@@ -178,7 +178,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="docker.html#FileConfig">FileConfig</a></p>
+                    <p>Array of FileConfig</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/knative/records/ConfigMapMount.html
+++ b/swan-lake/learn/api-docs/ballerina/knative/records/ConfigMapMount.html
@@ -262,7 +262,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes.html#ConfigMap">ConfigMap</a></p>
+                    <p>Array of ConfigMap</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/knative/records/SecretMount.html
+++ b/swan-lake/learn/api-docs/ballerina/knative/records/SecretMount.html
@@ -246,7 +246,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="knative.html#Secret">Secret</a></p>
+                    <p>Array of Secret</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/knative/records/ServiceConfiguration.html
+++ b/swan-lake/learn/api-docs/ballerina/knative/records/ServiceConfiguration.html
@@ -395,7 +395,7 @@ it will be prepended to the docker image name as <code>&lt;registry&gt;/&lt;OUTP
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes#FileConfig">External files</a> for docker image</p>
+                    <p>Array of External files for the Docker image</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
+++ b/swan-lake/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
@@ -314,7 +314,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes.html#ConfigMap">ConfigMap</a></p>
+                    <p>Array of ConfigMap</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
+++ b/swan-lake/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
@@ -476,7 +476,7 @@ If DOCKER_HOST is unavailable, use <code>&quot;unix:///var/run/docker.sock&quot;
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes#FileConfig">External files</a> for docker image.</p>
+                    <p>Array of External files for the Docker image.</p>
 
                 </p>
             </li>


### PR DESCRIPTION
## Purpose
Fix broken links of the deployment modules in both 1.2.x and Swan Lake API Docs.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
