### PR TITLE
Fix the Broken Edit Links in the BBE Index Pages

### DIFF
--- a/1.0/learn/by-example/index.html
+++ b/1.0/learn/by-example/index.html
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-inner-page
+layout: ballerina-no-git-inner-page
 title: Ballerina by Example
 description: Ballerina by Example enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
 ---

--- a/1.1/learn/by-example/index.html
+++ b/1.1/learn/by-example/index.html
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-inner-page
+layout: ballerina-no-git-inner-page
 title: Ballerina by Example
 description: Ballerina by Example enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
 ---

--- a/swan-lake/learn/by-example/index.html
+++ b/swan-lake/learn/by-example/index.html
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-inner-page
+layout: ballerina-no-git-inner-page
 title: Ballerina by Example
 description: Ballerina by Example enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
 ---


### PR DESCRIPTION
## Purpose
Fix the broken edit links in the BBE index pages.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
