### PR TITLE
Add Guidelines on Documenting Comments

### DIFF
--- a/1.0/learn/how-to-document-ballerina-code/index.html
+++ b/1.0/learn/how-to-document-ballerina-code/index.html
@@ -273,6 +273,19 @@
 #            &lt;return_parameter_description_line_2&gt;
 </code></pre></div></div>
 
+<blockquote>
+    <p><strong>Tip:</strong> As a best practice, do not add a full stop at the end of the first sentence of the parameter and return type descriptions. Instead, add a fullstop only at the end of a function description. For Example,</p>
+    </blockquote>
+    <pre><code># Description for the function.
+    #
+    # + i - One sentence only
+    # + s - Sentence one. Sentence two.
+    # + return - Return description
+    public function foo(int i, string s) returns boolean {
+    return true;
+    }
+    </code></pre>
+
 <h3 id="sample-usage">Sample Usage</h3>
 
 <pre><code class="language-ballerina"># Submits an HTTP request to a service with the specified HTTP verb.
@@ -288,7 +301,7 @@
 # + httpVerb - The HTTP verb value
 # + path - The resource path
 # + request - An HTTP outbound request message
-# + return - An `HttpFuture` that represents an asynchronous service invocation, 
+# + return - An `HttpFuture` that represents an asynchronous service invocation 
 #            or an `error` if the submission fails
 public function submit(@sensitive string httpVerb, string path, Request request) returns HttpFuture|error;
 </code></pre>
@@ -326,7 +339,7 @@ public function submit(@sensitive string httpVerb, string path, Request request)
 
 <h2 id="generating-ballerina-documentation">Generating Ballerina Documentation</h2>
 
-<p>Ballerina provides a <code class="highlighter-rouge">doc</code> command which can be executed against a given Ballerina project. This command will result in generating the Ballerina documentation as HTML files, for all the modules in the project.</p>
+<p>Ballerina provides a <code class="highlighter-rouge">doc</code> command, which can be executed against a given Ballerina project. This command will result in generating the Ballerina documentation as HTML files, for all the modules in the project.</p>
 
 <p>First, let’s create a new Ballerina project:</p>
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>$ ballerina new myproject

--- a/1.1/learn/how-to-document-ballerina-code.md
+++ b/1.1/learn/how-to-document-ballerina-code.md
@@ -64,6 +64,19 @@ The supported structure of documentation syntax is as follows:
 #            <return_parameter_description_line_2>
 ```
 
+>**Tip:** As a best practice, do not add a full stop at the end of the first sentence of the parameter and return type descriptions. Instead, add a fullstop only at the end of a function description. For Example,
+
+```
+# Description for the function.
+#
+# + i - One sentence only
+# + s - Sentence one. Sentence two.
+# + return - Return description
+public function foo(int i, string s) returns boolean {
+return true;
+}
+```
+
 ### Sample Usage
 
 ```ballerina
@@ -80,14 +93,14 @@ The supported structure of documentation syntax is as follows:
 # + httpVerb - The HTTP verb value
 # + path - The resource path
 # + request - An HTTP outbound request message
-# + return - An `HttpFuture` that represents an asynchronous service invocation, 
+# + return - An `HttpFuture` that represents an asynchronous service invocation 
 #            or an `error` if the submission fails
 public function submit(@sensitive string httpVerb, string path, Request request) returns HttpFuture|error;
 ```
 
 ## Documenting A Module
 
-A Ballerina module can have a `Module.md` file which describes the module and its usage.
+A Ballerina module can have a `Module.md` file, which describes the module and its usage.
 
 A typical project structure of a Ballerina project is like this:
 
@@ -120,7 +133,7 @@ Check [HTTP module documentation](/1.1/learn/api-docs/ballerina/http/index.html)
 
 ## Generating Ballerina Documentation
 
-Ballerina provides a `doc` command which can be executed against a given Ballerina project. This command will result in generating the Ballerina documentation as HTML files, for all the modules in the project.
+Ballerina provides a `doc` command, which can be executed against a given Ballerina project. This command will result in generating the Ballerina documentation as HTML files, for all the modules in the project.
 
 First, let's create a new Ballerina project:
 ```

