### PR TITLE
Update the "Edit on GitHub" Option to Link to the Dev Site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ breadcrumbs:
     hide: true  # show breadcrumbs on root/home page
     image: false # Show image or title text  
 github_username:  ballerina-platform
-git_repo: ballerina-platform.github.io
+git_repo: ballerina-dev-website
 latest_version: 1.2
 #keep_files: ['0.990','0.991',"1.1"]
 # Exclude from processing.


### PR DESCRIPTION
## Purpose
Update the "Edit on GitHub" option to link to the dev site. Currently, it is linked to the live site.
> Fixes https://github.com/ballerina-platform/ballerina-dev-website/issues/1303

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
