### PR TITLE
Add Code Owners to the Dev Website Repo

### DIFF
--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -9,7 +9,8 @@
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
-*.md    @opraneesha @github/md
+*.md    @praneesha @github/md
+*.html  @praneesha @github/html
 
 # You can also use email addresses if you prefer.
 learn/* praneesha@wso2.com

--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -2,7 +2,6 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @defunkt 
 *       @praneesha 
 *       @Samallama 
 *       @lafernando
@@ -10,11 +9,9 @@
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
-*.js    @octocat @github/js
 *.md    @opraneesha @github/md
 
 # You can also use email addresses if you prefer.
-docs/*  docs@example.com
 learn/* praneesha@wso2.com
 swan-lake/* praneesha@wso2.com
 1.1/* praneesha@wso2.com

--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -11,11 +11,11 @@
 # will be requested to review.
 *.md    @praneesha @github/md
 *.html  @praneesha @github/html
+*learn/*    @praneesha
+*swan-lake/*    @praneesha
+*1.1/*    @praneesha
+*1.0/*    @praneesha
+*0.990/*    @praneesha
+*community/*    @Samallama
 
 # You can also use email addresses if you prefer.
-learn/* praneesha@wso2.com
-swan-lake/* praneesha@wso2.com
-1.1/* praneesha@wso2.com
-1.0/* praneesha@wso2.com
-0.990/* praneesha@wso2.com
-community/* samudra@wso2.com

--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -1,0 +1,18 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @defunkt
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+*.js    @octocat @github/js
+
+# You can also use email addresses if you prefer.
+docs/*  docs@example.com
+learn/* praneesha@wso2.com
+swan-lake/* praneesha@wso2.com
+1.1/* praneesha@wso2.com
+1.0/* praneesha@wso2.com
+0.990/* praneesha@wso2.com

--- a/CODEOWNERS.md
+++ b/CODEOWNERS.md
@@ -2,12 +2,16 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @defunkt
+*       @defunkt 
+*       @praneesha 
+*       @Samallama 
+*       @lafernando
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners
 # will be requested to review.
 *.js    @octocat @github/js
+*.md    @opraneesha @github/md
 
 # You can also use email addresses if you prefer.
 docs/*  docs@example.com
@@ -16,3 +20,4 @@ swan-lake/* praneesha@wso2.com
 1.1/* praneesha@wso2.com
 1.0/* praneesha@wso2.com
 0.990/* praneesha@wso2.com
+community/* samudra@wso2.com


### PR DESCRIPTION
## Purpose
Add code owners to the Dev Website repo as per [1].

[1] https://github.blog/2017-07-06-introducing-code-owners/

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