--- a/learn/documenting-ballerina-code.md
+++ b/learn/documenting-ballerina-code.md
@@ -68,6 +68,19 @@ The supported structure of documentation syntax is as follows:
 #            <return_parameter_description_line_2>
 ```
 
+>**Tip:** As a best practice, do not add a full stop at the end of the first sentence of the parameter and return type descriptions. Instead, add a fullstop only at the end of a function description. For Example,
+
+```
+# Description for the function.
+#
+# + i - One sentence only
+# + s - Sentence one. Sentence two.
+# + return - Return description
+public function foo(int i, string s) returns boolean {
+return true;
+}
+```
+
 ### Sample Usage
 
 ```ballerina
@@ -84,14 +97,14 @@ The supported structure of documentation syntax is as follows:
 # + httpVerb - The HTTP verb value
 # + path - The resource path
 # + request - An HTTP outbound request message
-# + return - An `HttpFuture` that represents an asynchronous service invocation, 
+# + return - An `HttpFuture` that represents an asynchronous service invocation 
 #            or an `error` if the submission fails
 public function submit(@sensitive string httpVerb, string path, Request request) returns HttpFuture|error;
 ```
 
 ## Documenting A Module
 
-A Ballerina module can have a `Module.md` file which describes the module and its usage.
+A Ballerina module can have a `Module.md` file, which describes the module and its usage.
 
 A typical project structure of a Ballerina project is like this:
 
@@ -124,7 +137,7 @@ Check [HTTP module documentation](/learn/api-docs/ballerina/http/index.html) for
 
 ## Generating Ballerina Documentation
 
-Ballerina provides a `doc` command which can be executed against a given Ballerina project. This command will result in generating the Ballerina documentation as HTML files, for all the modules in the project.
+Ballerina provides a `doc` command, which can be executed against a given Ballerina project. This command will result in generating the Ballerina documentation as HTML files, for all the modules in the project.
 
 First, let's create a new Ballerina project:
 ```

--- a/swan-lake/learn/documenting-ballerina-code.md
+++ b/swan-lake/learn/documenting-ballerina-code.md
@@ -42,7 +42,7 @@ Ballerina Flavored Markdown documentation is a first class syntax in the Balleri
 # ...
 ```
 
-When you write documentation, you can use the markdown documentation syntax given above. For example:
+When you write documentation, you can use the markdown documentation syntax given above. For example,
 
 ```
 # Provides the HTTP actions for interacting with an HTTP server. Apart from the standard 
@@ -66,6 +66,19 @@ The supported structure of documentation syntax is as follows:
 #            <return_parameter_description_line_2>
 ```
 
+>**Tip:** As a best practice, do not add a full stop at the end of the first sentence of the parameter and return type descriptions. Instead, add a fullstop only at the end of a function description. For Example,
+
+```
+# Description for the function.
+#
+# + i - One sentence only
+# + s - Sentence one. Sentence two.
+# + return - Return description
+public function foo(int i, string s) returns boolean {
+return true;
+}
+```
+
 ### Sample Usage
 
 ```ballerina
@@ -82,14 +95,14 @@ The supported structure of documentation syntax is as follows:
 # + httpVerb - The HTTP verb value
 # + path - The resource path
 # + request - An HTTP outbound request message
-# + return - An `HttpFuture` that represents an asynchronous service invocation, 
+# + return - An `HttpFuture` that represents an asynchronous service invocation 
 #            or an `error` if the submission fails
 public function submit(@sensitive string httpVerb, string path, Request request) returns HttpFuture|error;
 ```
 
 ## Documenting a Module
 
-A Ballerina module can have a `Module.md` file which describes the module and its usage.
+A Ballerina module can have a `Module.md` file, which describes the module and its usage.
 
 A typical project structure of a Ballerina project is like this:
 
@@ -122,7 +135,7 @@ Check [HTTP module documentation](/swan-lake/learn/api-docs/ballerina/http/index
 
 ## Generating Ballerina Documentation
 
-Ballerina provides a `doc` command which can be executed against a given Ballerina project. This command will result in generating the Ballerina documentation as HTML files, for all the modules in the project.
+Ballerina provides a `doc` command, which can be executed against a given Ballerina project. This command will result in generating the Ballerina documentation as HTML files, for all the modules in the project.
 
 First, let's create a new Ballerina project:
 ```


### PR DESCRIPTION
## Purpose
Add guidelines on documenting comments.

Fixes https://github.com/ballerina-platform/ballerina-dev-website/issues/1208

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
