### PR TITLE
Fix More API Docs Links in BBEs

### DIFF
--- a/swan-lake/learn/by-example/http-filters.html
+++ b/swan-lake/learn/by-example/http-filters.html
@@ -405,7 +405,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Creates a new <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/ResponseFilter.html">ResponseFilter</a>.</p>
+                                            <p>Creates a new <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html">Response</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/websocket-cookie.html
+++ b/swan-lake/learn/by-example/websocket-cookie.html
@@ -979,7 +979,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/learn/api-docs/ballerina/http/classes/Response.html#getCookies">Gets cookies from the <code>http:Response</code></a></p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getCookies">Gets cookies from the <code>http:Response</code></a></p>
 
                                         </div>
                                     </div>


### PR DESCRIPTION
## Purpose
Fix more API Docs links in BBEs.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
