### PR TITLE
Fix More Broken Links in the K8S API Docs

### DIFF
--- a/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
+++ b/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
@@ -468,7 +468,7 @@ If DOCKER_HOST is unavailable, use <code>&quot;unix:///var/run/docker.sock&quot;
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes#FileConfig">External files</a> for docker image.</p>
+                    <p>Array of External files for the Docker image.</p>
 
                 </p>
             </li>

--- a/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
+++ b/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
@@ -296,7 +296,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes.html#PersistentVolumeClaimConfig">PersistentVolumeClaimConfig</a></p>
+                    <p>Array of PersistentVolumeClaimConfig</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
+++ b/swan-lake/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
@@ -460,7 +460,7 @@ If DOCKER_HOST is unavailable, use <code>&quot;unix:///var/run/docker.sock&quot;
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes#FileConfig">External files</a> for docker image.</p>
+                    <p>Array of External files for the Docker image.</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
+++ b/swan-lake/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
@@ -298,7 +298,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes.html#PersistentVolumeClaimConfig">PersistentVolumeClaimConfig</a></p>
+                    <p>Array of PersistentVolumeClaimConfig</p>
 
                 </p>
             </li>


### PR DESCRIPTION
## Purpose
Fix more broken links in the K8S API Docs.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
