### PR TITLE
Fix More K8S API Docs Broken Links

### DIFF
--- a/1.1/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
@@ -843,7 +843,7 @@ permalink: /1.1/learn/api-docs/ballerina/kubernetes/records/SecretMount
                 
             </li>
             <li>
-                <p><p>Array of Secret</p>
+                <p><p>Array of secrets</p>
 </p>
             </li>
         </ul>

--- a/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
+++ b/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
@@ -296,7 +296,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes.html#ResourceQuotaConfig">ResourceQuotaConfig</a></p>
+                    <p>Array of ResourceQuotaConfig</p>
 
                 </p>
             </li>

--- a/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
+++ b/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
@@ -313,7 +313,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes.html#Secret">Secret</a></p>
+                    <p>Array of secret</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
+++ b/swan-lake/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
@@ -298,7 +298,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes.html#ResourceQuotaConfig">ResourceQuotaConfig</a></p>
+                    <p>Array of ResourceQuotaConfig</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
+++ b/swan-lake/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
@@ -314,7 +314,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="kubernetes.html#Secret">Secret</a></p>
+                    <p>Array of secrets</a></p>
 
                 </p>
             </li>


### PR DESCRIPTION
## Purpose
Fix more K8S API Docs broken links.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
