### PR TITLE
Fix the "Previous" Link of the Web Socket Client BBE

### DIFF
--- a/1.0/learn/by-example/websocket-client.html
+++ b/1.0/learn/by-example/websocket-client.html
@@ -44,7 +44,7 @@ redirect_from:
                             <div class="cTopButtonContainer">
                                 
                                 <div class="cButtonInfoContainer">
-                                    <a class="prev" href="http-2.0-server-push.html">
+                                    <a class="prev" href="http-2-0-server-push.html">
                                         <span>< PREVIOUS</span>
                                         <p>HTTP 2.0 Server Push</p>
                                     </a>

--- a/learn/by-example/testerina-before-each-test.html
+++ b/learn/by-example/testerina-before-each-test.html
@@ -93,7 +93,7 @@ redirect_from:
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>-->
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-lang/tree/ballerina-1.2.x/examples/testerina-before-each-test/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-lang/tree/ballerina-1.2.x/examples/testerina-before-and-after-each"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                     </ul>
                                 </div>


### PR DESCRIPTION
## Purpose
Fix the "previous" link of the Web Socket Client BBE.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
