### PR TITLE
Change the Layout of the Release Notes Pages

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -209,7 +209,7 @@ redirect_from:
    <div class="container">
       <div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">
          <div class="cReleaseNotes">
-            <p><a href="/downloads/all-swan-lake-release-notes">RELEASE NOTES ></a></p>
+            <p><a href="/downloads/swan-lake-release-notes">RELEASE NOTES ></a></p>
          </div>
          <div class="cReleaseNotes">
             <p><a href="/downloads/swan-lake-archived">ARCHIVED VERSIONS ></a></p>

--- a/downloads/RELEASE_NOTE.md
+++ b/downloads/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of jBallerina {{ site.data.stable-latest.metadata.version }}

--- a/downloads/release-notes/1.2.1/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.1/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 

--- a/downloads/release-notes/1.2.2/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.2/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of jBallerina 1.2.2

--- a/downloads/release-notes/1.2.3/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.3/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of jBallerina 1.2.3

--- a/downloads/release-notes/1.2.4/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.4/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of jBallerina 1.2.4

--- a/downloads/release-notes/1.2.5/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.5/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of jBallerina 1.2.5

--- a/downloads/release-notes/1.2.6/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.6/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of jBallerina 1.2.6

--- a/downloads/release-notes/1.2.7/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.7/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of jBallerina {{ site.data.stable-latest.metadata.version }}

--- a/downloads/release-notes/1.2.8/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.8/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of jBallerina {{ site.data.stable-latest.metadata.version }}

--- a/downloads/swan-lake-release-notes/swan-lake-preview1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview1/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of Ballerina Swan Lake - Preview 1

--- a/downloads/swan-lake-release-notes/swan-lake-preview2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview2/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of Ballerina Swan Lake Preview 2

--- a/downloads/swan-lake-release-notes/swan-lake-preview3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview3/RELEASE_NOTE.md
@@ -1,5 +1,5 @@
 ---
-layout: release-note
+layout: ballerina-inner-page
 title: Release note
 ---
 ### Overview of Ballerina Swan Lake Preview 3


### PR DESCRIPTION
## Purpose
Change the layout of the release notes pages.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
