### PR TITLE
Add info on How to Copy JDBC Driver Files to Docker Images

### DIFF
--- a/learn/deployment/docker.md
+++ b/learn/deployment/docker.md
@@ -467,7 +467,7 @@ This sample sends a greeting to the caller by getting the name from a text file.
 }
 ```
 
->**Note:** In addition to the above, if you want to copy driver files such as JDBC, you can create a `Ballerina.toml` file as shown below and change the path to the JDBC driver appropriately.
+>**Note:** In addition to the above, if you want to copy driver files such as JDBC, you can create a Ballerina project, add following entires to its `Ballerina.toml` file, and change the path to the JDBC driver appropriately.
 
 `Ballerina.toml`
 

--- a/learn/deployment/docker.md
+++ b/learn/deployment/docker.md
@@ -456,6 +456,8 @@ function readFile(string filePath) returns  string {
 
 This sample sends a greeting to the caller by getting the name from a text file. When this is run in a container, you need to copy the `name.txt` file into the Docker image. The `@docker:CopyFiles` annotation is used for this and you can give multiple files by following the syntax below.
 
+`name.txt`
+
 ```
 @docker:CopyFiles {
    files: [
@@ -463,6 +465,24 @@ This sample sends a greeting to the caller by getting the name from a text file.
 	{ sourceFile: "./abc.txt", target: "/home/ballerina/abc.txt" }
    ]
 }
+```
+
+>**Note:** In addition to the above, if you want to copy driver files such as JDBC, you can create a `Ballerina.toml` file as shown below and change the path to the JDBC driver appropriately.
+
+`Ballerina.toml`
+
+```
+[project]
+org-name= "sample"
+version= "0.1.0"
+
+[platform]
+target = "java8"
+
+    [[platform.libraries]]
+    artafactId = "mysql-connector-java"
+    version = "8.0.17"
+    path = "/path/to/mysql-connector-java-8.0.17.jar"
 ```
 
 #### Steps to run

--- a/swan-lake/learn/deployment/docker.md
+++ b/swan-lake/learn/deployment/docker.md
@@ -467,7 +467,7 @@ This sample sends a greeting to the caller by getting the name from a text file.
 }
 ```
 
->**Note:** In addition to the above, if you want to copy driver files such as JDBC, you can create a `Ballerina.toml` file as shown below and change the path to the JDBC driver appropriately.
+>**Note:** In addition to the above, if you want to copy driver files such as JDBC, you can create a Ballerina project, add following entires to its `Ballerina.toml` file, and change the path to the JDBC driver appropriately.
 
 `Ballerina.toml`
 

--- a/swan-lake/learn/deployment/docker.md
+++ b/swan-lake/learn/deployment/docker.md
@@ -454,6 +454,8 @@ function readFile(string filePath) returns  string {
 }
 ```
 
+`name.txt`
+
 This sample sends a greeting to the caller by getting the name from a text file. When this is run in a container, you need to copy the `name.txt` file into the Docker image. The `@docker:CopyFiles` annotation is used for this and you can give multiple files by following the syntax below.
 
 ```
@@ -463,6 +465,24 @@ This sample sends a greeting to the caller by getting the name from a text file.
 	{ sourceFile: "./abc.txt", target: "/home/ballerina/abc.txt" }
    ]
 }
+```
+
+>**Note:** In addition to the above, if you want to copy driver files such as JDBC, you can create a `Ballerina.toml` file as shown below and change the path to the JDBC driver appropriately.
+
+`Ballerina.toml`
+
+```
+[project]
+org-name= "sample"
+version= "0.1.0"
+
+[platform]
+target = "java8"
+
+    [[platform.libraries]]
+    artafactId = "mysql-connector-java"
+    version = "8.0.17"
+    path = "/path/to/mysql-connector-java-8.0.17.jar"
 ```
 
 #### Steps to run


### PR DESCRIPTION
## Purpose
Add info on how to copy JDBC driver files to Docker images.

> Fixes https://github.com/ballerina-platform/ballerina-dev-website/issues/112

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
