### PR TITLE
Fix Broken Links in the Live Site After the 1.2.8 Release

### DIFF
--- a/1.0/learn/api-docs/ballerina/observe/index.html
+++ b/1.0/learn/api-docs/ballerina/observe/index.html
@@ -659,7 +659,7 @@
 Ballerina supports Observability out of the box. This module provides user api's to make Ballerina Observability more flexible for the user.</p>
 <p>To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service.
 i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true'
-For more information on Ballerina Observability visit <a href="https://v1-0.ballerina.io/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
+For more information on Ballerina observability, see <a href="/1.0/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
 <h1>Tracing</h1>
 <h2>Samples</h2>
 <h3>Start a root span &amp; attach a child span</h3>

--- a/1.1/learn/api-docs/ballerina/observe/index.html
+++ b/1.1/learn/api-docs/ballerina/observe/index.html
@@ -604,7 +604,7 @@ keywords: Ballerina, ballerinalang
 Ballerina supports Observability out of the box. This module provides user api's to make Ballerina Observability more flexible for the user.</p>
 <p>To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service.
 i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true'
-For more information on Ballerina Observability visit <a href="https://v1-0.ballerina.io/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
+For more information on Ballerina observability, see <a href="/1.1/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
 <h1>Tracing</h1>
 <h2>Samples</h2>
 <h3>Start a root span &amp; attach a child span</h3>

--- a/1.1/learn/by-example/websocket-client.html
+++ b/1.1/learn/by-example/websocket-client.html
@@ -44,7 +44,7 @@ redirect_from:
                             <div class="cTopButtonContainer">
                                 
                                 <div class="cButtonInfoContainer">
-                                    <a class="prev" href="http-2.0-server-push.html">
+                                    <a class="prev" href="http-2-0-server-push.html">
                                         <span>< PREVIOUS</span>
                                         <p>HTTP 2.0 Server Push</p>
                                     </a>

--- a/learn/api-docs/ballerina/observe/index.html
+++ b/learn/api-docs/ballerina/observe/index.html
@@ -347,7 +347,7 @@ Ballerina supports Observability out of the box. This module provides user api's
 Ballerina supports Observability out of the box. This module provides user api's to make Ballerina Observability more flexible for the user.</p>
 <p>To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service.
 i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true'
-For more information on Ballerina Observability visit <a href="https://ballerina.io/v1-2/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
+For more information on Ballerina observability, see <a href="/learn/observing-ballerina-code/">Observing Ballerina Code</a>.</p>
 <h2>Tracing</h2>
 <h3>Samples</h3>
 <h4>Start a root span &amp; attach a child span</h4>

--- a/learn/by-example/testerina-before-and-after-test.html
+++ b/learn/by-example/testerina-before-and-after-test.html
@@ -84,7 +84,7 @@ redirect_from:
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>-->
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-lang/tree/ballerina-1.2.x/examples/testerina-before-and-after-test/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-lang/tree/ballerina-1.2.x/examples/testerina-before-and-after-each"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>

--- a/learn/by-example/testerina-function-mocks.html
+++ b/learn/by-example/testerina-function-mocks.html
@@ -106,7 +106,7 @@ redirect_from:
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>-->
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-lang/tree/ballerina-1.2.x/examples/testerina-function-mocks/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-lang/tree/ballerina-1.2.x/examples/testeina-mocking-functions"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>

--- a/learn/by-example/testerina-object-mocks.html
+++ b/learn/by-example/testerina-object-mocks.html
@@ -171,7 +171,7 @@ redirect_from:
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>-->
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-lang/tree/ballerina-1.2.x/examples/testerina-object-mocks/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-lang/tree/ballerina-1.2.x/examples/testerina-mocking-objects"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>

--- a/swan-lake/learn/api-docs/ballerina/observe/index.html
+++ b/swan-lake/learn/api-docs/ballerina/observe/index.html
@@ -140,7 +140,7 @@ Ballerina supports Observability out of the box. This module provides user api's
 Ballerina supports Observability out of the box. This module provides user api's to make Ballerina Observability more flexible for the user.</p>
 <p>To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service.
 i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true'
-For more information on Ballerina Observability visit <a href="https://ballerina.io/swan-lake/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
+For more information on Ballerina observability, see <a href="/swan-lake/learn/observing-ballerina-code/">Observing Ballerina Code</a>.</p>
 <h2>Tracing</h2>
 <p>Tracing provides information regarding the roundtrip of a service invocation based on the concept of spans, which are
 structured in a hierarchy based on the cause and effect concept. The tracing API allows users to tap into that


### PR DESCRIPTION
## Purpose
Fix broken links in live site after 1.2.8.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
