### PR TITLE
Fix the JDBC Driver Path in 1.1.x & 1.0.x Docs

### DIFF
--- a/1.0/learn/api-docs/ballerina/java.jdbc/index.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/index.html
@@ -692,7 +692,7 @@ target = &quot;java8&quot;
     groupId = &quot;mysql&quot;
     modules = [&quot;samplemodule&quot;]
 </code></pre>
-<p>Or, if you're trying to run a single bal file, you can copy the JDBC driver into <code>${BALLERINA_HOME}/bre/lib</code> and
+<p>Or, if you're trying to run a single bal file, you can copy the JDBC driver into <code>&lt;BALLERINA_HOME&gt;/bre/lib/distributions/jballerina-&lt;VERSION&gt;/bre/lib</code> and
 run the bal file with <code>ballerina run</code> command.</p>
 <h2>Client</h2>
 <p>To access a database, you must first create a <code>Client</code> object. The code for creating a JDBC client can be found below.</p>

--- a/1.0/learn/by-example/jdbc-client-batch-update.html
+++ b/1.0/learn/by-example/jdbc-client-batch-update.html
@@ -103,7 +103,7 @@ redirect_from:
                             <h2>JDBC Client Batch Update</h2>
                             <p><p>This example demonstrates how to execute batch update using JDBC Client.
  This sample uses MySQL DB. Before running the sample, copy the
- MySQL JDBC driver to the <code>BALLERINA_HOME/bre/lib</code> folder and change the DB
+ MySQL JDBC driver to the <code>&lt;BALLERINA_HOME&gt;/bre/lib/distributions/jballerina-&lt;VERSION&gt;/bre/lib</code> folder and change the DB
  connection properties as required.</p>
 </p>
 

--- a/1.0/learn/by-example/jdbc-client-call-procedures.html
+++ b/1.0/learn/by-example/jdbc-client-call-procedures.html
@@ -105,7 +105,7 @@ redirect_from:
                             <h2>JDBC Client Call Procedures</h2>
                             <p><p>This example demonstrates how to execute stored procedures using JDBC Client.
  This sample uses MySQL DB. Before running the sample, copy the
- MySQL JDBC driver to the <code>BALLERINA_HOME/bre/lib</code> folder and change the DB
+ MySQL JDBC driver to the <code>&lt;BALLERINA_HOME&gt;/bre/lib/distributions/jballerina-&lt;VERSION&gt;/bre/lib</code> folder and change the DB
  connection properties as required.</p>
 </p>
 

--- a/1.0/learn/by-example/jdbc-client-crud-operations.html
+++ b/1.0/learn/by-example/jdbc-client-crud-operations.html
@@ -100,7 +100,7 @@ redirect_from:
                             <p><p>This example demonstrates how to execute data definition statements, insert/update/delete data
  and select data using JDBC Client.
  This sample uses MySQL DB. Before running the sample, copy the
- MySQL JDBC driver to the <code>BALLERINA_HOME/bre/lib</code> folder and change the DB connection
+ MySQL JDBC driver to the <code>&lt;BALLERINA_HOME&gt;/bre/lib/distributions/jballerina-&lt;VERSION&gt;/bre/lib</code> folder and change the DB connection
  properties as required.</p>
 </p>
 

--- a/1.1/learn/api-docs/ballerina/java.jdbc/index.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/index.html
@@ -712,7 +712,7 @@ target = &quot;java8&quot;
     groupId = &quot;mysql&quot;
     modules = [&quot;samplemodule&quot;]
 </code></pre>
-<p>Or, if you're trying to run a single bal file, you can copy the JDBC driver into <code>${BALLERINA_HOME}/bre/lib</code> and
+<p>Or, if you're trying to run a single bal file, you can copy the JDBC driver into <code>&lt;BALLERINA_HOME&gt;/bre/lib/distributions/jballerina-&lt;VERSION&gt;/bre/lib</code> and
 run the bal file with <code>ballerina run</code> command.</p>
 <h2>Client</h2>
 <p>To access a database, you must first create a <code>Client</code> object. The code for creating a JDBC client can be found below.</p>

--- a/1.1/learn/by-example/jdbc-client-batch-update.html
+++ b/1.1/learn/by-example/jdbc-client-batch-update.html
@@ -311,7 +311,7 @@
                             <h2>JDBC Client Batch Update</h2>
                             <p><p>This example demonstrates how to execute batch update using JDBC Client.
  This sample uses MySQL DB. Before running the sample, copy the
- MySQL JDBC driver to the <code>BALLERINA_HOME/bre/lib</code> folder and change the DB
+ MySQL JDBC driver to the <code>&lt;BALLERINA_HOME&gt;/bre/lib/distributions/jballerina-&lt;VERSION&gt;/bre/lib</code> folder and change the DB
  connection properties as required.</p>
 </p>
 

--- a/1.1/learn/by-example/jdbc-client-call-procedures.html
+++ b/1.1/learn/by-example/jdbc-client-call-procedures.html
@@ -321,7 +321,7 @@
                             <h2>JDBC Client Call Procedures</h2>
                             <p><p>This example demonstrates how to execute stored procedures using JDBC Client.
  This sample uses MySQL DB. Before running the sample, copy the
- MySQL JDBC driver to the <code>BALLERINA_HOME/bre/lib</code> folder and change the DB
+ MySQL JDBC driver to the <code>&lt;BALLERINA_HOME&gt;/bre/lib/distributions/jballerina-&lt;VERSION&gt;/bre/lib</code> folder and change the DB
  connection properties as required.</p>
 </p>
 

--- a/1.1/learn/by-example/jdbc-client-crud-operations.html
+++ b/1.1/learn/by-example/jdbc-client-crud-operations.html
@@ -312,7 +312,7 @@
                             <p><p>This example demonstrates how to execute data definition statements, insert/update/delete data
  and select data using JDBC Client.
  This sample uses MySQL DB. Before running the sample, copy the
- MySQL JDBC driver to the <code>BALLERINA_HOME/bre/lib</code> folder and change the DB connection
+ MySQL JDBC driver to the <code>&lt;BALLERINA_HOME&gt;/bre/lib/distributions/jballerina-&lt;VERSION&gt;/bre/lib</code> folder and change the DB connection
  properties as required.</p>
 </p>
 


### PR DESCRIPTION
## Purpose
Fix the JDBC Driver Path in 1.1.x & 1.0.x docs.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
