### PR TITLE
Fix TOC Issues in the 1.2 Learn Pages

### DIFF
--- a/learn/coding-conventions.md
+++ b/learn/coding-conventions.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina style guide
 permalink: /learn/coding-conventions/
 active: coding-conventions
 intro: This Ballerina Style Guide aims at maintaining a standard coding style among the Ballerina community. Therefore, the Ballerina code formatting tools are based on this guide.
-
-You can follow your own coding style when writing Ballerina source code. Also, plugins and tools can be configured to match your coding style.
 redirect_from:
   - /learn/style-guide
   - /learn/style-guide/
@@ -15,6 +13,8 @@ redirect_from:
   - /v1-2/learn/style-guide/
   - /learn/coding-conventions
 ---
+
+> You can follow your own coding style when writing Ballerina source code. Also, plugins and tools can be configured to match your coding style.
 
 ## Indentation and line length
 * Use four spaces (not tabs) for each level of indentation.

--- a/learn/deployment/kubernetes.md
+++ b/learn/deployment/kubernetes.md
@@ -12,16 +12,6 @@ redirect_from:
 
 The Kubernetes builder extension takes care of the creation of the Docker images, so you don't need to explicitly create Docker images prior to deployment on Kubernetes.
 
-- [Supported Configurations](#supported-configurations)
-- [Using Kubernetes Annotations](#using-kubernetes-annotations)
-- [Building the Deployed Service](#building-the-deployed-service)
-- [Creating the Kubernetes Deployment](#creating-the-kubernetes-deployment)
-    - [Accessing via Node Port](#accessing-via-node-port)
-    - [Accessing via Ingress](#accessing-via-ingress)
-    - [Accessing the Service](#accessing-the-service)
-- [Supported Kubernetes Annotations](#supported-kubernetes-annotations)
-- [Extending Ballerina Deployment and Annotations](#extending-ballerina-deployment-and-annotations)
-
 ## Supported Configurations
 
 The following Kubernetes configurations are supported:

--- a/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
+++ b/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
@@ -1,28 +1,24 @@
 ---
 layout: ballerina-left-nav-pages
 title: Generating Ballerina Code for Protocol Buffer Definitions
-description: The Protocol Buffers to Ballerina tool provides capabilities to generate Ballerina source code for the Protocol Buffer definition.
+description: The `Protocol Buffers to Ballerina` Tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions.
 keywords: ballerina, protocol buffers, programming language
 permalink: /learn/generating-ballerina-code-for-protocol-buffer-definitions/
 active: generating-ballerina-code-for-protocol-buffer-definitions
-intro: The `Protocol Buffers` to Ballerina tool provides capabilities to generate Ballerina source code for the Protocol
-Buffer definition. The code generation tool can produce `ballerina stub` and `ballerina service/client template` files.
+intro: The `Protocol Buffers to Ballerina` tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions. 
 redirect_from:
   - /learn/how-to-generate-code-for-protocol-buffers
   - /learn/how-to-generate-code-for-protocol-buffers/
   - /v1-2/learn/how-to-generate-code-for-protocol-buffers
   - /v1-2/learn/how-to-generate-code-for-protocol-buffers/
   - /learn/generating-ballerina-code-for-protocol-buffer-definitions
-  
 ---
- 
-> In Ballerina, Protocol Buffers serialization is only supported in the gRPC module. Therefore, you can only use
-> this tool to generate Ballerina source code for gRPC service definitions.
 
-- [CLI Command](#cli-command)
-  - [CLI Command Options](#cli-command-options)
-- [Sample](#sample)
-  - [Executing the Sample](#executing-the-sample)
+## Usage of the Tool
+
+The code generation Tool can produce `ballerina stub` and `ballerina service/client template` files.
+
+> In Ballerina, Protocol Buffers serialization is only supported in the gRPC module. Therefore, you can only use this tool to generate Ballerina source code for gRPC service definitions.
 
 ## CLI Command
 

--- a/learn/keeping-ballerina-up-to-date.md
+++ b/learn/keeping-ballerina-up-to-date.md
@@ -5,7 +5,7 @@ description: Learn how to maintain your Ballerina programming language installat
 keywords: ballerina, programming language, release, update
 permalink: /learn/keeping-ballerina-up-to-date/
 active: keeping-ballerina-up-to-date
-intro: This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases. If you haven’t installed Ballerina yet, visit [installation guide](/learn/installing-ballerina/).
+intro: This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases. 
 redirect_from:
   - /v1-2/learn/how-to-keep-ballerina-up-to-date
   - /v1-2/learn/how-to-keep-ballerina-up-to-date/
@@ -13,6 +13,8 @@ redirect_from:
   - /learn/how-to-keep-ballerina-up-to-date
   - /learn/keeping-ballerina-up-to-date
 ---
+
+If you haven’t installed Ballerina yet, see the [Installing Ballerina](/learn/installing-ballerina/).
 
 ## Terminology
 

--- a/learn/observing-ballerina-code.md
+++ b/learn/observing-ballerina-code.md
@@ -4,9 +4,19 @@ title: Observing Ballerina Code
 description: See how Ballerina supports observability by exposing itself via metrics, tracing and logs to external systems.
 keywords: ballerina, observability, metrics, tracing, logs
 permalink: /learn/observing-ballerina-code/
-active: how-to-observing-ballerina-code
-intro: Observability is a measure of how well internal states of a system can be inferred from knowledge of its external
-outputs. 
+active: observing-ballerina-code
+intro: Observability is a measure of how well internal states of a system can be inferred from knowledge of its external outputs. 
+redirect_from:
+  - /learn/how-to-observe-ballerina-code
+  - /learn/how-to-observe-ballerina-code/
+  - /v1-2/learn/how-to-observe-ballerina-code
+  - /v1-2/learn/how-to-observe-ballerina-code/
+  - /learn/how-to-observe-ballerina-services/
+  - /learn/how-to-observe-ballerina-services
+  - /learn/observing-ballerina-code
+---
+
+## Providing observability in Ballerina
 
 Monitoring, logging, and distributed tracing are key methods that reveal the internal state of the system to provide the observability. Ballerina becomes fully observable by exposing itself via these three methods to various external systems allowing to monitor metrics such as request count and response time statistics, analyze logs, and
 perform distributed tracing. 
@@ -17,15 +27,7 @@ connectors use semantic tags to make tracing and metrics monitoring more informa
 This guide focuses on enabling Ballerina service observability with some of its default supported systems.
 [Prometheus] and [Grafana] are used for metrics monitoring, and [Jaeger] is used for distributed tracing. 
 Ballerina logs can be fed to any external log monitoring system like [Elastic Stack] to perform log monitoring and analysis.
-redirect_from:
-  - /learn/how-to-observe-ballerina-code
-  - /learn/how-to-observe-ballerina-code/
-  - /v1-2/learn/how-to-observe-ballerina-code
-  - /v1-2/learn/how-to-observe-ballerina-code/
-  - /learn/how-to-observe-ballerina-services/
-  - /learn/how-to-observe-ballerina-services
-  - /learn/observing-ballerina-code
----
+
 
 ## Observing a Ballerina Service
 

--- a/learn/running-ballerina-code.md
+++ b/learn/running-ballerina-code.md
@@ -5,7 +5,19 @@ description: Learn how to run Ballerina programs and services using the CLI tool
 keywords: ballerina, programming language, services
 permalink: /learn/running-ballerina-code/
 active: running-ballerina-code
-intro: A Ballerina application can have:
+intro: 
+redirect_from:
+  - /learn/how-to-deploy-and-run-ballerina-programs
+  - /learn/how-to-deploy-and-run-ballerina-programs/
+  - /learn/how-to-run-ballerina-programs/
+  - /v1-2/learn/how-to-deploy-and-run-ballerina-programs
+  - /v1-2/learn/how-to-deploy-and-run-ballerina-programs/
+  - /learn/running-ballerina-code
+---
+
+## Understanding the structure
+
+A Ballerina application can have:
 
 1. A [`main()`](/learn/by-example/the-main-function.html) function that runs as a terminating process.
 
@@ -16,14 +28,6 @@ Both of these are considered as entry points for program execution.
 These applications can be structured into a single program file or a Ballerina module. A collection of modules can be managed together with versioning and dependency management as part of a Ballerina project. 
 
 Source files and modules can contain zero or more entrypoints, and the runtime engine has precedence and sequence rules for choosing which entrypoint to execute.
-redirect_from:
-  - /learn/how-to-deploy-and-run-ballerina-programs
-  - /learn/how-to-deploy-and-run-ballerina-programs/
-  - /learn/how-to-run-ballerina-programs/
-  - /v1-2/learn/how-to-deploy-and-run-ballerina-programs
-  - /v1-2/learn/how-to-deploy-and-run-ballerina-programs/
-  - /learn/running-ballerina-code
----
 
 ## Running Standalone Source Code
 A single Ballerina source code file can be placed into any folder. 

--- a/learn/structuring-ballerina-code.md
+++ b/learn/structuring-ballerina-code.md
@@ -5,10 +5,7 @@ description: Learn how to develop a Ballerina project, structure code, and use t
 keywords: ballerina, programming language, ballerina modules, structure code
 permalink: /learn/structuring-ballerina-code/
 active: structuring-ballerina-code
-intro: This document demonstrates the development of a Ballerina project and shows how to use the `Ballerina Tool` to fetch, 
-build, and install Ballerina modules. These commands work with repositories that are both local and remote.
-
-Ballerina Central is a globally hosted module management system that is used to discover, download, and publish modules.
+intro: This document demonstrates the development of a Ballerina project and shows how to use the `Ballerina Tool` to fetch, build, and install Ballerina modules. 
 redirect_from:
   - /learn/how-to-structure-ballerina-code
   - /learn/how-to-structure-ballerina-code/
@@ -18,6 +15,10 @@ redirect_from:
 ---
 
 ## Organizing Your Code
+
+> These commands work with repositories that are both local and remote.
+
+Ballerina Central is a globally hosted module management system that is used to discover, download, and publish modules.
 
 The `Ballerina Tool` requires you to organize your code in a specific way. This document explains the simplest way to get it up and running with a Ballerina installation.
 

--- a/learn/using-the-openapi-tools.md
+++ b/learn/using-the-openapi-tools.md
@@ -1,21 +1,20 @@
 ---
-layout: ballerina-left-nav-pages-swanlake
+layout: ballerina-left-nav-pages
 title: Using the OpenAPI Tools
 description: Check out how the Ballerina OpenAPI tooling makes it easy for users to start developing a service documented in the OpenAPI contract.
 keywords: ballerina, programming language, openapi, open api, restful api
-permalink: /swan-lake/learn/using-the-openapi-tools/
+permalink: /learn/using-the-openapi-tools/
 active: using-the-openapi-tools
+intro: OpenAPI Specification is a specification that creates a RESTFUL contract for APIs, detailing all of its resources and operations in a human and machine-readable format for easy development, discovery, and integration. Ballerina OpenAPI tooling will make it easy for users to start development of a service documented in OpenAPI contract in Ballerina by generating Ballerina service and client skeletons.
 redirect_from:
-  - /swan-lake/learn/how-to-use-openapi-tools
-  - /swan-lake/learn/how-to-use-openapi-tools/
-  - /swan-lake/learn/using-the-openapi-tools
+  - /learn/how-to-use-openapi-tools
+  - /learn/how-to-use-openapi-tools/
+  - /learn/using-the-openapi-tools
 ---
 
-# Using the OpenAPI Tools
+## Using the capabilities of the OpenAPI Tools
 
-OpenAPI Specification is a specification that creates a RESTFUL contract for APIs, detailing all of its resources and operations in a human and machine-readable format for easy development, discovery, and integration. Ballerina OpenAPI tooling will make it easy for users to start development of a service documented in OpenAPI contract in Ballerina by generating Ballerina service and client skeletons.
-
-The OpenAPI tools provides following capabilities.
+The OpenAPI tools provide the following capabilities.
 
 1. Generate the Ballerina Service or Client code for a given OpenAPI definition.
 2. Generate the client stub for an existing Ballerina service at build time.
@@ -25,16 +24,6 @@ The `openapi` command in Ballerina is used for OpenAPI to Ballerina and Ballerin
 Code generation from OpenAPI to Ballerina can produce `ballerina mock services` and `ballerina client stubs`.
 
 For build time client stub generation, annotation support is provided.
-
-- [Mock Service from OpenAPI](#mock-service-from-openapi)
-- [Client Stub from OpenAPI](#client-stub-from-openapi)
-- [Service to OpenAPI Export](#service-to-openapi-export)
-- [Client Stub for Service](#client-stub-for-service)
-- [Samples](#samples)
-    - [Mock Service from OpenAPI Sample](#mock-service-from-openapi-sample)
-    - [Client Stub from OpenAPI Sample](#client-stub-from-openapi-sample)
-    - [OpenAPI from Service Sample](#openapi-from-service-sample)
-    - [Client Stub from Service Sample](#client-stub-from-service-sample)
 
 ## Mock Service from OpenAPI
 


### PR DESCRIPTION
## Purpose
Fix TOC issues in the 1.2 Learn pages.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
