### PR TITLE
Fix Deployment API Docs Object Links

### DIFF
--- a/swan-lake/learn/api-docs/ballerina/awslambda/index.html
+++ b/swan-lake/learn/api-docs/ballerina/awslambda/index.html
@@ -134,7 +134,7 @@
     <h2>Module Overview</h2>
 <p>This module offers the capabilities of creating AWS Lambda functions using ballerina.</p>
 <ul>
-<li>For information on the operations, which you can perform with this module, see <a href="/swan-lake/learn/api-docs/ballerina/awslambda/index.html#objects">Objects</a>.</li>
+<li>For information on the operations, which you can perform with this module, see <a href="/swan-lake/learn/api-docs/ballerina/awslambda/index.html#classes">Classes</a>.</li>
 <li>For information on the deployment, see the <a href="/swan-lake/learn/deployment/aws-lambda/">AWS Lambda Deployment Guide</a>.</li>
 <li>For examples on the usage of the operations, see the <a href="/swan-lake/learn/by-example/aws-lambda-deployment.html">AWS Lambda Deployment Example</a>.</li>
 </ul>

--- a/swan-lake/learn/api-docs/ballerina/azure.functions/index.html
+++ b/swan-lake/learn/api-docs/ballerina/azure.functions/index.html
@@ -134,7 +134,7 @@
     <h1>Module Overview</h1>
 <p>Annotation based Azure Functions extension implementation for Ballerina.</p>
 <ul>
-<li>For information on the operations, which you can perform with this module, see <a href="/swan-lake/learn/api-docs/ballerina/azure.functions/index.html#objects">Objects</a>.</li>
+<li>For information on the operations, which you can perform with this module, see <a href="/swan-lake/learn/api-docs/ballerina/azure.functions/index.html#classes">Classes</a>.</li>
 <li>For more information on the deployment, see the <a href="/swan-lake/learn/deployment/azure-functions/">Azure Functions Deployment Guide</a>.</li>
 <li>For examples on the usage of the operations, see the <a href="/swan-lake/learn/by-example/azure-functions-deployment.html">Azure Functions Deployment Example</a>.</li>
 </ul>

--- a/swan-lake/learn/api-docs/ballerina/istio/index.html
+++ b/swan-lake/learn/api-docs/ballerina/istio/index.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
-    <meta name="description" content="This module offers an annotation-based Istio extension implementation for Ballerina. For information on the operations, which you can perform with this module, see Objects.
+    <meta name="description" content="This module offers an annotation-based Istio extension implementation for Ballerina. 
 ">
     <meta name="keywords" content="ballerina,ballerina lang,api docs,istio">
 
@@ -124,7 +124,7 @@
     <div>Version : 1.0.0</div>
     
     <h2>Module Overview</h2>
-<p>This module offers an annotation-based Istio extension implementation for Ballerina. For information on the operations, which you can perform with this module, see <a href="/swan-lake/learn/api-docs/ballerina/istio/index.html#objects">Objects</a>.</p>
+<p>This module offers an annotation-based Istio extension implementation for Ballerina.</p>
 
 
     

--- a/swan-lake/learn/api-docs/ballerina/knative/index.html
+++ b/swan-lake/learn/api-docs/ballerina/knative/index.html
@@ -134,7 +134,6 @@
     <h2>Module Overview</h2>
 <p>This module offers an annotation based Knative extension implementation for Ballerina.</p>
 <ul>
-<li>For information on the operations, which you can perform with this module, see <a href="/swan-lake/learn/api-docs/ballerina/knative/index.html#objects">Objects</a>.</li>
 <li>For examples on the usage of the operations, see the <a href="/swan-lake/learn/by-example/knative-deployment.html">AWS Lambda Deployment Example</a>.</li>
 </ul>
 <h3>Annotation Usage Sample:</h3>

--- a/swan-lake/learn/api-docs/ballerina/kubernetes/index.html
+++ b/swan-lake/learn/api-docs/ballerina/kubernetes/index.html
@@ -134,7 +134,6 @@
     <h2>Module Overview</h2>
 <p>This module offers an annotation based Kubernetes extension implementation for Ballerina.</p>
 <ul>
-<li>For information on the operations, which you can perform with this module, see <a href="/swan-lake/learn/api-docs/ballerina/kubernetes/index.html#objects">Objects</a>.</li>
 <li>For more information on the deployment, see the <a href="/swan-lake/learn/deployment/kubernetes/">Kubernetes Deployment Guide</a>.</li>
 <li>For examples on the usage of the operations, see the <a href="/swan-lake/learn/by-example/kubernetes-deployment.html">AWS Lambda Deployment Example</a>.</li>
 </ul>

--- a/swan-lake/learn/api-docs/ballerina/openshift/index.html
+++ b/swan-lake/learn/api-docs/ballerina/openshift/index.html
@@ -130,7 +130,6 @@
     <h2>Module Overview</h2>
 <p>This module offers an annotation based OpenShift extension implementation for Ballerina.</p>
 <ul>
-<li>For information on the operations, which you can perform with this module, see <a href="/swan-lake/learn/api-docs/ballerina/openshift/index.html#objects">Objects</a>.</li>
 <li>For examples on the usage of the operations, see the <a href="/swan-lake/learn/by-example/openshift-deployment.html">AWS Lambda Deployment Example</a>.</li>
 </ul>
 <h3>Annotation Usage Sample:</h3>


### PR DESCRIPTION
## Purpose
Fix deployment API Docs Object links.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
