### PR TITLE
Fix More Object API Docs Links in BBEs

### DIFF
--- a/swan-lake/learn/by-example/http-filters.html
+++ b/swan-lake/learn/by-example/http-filters.html
@@ -224,7 +224,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/RequestFilter.html">Request filter</a> implementation.
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html">Request</a> implementation.
  It intercepts the request and adds a new header to the request before it is dispatched to the HTTP resource.</p>
 
                                         </div>
@@ -246,7 +246,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/RequestFilter.html#filterRequest">Intercepts the request</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#filterRequest">Intercepts the request</a>.</p>
 
                                         </div>
                                     </div>
@@ -325,7 +325,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/ResponseFilter.html">response filter</a> implementation.
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html">response</a> implementation.
  It intercepts the response in the response path and adds a new header to the response.</p>
 
                                         </div>
@@ -346,7 +346,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/ResponseFilter.html#filterResponse">Intercepts the response</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#filterResponse">Intercepts the response</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/http-to-websocket-upgrade.html
+++ b/swan-lake/learn/by-example/http-to-websocket-upgrade.html
@@ -244,7 +244,7 @@ service httpService on new http:Listener(9090) {
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>This is an HTTP to WebSocket upgrade resource. This is defined using the WebSocket upgrade resource config.
- Here you have access to the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/objects/Request.html">http:Request</a>, query, and path params where applicable.</p>
+ Here you have access to the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html">http:Request</a>, query, and path params where applicable.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/request-with-multiparts.html
+++ b/swan-lake/learn/by-example/request-with-multiparts.html
@@ -319,7 +319,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/objects/Request.html#getBodyParts">Extracts bodyparts</a> from the request.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getBodyParts">Extracts bodyparts</a> from the request.</p>
 
                                         </div>
                                     </div>
@@ -457,7 +457,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/objects/Request.html#setBodyParts">Set the body parts</a> to the request.
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#setBodyParts">Set the body parts</a> to the request.
  Here the content-type is set as multipart form data.
  This also works with any other multipart media type.
  eg:- <code>multipart/mixed</code>, <code>multipart/related</code> etc.
@@ -527,7 +527,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/objects/Entity.html#getXml">Extracts <code>xml</code> data</a> from the body part.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getXml">Extracts <code>xml</code> data</a> from the body part.</p>
 
                                         </div>
                                     </div>
@@ -552,7 +552,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/objects/Entity.html#getJson">Extracts <code>json</code> data</a> from the body part.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getJson">Extracts <code>json</code> data</a> from the body part.</p>
 
                                         </div>
                                     </div>
@@ -579,7 +579,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/objects/Entity.html#getText">Extracts text data</a> from the body part.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getText">Extracts text data</a> from the body part.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/websocket-cookie.html
+++ b/swan-lake/learn/by-example/websocket-cookie.html
@@ -373,7 +373,7 @@ service cookieServer on new http:Listener(9095) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/objects/Cookie.html">Create a new cookie</a> by setting the <code>name</code> as the <code>username</code>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Cookie.html">Create a new cookie</a> by setting the <code>name</code> as the <code>username</code>
  and <code>value</code> as the logged-in user&rsquo;s name.</p>
 
                                         </div>
@@ -414,7 +414,7 @@ service cookieServer on new http:Listener(9095) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/objects/Response.html#addCookie">Add the created cookie to the response</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#addCookie">Add the created cookie to the response</a>.</p>
 
                                         </div>
                                     </div>
@@ -486,7 +486,7 @@ service cookieServer on new http:Listener(9095) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/objects/Request.html#getCookies">Retrieve cookies from the request</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getCookies">Retrieve cookies from the request</a>.</p>
 
                                         </div>
                                     </div>
@@ -979,7 +979,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/learn/api-docs/ballerina/http/objects/Response.html#getCookies">Gets cookies from the <code>http:Response</code></a></p>
+                                            <p><a href="https://ballerina.io/learn/api-docs/ballerina/http/classes/Response.html#getCookies">Gets cookies from the <code>http:Response</code></a></p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/websub-hub-client-sample.html
+++ b/swan-lake/learn/by-example/websub-hub-client-sample.html
@@ -279,7 +279,7 @@ import ballerina/websub;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Registers a topic at the hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/objects/Hub.html#registerTopic">registerTopic</a>.</p>
+                                            <p>Registers a topic at the hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/classes/Hub.html#registerTopic">registerTopic</a>.</p>
 
                                         </div>
                                     </div>


### PR DESCRIPTION
## Purpose
Fix more object API Docs links in BBEs.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
