### PR TITLE
Add Quotes in the "Why Ballerina" Page Samples

### DIFF
--- a/why-ballerina/network-aware-type-system.md
+++ b/why-ballerina/network-aware-type-system.md
@@ -241,7 +241,7 @@ service RecordService on new http:Listener(8080) {
                                        A request is sent without setting the <code>married</code> field. Since this field has a default value in the <code>Person</code> type, the value is automatically populated to that. The <code>ethnicity</code> field is not set since it is marked as optional.
                                     </td>
                                     <td>
-                                       <span class="cTableCode">curl -d '{ "name": "John Little",  "birthYear": 1855 }' http://localhost:8080/record</span>
+                                       <span class="cTableCode">curl -d '{ "name": "John Little",  "birthYear": "1855" }' http://localhost:8080/record</span>
                                     </td>
                                     <td>
                                         <span class="cTableCode">Non-Asian Record: name=John Little birthYear=1855 married=false</span>
@@ -250,7 +250,7 @@ service RecordService on new http:Listener(8080) {
                                  <tr>
                                     <td>A request is sent with a string value given for the integer field <code>birthYear</code>. The service validates the value for the field and the request fails.</td>
                                    <td>
-                                       <span class="cTableCode">curl -d '{ "name": "John Little",  "birthYear": 1855 }' http://localhost:8080/record</span>
+                                       <span class="cTableCode">curl -d '{ "name": "John Little",  "birthYear": "1855" }' http://localhost:8080/record</span>
                                     </td>
                                     <td>
                                         <span class="cTableCode">data binding failed: error {ballerina/lang.typedesc}ConversionError message='map '<' json > ' value cannot be converted to 'Person'</span>
@@ -259,7 +259,7 @@ service RecordService on new http:Listener(8080) {
                               <tr>
                                     <td>A request is sent with the optional <code>ethnicity</code> field also set. </td>
                                     <td>
-                                       <span class="cTableCode">curl -d '{ "name": "Sunil Perera",  "birthYear": 1950, "married": true, "ethnicity": "Asian" }' http://localhost:8080/record</span>
+                                       <span class="cTableCode">curl -d '{ "name": "Sunil Perera",  "birthYear": "1950", "married": true, "ethnicity": "Asian" }' http://localhost:8080/record</span>
                                     </td>
                                     <td>
                                        <span class="cTableCode">Asian Record: name=Sunil Perera birthYear=1950 married=true ethnicity=Asian
@@ -269,7 +269,7 @@ service RecordService on new http:Listener(8080) {
                                    <tr>
                                     <td>A request is sent with a non-existing value of the <code>Ethnicity</code> union type. This is validated by the service and the request fails.</td>
                                     <td>
-                                       <span class="cTableCode">curl -d '{ "name": "Tim Kern",  "birthYear": 1995, "ethnicity": "Japanese", "country": "Japan", "zipcode": "98101" }' http://localhost:8080/record</span>
+                                       <span class="cTableCode">curl -d '{ "name": "Tim Kern",  "birthYear": "1995", "ethnicity": "Japanese", "country": "Japan", "zipcode": "98101" }' http://localhost:8080/record</span>
                                     </td>
                                     <td>
                                        <span class="cTableCode">data binding failed: error {ballerina/lang.typedesc}ConversionError message='map< json >' value cannot be converted to 'Person'</span>
@@ -278,7 +278,7 @@ service RecordService on new http:Listener(8080) {
                                   <tr>
                                     <td>A request is sent with additional fields not explicitly mentioned in the <code>Person</code> type. Since <code>Person</code> is an open record type, the service accepts and makes these extra fields available to be passed through to other systems, e.g. a forwarding service.</td>
                                     <td>
-                                       <span class="cTableCode">curl -d '{ "name": "Tim Kern",  "birthYear": 1995, "ethnicity": "Asian", "country": "Japan", "zipcode": "98101" }' http://localhost:8080/record</span>
+                                       <span class="cTableCode">curl -d '{ "name": "Tim Kern",  "birthYear": "1995", "ethnicity": "Asian", "country": "Japan", "zipcode": "98101" }' http://localhost:8080/record</span>
                                     </td>
                                     <td>
                                        <span class="cTableCode">Asian Record: name=Tim Kern birthYear=1995 married=false ethnicity=Asian country=Japan zipcode=98101</span>

--- a/why-ballerina/network-aware-type-system.md
+++ b/why-ballerina/network-aware-type-system.md
@@ -241,7 +241,7 @@ service RecordService on new http:Listener(8080) {
                                        A request is sent without setting the <code>married</code> field. Since this field has a default value in the <code>Person</code> type, the value is automatically populated to that. The <code>ethnicity</code> field is not set since it is marked as optional.
                                     </td>
                                     <td>
-                                       <span class="cTableCode">curl -d '{ "name": "John Little",  "birthYear": "1855" }' http://localhost:8080/record</span>
+                                       <span class="cTableCode">curl -d '{ "name": "John Little",  "birthYear": 1855 }' http://localhost:8080/record</span>
                                     </td>
                                     <td>
                                         <span class="cTableCode">Non-Asian Record: name=John Little birthYear=1855 married=false</span>
@@ -259,7 +259,7 @@ service RecordService on new http:Listener(8080) {
                               <tr>
                                     <td>A request is sent with the optional <code>ethnicity</code> field also set. </td>
                                     <td>
-                                       <span class="cTableCode">curl -d '{ "name": "Sunil Perera",  "birthYear": "1950", "married": true, "ethnicity": "Asian" }' http://localhost:8080/record</span>
+                                       <span class="cTableCode">curl -d '{ "name": "Sunil Perera",  "birthYear": 1950, "married": true, "ethnicity": "Asian" }' http://localhost:8080/record</span>
                                     </td>
                                     <td>
                                        <span class="cTableCode">Asian Record: name=Sunil Perera birthYear=1950 married=true ethnicity=Asian
@@ -269,7 +269,7 @@ service RecordService on new http:Listener(8080) {
                                    <tr>
                                     <td>A request is sent with a non-existing value of the <code>Ethnicity</code> union type. This is validated by the service and the request fails.</td>
                                     <td>
-                                       <span class="cTableCode">curl -d '{ "name": "Tim Kern",  "birthYear": "1995", "ethnicity": "Japanese", "country": "Japan", "zipcode": "98101" }' http://localhost:8080/record</span>
+                                       <span class="cTableCode">curl -d '{ "name": "Tim Kern",  "birthYear": 1995, "ethnicity": "Japanese", "country": "Japan", "zipcode": "98101" }' http://localhost:8080/record</span>
                                     </td>
                                     <td>
                                        <span class="cTableCode">data binding failed: error {ballerina/lang.typedesc}ConversionError message='map< json >' value cannot be converted to 'Person'</span>
@@ -278,7 +278,7 @@ service RecordService on new http:Listener(8080) {
                                   <tr>
                                     <td>A request is sent with additional fields not explicitly mentioned in the <code>Person</code> type. Since <code>Person</code> is an open record type, the service accepts and makes these extra fields available to be passed through to other systems, e.g. a forwarding service.</td>
                                     <td>
-                                       <span class="cTableCode">curl -d '{ "name": "Tim Kern",  "birthYear": "1995", "ethnicity": "Asian", "country": "Japan", "zipcode": "98101" }' http://localhost:8080/record</span>
+                                       <span class="cTableCode">curl -d '{ "name": "Tim Kern",  "birthYear": 1995, "ethnicity": "Asian", "country": "Japan", "zipcode": "98101" }' http://localhost:8080/record</span>
                                     </td>
                                     <td>
                                        <span class="cTableCode">Asian Record: name=Tim Kern birthYear=1995 married=false ethnicity=Asian country=Japan zipcode=98101</span>


### PR DESCRIPTION
## Purpose
Add quotes in the "Network-Aware Type System"[1] "Why Ballerina" Page Samples.

This is for the fix done in [2].

[1] https://ballerina.io/why-ballerina/network-aware-type-system/
[2] https://github.com/ballerina-platform/ballerina-platform.github.io/pull/189

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
