### PR TITLE
Fix Broken Links After SLP4

### DIFF
--- a/swan-lake/learn/api-docs/ballerina/kafka/index.html
+++ b/swan-lake/learn/api-docs/ballerina/kafka/index.html
@@ -146,10 +146,10 @@ This module supports Kafka 1.x.x and 2.0.0 versions.</p>
 <p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>.
 For examples on the usage of the operations, see the following.</p>
 <ul>
-<li><a href="https://ballerina.io/swan-lake/learn/by-example/kafka_producer.html">Producer Example</a></li>
-<li><a href="https://ballerina.io/swan-lake/learn/by-example/kafka_consumer_service.html">Consumer Service Example</a></li>
-<li><a href="https://ballerina.io/swan-lake/learn/by-example/kafka_consumer_client.html">Consumer Client Example</a></li>
-<li><a href="https://ballerina.io/swan-lake/learn/by-example/kafka_producer_transactional.html">Transactional Producer Example</a></li>
+<li><a href="https://ballerina.io/swan-lake/learn/by-example/kafka-producer.html">Producer Example</a></li>
+<li><a href="https://ballerina.io/swan-lake/learn/by-example/kafka-consumer-service.html">Consumer Service Example</a></li>
+<li><a href="https://ballerina.io/swan-lake/learn/by-example/kafka-consumer-client.html">Consumer Client Example</a></li>
+<li><a href="https://ballerina.io/swan-lake/learn/by-example/kafka-producer-transactional.html">Transactional Producer Example</a></li>
 <li><a href="https://ballerina.io/swan-lake/learn/by-example/kafka-authentication-sasl-plain-consumer.html">Consumer with SASL Authentication Example</a></li>
 <li><a href="https://ballerina.io/swan-lake/learn/by-example/kafka-authentication-sasl-plain-producer.html">Producer with SASL Authentication Example</a></li>
 </ul>


### PR DESCRIPTION
## Purpose
Fix broken links after SLP4.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
