### PR TITLE
Add the Syntax Highlighter Class to Old Versions of the Release Notes

### DIFF
--- a/downloads/release-notes/0.970.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.970.0/RELEASE_NOTE.html
@@ -114,7 +114,7 @@
 <h2>Textual Syntax</h2>
 <p>Ballerina’s textual syntax is largely inspired by C, Java, and Go languages. The key language constructs in Ballerina are as follows. </p>
 <p><strong>Function:</strong></p>
-<pre><code class="ballerina">import ballerina/io;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/io;
 
 function add(int a, int b) returns (int) {
     return a + b;
@@ -127,7 +127,7 @@ function main(string... args) {
 </code></pre>
 
 <p><strong>Worker:</strong></p>
-<pre><code class="ballerina">import ballerina/io;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/io;
 function main(string... args) {
     worker w1 {
         io:println(&quot;Hello, World! #w1&quot;);
@@ -140,7 +140,7 @@ function main(string... args) {
 </code></pre>
 
 <p><strong>Service:</strong></p>
-<pre><code class="ballerina">import ballerina/http;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/http;
 
 service&lt;http:Service&gt; hello bind { port: 9090 } {
 
@@ -304,7 +304,7 @@ service&lt;http:Service&gt; hello bind { port: 9090 } {
 </ul>
 </li>
 </ul>
-<pre><code class="ballerina">    import ballerina/log;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">    import ballerina/log;
     import ballerina/websub;
 
     endpoint websub:Listener websubEP {
@@ -347,7 +347,7 @@ service&lt;http:Service&gt; hello bind { port: 9090 } {
 <h2>gRPC</h2>
 <p>gRPC is a protocol which is layered over HTTP/2 and enables client and server communication by combination of any supported languages. In gRPC a client application can directly call methods on a server application on a different machine, making it easier for you to create distributed applications and services.</p>
 <p>Ballerina also supports creating gRPC client and server as other supported language.  Ballerina based gRPC server/client supports interacting with server and client written either in Ballerina or any other supported languages. For example: you can easily create gRPC server in Ballerina and connect with client in Go. Syntax for writing simple gRPC unary server is like below,</p>
-<pre><code class="ballerina">endpoint grpc:Listener listener {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">endpoint grpc:Listener listener {
     port:9090,
 };
 
@@ -383,7 +383,7 @@ service SamplegRPCService bind listener {
 - Data access support via <code>select</code> operation, which allows easy access of data using returned tables.
 - Proxy table support, which allows read/delete on the actual DB table via a proxied table.
 - All operations are transaction aware. </p>
-<pre><code class="ballerina">endpoint jdbc:Client testDB {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">endpoint jdbc:Client testDB {
     url: &quot;jdbc:mysql://localhost:3306/testdb&quot;,
     username: &quot;root&quot;,
     password: &quot;root&quot;,
@@ -397,7 +397,7 @@ table&lt;Student&gt; tb = check testDB-&gt;select(&quot;SELECT * FROM student&qu
 <h2>Messaging endpoints</h2>
 <p>Messaging connectors enable the services and programs written in Ballerina to communicate with messaging backends like Ballerina Message Broker and ActiveMQ. The messaging connector API provides features like transactions, message headers, properties, and different acknowledgement mode support to address the common requirements of a modern integration engineer when integrating with a messaging system.</p>
 <p>The Ballerina JMS API provides the constructs to connect to any JMS provider as shown below.</p>
-<pre><code class="ballerina">endpoint jms:SimpleQueueReceiver consumer {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">endpoint jms:SimpleQueueReceiver consumer {
    initialContextFactory: &quot;bmbInitialContextFactory&quot;,
    providerUrl: &quot;amqp://admin:admin@ballerina/default?brokerlist='tcp://localhost:5672'&quot;,
    queueName: &quot;MyQueue&quot;
@@ -411,7 +411,7 @@ service&lt;jms:Consumer&gt; jmsListener bind consumer {
 </code></pre>
 
 <p>The Ballerina MB API provides the constructs to connect to the Ballerina Message Broker provided in the Ballerina platform, as shown below.</p>
-<pre><code class="ballerina">endpoint mb:SimpleQueueReceiver receiver {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">endpoint mb:SimpleQueueReceiver receiver {
    host: &quot;localhost&quot;,
    port: 5672,
    queueName: &quot;MyQueue&quot;
@@ -428,7 +428,7 @@ service&lt;mb:Consumer&gt; mbListener bind receiver {
 <p>The Ballerina standard library provides a set of commonly used functionalities. The following packages are available as a part of the standard library:</p>
 <h2>ballerina/auth</h2>
 <p>Provides an interface for looking up user data for authentication and authorization purposes. Also it contains a sample implementation that uses a Ballerina configuration file as user registry.</p>
-<pre><code class="ballerina">// Check if the user exists (for authentication)
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">// Check if the user exists (for authentication)
 auth:ConfigAuthProvider authProvider;
 boolean isAuthenticated = authProvider.authenticate(&lt;username&gt;, &lt;password&gt;);
 // Retrieve the scopes of the user (for authorization)
@@ -439,7 +439,7 @@ string[] scopes = authProvider.getScopes(&lt;username&gt;);
 <p>Provides a configurable in-memory caching solution that supports both time-based eviction and size-based eviction.</p>
 <h2>ballerina/config</h2>
 <p>Provides a configuration lookup and resolve mechanism, with the option for securing configurations, and an API for reading these configurations.</p>
-<pre><code class="ballerina">// Look up a string config value
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">// Look up a string config value
 string host = config:getAsString(“http.host”);
 // Look up an int config value. If the specified key cannot be
 // found, the default value is returned
@@ -450,7 +450,7 @@ int port = config:getAsInt(“http.port”, default = 9090);
 <p>Provides a set of functions for some of the commonly used hashing algorithms.</p>
 <h2>ballerina/file</h2>
 <p>Provides a directory listener that can be used to listen to directory events.</p>
-<pre><code class="ballerina">import ballerina/file;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/file;
 import ballerina/log;
 
 endpoint file:Listener localFolder {
@@ -479,7 +479,7 @@ service watcher bind localFolder {
 <ul>
 <li>Reading and writing bytes:</li>
 </ul>
-<pre><code class="ballerina">  // Retrieving a ByteChannel to the file.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">  // Retrieving a ByteChannel to the file.
   io:ByteChannel channel = io:openFile(filePath, permission);
   // Reading the bytes from the channel
   var result = channel.read(numberOfBytes)
@@ -490,7 +490,7 @@ service watcher bind localFolder {
 <ul>
 <li>Reading and writing characters:</li>
 </ul>
-<pre><code class="ballerina">  // Reading/writing characters of different encodings e.g.: utf-8
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">  // Reading/writing characters of different encodings e.g.: utf-8
   // First, get the ByteChannel representation of the file.
   io:ByteChannel channel = io:openFile(filePath, permission);
   io:CharacterChannel characterChannel = new(channel, encoding);
@@ -518,7 +518,7 @@ service watcher bind localFolder {
 <ul>
 <li>Reading and writing text records:</li>
 </ul>
-<pre><code class="ballerina">  // Reading and writing delimited text records
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">  // Reading and writing delimited text records
 
   io:ByteChannel channel = io:openFile(filePath, permission);
   // Create a `character channel` from the `byte channel` to read content as text.
@@ -535,7 +535,7 @@ service watcher bind localFolder {
 <ul>
 <li>Processing CSV records:</li>
 </ul>
-<pre><code class="ballerina">  io:CSVChannel srcCsvChannel = io:openCsvFile(&quot;./filepath&quot;);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">  io:CSVChannel srcCsvChannel = io:openCsvFile(&quot;./filepath&quot;);
 
   match channel.getNext() {
   string[] fields =&gt; {
@@ -618,7 +618,7 @@ service watcher bind localFolder {
 - Inheriting authentication/authorization rules from service level and overriding at the resource level
 - Authentication and authorization at downstream services via JWT token propagation</p>
 <p>Sample service secured with basic authentication:</p>
-<pre><code class="ballerina">import ballerina/http;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/http;
 
 // The endpoint used here is 'http:SecureListener', which by default tries to
 // authenticate and authorize each request. The developer has the option to

--- a/downloads/release-notes/0.975.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.975.0/RELEASE_NOTE.html
@@ -5,13 +5,13 @@
 <h2>New int range expression</h2>
 <p>Previously <code>[x .. y]</code> syntax was used to represents an integer range in a <code>foreach</code> statement. This syntax is now <code>x ... y</code> in Ballerina 0.975.0.</p>
 <p>Old syntax (0.970.1)</p>
-<pre><code class="ballerina">foreach val in [1 .. 5] {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">foreach val in [1 .. 5] {
    io:println(val);
 }
 </code></pre>
 
 <p>New syntax</p>
-<pre><code class="ballerina">foreach val in 1 ... 5 {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">foreach val in 1 ... 5 {
    io:println(val);
 }
 </code></pre>
@@ -19,14 +19,14 @@
 <h2>Syntax change in record type definitions</h2>
 <p>The record type definition syntax now requires a <code>record</code> keyword. The syntax used previously also works on Ballerina 0.975.0, but this will not be supported in future releases.</p>
 <p>Old syntax (0.970.1)</p>
-<pre><code class="ballerina">type Person {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person {
    string name,
    int age,
 };
 </code></pre>
 
 <p>New syntax</p>
-<pre><code class="ballerina">type Person record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person record {
    string name,
    int age,
 };
@@ -35,7 +35,7 @@
 <h2>Syntax change for the next statement</h2>
 <p>The <code>next</code> statement is renamed to <code>continue</code>.</p>
 <p>Old syntax (0.970.1)</p>
-<pre><code class="ballerina">while (i &lt; 5) {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">while (i &lt; 5) {
    i = i + 1;
    if (i == 2) {
        next;
@@ -44,7 +44,7 @@
 </code></pre>
 
 <p>New syntax</p>
-<pre><code class="ballerina">while (i &lt; 5) {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">while (i &lt; 5) {
    i = i + 1;
    if (i == 2) {
        continue;
@@ -55,14 +55,14 @@
 <h2>New blob literal support</h2>
 <p><code>base16</code> and <code>base64</code> based literal values are the two types of literal values supported for blob. The <code>base16</code> type has a base 16 based character sequence and the <code>base64</code> type has a base 64 based character sequence or padded character sequence.  </p>
 <p>New syntax</p>
-<pre><code class="ballerina">blob a = base16 `aaabcfccad afcd34 1a4bdf abcd8912df`;  
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">blob a = base16 `aaabcfccad afcd34 1a4bdf abcd8912df`;  
 blob b = base64 `aaabcfccad afcd3 4bdf abcd ferf =`;
 </code></pre>
 
 <h2>Variable shadowing removed</h2>
 <p>Now variables cannot be shadowed and are required to have unique names. The only exception is in XML namespaces that already have variable shadowing support.</p>
 <p>Old syntax (0.970.1)</p>
-<pre><code class="ballerina">string name;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string name;
 
 type User object {
     private {
@@ -80,7 +80,7 @@ function print(string name) {
 </code></pre>
 
 <p>New syntax</p>
-<pre><code class="ballerina">string name;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string name;
 
 type User object {
 
@@ -105,7 +105,7 @@ function print(string n) {
 <li>Add capability to read/write fixed signed integer, float, boolean and string values via data IO APIs</li>
 <li>Error handling support for WebSocket service</li>
 </ul>
-<pre><code class="ballerina">@http:WebSocketServiceConfig {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">@http:WebSocketServiceConfig {
    path: &quot;/error/ws&quot;
 }
 service&lt;http:WebSocketService&gt; errorService bind { port: 9090 } {
@@ -118,7 +118,7 @@ service&lt;http:WebSocketService&gt; errorService bind { port: 9090 } {
 <ul>
 <li>Allow different types of payloads to be used directly with HTTP client actions and response calls. E.g.,</li>
 </ul>
-<pre><code class="ballerina">response = clientEP-&gt;post(&quot;/test&quot;, xml `&lt;color&gt;Red&lt;/color&gt;`);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">response = clientEP-&gt;post(&quot;/test&quot;, xml `&lt;color&gt;Red&lt;/color&gt;`);
 response = clientEP-&gt;post(&quot;/test&quot;, { name: &quot;apple&quot;, color: &quot;red&quot; });
 _ = caller -&gt; respond(&quot;Hello World!&quot;);
 </code></pre>
@@ -128,7 +128,7 @@ _ = caller -&gt; respond(&quot;Hello World!&quot;);
 <li>Support event notification payloads of different content types with WebSub</li>
 <li>HTTP name based virtual hosting support</li>
 </ul>
-<pre><code class="ballerina">@http:ServiceConfig {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">@http:ServiceConfig {
    basePath:&quot;/page&quot;,
    host:&quot;abc.com&quot;
 }
@@ -138,7 +138,7 @@ _ = caller -&gt; respond(&quot;Hello World!&quot;);
 <li>Improve the HTTP error handler to recover from source connection failure</li>
 <li>Enhance the API to control the circuit breaker status as per user requirements</li>
 </ul>
-<pre><code class="ballerina"> http:CircuitBreakerClient cbClient = check &lt;http:CircuitBreakerClient&gt;clientEP.getCallerActions();
+<pre class="line-numbers language-ballerina"><code class="language-ballerina"> http:CircuitBreakerClient cbClient = check &lt;http:CircuitBreakerClient&gt;clientEP.getCallerActions();
         if (counter == 2) {
             cbClient.forceOpen();
         }

--- a/downloads/release-notes/0.980.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.980.0/RELEASE_NOTE.html
@@ -18,7 +18,7 @@ any country = tom.country; // or use tom[&quot;country&quot;]
 </code></pre>
 
 <p>Extra fields can be defined by using an optional <code>record rest descriptor</code>; <code>RecordRestType...</code> at end of the record definition. In the above example, the <strong>Person record</strong> definition is equivalent to the definition with <code>any...</code>.</p>
-<pre><code class="ballerina">type Person record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person record {
     string name,
     int age = 10,
     any...
@@ -26,7 +26,7 @@ any country = tom.country; // or use tom[&quot;country&quot;]
 </code></pre>
 
 <p>In the following record definition, the <strong>rest fields</strong> are constrained to <code>string</code>.</p>
-<pre><code class="ballerina">type Person record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person record {
     string name,
     int age = 10,
     string… // the rest descriptor
@@ -38,7 +38,7 @@ string country = tom.country;
 </code></pre>
 
 <p>If <code>RecordRestType</code> is <code>!</code>, then the record may not contain any extra fields. </p>
-<pre><code class="ballerina">type Person record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person record {
     string name,
     int age = 10,
     !... // indicates that additional fields are not allowed
@@ -51,12 +51,12 @@ Person tom = { name : &quot;tom&quot;, age : 20, country : &quot;USA&quot;}; // 
 <p>A record type including <code>!...</code> is called <code>closed</code>; a record type that is not closed is called <code>open</code>.</p>
 <h2>Fixed Length Arrays</h2>
 <p>Now the length of an array can be fixed by providing the array length with the array type descriptor. </p>
-<pre><code class="ballerina">int[5] array1 = [2, 15, 200, 1500, 5000];
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int[5] array1 = [2, 15, 200, 1500, 5000];
 int[5] array2; // Creates an integer array of size five, filled with default integer values
 </code></pre>
 
 <p>An array length of <code>!...</code> means that the length of the array is to be implied from the context as shown below:</p>
-<pre><code class="ballerina">int[!...] sealedArray = [1, 3, 5]; // Creates a sealed integer array of size 3.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int[!...] sealedArray = [1, 3, 5]; // Creates a sealed integer array of size 3.
 </code></pre>
 
 <h2>Object Syntax Change</h2>
@@ -64,7 +64,7 @@ int[5] array2; // Creates an integer array of size five, filled with default int
 <ol>
 <li>Object field definition change.</li>
 </ol>
-<pre><code class="ballerina">public type Person object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public type Person object {
       public string name;  //visible everywhere
       private int age;        //visible only within object and its member functions
       string email;            //visible only within same package
@@ -78,11 +78,11 @@ int[5] array2; // Creates an integer array of size five, filled with default int
 <h2>Byte Type and Blob Type Change</h2>
 <p>The <code>byte</code> type represents the set of 8-bit unsigned integers. The implicit initial value of the <code>byte</code> type is <code>0</code>. Value space for <code>byte</code> is 0-255 both inclusive. </p>
 <p>The following is an example of byte definition.</p>
-<pre><code class="ballerina">byte c = 23;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">byte c = 23;
 </code></pre>
 
 <p>Along with general byte array type, there is also a special syntax for defining base64 and base16 based array of bytes. With this, blob type is replaced by byte array.</p>
-<pre><code class="ballerina">byte[] arr1 = [5, 24, 56, 243];
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">byte[] arr1 = [5, 24, 56, 243];
 byte[] arr2 = base16 `aeeecdefabcd12345567888822`;
 byte[] arr3 = base64 `aGVsbG8gYmFsbGVyaW5hICEhIQ==`;
 </code></pre>
@@ -91,7 +91,7 @@ byte[] arr3 = base64 `aGVsbG8gYmFsbGVyaW5hICEhIQ==`;
 <p>Above bitwise operations have been added for <code>byte</code> type and <code>int</code> type with the following rules.</p>
 <p>Both the right-hand-side and left-hand-side of the expression should be of the same type (<code>byte</code> or <code>int</code>), and the expected type will be also of the same type. If this is not the case, it will result in a compilation error.</p>
 <p>An explicit conversion operation should be applied if the type of one side is not the same as the other side.</p>
-<pre><code class="ballerina">byte a = 13;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">byte a = 13;
 byte b = 45;
 byte c = a &amp; b;
 byte d = a | b;
@@ -100,7 +100,7 @@ byte e = a ^ b;
 
 <h2>Table Expression Change</h2>
 <p>The table expression has changed to support the following syntax. A table is intended to be similar to the table of a relational database table. A table value contains an immutable set of column names and a set of data rows.</p>
-<pre><code class="ballerina">table&lt;Person&gt; t1 = table {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">table&lt;Person&gt; t1 = table {
     { primarykey id, primarykey salary, name, age, married }, [
          {1, 300.5, &quot;jane&quot;,  30, true},
          {2, 302.5, &quot;anne&quot;,  23, false},
@@ -109,7 +109,7 @@ byte e = a ^ b;
 };
 </code></pre>
 
-<pre><code class="ballerina">Person p1 = { id: 1, age: 30, salary: 300.50, name: &quot;jane&quot;, married: true };
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">Person p1 = { id: 1, age: 30, salary: 300.50, name: &quot;jane&quot;, married: true };
 Person p2 = { id: 1, age: 30, salary: 300.50, name: &quot;jane&quot;, married: true };
 
 table&lt;Person&gt; t1 = table {
@@ -121,7 +121,7 @@ table&lt;Person&gt; t1 = table {
 <h2>Map Access Change</h2>
 <p>Values of a map can be accessed using index-based syntax as well as field-access syntax. These two syntaxes now behave differently. Getting a value using field-access syntax returns the value if the key exists. Alternately, a runtime error is thrown. Index-based syntax also will return the value if the key exists. However, it will return a null value if the key does not exist.</p>
 <p>This would also mean that, for a constrained map, the type of the return value for the index-based syntax is always the <code>constraint_type|()</code>.</p>
-<pre><code class="ballerina">map&lt;string&gt; m = {&quot;fname&quot; : &quot;John&quot;, &quot;lname&quot; : &quot;Doe&quot;}
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">map&lt;string&gt; m = {&quot;fname&quot; : &quot;John&quot;, &quot;lname&quot; : &quot;Doe&quot;}
 
 // Field based access
 string firstName = m.fname;
@@ -152,7 +152,7 @@ string? middleName = m[&quot;mname&quot;];     // returns null
 </ul>
 </li>
 </ul>
-<pre><code class="ballerina">rollingWindow: {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">rollingWindow: {
             timeWindowMillis: 10000,
             bucketSizeMillis: 2000,
             requestVolumeThreshold: 10
@@ -190,7 +190,7 @@ string? middleName = m[&quot;mname&quot;];     // returns null
 <li>Introduced APIs such that developers can define their own trace blocks and metrics.</li>
 <li>Developers can attach the trace information of their code block to the default Ballerina traces, or a new trace.</li>
 </ul>
-<pre><code class="ballerina">   //Create and attach span to the default Ballerina request trace.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">   //Create and attach span to the default Ballerina request trace.
    int spanId = check observe:startSpan(&quot;Child Span&quot;);
        // Do Something
    _ = observe:finishSpan(spanId);
@@ -208,7 +208,7 @@ string? middleName = m[&quot;mname&quot;];     // returns null
 <ul>
 <li>Developers can create a metric (counter or gauge) and have have their own measurements. A counter is a cumulative metric that represents a single monotonically increasing value. Gauge is a single numerical value that can arbitrarily go up and down, and also based on the statistics configurations provided to the gauge, it can also report the statistics such as max, min, mean, percentiles, etc. The created metric can be registered in order to include its measurements to reporters such as Prometheus.</li>
 </ul>
-<pre><code class="ballerina">   //Create counter and register.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">   //Create counter and register.
    map&lt;string&gt; counterTags = { &quot;method&quot;: &quot;GET&quot; };
    observe:Counter counterWithTags = new (&quot;CounterWithTags&quot;, desc = &quot;Some description&quot;, tags = counterTags);
    counterWithTags.register() but {
@@ -228,7 +228,7 @@ string? middleName = m[&quot;mname&quot;];     // returns null
 <ul>
 <li>All metrics registered can be retrieved and looked up individually.</li>
 </ul>
-<pre><code class="ballerina">   //Get All Metrics
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">   //Get All Metrics
     observe:Metric[] metrics = observe:getAllMetrics();
     foreach metric in metrics {
        //do something.

--- a/downloads/release-notes/0.981.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.981.0/RELEASE_NOTE.html
@@ -4,11 +4,11 @@
 <h1>Compatibility and Support</h1>
 <p>The <code>native</code> keyword has been changed to <code>extern</code> due to Ballerina moving towards a model of native compilation. With this model, code will be an external library and everything is native. Libraries can be written or not written in Ballerina.</p>
 <p>Old syntax:</p>
-<pre><code class="ballerina">public native function string::toUpper() returns string;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public native function string::toUpper() returns string;
 </code></pre>
 
 <p>New syntax:</p>
-<pre><code class="ballerina">public extern function string::toUpper() returns string;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public extern function string::toUpper() returns string;
 </code></pre>
 
 <h1>Improvements</h1>
@@ -16,14 +16,14 @@
 <ul>
 <li>Bitwise complement (~) operator inverts the bits of its operand expression. The static type of the operand must be int, and the static type of the result is an int.</li>
 </ul>
-<pre><code class="ballerina">int i = 387465;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int i = 387465;
 int j = ~i;
 </code></pre>
 
 <ul>
 <li>Introduce index based access for tuples. Elements of a tuple type can now be accessed via indexes as follows:</li>
 </ul>
-<pre><code class="ballerina">(boolean, int, string) x = (true, 3, &quot;abc&quot;);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">(boolean, int, string) x = (true, 3, &quot;abc&quot;);
 boolean tempBool = x[0];
 string tempString = x[2];
 x[1] = 4;
@@ -38,13 +38,13 @@ x[1] = 4;
 <p>The <code>pushText</code> function takes a union type instead of a string type. The new signature is as follows: </p>
 </li>
 </ul>
-<pre><code class="ballerina">public function pushText(string|json|xml|boolean|int|float|byte|byte[] data, boolean final = true) returns error? 
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public function pushText(string|json|xml|boolean|int|float|byte|byte[] data, boolean final = true) returns error? 
 </code></pre>
 
 <ul>
 <li>The <code>onText</code> function can take a string, JSON, XML, record, or byte[] types instead of only string. The <code>onText</code> signature can be any one of the following:</li>
 </ul>
-<pre><code class="ballerina">onText(endpoint caller, string text, boolean final)
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">onText(endpoint caller, string text, boolean final)
 onText(endpoint caller, json jsonVal)
 onText(endpoint caller, xml xmlVal)
 onText(endpoint caller, Person person)

--- a/downloads/release-notes/0.982.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.982.0/RELEASE_NOTE.html
@@ -8,7 +8,7 @@
 <h2>Syntax changes</h2>
 <h3>New documentation syntax</h3>
 <p>Old syntax:</p>
-<pre><code class="ballerina">documentation {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">documentation {
     Adds parameter `x` and parameter `y`.
     P{{x}} one thing to be added
     P{{y}} another thing to be added
@@ -18,7 +18,7 @@ function add(int x, int y) returns int { return x + y; }
 </code></pre>
 
 <p>New syntax:</p>
-<pre><code class="ballerina"># Adds parameter `x` and parameter `y`.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina"># Adds parameter `x` and parameter `y`.
 # + x - one thing to be added
 # + y - another thing to be added
 # + return - the sum of them
@@ -29,7 +29,7 @@ function add(int x, int y) returns int { return x + y; }
 <h3>Reorder documentation in resources</h3>
 <p>In previous versions, documentation was added after annotation attachments. With the latest changes, documentation should be added before the annotation attachment.</p>
 <p>Old syntax:</p>
-<pre><code class="ballerina">service&lt;http:Service&gt; update_token bind { port: 9295 } {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">service&lt;http:Service&gt; update_token bind { port: 9295 } {
 
     @http:ResourceConfig {
         methods:[&quot;GET&quot;]
@@ -44,7 +44,7 @@ function add(int x, int y) returns int { return x + y; }
 </code></pre>
 
 <p>New syntax:</p>
-<pre><code class="ballerina">service&lt;http:Service&gt; update_token bind { port: 9295 } {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">service&lt;http:Service&gt; update_token bind { port: 9295 } {
 
     # Updates the access token.
     #
@@ -60,7 +60,7 @@ function add(int x, int y) returns int { return x + y; }
 
 <h3>Changes to record/object field syntax</h3>
 <p>Old syntax:</p>
-<pre><code class="ballerina">type foo record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type foo record {
     string a,
     string b,
 };
@@ -72,7 +72,7 @@ type bar object {
 </code></pre>
 
 <p>New syntax:</p>
-<pre><code class="ballerina">type foo record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type foo record {
     string a;
     string b;
 };
@@ -86,14 +86,14 @@ type bar object {
 <h3>New anonymous function syntax</h3>
 <p>The syntax of the anonymous function has been changed to resemble the normal function definition.</p>
 <p>Old syntax:</p>
-<pre><code class="ballerina">var lambda = (int b) =&gt; (int) {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">var lambda = (int b) =&gt; (int) {
     int x = b * b;
     return x;
 };
 </code></pre>
 
 <p>New syntax:</p>
-<pre><code class="ballerina">var lambda = function (int b) returns (int) {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">var lambda = function (int b) returns (int) {
     int x = b * b;
     return x;
 };
@@ -104,7 +104,7 @@ type bar object {
 <h2>Runtime changes</h2>
 <h3>Removal of implicit cast from int to float</h3>
 <p>Now it is necessary to explicitly define a float with a decimal point.</p>
-<pre><code class="ballerina">float x = 0; // Compile Error
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">float x = 0; // Compile Error
 float x = 0.0; // Working Code
 </code></pre>
 
@@ -116,7 +116,7 @@ float x = 0.0; // Working Code
 <li>If a function is not specified, <code>main</code> is considered as the function to run.</li>
 <li>The function invoked via <code>ballerina run</code> (including the <code>main</code> function) will be data-binding and can have zero or more parameters of any supported type, including any number of required/defaultable parameters and a single rest parameter. This function can also return a value. For example, consider the following public function in the <code>currency</code> package:</li>
 </ul>
-<pre><code class="ballerina">  function queryChanges(string host, int port = 8080, string… params) returns float {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">  function queryChanges(string host, int port = 8080, string… params) returns float {
   }
 </code></pre>
 
@@ -134,11 +134,11 @@ float x = 0.0; // Working Code
 <p>Option vs parameter ordering is enforced with the run command, and all options need to be specified before the file/package to run. 
 Any arguments (even if they match an option recognized by the run command) specified after the file/package are now considered program arguments.
 A config file can be specified with the run command as follows:</p>
-<pre><code class="ballerina">ballerina run --config myConfig.conf calculator 4 5
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">ballerina run --config myConfig.conf calculator 4 5
 </code></pre>
 
 <p>Specifying the <code>--config</code> argument as follows does not identify it as an option:</p>
-<pre><code class="ballerina">ballerina run calculator --config myConfig.conf 4 5
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">ballerina run calculator --config myConfig.conf 4 5
 </code></pre>
 
 <h1>Ballerina Native</h1>
@@ -170,7 +170,7 @@ Run the created executable
 <li>Tracking tainted state changes of function parameters : Taint analyzer keeps track of the tainted state of the parameters in different execution conditions. This information is used to update the tainted state of the arguments used in a function invocation, and to make sure that the tainted state of arguments propagate correctly when the parameter is an out parameter or an in-out parameter.</li>
 <li>Introduction of abstract objects. An abstract object is identified by the ‘abstract’ keyword. It describes the type of each field and each method, but not the implementation of the methods. An abstract object type must not have an object constructor method and does not have an implicit initial value. An abstract object type cannot be initialized using the object initializer.</li>
 </ul>
-<pre><code class="ballerina">  public type Foo abstract object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">  public type Foo abstract object {
       public string name;
       public int id;
 
@@ -183,7 +183,7 @@ Run the created executable
 <ul>
 <li>Introduction of record iteration support. Records are now an iterable type. Therefore, the foreach loop and iterable operations can now be used with records. When iterating a record, you can either iterate over the fields (i.e., field name and value pair) or iterate only over the field values.</li>
 </ul>
-<pre><code class="ballerina">  type Person record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">  type Person record {
        string name;
        int age;
        string address;
@@ -192,14 +192,14 @@ Run the created executable
 
 <pre><code>Foreach loop can be used on an instance of this record as follows:
 </code></pre>
-<pre><code class="ballerina">  foreach field, value in person {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">  foreach field, value in person {
        io:println(field + &quot; : &quot; + &lt;string&gt;value);
   }
 </code></pre>
 
 <pre><code>Or if iterating only through the field values:
 </code></pre>
-<pre><code class="ballerina">  foreach value in person {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">  foreach value in person {
        io:println(value);
   }
 </code></pre>
@@ -208,18 +208,18 @@ Run the created executable
 <li>Introduction of Channel type. Channel is a constrained type that can be defined only as a top level node. It is introduced for communication between parallel processes in Ballerina programs. Channels can be used for message correlation by sending and receiving messages via different resources to the same channel. It can also be used for  inter-worker communication and synchronize workers.</li>
 </ul>
 <p>Defines a channel with json constrained type</p>
-<pre><code class="ballerina">channel&lt;json&gt; jsonChannel;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">channel&lt;json&gt; jsonChannel;
 </code></pre>
 
 <p>Send a message to the channel</p>
-<pre><code class="ballerina">    # One of the receivers waiting on this key receives it.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">    # One of the receivers waiting on this key receives it.
     # If there is no receiver, the message is stored and execution continues.
     # A receiver can arrive later and fetch the message.
     message -&gt; jsonChannel, key;
 </code></pre>
 
 <p>Receive a message from the channel with given key. Execution waits here if the message is not available</p>
-<pre><code class="ballerina">json result &lt;- jsonChannel, key;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">json result &lt;- jsonChannel, key;
 </code></pre>
 
 <h2>Build &amp; Package Management</h2>

--- a/downloads/release-notes/0.983.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.983.0/RELEASE_NOTE.html
@@ -6,7 +6,7 @@
 <h2>Syntax Changes</h2>
 <p><strong>Object type reference syntax</strong>
 Object type references provide a way to copy the members from an abstract object into another object. It is equivalent to specifying the members explicitly within the new object.</p>
-<pre><code class="ballerina">type Person abstract object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person abstract object {
     public int age;
     public string firstName;
     public string lastName;
@@ -28,7 +28,7 @@ type Manager object {
 
 <p><strong>Optional fields in records</strong></p>
 <p>Fields in records can now be marked as optional by adding <code>?</code> to the end of the identifier. When creating a record, optional fields can be omitted. Omitting a required field results in a compile error. Fields with implicit initial values or explicitly defined default values are effectively optional fields even if they are not marked as optional. Explicit default values cannot be set to optional fields.</p>
-<pre><code class="ballerina">type Gender &quot;male&quot;|&quot;female&quot;;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Gender &quot;male&quot;|&quot;female&quot;;
 
 type Person record {
    string fname = &quot;default&quot;; // required field with explicit default value
@@ -47,7 +47,7 @@ public function main() {
 
 <p><strong>Table syntax</strong>
 The keyword used for the primary key of a table has changed to “key”.</p>
-<pre><code class="ballerina">table&lt;Employee&gt; tbEmployee = table {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">table&lt;Employee&gt; tbEmployee = table {
         { key id, name, salary },
         [ { 1, &quot;Mary&quot;,  300.5 },
         { 2, &quot;John&quot;,  200.5 },
@@ -59,12 +59,12 @@ The keyword used for the primary key of a table has changed to “key”.</p>
 <p><strong>Post increment and decrement operators</strong>
 These were statements in Ballerina and there was no siginificant improvement as these cannot be used as expressions. Therefore, these statements have been removed to simplify usage.</p>
 <p>Old syntax</p>
-<pre><code class="ballerina">int i = 1;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int i = 1;
 i++;
 </code></pre>
 
 <p>Alternative syntax</p>
-<pre><code class="ballerina">int i = 1;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int i = 1;
 i += 1;
 </code></pre>
 
@@ -94,7 +94,7 @@ i += 1;
 <li>Doc preview - Shows generated API Doc of a source file in real time</li>
 <li>Script arguments and command options for the <code>launch.json</code>.</li>
 </ul>
-<pre><code class="ballerina">    &quot;scriptArguments&quot;: [&quot;foo&quot;, &quot;bar&quot;],
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">    &quot;scriptArguments&quot;: [&quot;foo&quot;, &quot;bar&quot;],
     &quot;commandOptions&quot;: [&quot;-e&quot;, &quot;b7a.log.level=DEBUG&quot;]
 </code></pre>
 

--- a/downloads/release-notes/0.990.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.990.0/RELEASE_NOTE.html
@@ -42,7 +42,7 @@
 <p>The <code>self</code> keyword has been mandated to access object members within the object definition. The following code will not compile with this Ballerina version.</p>
 </li>
 </ul>
-<pre><code class="ballerina">type Person object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person object {
     private string name;
     function getName () returns string {
         return name;
@@ -52,7 +52,7 @@
 </code></pre>
 
 <p>Now you need to use <code>self</code> when referring to object members as follows. </p>
-<pre><code class="ballerina">type Person object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person object {
     private string name;
     function getName () returns string {
     return self.name;
@@ -62,7 +62,7 @@
 </code></pre>
 
 <p>Object constructor syntax has been changed from this release onwards. Here is the old syntax.  </p>
-<pre><code class="ballerina">type Person object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person object {
     private string name;
     new (name) {
     }
@@ -71,7 +71,7 @@
 </code></pre>
 
 <p>Here is the new syntax. With this change, we have removed the special signature in the constructor that existed in the previous release. </p>
-<pre><code class="ballerina">type Person object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person object {
      private string name;
      function __init (string name) {
           self.name = name;
@@ -91,19 +91,19 @@
 <p>Endpoints and services are the key abstractions in Ballerina that bring network programming to a higher level of abstraction when compared to traditional languages. There are two kinds of endpoints: listener endpoints and client endpoints.  We have changed the listener (inbound) endpoint variable definition syntax. Here is the old syntax.</p>
 </li>
 </ul>
-<pre><code class="ballerina">endpoint http:Listener httpEp {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">endpoint http:Listener httpEp {
     port: 9095
 };
 
 </code></pre>
 
 <p>Now listener endpoints are Ballerina objects that implement the abstract listener object. Therefore, you can create a new instance of a module-level listener endpoint as follows. For more information, refer to endpoints and services section.</p>
-<pre><code class="ballerina">listener http:Listener httpEp = new (9095);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">listener http:Listener httpEp = new (9095);
 
 </code></pre>
 
 <p>The service and resource definition syntax has been changed. Here is the old syntax.</p>
-<pre><code class="ballerina">service hello bind httpEp {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">service hello bind httpEp {
     hi (endpoint caller, http:Request req) {
         _ = caller-&gt;respond(&quot;Hello, World!&quot;);
     }
@@ -112,7 +112,7 @@
 </code></pre>
 
 <p>Now services are first-class values and are like singleton objects. Resource definition has been modified slightly. Now a resource definition looks like a function definition with the resource qualifier. For more information, refer to standard library syntax section.</p>
-<pre><code class="ballerina">service hello on httpEp {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">service hello on httpEp {
     resource function hi (http:Caller caller, http:Request req) {
         _ = caller-&gt;respond(&quot;Hello, World!&quot;);
     }
@@ -146,7 +146,7 @@
 <p>The <code>foreach</code> statement has been changed in a consistent way to match with type binding patterns. Here is the old syntax.</p>
 </li>
 </ul>
-<pre><code class="ballerina">map&lt;Student&gt; class = { ... }
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">map&lt;Student&gt; class = { ... }
 foreach name, std in class {
     string msg = name + &quot; details: &quot;;
     io:println(msg, std);
@@ -155,7 +155,7 @@ foreach name, std in class {
 </code></pre>
 
 <p>Now the <code>foreach</code> statement allows the value to be destructured, while iterating over a sequence. Here is an example.</p>
-<pre><code class="ballerina">foreach (string, Student)  (name, std) in class {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">foreach (string, Student)  (name, std) in class {
     string msg = name + &quot; details: &quot;;
     io:println(msg, std);
 }
@@ -195,7 +195,7 @@ foreach name, std in class {
 <p>Performs a deep copy of a pure value. It is a no-op operation on simple values and error values. This operation is guaranteed to succeed on pure values and preserves cycles, inherent type, and immutability of values.</p>
 <h3>Record type referencing</h3>
 <p>Record type referencing is a mechanism for copying the fields from one record type descriptor into another record type descriptor. It is equivalent to defining those fields in the new type descriptor. If the fields have explicit default values specified, those values will be copied as well.</p>
-<pre><code class="ballerina">type Person record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person record {
    string name;
    int age = 25;
    !...
@@ -210,7 +210,7 @@ type Employee record {
 </code></pre>
 
 <p>The above Employee type descriptor is equivalent to the following type descriptor:</p>
-<pre><code class="ballerina">type Employee record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Employee record {
    string name;
    int age = 25;
    string company?;
@@ -227,7 +227,7 @@ type Employee record {
 <p>We have introduced immutable values from this release onwards. Immutability is not part of the static type system in the language. It exists only in the runtime. You can use the <code>freeze</code> built-in method to make a structured value frozen at runtime. This method sets the <code>frozen</code> flags in the value. A <code>frozen</code> structured value cannot be modified afterward and any such attempts will results in panics.</p>
 <p>The <code>freeze</code> built-in method changes the value to which it is applied to be frozen and returns that value. It works in a similar way to the <code>clone</code> method.</p>
 <p>There is a <code>isFrozen()</code> built-in method on all structural basic types that returns <code>true</code> or <code>false</code> depending on whether the value is frozen. </p>
-<pre><code class="ballerina">person p1 = {name:&quot;John&quot;, age:34};
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">person p1 = {name:&quot;John&quot;, age:34};
 person p1Frozen = p1.freeze();
 boolean b = p1 === p1Frozen; // true
 
@@ -235,7 +235,7 @@ boolean b = p1 === p1Frozen; // true
 
 <h3>Type test expression</h3>
 <p>The type test can be used to determine whether a value is of a particular type.</p>
-<pre><code class="ballerina">int|string x = getValue();
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int|string x = getValue();
 if x is string {
    // x is now string after implicit narrowing
    return;
@@ -245,7 +245,7 @@ if x is string {
 
 <h3>Type assertions</h3>
 <p>Type assertions can be used to assert the inherent type of a value. Assertion fails and results in a panic, if the asserted type is not exactly the storage type.</p>
-<pre><code class="ballerina">
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">
 Employee e = { ... };
 Person p = e;
 
@@ -255,7 +255,7 @@ Person p2 = &lt;Person&gt; p; // panics since storage type is Employee
 
 <h3>Match statement</h3>
 <p>The existing match has been changed in this release from a type match to a value match statement. The match statement is a value switching construct that allows selective code execution based on the value of the expression that is being tested.</p>
-<pre><code class="ballerina">match variable {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">match variable {
     “Bal” =&gt; io:println(“Matched a String with value Bal”);
     0 =&gt; io:println(“Matched an int with value 0”);
     10 =&gt; io:println(“Matched an int with value 10”);
@@ -268,7 +268,7 @@ Person p2 = &lt;Person&gt; p; // panics since storage type is Employee
 </code></pre>
 
 <p>The <code>match</code> statement can also be used to match the structure of a value by using binding patterns. The matched value will be destructured to new variables within the scope of the match pattern. Here is an example of the structured value match.</p>
-<pre><code class="ballerina">match variable {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">match variable {
     var (var1, var2) =&gt; { // match a tuple value with two members
         io:println(var1);
         io:println(var2);
@@ -293,7 +293,7 @@ Person p2 = &lt;Person&gt; p; // panics since storage type is Employee
 <h3>The error type</h3>
 <p>The error type is a structured basic type which is used only for representing errors. A value of error type contains a reason which is a string identifier for the category of error, a detail which is a frozen mapping providing additional information and a stack trace. Error values are made immutable from this release onwards, since they can propagate across concurrent execution blocks. Allowing them to be mutable can be dangerous.</p>
 <p>Here is an example for usage of error type. The function <code>getAcctBalance</code> returns a union of <code>decimal</code> and <code>error&lt;string, AccountData&gt;</code> types.</p>
-<pre><code class="ballerina">type AccountData record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type AccountData record {
     string accountID;
 };
 
@@ -307,7 +307,7 @@ returns decimal | error&lt;string, AccountData&gt; {...}
 <p>The <code>check</code> expression is a useful unary operator in the language, which allows you to get an error out of the way in arbitrary expressions. If the type of the expression E is <code>T | error</code>, then the type of expression check E will be <code>T</code> if it evaluates to <code>T</code>. If the expression evaluates to error, then the function terminates immediately as if by <code>return E</code>. The <code>check</code> operator forces you to declare error as part of the return type of your function. </p>
 <p>In the previous release, check throws the error if the function does not have error type as part of the <code>return</code> type. This causes normal errors to become exceptions or abnormal errors due to negligence of the programmer. </p>
 <p>Here is a sample usage of check operator.</p>
-<pre><code class="ballerina">function startHTTPListener() returns Listener | error {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function startHTTPListener() returns Listener | error {
     string strVal = getValue(HTTP_PORT);
     // int.convert() has the type 'int | error'
     int port = check int.convert(strVal);
@@ -318,7 +318,7 @@ returns decimal | error&lt;string, AccountData&gt; {...}
 
 <h3>Panic statement</h3>
 <p>This is a replacement for the <code>throw</code> statement to allow programmers to create a panic, which causes the execution to stop. Function calls will unwind until the panic is stopped by trapping it and converting it into an error. Stack trace is recorded in the error value at the time of panic. </p>
-<pre><code class="ballerina">int | error i = int.convert(&quot;4t4&quot;);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int | error i = int.convert(&quot;4t4&quot;);
 if i is error {
     panic i;
 }
@@ -331,7 +331,7 @@ if i is error {
 <p>Binding patterns are used to support destructuring, which allows different parts of a single structured value each to be assigned to separate variables at the same time. Binding patterns can be used both with or without a type. Using a <code>typed binding pattern</code> will assign the destructured values to new variables, while a <code>destructure assignment binding pattern</code> will assign the destructured values to existing variable references.</p>
 <p>This release introduces two binding patterns; tuple binding pattern and record binding pattern.</p>
 <p>Tuple binding pattern destructures a <code>tuple</code> value based on the number of members in the <code>tuple</code> value. Here is an example of a tuple binding pattern.</p>
-<pre><code class="ballerina">(int, string) tupleVar = (20, “Ballerina”);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">(int, string) tupleVar = (20, “Ballerina”);
 (int, string) (intVariable, stringVariable) = tupleVar; //typed binding pattern
 io:println(intVariable + “ “ + stringVariable);
 int intVariable2;
@@ -342,7 +342,7 @@ io:println(intVariable2 + “ “ + stringVariable2);
 </code></pre>
 
 <p>Record binding pattern destructures a mapping value based on the presence of a field name. Here is an example of a record binding pattern. In this example a <code>Person</code> typed record with fields <code>name</code> and <code>age</code> will be destructured. The variable name to which the value is to be assigned can be given against a field name following a colon. Omitting a variable name will result in using the same name as the field name.</p>
-<pre><code class="ballerina">Person {name, age: personAge} = getPerson(); //typed binding pattern
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">Person {name, age: personAge} = getPerson(); //typed binding pattern
 io:println(name + “ “ + personAge);
 string personName;
 int age;
@@ -370,7 +370,7 @@ io:println(personName + “ “ + age);
 <p><code>flush</code> will wait until all the messages are sent from the current worker to the specified worker. If the receiver failed or panicked, then that error will be propagated to the waiting strand.</p>
 <h3>Lock</h3>
 <p>Lock can be used to make the concurrent access safe for a set of variables. It creates two phase deadlock-free synchronization guaranteeing unique access to each variable.</p>
-<pre><code class="ballerina">public function invokeWorkers() returns int {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public function invokeWorkers() returns int {
     worker w1 {
         int i = 5;
         i -&gt; w2;
@@ -386,12 +386,12 @@ io:println(personName + “ “ + age);
 <h2>Variable Initialization</h2>
 <h3>Compile time constants</h3>
 <p>A compile-time constant is a typed identifier whose value is computed at compile time. Compile time reference values are <code>frozen</code> values. </p>
-<pre><code class="ballerina">const i = 10;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">const i = 10;
 </code></pre>
 
 <h3>Final variables</h3>
 <p>The modified <code>final</code> variable can be applied to a variable declaration to mean that the variable cannot be modified after it has been initialized.</p>
-<pre><code class="ballerina">final int port = getValue();
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">final int port = getValue();
 
 // Here the type is inferred from the right-hand side expression. 
 final var addr = getAddr();
@@ -409,7 +409,7 @@ final var addr = getAddr();
 <h3>Client Object</h3>
 <p>An object that has a client modifier is a client object type. A method on a client object can have a remote modifier; a method with a remote modifier is called a remote method. A remote method can be called only using a <code>remote method call</code>.  E.g., <code>clientObj-&gt;remoteFunctionName (arguments)</code>. This is previously called <code>action invocation</code>.</p>
 <p>E.g.:</p>
-<pre><code class="ballerina">    public type Twitter client object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">    public type Twitter client object {
         public remote function tweet (string message) returns error? { ... }
     };
 </code></pre>
@@ -419,7 +419,7 @@ final var addr = getAddr();
  - in a function initialization (before any worker declarations or statements).
  - as an argument to the function.</p>
 <p>Eg:</p>
-<pre><code class="ballerina">Twitter globalClient = new;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">Twitter globalClient = new;
 
 public function tweetSomething(Twitter paramClient)  {
     Twitter localClient= new;
@@ -435,7 +435,7 @@ public function tweetSomething(Twitter paramClient)  {
 
 <h3>Listeners</h3>
 <p>A listener is an object that implements the abstract listener object. It defines the life cycle of the listener.</p>
-<pre><code class="ballerina">public type AbstractListener abstract object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public type AbstractListener abstract object {
     public function __start() returns error?;
     public function __stop() returns error?;
     public function __attach(service s, map&lt;any&gt; annotationData) returns error?;
@@ -444,7 +444,7 @@ public function tweetSomething(Twitter paramClient)  {
 
 <h3>Module Listeners</h3>
 <p>A module listener is a Listener object that is managed as part of the module’s lifecycle. It is like a final global variable but registers itself with the module life cycle. So a module starts all its module listeners after all services have been attached the listeners and stops the listeners when the module stops. Module listeners are created as follows.</p>
-<pre><code class="ballerina">listener http:Listener httpEp = new (9095);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">listener http:Listener httpEp = new (9095);
 </code></pre>
 
 <p>Module Listeners can be attached to module service.  With this change, the old endpoint declaration and endpoint bind syntax have been removed from the language. </p>
@@ -453,7 +453,7 @@ public function tweetSomething(Twitter paramClient)  {
 <p>Precise service typing is not provided in this version of Ballerina. This will be added in future versions.</p>
 <p>A service value can be constructed using the service constructor expression.</p>
 <p>Eg: </p>
-<pre><code class="ballerina">        service myService = @http:ServiceConfig { basePath : &quot;/hello&quot;} service {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">        service myService = @http:ServiceConfig { basePath : &quot;/hello&quot;} service {
                 resource function hi (http:Caller caller, http:Request request ) {
                         _ = caller -&gt; respond(self.getHelloWorld());
                 }
@@ -467,7 +467,7 @@ public function tweetSomething(Twitter paramClient)  {
 <p><code>resource</code> qualifier is used to represent the resource methods of the service. Resource methods cannot be called using the <code>method call</code> expression. They are intended to invoke in response to an incoming network request. A service’s non-resource methods can be called using a method call expression.</p>
 <h3>Module Services</h3>
 <p>A module service is a syntax for creating service value at the module level. A module service must have one or more module listeners or anonymous module listeners (created using type new expression) attached. Here is the syntax.</p>
-<pre><code class="ballerina">listener http:Listener httpEp = new (9095);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">listener http:Listener httpEp = new (9095);
 
 @http:ServiceConfig { basePath : &quot;/hello&quot;} 
 service MyService on httpEp, new http:Listener (9085) {
@@ -479,7 +479,7 @@ service MyService on httpEp, new http:Listener (9085) {
 
 <p><code>MyService</code> is a service value, which is attached to both <code>httpEP listener</code> and the new HTTP module Listener.  Previously this was referred as a services name, now it is a final module service variable.</p>
 <p>Above code is a syntactic sugar and equal to the following code, which runs at module init time. </p>
-<pre><code class="ballerina">http:Listener httpEp = new http:Listener(9085);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">http:Listener httpEp = new http:Listener(9085);
 
 service MyService = @http:ServiceConfig { basePath : &quot;/hello&quot;} service  {
     resource function hi (http:Caller caller, http:Request req) {
@@ -496,7 +496,7 @@ check anonEP.__start();
 
 <h2>Decimal type</h2>
 <p>Decimal type is a basic, simple type in Ballerina. The decimal type corresponds to the 128-bit IEEE 754-2008 decimal (radix 10) floating point number format. A decimal value has 34 decimal digits of significand and an exponent range of −6143 to +6144.</p>
-<pre><code class="ballerina">decimal d = 4.565;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">decimal d = 4.565;
 </code></pre>
 
 <p>Defining a decimal variable is very similar to defining a float variable in Ballerina
@@ -534,7 +534,7 @@ This is because of the non-representability of 0.1 (0.0001100110011..) and 0.2 (
 <h2>Micro-Transactions</h2>
 <h3>Transaction initiator statement</h3>
 <p><code>oncommit</code> and <code>onabort</code> function handlers are removed from the transaction statement and are substituted with committed and aborted blocks.</p>
-<pre><code class="ballerina">transaction with retries = 2 {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">transaction with retries = 2 {
     _ = testDB-&gt;update(&quot;Insert into Customers (firstName,lastName,registrationID,creditLimit,country)
                             values ('James', 'Clerk', 200, 5000.75, 'USA')&quot;);
     _ = testDB-&gt;update(&quot;Insert into Customers (firstName,lastName,registrationID,creditLimit,country)
@@ -553,7 +553,7 @@ This is because of the non-representability of 0.1 (0.0001100110011..) and 0.2 (
 <p>And panic propagating out of such participant is considered as transaction participant failure when deciding to commit the transaction.</p>
 <p>With this introduction of transaction participants, nesting transaction blocks are prohibited, both statically and at runtime.</p>
 <h4>Local participants</h4>
-<pre><code class="ballerina">@transactions:Participant {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">@transactions:Participant {
     oncommit:commitFunc,
     onabort:abortFunc
 }
@@ -572,7 +572,7 @@ public function participantLocal() {
 <h4>Remote participants</h4>
 <p>Similar to local transactions we can also annotate resource functions so that they are considered transaction participants. Annotated transaction participants are not allowed to have transaction blocks similar to local participants.</p>
 <p>Panic in remote participants will result in transaction failure.</p>
-<pre><code class="ballerina">@transactions:Participant {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">@transactions:Participant {
     oncommit:commitFunc,
     onabort:abortFunc
 }
@@ -586,7 +586,7 @@ resource function participantRemote(http:Caller ep, http:Request req) {
 <h2>HTTP Listener/Client</h2>
 <p>With endpoints and service syntax changes, HTTP endpoint and service are changed as follows:</p>
 <p>HTTP Listener:</p>
-<pre><code class="ballerina">listener http:Listener httpEp = new(9090, config = {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">listener http:Listener httpEp = new(9090, config = {
     secureSocket: {}
 });
 </code></pre>
@@ -595,7 +595,7 @@ resource function participantRemote(http:Caller ep, http:Request req) {
 <p><strong>Note</strong>: Listener endpoint port is the first argument which is a required parameter and other listener configurations go under the second argument. </p>
 </blockquote>
 <p>Service and resource definition:</p>
-<pre><code class="ballerina">service hello on httpEp {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">service hello on httpEp {
     resource function sayHello(http:Caller caller, http:Request req) {
         _ = caller-&gt;respond(&quot;hello ballerina!&quot;);
     }
@@ -603,14 +603,14 @@ resource function participantRemote(http:Caller ep, http:Request req) {
 </code></pre>
 
 <p>Service can get attached to a listener endpoint that is declared inline as follows.</p>
-<pre><code class="ballerina">service hello on new http:Listener(9090) {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">service hello on new http:Listener(9090) {
     //...
 }
 
 </code></pre>
 
 <p>Client endpoint:</p>
-<pre><code class="ballerina">http:Client clientEndpoint = new(&quot;https://localhost:9092&quot;, config = {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">http:Client clientEndpoint = new(&quot;https://localhost:9092&quot;, config = {
     secureSocket: {}
 });
 
@@ -622,7 +622,7 @@ resource function participantRemote(http:Caller ep, http:Request req) {
 <h2>Load Balancer</h2>
 <p>The Load Balancer exposes an abstract object to allow users to customize the routing decision making(load balancing rule) for special purposes. Only one rule is active at any time and it is specified with the lbRule in the <code>LoadBalanceClientEndpointConfiguration</code> record. By default, round robin rule is used as the load balancing strategy.</p>
 <p>Load balancer client endpoint syntax goes as follows.</p>
-<pre><code class="ballerina">http:LoadBalanceClient customLoadBalanceClient = new ({
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">http:LoadBalanceClient customLoadBalanceClient = new ({
    targets: [
        { url: &quot;http://localhost:8081/mock&quot; },
        { url: &quot;http://localhost:8082/mock&quot; },
@@ -635,12 +635,12 @@ resource function participantRemote(http:Caller ep, http:Request req) {
 
 <h2>TCP client/server</h2>
 <p>TCP server and client are completely redesigned with this release. Now users can use the TCP server similar to the WebSocket listener where there are set of predefined resources to invoke based on actions that take place. TCP client can be used to connect to a remote TCP server for data sending purpose. Additionally, callback service can be attached to the client if there is a data retrieval use case.</p>
-<pre><code class="ballerina">import ballerina/socket;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/socket;
 
 </code></pre>
 
 <p>Listener:</p>
-<pre><code class="ballerina">listener socket:Listener server = new ({ port:&lt;PORT_NUMBER&gt; });
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">listener socket:Listener server = new ({ port:&lt;PORT_NUMBER&gt; });
 service echoServer on server {
     resource function onAccept (socket:Caller caller) { }
     resource function onReadReady (socket:Caller caller, byte[] content) { }
@@ -651,7 +651,7 @@ service echoServer on server {
 </code></pre>
 
 <p>Client:</p>
-<pre><code class="ballerina">socket:Client socketClient = new({host: &quot;localhost&quot;, port: 54387, callbackService: ClientService});
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">socket:Client socketClient = new({host: &quot;localhost&quot;, port: 54387, callbackService: ClientService});
 byte[] payloadByte = “Hello Ballerina”.toByteArray(&quot;UTF-8&quot;);
 _ = socketClient-&gt;write(payloadByte);
 
@@ -667,7 +667,7 @@ service ClientService = service {
 <p><code>socket:Client/socket:Caller</code> has <code>shutdownRead</code> and <code>shutdownWrite</code> functions available in addition to the write.</p>
 <h2>MySQL Client</h2>
 <p>MySQL client syntax is changed as follows.</p>
-<pre><code class="ballerina">mysql:Client testDB = new({
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">mysql:Client testDB = new({
         host: &quot;localhost&quot;,
         port: 3306,
         name: &quot;testdb&quot;,
@@ -682,7 +682,7 @@ service ClientService = service {
 <p>Compile time validation for InMemory, Server and Embedded Mode configurations are introduced along with the
 changes in client syntax changes.</p>
 <p>Creating a client in H2 Embedded Mode</p>
-<pre><code class="ballerina">h2:Client testDB = new({
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">h2:Client testDB = new({
         path: &quot;/home/ballerina/test/&quot;,
         name: &quot;testdb&quot;,
         username: &quot;SA&quot;,
@@ -692,7 +692,7 @@ changes in client syntax changes.</p>
 </code></pre>
 
 <p>Creating a client in H2 Server Mode</p>
-<pre><code class="ballerina">h2:Client testDB = new({
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">h2:Client testDB = new({
         host: &quot;localhost&quot;,
         port: 9092,
         name: &quot;testdb&quot;,
@@ -703,7 +703,7 @@ changes in client syntax changes.</p>
 </code></pre>
 
 <p>Creating a client in H2 In-Memory Mode</p>
-<pre><code class="ballerina">h2:Client testDB = new({
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">h2:Client testDB = new({
         name: &quot;testdb&quot;,
         username: &quot;SA&quot;,
         password: &quot;&quot;,
@@ -715,7 +715,7 @@ changes in client syntax changes.</p>
 <p>gRPC is a protocol that is layered over HTTP/2 and enables client and server communication by combination of any supported languages. In gRPC, a client application can directly call methods on a server application on a different machine, making it easier for you to create distributed applications and services.</p>
 <p>With endpoints and service syntax changes, gRPC endpoint and service are changed as follows:</p>
 <p>Listener (inbound) endpoint:</p>
-<pre><code class="ballerina">listener grpc:Listener grpcEp = new (9095, config = {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">listener grpc:Listener grpcEp = new (9095, config = {
     secureSocket: {}
 });
 
@@ -725,7 +725,7 @@ changes in client syntax changes.</p>
 <p><strong>Note</strong>: Listener endpoint port is the first argument and other listener configurations go under the second argument. </p>
 </blockquote>
 <p>Service and resource definition:</p>
-<pre><code class="ballerina">service Hello on grpcEp {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">service Hello on grpcEp {
     resource function hi (grpc:Caller caller, string req) {
         _ = caller-&gt;send(&quot;Hello, World!&quot;);
     }
@@ -734,7 +734,7 @@ changes in client syntax changes.</p>
 </code></pre>
 
 <p>Client endpoint:</p>
-<pre><code class="ballerina">HelloClient helloEp = new(&quot;https://localhost:9090&quot;, config = {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">HelloClient helloEp = new(&quot;https://localhost:9090&quot;, config = {
     secureSocket: {}
 });
 
@@ -747,7 +747,7 @@ changes in client syntax changes.</p>
 <h2>WebSocket</h2>
 <p>With endpoints and service syntax changes, WebSocket endpoint and service are changed as follows:</p>
 <p>WebSocket Listener:</p>
-<pre><code class="ballerina">listener http:WebSocketListener helloListener = new(9095, config = {secureSocket: {}});
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">listener http:WebSocketListener helloListener = new(9095, config = {secureSocket: {}});
 service onTextString on helloListener {
     resource function onText(http:WebSocketCaller caller, string data, boolean finalFrame) {
         var returnVal = caller-&gt;pushText(data);
@@ -757,7 +757,7 @@ service onTextString on helloListener {
 </code></pre>
 
 <p>WebSocket Client:</p>
-<pre><code class="ballerina">http:WebSocketClient wsClientEp = new(REMOTE_BACKEND_URL, config = { callbackService: clientService });
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">http:WebSocketClient wsClientEp = new(REMOTE_BACKEND_URL, config = { callbackService: clientService });
 service clientService = @http:WebSocketServiceConfig {} service {
     resource function onText(http:WebSocketClient caller, string text) {
             var returnVal = caller-&gt;pushText(data); 
@@ -769,11 +769,11 @@ service clientService = @http:WebSocketServiceConfig {} service {
 <h2>WebSub</h2>
 <p>WebSub endpoint and service are changed as follows with the new endpoints and service syntax change</p>
 <p>Listener:</p>
-<pre><code class="ballerina">listener websub:Listener websubEP = new(8181);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">listener websub:Listener websubEP = new(8181);
 </code></pre>
 
 <p>Service and resource definition:</p>
-<pre><code class="ballerina">service websubSubscriber on websubEP {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">service websubSubscriber on websubEP {
     resource function onNotification(websub:Notification notification) {
         log:printInfo(&quot;WebSub Notification Received&quot;);
     }
@@ -783,14 +783,14 @@ service clientService = @http:WebSocketServiceConfig {} service {
 <p>WebSub Hub start up function signature is improved to accept parameters under two categories. 
 It accepts an <code>http:Listener</code>, on which the hub service will start on, as the first parameter, 
 and a <code>HubListenerConfiguration</code> record as a defaultable parameter to specify hub related configuration.  </p>
-<pre><code class="ballerina">var webSubHub = websub:startHub(new http:Listener(9090), hubConfiguration = {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">var webSubHub = websub:startHub(new http:Listener(9090), hubConfiguration = {
             leaseSeconds: 86400
     });
 
 </code></pre>
 
 <p>Improved the hub client by extending configuration to have the complete functionality of the HTTP Client.</p>
-<pre><code class="ballerina">http:ClientEndpointConfig conf = {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">http:ClientEndpointConfig conf = {
     followRedirects: { enabled: true, maxCount: 5 }
 }; 
 
@@ -804,7 +804,7 @@ websub:Client websubHubClientEP = new(&quot;https://localhost:9191/websub/hub&qu
 <blockquote>
 <p><strong>Note</strong>: JMS Connection and session definitions remain unchanged. </p>
 </blockquote>
-<pre><code class="ballerina">jms:Connection conn = new({
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">jms:Connection conn = new({
             initialContextFactory:&lt;provider specific initial context factory&gt;,
             providerUrl: &lt;provider url&gt;
 });
@@ -816,7 +816,7 @@ jms:Session jmsSession = new(conn, {
 </code></pre>
 
 <p>JMS message producer definition:</p>
-<pre><code class="ballerina">jms:QueueSender queueSender = new({
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">jms:QueueSender queueSender = new({
         session: jmsSession,
         queueName: &quot;MyQueue&quot;
 });
@@ -824,7 +824,7 @@ jms:Session jmsSession = new(conn, {
 </code></pre>
 
 <p>JMS message receiver, service, and resource definition: </p>
-<pre><code class="ballerina">listener jms:QueueReceiver consumerEndpoint = new({
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">listener jms:QueueReceiver consumerEndpoint = new({
          session: jmsSession,
              queueName: &quot;MyQueue&quot;
 });

--- a/downloads/release-notes/0.990.1/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.990.1/RELEASE_NOTE.html
@@ -4,20 +4,20 @@
 <h1>Improvements</h1>
 <h2>Language</h2>
 <p>Return statement is now optional for functions with optional return type signatures.</p>
-<pre><code class="ballerina">function foo(string txt) returns error? {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function foo(string txt) returns error? {
     int x = check int.convert(txt);
 }
 </code></pre>
 
 <p>The above is the same as the following code.</p>
-<pre><code class="ballerina">function foo(string txt) returns error? {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function foo(string txt) returns error? {
     int x = check int.convert(txt);
     return;
 }
 </code></pre>
 
 <p>Function invocation support for string literals.</p>
-<pre><code class="ballerina">string name = “ballerina”.toUpper();
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string name = “ballerina”.toUpper();
 </code></pre>
 
 <p>There are some updates to the underlying stream processing layer of Ballerina. It introduces a few changes in the syntax.</p>

--- a/downloads/release-notes/0.990.3/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.990.3/RELEASE_NOTE.html
@@ -5,7 +5,7 @@
 <ul>
 <li>The record <code>rest-fields</code> descriptor should now be followed by a semi colon.</li>
 </ul>
-<pre><code class="ballerina">type Person record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person record {
     string name;
     string...;
 };
@@ -16,7 +16,7 @@
 <li>Binary integer literals are no longer supported.</li>
 <li>Use of <code>var</code> in the left hand side, with iterable operations ending with <code>map()</code> or <code>filter()</code> operations is disallowed.</li>
 </ul>
-<pre><code class="ballerina">int[] numbers = [-5, -3, 2, 7, 12];
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int[] numbers = [-5, -3, 2, 7, 12];
 
 // The following now results in a compilation error.
 var filtered = numbers.filter(function (int i) returns boolean {

--- a/downloads/release-notes/0.991.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.991.0/RELEASE_NOTE.html
@@ -130,9 +130,7 @@ string? name = null; // Compile error
 <p><code>anydata</code> was updated to include structures of pure values (values whose types are subtypes of <code>anydata|error</code>). <code>anydata</code> is now the union of the following:</p>
 </li>
 </ul>
-<pre class="line-numbers language-ballerina"><code class="language-ballerina">() | boolean | int | float | decimal | string | (anydata|error)[] | map&lt;anydata|error&gt; | xml | table
-
-</code></pre>
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">() | boolean | int | float | decimal | string | (anydata|error)[] | map&lt;anydata|error&gt; | xml | table</code></pre>
 
 <ul>
 <li>

--- a/downloads/release-notes/0.991.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/0.991.0/RELEASE_NOTE.html
@@ -13,7 +13,7 @@
 <li>Closed record syntax was updated to use the {| and |} delimiters to indicate that the record is closed.</li>
 </ul>
 <p><em>Previous syntax</em></p>
-<pre><code class="ballerina">type Person record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person record {
     string name;
     int age;
     !...;
@@ -21,7 +21,7 @@
 </code></pre>
 
 <p><em>New syntax</em></p>
-<pre><code class="ballerina">type Person record {|
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person record {|
     string name;
     int age;
 |};
@@ -31,12 +31,12 @@
 <li>The syntax for destructure binding pattern for closed records was also updated to use the {| and |} delimiters.</li>
 </ul>
 <p><em>Previous syntax</em></p>
-<pre><code class="ballerina">Person p = { name: &quot;John Doe&quot;, age: 25 };
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">Person p = { name: &quot;John Doe&quot;, age: 25 };
 Person { name: pName, age: pAge, !... } = p;
 </code></pre>
 
 <p><em>New syntax</em></p>
-<pre><code class="ballerina">Person p = { name: &quot;John Doe&quot;, age: 25 };
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">Person p = { name: &quot;John Doe&quot;, age: 25 };
 Person {| name: pName, age: pAge |} = p;
 </code></pre>
 
@@ -44,11 +44,11 @@ Person {| name: pName, age: pAge |} = p;
 <li>The syntax for closed arrays with inferred length was changed as follows.</li>
 </ul>
 <p><em>Previous syntax</em></p>
-<pre><code class="ballerina">string[!...] array = [&quot;a&quot;, &quot;b&quot;, &quot;c&quot;];
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string[!...] array = [&quot;a&quot;, &quot;b&quot;, &quot;c&quot;];
 </code></pre>
 
 <p><em>New syntax</em></p>
-<pre><code class="ballerina">string[*] array = [&quot;a&quot;, &quot;b&quot;, &quot;c&quot;];
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string[*] array = [&quot;a&quot;, &quot;b&quot;, &quot;c&quot;];
 </code></pre>
 
 <ul>
@@ -59,7 +59,7 @@ Person {| name: pName, age: pAge |} = p;
 <p>Use of the <code>null</code> literal is now restricted to JSON contexts.</p>
 </li>
 </ul>
-<pre><code class="ballerina">json response = null; // Allowed
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">json response = null; // Allowed
 string? name = null; // Compile error
 </code></pre>
 
@@ -67,22 +67,22 @@ string? name = null; // Compile error
 <li>String template expression interpolation syntax was updated.</li>
 </ul>
 <p><em>Previous syntax</em></p>
-<pre><code class="ballerina">string s = string `Hello {{name}}!`;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string s = string `Hello {{name}}!`;
 </code></pre>
 
 <p><em>New syntax</em></p>
-<pre><code class="ballerina">string s = string `Hello ${name}!`;
+<<pre class="line-numbers language-ballerina"><code class="language-ballerina">string s = string `Hello ${name}!`;
 </code></pre>
 
 <ul>
 <li>XML literal interpolation syntax was updated.</li>
 </ul>
 <p><em>Previous syntax</em></p>
-<pre><code class="ballerina">xml x = xml `&lt;Person name={{name}}&gt;{{content}}&lt;/Person&gt;`;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">xml x = xml `&lt;Person name={{name}}&gt;{{content}}&lt;/Person&gt;`;
 </code></pre>
 
 <p><em>New syntax</em></p>
-<pre><code class="ballerina">xml x = xml `&lt;Person name=${name}&gt;${content}&lt;/Person&gt;`;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">xml x = xml `&lt;Person name=${name}&gt;${content}&lt;/Person&gt;`;
 </code></pre>
 
 <ul>
@@ -94,11 +94,11 @@ string? name = null; // Compile error
 </li>
 </ul>
 <p><em>Previous syntax</em></p>
-<pre><code class="ballerina">map&lt;anydata&gt; attributeMap = map&lt;anydata&gt;.convert(x1@);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">map&lt;anydata&gt; attributeMap = map&lt;anydata&gt;.convert(x1@);
 </code></pre>
 
 <p><em>New syntax</em></p>
-<pre><code class="ballerina">map&lt;string&gt;? attributeMap = x1@;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">map&lt;string&gt;? attributeMap = x1@;
 </code></pre>
 
 <ul>
@@ -115,7 +115,7 @@ string? name = null; // Compile error
 <p>The diamond operator was updated to perform type-casting as follows:</p>
 </li>
 </ul>
-<pre><code class="ballerina">Foo f = &lt;Foo&gt; value;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">Foo f = &lt;Foo&gt; value;
 </code></pre>
 
 <p>If <code>value</code> belongs to <code>Foo</code>, casting will be successful and <code>value</code> will be assigned to <code>f</code>. Else, casting will result in a panic.</p>
@@ -130,7 +130,7 @@ string? name = null; // Compile error
 <p><code>anydata</code> was updated to include structures of pure values (values whose types are subtypes of <code>anydata|error</code>). <code>anydata</code> is now the union of the following:</p>
 </li>
 </ul>
-<pre><code class="ballerina">() | boolean | int | float | decimal | string | (anydata|error)[] | map&lt;anydata|error&gt; | xml | table
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">() | boolean | int | float | decimal | string | (anydata|error)[] | map&lt;anydata|error&gt; | xml | table
 
 </code></pre>
 
@@ -143,22 +143,22 @@ string? name = null; // Compile error
 </li>
 </ul>
 <p><em>Previous syntax</em></p>
-<pre><code class="ballerina">extern function externFunction();
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">extern function externFunction();
 </code></pre>
 
 <p><em>New syntax</em></p>
-<pre><code class="ballerina">function externFunction() = external;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function externFunction() = external;
 </code></pre>
 
 <ul>
 <li>The signature of the <code>__attach()</code> method of <code>AbstractListener</code> has been changed as follows:</li>
 </ul>
 <p><em>Previous signature</em></p>
-<pre><code class="ballerina">public function __attach(service s, map&lt;any&gt; annotationData) returns error?
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public function __attach(service s, map&lt;any&gt; annotationData) returns error?
 </code></pre>
 
 <p><em>New signature</em></p>
-<pre><code class="ballerina">public function __attach(service s, string? name = ()) returns error?;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public function __attach(service s, string? name = ()) returns error?;
 </code></pre>
 
 <ul>
@@ -170,12 +170,12 @@ string? name = null; // Compile error
 <li>Ballerina crypto stdlib was made flexible enough to introduce new features and algorithms in future.</li>
 </ul>
 <p><em>Previous syntax</em></p>
-<pre><code class="ballerina">string input = &quot;Hello Ballerina&quot;;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string input = &quot;Hello Ballerina&quot;;
 crypto:hash(input, crypto:MD5)
 </code></pre>
 
 <p><em>New syntax</em></p>
-<pre><code class="ballerina">string input = &quot;Hello Ballerina&quot;;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string input = &quot;Hello Ballerina&quot;;
 byte[] inputArr = input.toByteArray(&quot;UTF-8&quot;);
 byte[] output = crypto:hashMd5(inputArr);
 </code></pre>
@@ -189,7 +189,7 @@ byte[] output = crypto:hashMd5(inputArr);
 <p>Timer was previously created by providing <code>onTrigger</code> and <code>onError</code> functions along with the <code>interval</code> and <code>delay</code> parameters. Now <code>interval</code> and <code>delay</code> parameters are provided through a <code>task:TimerConfiguration</code> record type, while <code>onTrigger</code>  function should be implemented as a resource function inside the attaching service. 
 Service can be created on top of a <code>task:Listener</code> or can be manually attached to a <code>task:Scheduler</code> object. </p>
 <p><em>Previous Syntax</em></p>
-<pre><code class="ballerina">function startTimer() {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function startTimer() {
     ((function) returns error?) onTriggerFunction = cleanup;
     function (error) onErrorFunction = cleanupError;
     timer = new task:Timer(onTriggerFunction, onErrorFunction, 1000, delay = 500);
@@ -206,7 +206,7 @@ function cleanupError(error e) {
 </code></pre>
 
 <p><em>New Syntax</em></p>
-<pre><code class="ballerina">function startTimer() {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function startTimer() {
     task:TimerConfiguration timerConfiguration = {
         interval: 1000,
         initialDelay: 500
@@ -234,7 +234,7 @@ Service timerService = service {
 </code></pre>
 
 <p>OR</p>
-<pre><code class="ballerina">task:TimerConfiguration timerConfiguration = {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">task:TimerConfiguration timerConfiguration = {
    interval: 1000,
    initialDelay: 3000
 };
@@ -250,7 +250,7 @@ Service timerService on timer {
 <p><code>task:Appointment</code> functionality can be implemented using <code>task:Listener</code> and the <code>task:Scheduler</code> objects. Previously the <code>cronExpression</code> used for the appointment given as a parameter, along with the <code>onTrigger</code> and <code>onError</code> functions. Now the <code>cronExpression</code> should be provided using <code>appointmentDetails</code> field inside the  <code>task:AppointmentConfiguration</code> record type. Alternatively, <code>task:AppointmentData</code> record can also be provided as the <code>appointmentDetails</code> field (see below examples).
 <code>onTrigger</code> function should be implemented inside a service, and the service can be created on top a <code>task:Listener</code> or the service can be attached to a <code>task:Scheduler</code> object, manually.</p>
 <p><em>Previous Syntax</em></p>
-<pre><code class="ballerina">function startAppointment() {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function startAppointment() {
     ((function) returns error?) onTriggerFunction = cleanup;
     function (error) onErrorFunction = cleanupError;
     appointment = new task:Appointment(onTriggerFunction, onErrorFunction, &quot;0/2 * * * * ?&quot;);
@@ -267,7 +267,7 @@ function cleanupError(error e) {
 </code></pre>
 
 <p><em>New Syntax</em></p>
-<pre><code class="ballerina">task:AppointmentData appointmentData = {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">task:AppointmentData appointmentData = {
     seconds: &quot;0/2&quot;,
     minutes: &quot;*&quot;,
     hours: &quot;*&quot;,
@@ -292,7 +292,7 @@ service appointmentService on appointment {
 </code></pre>
 
 <p>OR</p>
-<pre><code class="ballerina">function startAppointment() {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function startAppointment() {
     task:AppointmentConfiguration appointmentConfiguration = {
         appointmentDetails: “0/2 * * * * ?”
     };
@@ -320,11 +320,11 @@ service appointmentService = service {
 <h2>Time Library Changes</h2>
 <p>The <code>format</code>, <code>parse</code>, <code>createTime</code>and <code>toTimeZone</code>  functions are changed to return errors when there is an issue.</p>
 <p><em>Previous Syntax</em></p>
-<pre><code class="ballerina">time:Time timeVal = time:parse(&quot;2016-03-01T09:46:22.444&quot;, yyyy-MM-dd'T'HH:mm:ss.SSS&quot;);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">time:Time timeVal = time:parse(&quot;2016-03-01T09:46:22.444&quot;, yyyy-MM-dd'T'HH:mm:ss.SSS&quot;);
 </code></pre>
 
 <p><em>New Syntax</em></p>
-<pre><code class="ballerina">time:Time|error timeVal = time:parse(&quot;2016-03-01T09:46:22.444&quot;, yyyy-MM-dd'T'HH:mm:ss.SSS&quot;);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">time:Time|error timeVal = time:parse(&quot;2016-03-01T09:46:22.444&quot;, yyyy-MM-dd'T'HH:mm:ss.SSS&quot;);
 </code></pre>
 
 <h1>What&rsquo;s new in Ballerina 0.991.0</h1>
@@ -339,7 +339,7 @@ service appointmentService = service {
 <p>Error values can now be destructured using binding patterns and typed binding patterns as follows,</p>
 </li>
 </ul>
-<pre><code class="ballerina">// Usage of error typed binding pattern.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">// Usage of error typed binding pattern.
 var error (reasonString, detailMap) = getErrorValue();
 
 // Usage of error binding pattern.
@@ -356,7 +356,7 @@ error (reasonString, detailMap) = getErrorValue();
 <p>The return signature of the initializer of an object can now be <code>error?</code> (sub types of <code>error</code> allowed) or <code>()</code>.</p>
 </li>
 </ul>
-<pre><code class="ballerina">type Person object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person object {
     string name;
 
     function __init(string name) returns error? {
@@ -373,7 +373,7 @@ Person|error person = new(&quot;John Doe&quot;);
 <li>Patterns in the static value match statement now support const values.</li>
 <li>String can concatenate into XML values and the string part is automatically converted to an XML character sequence, resulting in XML concatenation. This supports both &lsquo;+&rsquo; and &lsquo;+=&rsquo; operators.</li>
 </ul>
-<pre><code class="ballerina">xml xValue = xml `&lt;name&gt;John&lt;/name&gt;`;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">xml xValue = xml `&lt;name&gt;John&lt;/name&gt;`;
 xml yValue = xValue + &quot;suf&quot;;
 yValue += &quot;fix&quot;;
 io:println(yValue);

--- a/downloads/release-notes/1.0.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/1.0.0/RELEASE_NOTE.html
@@ -41,7 +41,7 @@ Ballerina 1.0.0 consists of improvements to the language syntax and semantics ba
 <p>The error reason is now optional if the reason can be inferred based on the contextually-expected type.</p>
 </li>
 </ul>
-<pre><code class="ballerina">type Detail record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Detail record {
    int code;
 };
 
@@ -56,7 +56,7 @@ FooError e2 = error(code = 3456); // Also valid now, reason is set as &quot;foo&
 <ul>
 <li>A unary operator <code>typeof</code> has been introduced to retrieve a typedesc value for the runtime type of a value.</li>
 </ul>
-<pre><code class="ballerina">typedesc t = typeof valueExpr;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">typedesc t = typeof valueExpr;
 </code></pre>
 
 <ul>
@@ -194,12 +194,12 @@ FooError e2 = error(code = 3456); // Also valid now, reason is set as &quot;foo&
 <p>Previous Syntax</p>
 </li>
 </ul>
-<pre><code class="ballerina">int|error x = int.convert(&quot;100&quot;);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int|error x = int.convert(&quot;100&quot;);
 </code></pre>
 
 <pre><code>  New Syntax
 </code></pre>
-<pre><code class="ballerina">import ballerina/lang.'int; // Need to import `lang.int`
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/lang.'int; // Need to import `lang.int`
 
 int x = 'int:fromString(&quot;100&quot;);
 </code></pre>
@@ -210,12 +210,12 @@ int x = 'int:fromString(&quot;100&quot;);
 <p>Previous Syntax</p>
 </li>
 </ul>
-<pre><code class="ballerina">json person = {&quot;name&quot;:&quot;John&quot;, &quot;age&quot;:25};
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">json person = {&quot;name&quot;:&quot;John&quot;, &quot;age&quot;:25};
 string|error str = string.convert(person);
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">json person = {&quot;name&quot;:&quot;John&quot;, &quot;age&quot;:25};
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">json person = {&quot;name&quot;:&quot;John&quot;, &quot;age&quot;:25};
 string str = person.toString();
 </code></pre>
 
@@ -227,7 +227,7 @@ string str = person.toString();
 <li>The semantics of the <code>{</code>, <code>}</code> and <code>{|</code>, <code>|}</code> delimiters have changed. A record type descriptor written using the <code>{|</code> and <code>|}</code> delimiters defines a closed record type, which only accepts mapping values with the same fields as the ones described. A record type descriptor written using the <code>{</code> and <code>}</code> delimiters define a record type, which additionally allows pure type fields apart from the described fields, i.e., <code>record {}</code> is equivalent to <code>record {| anydata…; |}</code>. </li>
 </ul>
 <p>Previous Syntax</p>
-<pre><code class="ballerina">// Open record with a field `a`. It additionally allows
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">// Open record with a field `a`. It additionally allows
 // `anydata|error` fields.
 type Foo record {
    string a;
@@ -248,7 +248,7 @@ type Baz record {|
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">// Open record with a field `a`. It additionally allows
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">// Open record with a field `a`. It additionally allows
 // `anydata` fields.
 type Foo record {
    string a;
@@ -272,18 +272,18 @@ type Bar record {|
 <li>The syntax to specify expressions as keys in the mapping constructor has changed. Now, expressions need to be enclosed in <code>[]</code> (e.g., <code>[expr]</code>).</li>
 </ul>
 <p>Previous Syntax</p>
-<pre><code class="ballerina">map&lt;string&gt; m = { getString(): &quot;value&quot; };
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">map&lt;string&gt; m = { getString(): &quot;value&quot; };
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">map&lt;string&gt; m = { [getString()]: &quot;value&quot; };
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">map&lt;string&gt; m = { [getString()]: &quot;value&quot; };
 </code></pre>
 
 <ul>
 <li>String literals can now be used as keys in the mapping constructor for a record. The key for a <code>rest</code> field should either be a string literal or an expression in the mapping constructor (i.e., cannot be an identifier). </li>
 </ul>
 <p>Previous Syntax</p>
-<pre><code class="ballerina">type Foo record {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Foo record {
    string bar;
    int...;
 };
@@ -292,7 +292,7 @@ Foo f = { bar: &quot;test string&quot;, qux: 1 }; // `qux` is a rest field
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">type Foo record {|
+<<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Foo record {|
    string bar;
    int...;
 |};
@@ -304,14 +304,14 @@ Foo f = { bar: &quot;test string&quot;, &quot;qux&quot;: 1 }; // `qux` is a rest
 <li>Mapping values are now iterable as sequences of their members (values) instead of sequences of key-value pairs. A lang library function <code>entries()</code> is available to retrieve an array of key-value pairs for a mapping value.</li>
 </ul>
 <p>Previous Syntax</p>
-<pre><code class="ballerina">foreach (string, int) (k, v) in m {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">foreach (string, int) (k, v) in m {
    io:println(&quot;Key:   &quot;, k);
    io:println(&quot;Value: &quot;, v);
 }
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">// Iterating values.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">// Iterating values.
 foreach int v in m {
    io:println(&quot;Value: &quot;, v);
 }
@@ -328,12 +328,12 @@ foreach [string, int] [k, v] in m.entries() {
 <li>The requirement for array element types to have an implicit initial value to allow declaring variable-length arrays has been removed. Instead, when a value is being added to the array at runtime, the index is greater than the length of the list, and the element type does not have a filler value, it would result in a panic.  </li>
 </ul>
 <p>Previous Syntax</p>
-<pre><code class="ballerina">(int|string)[] arr = []; // Fails at compile time.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">(int|string)[] arr = []; // Fails at compile time.
 arr[1] = 1;
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">(int|string)[] arr = [];
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">(int|string)[] arr = [];
 arr[1] = 1; // Fails at runtime.
 </code></pre>
 
@@ -341,17 +341,17 @@ arr[1] = 1; // Fails at runtime.
 <li>Tuple types now use brackets instead of parentheses. </li>
 </ul>
 <p>Previous Syntax</p>
-<pre><code class="ballerina">(int, string) t = (1, &quot;hello world&quot;);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">(int, string) t = (1, &quot;hello world&quot;);
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">[int, string] t = [1, &quot;hello world&quot;];
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">[int, string] t = [1, &quot;hello world&quot;];
 </code></pre>
 
 <ul>
 <li>Tuple types now support rest descriptors. Therefore, the following syntax is valid now.</li>
 </ul>
-<pre><code class="ballerina">[int, string, boolean...] t = [1, &quot;hello world&quot;, true, true];
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">[int, string, boolean...] t = [1, &quot;hello world&quot;, true, true];
 [int...] t3 = [1, 2];
 </code></pre>
 
@@ -359,7 +359,7 @@ arr[1] = 1; // Fails at runtime.
 <ul>
 <li>Outside method definitions are no longer allowed for objects. All object function definitions need to be specified within the object itself. The following syntax is invalid now.</li>
 </ul>
-<pre><code class="ballerina">type Foo object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Foo object {
    int code = 0;
 
    function printCode();
@@ -379,7 +379,7 @@ function Foo.printCode() {
 <ul>
 <li>The error detail type must now belong to the <code>detail</code> type defined in the error lang library.</li>
 </ul>
-<pre><code class="ballerina">public type Detail record {|
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public type Detail record {|
    string message?;
    error cause?;
    (anydata|error)...;
@@ -390,12 +390,12 @@ function Foo.printCode() {
 <li>The error constructor now accepts <code>detail</code> fields as individual named arguments as opposed to accepting a single mapping as the <code>detail</code> argument.     </li>
 </ul>
 <p>Previous Syntax</p>
-<pre><code class="ballerina">Detail detail = { message: &quot;error message&quot;, code: 1100 };
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">Detail detail = { message: &quot;error message&quot;, code: 1100 };
 error e = error(&quot;error reason&quot;, detail);
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">error e = error(&quot;error reason&quot;, message = &quot;error message&quot;, code = 1100);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">error e = error(&quot;error reason&quot;, message = &quot;error message&quot;, code = 1100);
 </code></pre>
 
 <h3>Annotations</h3>
@@ -403,11 +403,11 @@ error e = error(&quot;error reason&quot;, detail);
 <li>Annotation declaration syntax and attachment points have been revised. Annotations can now be declared to be available only at compile time (source only annotations) or at both compile-time and runtime.</li>
 </ul>
 <p>Previous Syntax</p>
-<pre><code class="ballerina">annotation&lt;service&gt; annot Foo;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">annotation&lt;service&gt; annot Foo;
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">annotation Foo annot on service;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">annotation Foo annot on service;
 </code></pre>
 
 <h3>Expressions</h3>
@@ -420,12 +420,12 @@ error e = error(&quot;error reason&quot;, detail);
 <li>Delimited identifier syntax has been changed.</li>
 </ul>
 <p>Previous Syntax</p>
-<pre><code class="ballerina">string ^&quot;1&quot; = &quot;identifier one&quot;;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string ^&quot;1&quot; = &quot;identifier one&quot;;
 string ^&quot;identifier two&quot; = &quot;identifier two&quot;;
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">string '1 = &quot;identifier one&quot;;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string '1 = &quot;identifier one&quot;;
 string 'identifier\ two = &quot;identifier two&quot;;
 </code></pre>
 
@@ -433,28 +433,28 @@ string 'identifier\ two = &quot;identifier two&quot;;
 <li>The <code>untaint</code> unary operator has been replaced by an annotation to mark a value as trusted.</li>
 </ul>
 <p>Previous Syntax</p>
-<pre><code class="ballerina">var untaintedValue = untaint taintedValue;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">var untaintedValue = untaint taintedValue;
 </code></pre>
 
 <p>New Syntax</p>
-<pre><code class="ballerina">var untaintedValue = &lt;@untainted&gt; taintedValue;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">var untaintedValue = &lt;@untainted&gt; taintedValue;
 </code></pre>
 
 <ul>
 <li>Concatenation with the + operator is no longer allowed between <code>string</code> values and values of other basic types. The <code>.toString()</code> method can be used on any variable to retrieve the <code>string</code> representation prior to concatenating. Alternatively, the string template expression can also be used.</li>
 </ul>
 <p>Previously Syntax</p>
-<pre><code class="ballerina">int i = 1;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int i = 1;
 string s = &quot;Value: &quot; + i;
 </code></pre>
 
 <p>Alternative I</p>
-<pre><code class="ballerina">int i = 1;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int i = 1;
 string s = &quot;Value: &quot; + i.toString();
 </code></pre>
 
 <p>Alternative II</p>
-<pre><code class="ballerina">int i = 1;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">int i = 1;
 string s = string `Value: ${i}`;
 </code></pre>
 

--- a/downloads/release-notes/1.0.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/1.0.0/RELEASE_NOTE.html
@@ -62,10 +62,10 @@ FooError e2 = error(code = 3456); // Also valid now, reason is set as &quot;foo&
 <ul>
 <li>A binary operator <code>.@</code> has been introduced to access annotation values at runtime.</li>
 </ul>
-<p><code>ballerina
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">ballerina
    annotation Foo annot on service;
    typedesc t = typeof serviceValue;
-   Foo? fooAnnot = t.@annot;</code></p>
+   Foo? fooAnnot = t.@annot;</code></pre>
 <ul>
 <li>
 <p>Expressions are now allowed as default values for function parameters.</p>
@@ -83,7 +83,7 @@ FooError e2 = error(code = 3456); // Also valid now, reason is set as &quot;foo&
 <ul>
 <li>Ballerina project structure should match the following.</li>
 </ul>
-<pre><code>project-name/
+<pre class="language-plaintext line-numbers basic"><code class="language-plaintext">project-name/
 - Ballerina.toml
 - src/
 -- mymodule/
@@ -104,25 +104,25 @@ FooError e2 = error(code = 3456); // Also valid now, reason is set as &quot;foo&
 <ul>
 <li>To create a new project with a hello world, use the <em>new</em> command. This initializes a new directory.</li>
 </ul>
-<pre><code>$ ballerina new &lt;project-name&gt;
+<pre class="highlight line-numbers  language-bash"><code class="  language-bash">$ ballerina new &lt;project-name&gt;
 </code></pre>
 
 <ul>
 <li>To add a module, use the <em>add</em> command inside the project.</li>
 </ul>
-<pre><code>$ ballerina add &lt;modulename&gt; [-t main|service]
+<pre class="highlight line-numbers  language-bash"><code class="  language-bash">$ ballerina add &lt;modulename&gt; [-t main|service]
 </code></pre>
 
 <ul>
 <li>To create an executable, use the <em>build</em> command.</li>
 </ul>
-<pre><code>$ ballerina build
+<pre class="highlight line-numbers  language-bash"><code class="  language-bash">$ ballerina build
 </code></pre>
 
 <ul>
 <li>To run the executable, use the <em>run</em> command.</li>
 </ul>
-<pre><code>$ ballerina run mymodule.jar
+<pre class="highlight line-numbers  language-bash"><code class="  language-bash">$ ballerina run mymodule.jar
 </code></pre>
 
 <h3>Ballerina Central</h3>

--- a/downloads/release-notes/1.1.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/1.1.0/RELEASE_NOTE.html
@@ -77,14 +77,14 @@ ballerina update</p>
 <p>You can find the list of Language and Compiler related fixes in this release from <a href="https://github.com/ballerina-platform/ballerina-lang/issues?page=2&amp;q=is%3Aissue+milestone%3A%22Ballerina+1.1.0%22+is%3Aclosed+label%3AArea%2FLanguage&amp;utf8=%E2%9C%93">here</a>.</p>
 <h3>String Literal</h3>
 <p>The JBallerina 1.0.0 compiler allowed <code>0xA</code> and <code>0xD</code> code points in string literals even though they are invalid in a string literal. Validation has been added to disallow the same in this release.</p>
-<pre><code class="ballerina">// Following is a compile time error.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">// Following is a compile time error.
 string s = &quot;hello
 world&quot;;
 </code></pre>
 
 <h3>Foreach Statement</h3>
 <p>The compiler now validates the if the correct type is specified for record iteration. The following code should produce a compilation error now. </p>
-<pre><code class="ballerina">function testForeachRecord() {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function testForeachRecord() {
     record {| string s; anydata|error...; |} value = {s : &quot;aString&quot;};
     foreach any item in value { // Now gives a compilation error.
       // Some Code
@@ -102,14 +102,14 @@ world&quot;;
 <h3>Function Type and Value</h3>
 <p>Function type descriptors and anonymous functions now support rest parameters.</p>
 <p>Example:</p>
-<pre><code class="ballerina">var foo = function (string b, int... c) returns int {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">var foo = function (string b, int... c) returns int {
         return 5;
     };
 function (string, int...) returns int bar = foo;
 </code></pre>
 
 <p>Additionally, the 1.0.0 compiler accepted arrays in place of functions pointer rest arguments. It has now been fixed to only accept rest arguments.</p>
-<pre><code class="ballerina">function myFuncton(string b, int... c) { }
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function myFuncton(string b, int... c) { }
 
 public function main() {
     function(string, int...) func1 = myFuncton;
@@ -127,7 +127,7 @@ public function main() {
 
 <h3>Object Type</h3>
 <p><a href="https://ballerina.io/spec/lang/2019R3/#section_5.3.2.5">Object Initialization</a> specifies that if at any point in the <code>__init</code> method there are any potentially uninitialized fields, then using the <code>self</code> variable other than to access or modify the value of a field should produce a compile-time error. This validation has been added to the compiler in the 1.1.0 release. The following code should produce a compilation error now.</p>
-<pre><code class="ballerina">type Person object {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Person object {
     string name;
     int age = 0;
 
@@ -145,7 +145,7 @@ public function main() {
 <p>When the <code>__init</code> method is not present in an object, the 1.0.0 compiler skipped validating the arguments to the <code>new</code> expression. This behavior is corrected with the 1.1.0 release.</p>
 <h3>Iterable Objects</h3>
 <p>This release adds support for <a href="https://ballerina.io/spec/lang/2019R3/#section_5.5.2">Iterable objects</a>. Moreover the result of a range expression has also been updated to be a new object belonging to the abstract object type <code>Iterable&lt;int&gt;</code>.</p>
-<pre><code class="ballerina">import ballerina/io;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/io;
 
 type IterableObject object {
     function __iterator() returns IntIterator {
@@ -171,7 +171,7 @@ public function main() {
 <h3>Worker Actions</h3>
 <p>The 2019R3 specification defines that in a <a href="https://ballerina.io/spec/lang/2019R3/#section_7.8.2.1">single receive action</a> if the sending worker terminated with failure, the evaluation of the single receive completes normally with the result being the termination value of the sending worker, which will be an error. This validation was not enforced for the sync send action, but has been added with this release.</p>
 <p>The following results in a compilation error now.</p>
-<pre><code class="ballerina">function WorkerInteraction () {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function WorkerInteraction () {
     worker w1 returns error? {
         int i = 10;
         if (true) {
@@ -189,7 +189,7 @@ public function main() {
 <h3>Documentation String</h3>
 <p><a href="https://ballerina.io/spec/lang/2019R3/#section_9.3">Ballerina Flavored Markdown</a> syntax provides conventions for referring Ballerina-defined names from within the documentation string in a source file. This support has been added in JBallerina 1.1.0.</p>
 <p>Example:</p>
-<pre><code class="ballerina">    # Adds parameter `x` and parameter `z`
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">    # Adds parameter `x` and parameter `z`
     # + x - one thing to be added
     # + y - another thing to be added
     # + return - the sum of them

--- a/downloads/release-notes/1.1.1/RELEASE_NOTE.html
+++ b/downloads/release-notes/1.1.1/RELEASE_NOTE.html
@@ -29,7 +29,7 @@ and <a href="https://github.com/ballerina-platform/ballerina-lang/issues?utf8=�
 <h2>Language Specification Deviation Fixes</h2>
 <p>Previously, the implementation initialized an object field’s default value in the <code>__init()</code> function of the object, which caused the default values to be set to the field even when the <code>__init()</code> method was called explicitly. </p>
 <p>For example, the below sample prints “foo” as the value of <code>f.s</code> since the default value “foo” was set as the value of <code>f.s</code> whenever the <code>__init()</code> method was called. </p>
-<pre><code class="ballerina">import ballerina/io;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/io;
 
 type Foo object {
 

--- a/downloads/release-notes/1.2.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/1.2.0/RELEASE_NOTE.html
@@ -25,7 +25,7 @@
 <p>This release introduces a revamped XML support along with XPath-like query syntax allowing easy and safe manipulation of XML data. </p>
 <h4>XML navigation expression</h4>
 <p>XML step expressions allow to query the children of an XML element or children of members of an XML sequence.</p>
-<pre><code class="ballerina">xml x = xml `&lt;root&gt;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">xml x = xml `&lt;root&gt;
                  &lt;person&gt;
                      &lt;name&gt;
                          &lt;fname&gt;William&lt;/fname&gt;
@@ -62,7 +62,7 @@ xml allChildren = x/*;
 </code></pre>
 
 <p>XML filter expression allows filtering an XML sequence by an element name.</p>
-<pre><code class="ballerina">xml x = xml `&lt;root&gt;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">xml x = xml `&lt;root&gt;
                 &lt;rectangle length=&quot;5&quot; width=&quot;10&quot;/&gt;
                 &lt;rectangle length=&quot;5&quot; width=&quot;5&quot;/&gt;
                 &lt;circle radius=&quot;2&quot;/&gt;
@@ -73,14 +73,14 @@ xml rectangles = x/*.&lt;rectangle&gt;;
 </code></pre>
 
 <h4>XML attribute access</h4>
-<pre><code class="ballerina">xmlns &quot;www.ballerina.io/ns&quot; as ns;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">xmlns &quot;www.ballerina.io/ns&quot; as ns;
 xml val = xml `&lt;element type=&quot;fixed&quot; ns:count=&quot;2&gt;&lt;/element&gt;`;
 string|error 'type = val.'type;
 string|error count = val.ns:count;
 </code></pre>
 
 <p>XML attribute access is now lax typed. This means that compile-time type checking is relaxed and moved to runtime. Accessing a non-existent attribute or using field access expression on a non-XML element item will result in an error being returned. If optional field access syntax is used, then nil will be returned instead of an error when the field is not available. Attributes with namespace prefix are accessed using the <code>value.prefix:attrName</code> syntax where the XML prefix must be declared in the scope.</p>
-<pre><code class="ballerina">xml val = xml `&lt;element type=&quot;fixed&quot;&gt;&lt;/element&gt;`;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">xml val = xml `&lt;element type=&quot;fixed&quot;&gt;&lt;/element&gt;`;
 string|error nonEx = val.nonExsistent; // result in error
 string|error? nonExOptional = val?.nonExsistent; // result in nil
 </code></pre>
@@ -90,7 +90,7 @@ string|error? nonExOptional = val?.nonExsistent; // result in nil
 <p>A query expression provides a language-integrated query feature using SQL-like syntax. </p>
 <p>In its most basic form, a query expression consists of four kinds of clauses: <code>from</code>, <code>let</code>, <code>where</code>, and <code>select</code>. The first clause must be a <code>from</code> clause and the last clause must be a <code>select</code> clause. The result of the query expression is a list. In this basic form, a query expression is just a list comprehension.</p>
 <p>The <code>from</code> clause works similarly to a foreach statement. It creates an iterator from an iterable value and then binds variables to each value returned by the iterator. The <code>where</code> clause is a <code>boolean</code> expression, which can refer to variables bound by the <code>from</code> clause; when the <code>where</code> expression evaluates to <code>false</code>, the iteration skips following clauses. The <code>let</code> clause binds variables. The <code>select</code> clause is evaluated for each iteration; the result of the query expression is a list whose members are the result of the <code>select</code> clause. </p>
-<pre><code class="ballerina">Person[] outputPersonList =
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">Person[] outputPersonList =
        from var person in personList
        let string depName = &quot;WSO2&quot;, string replaceName = &quot;Alexander&quot;
        where person.deptAccess == &quot;A&quot; &amp;&amp; person.firstName == &quot;Alex&quot;
@@ -104,7 +104,7 @@ string|error? nonExOptional = val?.nonExsistent; // result in nil
 <p>As of now, query expressions are supported by lists and streams.</p>
 <h4>Query action</h4>
 <p>The clauses in the query pipeline of a query action are executed in the same way as the clauses in the query pipeline of a query expression. The query action is executed as follows. For each input frame <code>f</code> emitted by the query pipeline, execute the block-statement with <code>f</code> in the scope.</p>
-<pre><code class="ballerina">    error? result = from var student in studentList
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">    error? result = from var student in studentList
                     where student.score &gt; 1.0
                     do {
                         FullName fullName = {
@@ -126,7 +126,7 @@ string|error? nonExOptional = val?.nonExsistent; // result in nil
 - reduce
 - iterator</p>
 <p>The <code>map()</code> and <code>filter()</code> methods return streams and work lazily. Iterable basic types would have a <code>toStream()</code> method to convert to a stream; these should handle mutation similarly to iterators; as of now, it supports only for arrays.</p>
-<pre><code class="ballerina">stream&lt;Person, error&gt; personStream = getPersonStream();
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">stream&lt;Person, error&gt; personStream = getPersonStream();
 stream&lt;Person, error&gt; filteredPersonStream = personStream.filter(function (Person person) returns boolean {
    return person.age &gt; 100 &amp;&amp; person.name != &quot;James&quot;;
 });
@@ -134,7 +134,7 @@ stream&lt;Person, error&gt; filteredPersonStream = personStream.filter(function 
 
 <h3>Expression-bodied functions</h3>
 <p>This release introduces expression-bodied functions whose body is a single expression. The expression function body takes the form <code>=&gt; E;</code>, where <code>E</code> is any expression. It is equivalent to the block function body, <code>{ return E; }</code>. The following is an example where a <code>Person</code> record is mapped to an <code>Employee</code> record using an expression-bodied function.</p>
-<pre><code class="ballerina">function toEmployee(Person p, string pos) returns Employee =&gt; {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">function toEmployee(Person p, string pos) returns Employee =&gt; {
     name: p.fname + &quot; &quot; + p.lname,
     designation: pos
 };
@@ -142,7 +142,7 @@ stream&lt;Person, error&gt; filteredPersonStream = personStream.filter(function 
 
 <h3>Let expressions</h3>
 <p>This release introduces let expression. It takes the form <code>let T B = E1 in E2</code>, where <code>E1</code> is evaluated resulting in a value <code>v</code>. The typed binding pattern <code>T B</code> is matched to <code>v</code>, causing assignments to the variables occurring in <code>B</code>. Then <code>E2</code> is evaluated with those variables in scope; the resulting value is the result of the let expression.</p>
-<pre><code class="ballerina">const int globalVar = 2;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">const int globalVar = 2;
 public function main() {
     int b = let int x = 4, int y = 3 in x * y * globalVar; // b = 4 * 3 * 2 = 24
 }
@@ -151,7 +151,7 @@ public function main() {
 <h3>Improved mapping constructor syntax</h3>
 <h4>Spread operator</h4>
 <p>A mapping constructor expression can now have a spread field. A spread field can be used with another mapping value <code>V</code> to include all of the fields in <code>V</code> when creating the new mapping value.</p>
-<pre><code class="ballerina">type Foo record {|
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Foo record {|
     string s;
     decimal d;
 |};
@@ -175,7 +175,7 @@ public function main() {
 
 <h4>Variable names as fields of mapping constructors</h4>
 <p>A mapping constructor expression can also contain just a variable name (<code>foo</code>) as a field. This is equivalent to the key-value pair field <code>foo: foo</code>. The name of the variable is considered the key while the variable reference is considered the expression.</p>
-<pre><code class="ballerina">type Employee record {|
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">type Employee record {|
     string name;
     string department;
 |};
@@ -192,7 +192,7 @@ public function main() {
 <h3>Improvements to metadata</h3>
 <h4>Deprecation syntax</h4>
 <p>You can now mark type definitions, functions, object methods, and constants as deprecated using the <code>@deprecated</code> annotation. The compiler will generate warnings if a you use a deprecated construct. If the deprecated construct contains documentation, you need to add some additional bit of documentation called <code>Deprecated</code> documentation. The <code>Deprecated</code> documentation should ideally include details on why the construct was deprecated and suitable alternate options, which should be used instead.</p>
-<pre><code class="ballerina"># Creates and returns a `Baz` object.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina"># Creates and returns a `Baz` object.
 #
 # # Deprecated
 # This function is deprecated due to undesired side effects since it relies on module level
@@ -205,7 +205,7 @@ public function foo() returns Baz {
 
 <h4>Metadata on record and object fields</h4>
 <p>Metadata (documentation and annotations) are now allowed on record and object fields.</p>
-<pre><code class="ballerina">// An annotation allowed on record fields.
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">// An annotation allowed on record fields.
 annotation foo on record field;
 
 // An annotation allowed on object fields.
@@ -264,7 +264,7 @@ public type Obj object {
 </ul>
 </li>
 </ul>
-<pre><code class="ballerina">import ballerina/lang.'int;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/lang.'int;
 import ballerina/lang.'string;  
 
 public function main() {
@@ -275,7 +275,7 @@ public function main() {
 
 <h4>Redesigned <code>lang.xml</code> module</h4>
 <p>The XML lang module has been revamped to work with the <code>Element</code>, <code>Comment</code>, <code>ProcessingInstructions</code> and <code>Text</code> XML built-in types.  Previously, functions such as <code>getChildren()</code> and <code>getElementName()</code>, which are specific to an XML element type were allowed to be called on the <code>xml</code> type and if they were called on non-element items, it used to result in runtime errors. With <code>xml</code> built-in sub type improvements, these functions are statically type checked and only allowed on the built-in sub type <code>Element</code>. The same applies to other built-in sub types and functions.</p>
-<pre><code class="ballerina">import ballerina/lang.'xml as xmllib;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/lang.'xml as xmllib;
 
 public function main() {
      xmllib:Element element = &lt;xmllib:Element&gt; xml `&lt;elem&gt; hello &lt;/elem&gt;`;
@@ -284,7 +284,7 @@ public function main() {
 </code></pre>
 
 <p>The functions <code>isElement()</code>, <code>isProcessingInstruction()</code>, <code>isComment()</code> and <code>isText()</code> have been removed. The same functionality can be achieved using type testing as follows.</p>
-<pre><code class="ballerina">import ballerina/lang.'xml;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/lang.'xml;
 public function main() {
     xml cmnt = xml `&lt;!-- hello from comment --&gt;`;
     boolean isComment = cmnt is 'xml:Comment;
@@ -294,7 +294,7 @@ public function main() {
 <p>The functions <code>appendChildren()</code> and <code>removeChildren()</code> have been removed.</p>
 <h4>The <code>lang.boolean</code> module</h4>
 <p>The newly-added lang library module for the <code>boolean</code> basic type contains a function for parsing <code>string</code> values to <code>boolean</code> values. It accepts <code>”true”</code> or <code>”false”</code> in any combination of lower/upper case as well as <code>”1”</code> and <code>”0”</code>, which evaluates to <code>true</code> and <code>false</code> respectively. An error is returned for any other <code>string</code> value.</p>
-<pre><code class="ballerina">import ballerina/lang.'boolean;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/lang.'boolean;
 
 public function main() {
     boolean|error b = 'boolean:fromString(&quot;true&quot;);
@@ -342,7 +342,7 @@ public function main() {
 - Add persistent cookies support and add support to plug custom persistent storages.  </p>
 <h4>Trailer support</h4>
 <p>Add support to create, read, update, and delete trailing headers in the response message. All existing header functions are changed to accept a finite-typed variable. The default value is set as <code>leading</code>, which means by default, those functions apply to leading headers. In order to apply trailer headers, you need to set the position as trailing as shown below.</p>
-<pre><code class="ballerina">string trailerHeader = response.getHeader(&quot;foo&quot;, position = &quot;trailing&quot;);
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">string trailerHeader = response.getHeader(&quot;foo&quot;, position = &quot;trailing&quot;);
 </code></pre>
 
 <h4>Other changes</h4>
@@ -366,7 +366,7 @@ public function main() {
 }
 </code></pre>
 
-<pre><code class="ballerina">public type Person record {|
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public type Person record {|
    string passportId?;
    string nic?;
 |};
@@ -395,7 +395,7 @@ function setPerson_Nic(Person a, string nic) {
 }
 </code></pre>
 
-<pre><code class="ballerina">public type HelloRequest record {|
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">public type HelloRequest record {|
     record {| int key; string value; |}[] tags = [];
 |};
 </code></pre>
@@ -403,7 +403,7 @@ function setPerson_Nic(Person a, string nic) {
 <h4>Added client retry support for unary blocking calls</h4>
 <p>Client retry is only supported in unary blocking calls. This will be supported in other messaging patterns in the future. 
 Retry functionality can be enabled using the following retry configuration.</p>
-<pre><code class="ballerina">grpc:ClientConfiguration clientConfiguration = {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">grpc:ClientConfiguration clientConfiguration = {
    retryConfiguration: {
        retryCount: 5,
        intervalInMillis: 2000,
@@ -444,20 +444,20 @@ Retry functionality can be enabled using the following retry configuration.</p>
 <p>The Ballerina Task module is enhanced with multiple attachment support.</p>
 <h4>Breaking changes</h4>
 <p>Named arguments for task attachments will not work now. For example, the following code will no longer compile.</p>
-<pre><code class="ballerina">    task:Scheduler timer = new({ intervalInMillis: 1000 });
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">    task:Scheduler timer = new({ intervalInMillis: 1000 });
     Person person = { name: &quot;Sam&quot;, age: 29 };
     var attachResult = timer.attach(TimerService, attachment = p); 
 </code></pre>
 
 <p>To make it work, change it as follows.</p>
-<pre><code class="ballerina">    task:Scheduler timer = new({ intervalInMillis: 1000 });
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">    task:Scheduler timer = new({ intervalInMillis: 1000 });
     Person person = { name: &quot;Sam&quot;, age: 29 };
     var attachResult = timer.attach(TimerService, person);
 </code></pre>
 
 <h4>Multiple attachment support</h4>
 <p>Now, you can pass any number of attachments to the <code>attach()</code> function. For example,</p>
-<pre><code class="ballerina">    task:Scheduler timer = new({ intervalInMillis: 1000 });
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">    task:Scheduler timer = new({ intervalInMillis: 1000 });
     Person person = { name: &quot;Sam&quot;, age: 29 };
     Account account = { number: 188008, balance: 1233.02 };
     var attachResult = timer.attach(TimerService, person, account);
@@ -575,7 +575,7 @@ Retry functionality can be enabled using the following retry configuration.</p>
 <h2>Deployment</h2>
 <h3>Docker Annotations</h3>
 <p>Support for setting environment variables to the Docker image.</p>
-<pre><code class="ballerina">@docker:Config {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">@docker:Config {
     env:{
         testVar1: &quot;value1&quot;,
         testVar2: &quot;value2&quot;
@@ -584,14 +584,14 @@ Retry functionality can be enabled using the following retry configuration.</p>
 </code></pre>
 
 <p>The default base image for the generated Docker images have changed to <code>ballerina/jre8:v1</code>. Also, now, Docker images can be generated for <code>main()</code> functions.</p>
-<pre><code class="ballerina">@docker:Config {}
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">@docker:Config {}
 public function main() {
     io:println(&quot;Hello, World!&quot;);
 }
 </code></pre>
 
 <p>Ability to generate Docker images by only adding the import as <code>import ballerina/docker as _</code>. This will generate the Docker images with minimum configurations for services, listeners, and main functions.</p>
-<pre><code class="ballerina">import ballerina/http;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/http;
 import ballerina/docker as _;
 
 listener http:Listener helloWorldEP = new(9090);
@@ -610,7 +610,7 @@ service helloWorld on helloWorldEP {
 <ul>
 <li>Support for setting a port for Kubernetes NodePort Service types is provided.</li>
 </ul>
-<pre><code class="ballerina">@kubernetes:Service {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">@kubernetes:Service {
     nodePort: 31100,
     serviceType: &quot;NodePort&quot;
 }
@@ -619,7 +619,7 @@ service helloWorld on helloWorldEP {
 <ul>
 <li>Support for mounting the <code>ballerina.conf</code> file as a Kubernetes Secret is provided.</li>
 </ul>
-<pre><code class="ballerina">@kubernetes:Secret {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">@kubernetes:Secret {
     conf: &quot;./conf/ballerina.conf&quot;
 }
 </code></pre>
@@ -627,7 +627,7 @@ service helloWorld on helloWorldEP {
 <ul>
 <li>Support for enabling Rolling Updates for Kubernetes Deployments is provided.</li>
 </ul>
-<pre><code class="ballerina">@kubernetes:Deployment {
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">@kubernetes:Deployment {
     updateStrategy: {
             strategyType: kubernetes:STRATEGY_ROLLING_UPDATE,
             maxUnavailable: 3,
@@ -639,7 +639,7 @@ service helloWorld on helloWorldEP {
 <ul>
 <li>Ability to generate Kubernetes artifacts by only adding the import as <code>import ballerina/docker as _</code> is provided. This will generate the Kubernetes artifacts with minimum configurations for services, listeners, and main functions.</li>
 </ul>
-<pre><code class="ballerina">import ballerina/http;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/http;
 import ballerina/kubernetes as _;
 
 listener http:Listener helloWorldEP = new(9090);
@@ -656,7 +656,7 @@ service helloWorld on helloWorldEP {
 
 <h3>Knative Annotations</h3>
 <p>A new <code>@knative:Service</code> annotation is introduced. It allows you to generate Knative Service artifacts for Knative.</p>
-<pre><code class="ballerina">import ballerina/http;
+<pre class="line-numbers language-ballerina"><code class="language-ballerina">import ballerina/http;
 import ballerina/knative;
 
 @knative:Service {}

--- a/downloads/release-notes/1.2.0/RELEASE_NOTE.html
+++ b/downloads/release-notes/1.2.0/RELEASE_NOTE.html
@@ -358,7 +358,7 @@ public function main() {
 <h4>Redesigned <code>Oneof</code> field support</h4>
 <p>The <code>Oneof</code> fields in the protobuf definition are now mapped to optional fields in Ballerina. When you generate the code, the Ballerina record is generated with a new setter function for each field to restrict you from setting more than one of those fields and a valid function. </p>
 <p>For example,</p>
-<pre><code class="proto">message Person {
+<pre class="language-plaintext line-numbers basic"><code class="language-plaintext">message Person {
   oneof identity {
      string passportId = 1;
      string nic = 2;
@@ -390,7 +390,7 @@ function setPerson_Nic(Person a, string nic) {
 <h4>Redesigned Map field support</h4>
 <p>The map fields in the protobuf definition are now mapped to nested records in Ballerina.</p>
 <p>For example,</p>
-<pre><code class="proto">message HelloRequest {
+<pre class="language-plaintext line-numbers basic"><code class="language-plaintext">message HelloRequest {
     map&lt;int32, string&gt; tags = 4;
 }
 </code></pre>
@@ -678,7 +678,7 @@ service helloWorld on new http:Listener(8080) {
 </blockquote>
 <p>This CLI tool could be used to generate Ballerina bridge code for Java APIs. Here, Ballerina objects and the relevant Java interoperability mappings for specified Java classes will be auto-generated with the aim of providing a seamless coding experience to call existing Java code from Ballerina. These Ballerina bindings could be generated for Java classes residing inside Java libraries (for which the classpaths needs to be provided) or for standard Java classes. </p>
 <p><strong>Command:</strong></p>
-<pre><code class="sh">ballerina bindgen [(-cp|--classpath) &lt;classpath&gt;...]
+<pre class="highlight line-numbers  language-bash"><code class="  language-bash">ballerina bindgen [(-cp|--classpath) &lt;classpath&gt;...]
                   [(-o|--output) &lt;output&gt;]
                   (&lt;class-name&gt;...)
 </code></pre>

--- a/downloads/swan-lake-release-notes/swan-lake-preview4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview4/RELEASE_NOTE.md
@@ -430,34 +430,34 @@ $  ballerina openapi -i <contract>  -o <output path>
 - The above command generates both the service and client stubs.
 - The command will give an output of three files containing the service, client and schema.
 
-    **Command output example:**
+**Command output example:**
 
-    ``` bash
-    $ ballerina openapi -i petstore.yaml  
-    The service generation process is complete. The following files were created.
-    -- petstore-service.bal
-    -- petstore-client.bal
-    -- schema.bal
-    ```
+``` bash
+$ ballerina openapi -i petstore.yaml  
+The service generation process is complete. The following files were created.
+-- petstore-service.bal
+-- petstore-client.bal
+-- schema.bal
+```
 
 - If you are interested in creating only a service, you can use the `mode` option to give the required mode. The `mode` can be a service or a client.
 
-    ```bash
-    $  ballerina openapi -i <contract> --mode (service | client ) -o <output Path>
-	```
+```bash
+$  ballerina openapi -i <contract> --mode (service | client ) -o <output Path>
+```
 
 - You can specify the output path with the `-o` option.
 
-    ```bash
-    $  ballerina openapi -i <contract> --service-name <service name> -o <output Path>
-	```
+```bash
+$  ballerina openapi -i <contract> --service-name <service name> -o <output Path>
+```
 
 - If you are interested in creating a service with resources having a specific tag or an `operationId`, you can do the following.
 
-    ```bash
-    $  ballerina openapi -i <contract> --tags <tags> -o <output Path>
-	$  ballerina openapi -i <contract> --operations <operationIds> -o <output Path>
-	```
+```bash
+$  ballerina openapi -i <contract> --tags <tags> -o <output Path>
+$  ballerina openapi -i <contract> --operations <operationIds> -o <output Path>
+```
 
 ###### Ballerina to OpenAPI
 


### PR DESCRIPTION
## Purpose
Add the syntax highlighter class to old versions of the release notes.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
