### PR TITLE
Add TOCs to Swan Lake Learn Pages

### DIFF
--- a/learn/deployment/aws-lambda.md
+++ b/learn/deployment/aws-lambda.md
@@ -10,7 +10,7 @@ redirect_from:
   - /learn/deployment/aws-lambda
 ---
 
- Exposing a Ballerina function as an AWS Lambda function is done by importing the `ballerinax/awslambda` module and simply annotating the Ballerina function with the `awslambda:Function` annotation. Also, the Ballerina function must have the following signature: `function (awslambda:Context, json|EventType) returns json|error`. 
+Exposing a Ballerina function as an AWS Lambda function is done by importing the `ballerinax/awslambda` module and simply annotating the Ballerina function with the `awslambda:Function` annotation. Also, the Ballerina function must have the following signature: `function (awslambda:Context, json|EventType) returns json|error`. 
 
 ## Writing a Function
 

--- a/learn/deployment/azure-functions.md
+++ b/learn/deployment/azure-functions.md
@@ -10,7 +10,7 @@ redirect_from:
   - /learn/deployment/azure-functions
 ---
 
- This is done by importing the `ballerinax/azure.functions` module and simply annotating the Ballerina function with the `functions:Function` annotation. 
+This is done by importing the `ballerinax/azure.functions` module and simply annotating the Ballerina function with the `functions:Function` annotation. 
 
 ## Triggers and Bindings
 

--- a/learn/keeping-ballerina-up-to-date.md
+++ b/learn/keeping-ballerina-up-to-date.md
@@ -20,7 +20,7 @@ If you haven’t installed Ballerina yet, see the [Installing Ballerina](/learn/
 
 This section introduces various terms used throughout this guide. We recommend that you read this section before proceeding to the next.  
 
-### Ballerina tool
+### The Ballerina Tool
 
 **Ballerina** is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build and run programs, etc. 
 

--- a/learn/publishing-modules-to-ballerina-central.md
+++ b/learn/publishing-modules-to-ballerina-central.md
@@ -14,7 +14,7 @@ redirect_from:
   - /learn/publishing-modules-to-ballerina-central
 ---
 
-## CLI Command
+## The CLI command
 
 Pushing a module uploads it to [Ballerina Central](https://central.ballerina.io/).
 
@@ -22,7 +22,7 @@ Pushing a module uploads it to [Ballerina Central](https://central.ballerina.io/
 ballerina push <module-name>
 ```
 
-## Setting Up
+## Setting up
 
 Before you push your module, you must enter your Ballerina Central access token in `Settings.toml` in your home repository (`<USER_HOME>/.ballerina/`).
 

--- a/learn/running-ballerina-code.md
+++ b/learn/running-ballerina-code.md
@@ -5,7 +5,7 @@ description: Learn how to run Ballerina programs and services using the CLI tool
 keywords: ballerina, programming language, services
 permalink: /learn/running-ballerina-code/
 active: running-ballerina-code
-intro: 
+intro: The sections below include information on running Ballerina programs.
 redirect_from:
   - /learn/how-to-deploy-and-run-ballerina-programs
   - /learn/how-to-deploy-and-run-ballerina-programs/

--- a/learn/set-up-ballerina-sdk.md
+++ b/learn/set-up-ballerina-sdk.md
@@ -3,9 +3,7 @@ layout: ballerina-left-nav-pages
 title: Setting up Ballerina SDK
 permalink: /learn/set-up-ballerina-sdk/
 active: set-up-ballerina-sdk
-intro: After [installing the IntelliJ Ballerina plugin](intellij-plugin-doc.md), you need to set up Ballerina SDK for your Ballerina projects to activate all the capabilities of the plugin. 
-
-Click on the below links for instructions on how to set up Ballerina SDK.
+intro: After installing the IntelliJ Ballerina plugin, you need to set up Ballerina SDK for your Ballerina projects to activate all the capabilities of the plugin. Click on the below links for instructions on how to set up Ballerina SDK.
 redirect_from:
   - /learn/set-up-ballerina-sdk
   - /v1-2/learn/set-up-ballerina-sdk

--- a/learn/testing-ballerina-code.md
+++ b/learn/testing-ballerina-code.md
@@ -6,6 +6,15 @@ keywords: ballerina, programming language, testing
 permalink: /learn/testing-ballerina-code/
 active: testing-ballerina-code
 intro: Ballerina has a built-in test framework named Testerina. Testerina enables developers to write testable code. The test framework provides a set of building blocks to help write tests and a set of tools to help test. 
+redirect_from:
+  - /learn/how-to-test-ballerina-code
+  - /learn/how-to-test-ballerina-code/
+  - /v1-2/learn/how-to-test-ballerina-code
+  - /v1-2/learn/how-to-test-ballerina-code/
+  - /learn/testing-ballerina-code
+---
+
+## Writing and Running Tests 
 
 Developers and testers can cover multiple levels of the test pyramid including unit testing, integration testing and end to end testing with the building blocks the framework provides. It provides the flexibility to programmers and testers to build intelligent tests that suit the domain and application needs.
 
@@ -16,15 +25,6 @@ Testerina design and usage is aligned with project and module semantics of Balle
 * Test **assertions** can be used to verify the set of program behaviour expectations 
 * Data providers can be used to feed in the test data sets 
 * Function mocks can be used to mock a function in a module that you are testing or a function of an imported module
-redirect_from:
-  - /learn/how-to-test-ballerina-code
-  - /learn/how-to-test-ballerina-code/
-  - /v1-2/learn/how-to-test-ballerina-code
-  - /v1-2/learn/how-to-test-ballerina-code/
-  - /learn/testing-ballerina-code
----
-
-## Writing and Running Tests 
 
 To write tests, you need to import the `test` module in all Ballerina test source files. 
 

--- a/learn/testing-ballerina-code/mocking.md
+++ b/learn/testing-ballerina-code/mocking.md
@@ -14,7 +14,7 @@ redirect_from:
 
 ## Mocking Objects
 
-The test module provides capabilities to mock an object for unit testing. This allows you to control the behavior of the object member functions and values of member fields via stubbing or replacing the entire object with a user-defined equivalent. This feature will help you to test the Ballerina code independently from other modules and external endpoints.
+The `Test` module provides capabilities to mock an object for unit testing. This allows you to control the behavior of the object member functions and values of member fields via stubbing or replacing the entire object with a user-defined equivalent. This feature will help you to test the Ballerina code independently from other modules and external endpoints.
 
 Mocking of objects can be done in two ways.
 

--- a/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
+++ b/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
@@ -24,7 +24,7 @@ redirect_from:
 
 You can run Ballerina main/service programs with a single click without adding or changing any configurations.
 
-The below sections include instructions on how to run different elements of a Ballerina file.
+The sections below include instructions on how to run different elements of a Ballerina file.
 
 - [Running the main method](#running-the-main-method)
 - [Running Ballerina services](#running-ballerina-services)

--- a/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
+++ b/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
@@ -3,7 +3,7 @@ layout: ballerina-left-nav-pages
 title: Using the IntelliJ Ballerina Plugin
 permalink: /learn/setting-up-intellij-idea/using-the-intellij-plugin/
 active: using-the-intellij-plugin
-intro: The below sections include information to start using the IntelliJ Ballerina plugin after [installing it](/learn/intellij-plugin).
+intro: The sections below include information to start using the IntelliJ Ballerina plugin after installing it.
 redirect_from:
   - /v1-2/learn/tools-ides/intellij-plugin/using-the-intellij-plugin
   - /v1-2/learn/tools-ides/intellij-plugin/using-the-intellij-plugin/

--- a/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
@@ -3,9 +3,7 @@ layout: ballerina-left-nav-pages
 title: Graphical View
 permalink: /learn/setting-up-visual-studio-code/graphical-editor/
 active: graphical-editor
-intro: A rich set of visualization tools will immensely enhance your development experience especially in the integration space.The Graphical Editor of the VS Code Ballerina extension allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. 
-
-The sections below discuss how to use the Graphical Editor and explore its capabilities.
+intro: A rich set of visualization tools will immensely enhance your development experience especially in the integration space.The Graphical Editor of the VS Code Ballerina extension allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. The sections below discuss how to use the Graphical Editor and explore its capabilities.
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/graphical-editor
   - /v1-2/learn/tools-ides/vscode-plugin/graphical-editor/

--- a/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
@@ -3,9 +3,7 @@ layout: ballerina-left-nav-pages
 title: Language Intelligence
 permalink: /learn/setting-up-visual-studio-code/language-intelligence/
 active: language-intelligence
-intro: The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency.
-
-Language intelligence is built in to the extension via a Language Server implementation, which consists of the below language intelligence options.
+intro: The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency. Language intelligence is built in to the extension via a Language Server implementation, which consists of the below language intelligence options.
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/language-intelligence
   - /v1-2/learn/tools-ides/vscode-plugin/language-intelligence/

--- a/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
@@ -3,9 +3,7 @@ layout: ballerina-left-nav-pages
 title: Run and Debug
 permalink: /learn/setting-up-visual-studio-code/run-and-debug/
 active: run-and-debug
-intro: The VS Code Ballerina extension gives you the  same debugging experience as the conventional VS Code Debugger.
-
-Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
+intro: The VS Code Ballerina extension gives you the  same debugging experience as the conventional VS Code Debugger. Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/run-and-debug
   - /v1-2/learn/tools-ides/vscode-plugin/run-and-debug/

--- a/swan-lake/learn/calling-java-code-from-ballerina.md
+++ b/swan-lake/learn/calling-java-code-from-ballerina.md
@@ -5,6 +5,7 @@ description: See how Ballerina offers a straightforward way to call existing Jav
 keywords: ballerina, programming language, java api, interoperability
 permalink: /swan-lake/learn/calling-java-code-from-ballerina/
 active: calling-java-code-from-ballerina/
+intro: Ballerina offers a straightforward way to call the existing Java code from Ballerina and also provides a Java API to call Ballerina code from Java.  Although Ballerina is not designed to be a JVM language, the current implementation, which targets the JVM, aka jBallerina, provides Java interoperability by adhering to the Ballerina language semantics.
 redirect_from:
   - /swan-lake/learn/how-to-use-java-interoperability
   - /swan-lake/learn/how-to-use-java-interoperability/
@@ -13,79 +14,21 @@ redirect_from:
   - /swan-lake/learn/calling-java-code-from-ballerina
 ---
 
-# Calling Java Code from Ballerina
-
-Ballerina offers a straightforward way to call the existing Java code from Ballerina and also provides a Java API to call Ballerina code from Java.  Although Ballerina is not designed to be a JVM language, the current implementation, which targets the JVM, aka jBallerina, provides Java interoperability by adhering to the Ballerina language semantics. 
-
-- [Ballerina Bindings to Java Code](#ballerina-bindings-to-java-code)
-- [The Need to Call Java from Ballerina](#the-need-to-call-java-from-ballerina)
-- [Writing Ballerina Bindings](#writing-ballerina-bindings)
-- [Using the SnakeYAML Java Library in Ballerina](#using-the-snakeyaml-java-library-in-ballerina)
-    - [Step 1 - Writing the Java Code](#step-1---writing-the-java-code)
-    - [Step 2 - Setting Up the Ballerina Project](#step-2---setting-up-the-ballerina-project)
-        - [Creating a Ballerina Project](#creating-a-ballerina-project)
-        - [Adding a Ballerina Module to Your Project](#adding-a-ballerina-module-to-your-project)
-        - [Adding a Sample YAML File](#adding-a-sample-yaml-file)
-        - [Verifying the Project](#verifying-the-project)
-    - [Step 3 - Generating the Ballerina Bindings](#step-3---generating-the-ballerina-bindings)
-      - [Copying the SnakeYAML Library to Your Project](#copying-the-snakeyaml-library-to-your-project)
-      - [Adding the SnakeYAML Library to the Ballerina TOML File](#adding-the-snakeyaml-library-to-the-ballerina-toml-file)
-      - [Generating the Ballerina Bindings](#generating-the-ballerina-bindings)
-    - [Step 4 - Writing the Ballerina Code](#step-4---writing-the-ballerina-code)
-        - [Creating the `FileInputStream`](#creating-the-fileinputstream)
-        - [Creating the SnakeYAML Entry Point](#creating-the-snakeyaml-entry-point)
-        - [Loading the YAML Document](#loading-the-yaml-document)
-        - [Printing the Returned Map Instance](#printing-the-returned-map-instance)
-        - [Completing the Code](#completing-the-code)
-- [The Bindgen Tool](#the-bindgen-tool)
-- [The `bindgen` Command](#the-bindgen-command)
-    - [Generated Bridge Code](#generated-bridge-code)
-    - [Mapping Java Code with Ballerina](#mapping-java-code-with-ballerina)
-        - [Java Classes](#java-classes)
-        - [Constructors](#constructors)
-        - [Methods](#methods)
-        - [Fields](#fields)
-        - [External Interop Functions](#external-interop-functions)
-        - [Dependency Objects](#dependency-objects)
-        - [Ballerina Object](#ballerina-object)
-    - [Type Mappings between Java and Ballerina](#type-mappings-between-java-and-ballerina)
-- [Packaging Java Libraries with Ballerina Programs](#packaging-java-libraries-with-ballerina-programs)
-    - [Ballerina FFI](#ballerina-ffi)
-        - [The External Function Body](#the-external-function-body)
-        - [The Handle Type](#the-handle-type)
-- [Calling Java Programs from Ballerina](#calling-java-programs-from-ballerina)
-    - [Instantiating Java Classes](#instantiating-java-classes)
-        - [Dealing with Overloaded Constructors](#dealing-with-overloaded-constructors)
-        - [The `paramTypes` Field](#the-paramtypes-field)
-    - [Calling Java Methods](#calling-java-methods)
-        - [Calling Static Methods](#calling-static-methods)
-        - [Calling Instance Methods](#calling-instance-methods)
-        - [Mapping Java Classes into Ballerina Objects](#mapping-java-classes-into-ballerina-objects)
-        - [Calling Overloaded Java Methods](#calling-overloaded-java-methods)
-    - [Java Exceptions as Ballerina Errors](#java-exceptions-as-ballerina-errors)
-        - [Java Checked Exceptions](#java-checked-exceptions)
-        - [Mapping a Java Exception to a Ballerina Error Value](#mapping-a-java-exception-to-a-ballerina-error-value)
-    - [Null Safety](#null-safety)
-    - [Mapping Java Types to Ballerina Types and Vice Versa](#mapping-java-types-to-ballerina-types-and-vice-versa)
-        - [Mapping Java Types to Ballerina Types](#mapping-java-types-to-ballerina-types)
-        - [Mapping Ballerina Types to Java Types](#mapping-ballerina-types-to-java-types)
-        - [Access or Mutate Java Fields](#access-or-mutate-java-fields)
-
-### Ballerina Bindings to Java Code
+## Ballerina Bindings to Java Code
 Your task is to write Ballerina code (Ballerina bindings) that lets you call the corresponding Java API as illustrated in the below diagram. 
 
 <img src="/swan-lake/learn/images/interoperability-diagram.png" alt="Ballerina bindings to Java code" width="300" height="350">
 
 This guide teaches you how to write those bindings manually as well as how to generate those bindings automatically but first, let's look at why you want to call Java from Ballerina. 
 
-### The Need to Call Java from Ballerina 
+## The Need to Call Java from Ballerina 
 - Ballerina is a relatively new language. Therefore, you may experience a shortage of libraries in [Ballerina Central](https://central.ballerina.io/). In such situations, as a workaround, you can use an existing Java library.
 - You are already familiar with a stable Java API that you would like to use in your Ballerina project. 
 - You want to take advantage of the strengths of Ballerina but you don’t want to reinvest in the libraries that you or your company have written already. 
 
 There may be other reasons but these are great motivations to use Ballerina bindings. 
 
-### Writing Ballerina Bindings
+## Writing Ballerina Bindings
 Writing Ballerina bindings manually is a tedious task. You’ll soon see why. Therefore, we’ve developed a tool called `bindgen` that can generate Ballerina bindings for given Java APIs. The [first section](#how-to-use-the-snakeyaml-java-library-in-ballerina) of this guide shows you how to use it. The [second section](#the-bindgen-tool) is a reference guide to the tool. 
 
 The [third section](#packaging-java-libraries-with-ballerina-programs) explains how to package Java libraries (JAR files) with Ballerina programs. This section is useful because whenever you generate bindings for a Java library, you need to package this Java library and its transitive dependencies to produce a self-contained executable program. 
@@ -291,7 +234,7 @@ public class SnakeYamlSample {
 }
 ```
 
-### Creating the `FileInputStream`
+#### Creating the `FileInputStream`
 Our goal here is to create a new `java.io.FileInputStream` instance from the filename. In step 3, we generated bindings for the required Java classes. The following is the code snippet that does the job. 
 
 ```ballerina
@@ -312,12 +255,12 @@ if fileInputStream is error {
 	// The type of fileInputStream is FileInputStream within this block
 }
 ```
-### Creating the SnakeYAML Entry Point
+#### Creating the SnakeYAML Entry Point
 The `org.yaml.snakeyaml.Yaml` Class is the entry point to the SnakeYAML API.  The corresponding generated Ballerina object is `Yaml`. The `newYaml5()`  function is mapped to the default constructor of the Java class.   
 ```ballerina
 Yaml yaml = newYaml5();
 ```
-###  Loading the YAML Document
+####  Loading the YAML Document
 We'll be using the `org.yaml.snakeyaml.Yaml.load(InputStream is)` method to get a Java Map instance from the given InputStream. 
 ```ballerina
 
@@ -328,12 +271,12 @@ The generated code does not handle Java subtyping at the moment. Therefore, `Inp
 
 The `org.yaml.snakeyaml.Yaml.load(InputStream is)` is a generic method. The bindgen tool does not support Java generics at the moment. That is why the corresponding Ballerina method returns an Object.  
 
-###  Printing the Returned Map Instance
+####  Printing the Returned Map Instance
 You can print the content of the Map instance in the the standard out as follows. 
 ```ballerina
 io:println(mapObj);
 ```
-### Completing the Code 
+#### Completing the Code 
 Here, is the complete code. You can replace the contents in `src/yamlparser/main.bal` with the following code.
 ```ballerina
 import ballerina/io;
@@ -549,7 +492,7 @@ public function __init(handle obj) {
 
 ```
 
-#### Type Mappings between Java and Ballerina
+### Type Mappings between Java and Ballerina
 When using the Ballerina bindings, you could use the Ballerina primitive types, Ballerina string type, and the generated Ballerina objects. They will be mapped internally onto the respective Java primitives, Java String object, and the respective handle references of the objects.
 
 ## Packaging Java Libraries with Ballerina Programs

--- a/swan-lake/learn/coding-conventions.md
+++ b/swan-lake/learn/coding-conventions.md
@@ -5,29 +5,14 @@ description: The Ballerina Style Guide aims at maintaining a standard coding sty
 keywords: ballerina, programming language, ballerina style guide
 permalink: /swan-lake/learn/coding-conventions/
 active: coding-conventions
+intro: This Ballerina Style Guide aims at maintaining a standard coding style among the Ballerina community. Therefore, the Ballerina code formatting tools are based on this guide.
 redirect_from:
   - /swan-lake/learn/style-guide
   - /swan-lake/learn/style-guide/
   - /swan-lake/learn/coding-conventions
 ---
 
-# Coding Conventions
-
-This Ballerina Style Guide aims at maintaining a standard coding style among the Ballerina community. Therefore, the Ballerina code formatting tools are based on this guide.
-
-You can follow your own coding style when writing Ballerina source code. Also, plugins and tools can be configured to match your coding style.
-
-- [Indentation and Line Length](#indentation-and-line-length)
-- [Line Spacing](#line-spacing)
-- [Blank Lines](#blank-lines)
-- [Blocks](#blocks)
-- [Parentheses and Brackets](#parentheses-and-brackets)
-- [Line Breaks](#line-breaks)
-- [Top-Level Definitions](#top-level-definitions)
-    - [Operators, Keywords, and Types](#operators-keywords-and-types)
-    - [Statements](#statements)
-    - [Expressions](#expressions)
-    - [Annotations, Documentation, and Comments](#annotations-documentation-and-comments)
+> You can follow your own coding style when writing Ballerina source code. Also, plugins and tools can be configured to match your coding style.
 
 ## Indentation and Line Length
 * Use four spaces (not tabs) for each level of indentation.

--- a/swan-lake/learn/coding-conventions/annotations_documentation_and_comments.md
+++ b/swan-lake/learn/coding-conventions/annotations_documentation_and_comments.md
@@ -3,17 +3,12 @@ layout: ballerina-left-nav-pages-swanlake
 title: Annotations, Documentation and Comments
 permalink: /swan-lake/learn/coding-conventions/annotations_documentation_and_comments/
 active: annotations_documentation_and_comments
+intro: The sections below include the coding conventions with respect to annotations, documentation, and comments.
 redirect_from:
   - /swan-lake/learn/style-guide/annotations_documentation_and_comments/
   - /swan-lake/learn/style-guide/annotations_documentation_and_comments
   - /swan-lake/learn/coding-conventions/annotations_documentation_and_comments
 ---
-
-# Annotations, Documentation and Comments
-
-- [Annotations](#annotations)
-- [Comments](#comments)
-- [Documentation](#documentation)
 
 ## Annotations
 * Do not have spaces around the `@` symbol.

--- a/swan-lake/learn/coding-conventions/expressions.md
+++ b/swan-lake/learn/coding-conventions/expressions.md
@@ -3,21 +3,12 @@ layout: ballerina-left-nav-pages-swanlake
 title: Expressions
 active: expressions
 permalink: /swan-lake/learn/coding-conventions/expressions/
+intro: The sections below include the coding conventions with respect to expressions.
 redirect_from:
   - /swan-lake/learn/style-guide/expressions/
   - /swan-lake/learn/style-guide/expressions
   - /swan-lake/learn/coding-conventions/expressions
 ---
-
-# Expressions
-
-- [Function Invocation](#function-invocation)
-- [Record Literal](#record-literal)
-- [Map Literal](#map-literal)
-- [Tuple](#tuple)
-- [Array Literal](#array-literal)
-- [Type Casting](#type-casting)
-- [Table Literal](#table-literal)
 
 ## Function Invocation
 

--- a/swan-lake/learn/coding-conventions/operators_keywords_and_types.md
+++ b/swan-lake/learn/coding-conventions/operators_keywords_and_types.md
@@ -3,16 +3,12 @@ layout: ballerina-left-nav-pages-swanlake
 title: Operators, Keywords, and Types
 active: operators_keywords_and_types
 permalink: /swan-lake/learn/coding-conventions/operators_keywords_and_types/
+intro: The sections below include the coding conventions with respect to operators, keywords, and types.
 redirect_from:
   - /swan-lake/learn/style-guide/operators_keywords_and_types/
   - /swan-lake/learn/style-guide/operators_keywords_and_types
   - /swan-lake/learn/coding-conventions/operators_keywords_and_types
 ---
-
-# Operators, Keywords, and Types
-
-- [Keywords and types](#keywords-and-types)
-- [Operators](#operators)
 
 ## Keywords and Types
 * Do not keep spaces between the type and the pipe operator when it is in an union type (e.g., `string|int`).

--- a/swan-lake/learn/coding-conventions/statements.md
+++ b/swan-lake/learn/coding-conventions/statements.md
@@ -3,20 +3,13 @@ layout: ballerina-left-nav-pages-swanlake
 title: Statements
 active: statements
 permalink: /swan-lake/learn/coding-conventions/statements/
+intro: The sections below include the coding conventions with respect to statements.
 redirect_from:
   - /swan-lake/learn/style-guide/statements/
   - /swan-lake/learn/style-guide/statements
   - /swan-lake/learn/coding-conventions/statements
 
 ---
-
-# Statements
-
-- [If Statement](#if-statement)
-    - [Empty Block](#empty-block)
-- [Match Statement](#match-statement)
-    - [Match Patterns Clause](#match-patterns-clause)
-- [Transaction Statement](#transaction-statement)
 
 ## If Statement
 

--- a/swan-lake/learn/coding-conventions/top-level-definitions.md
+++ b/swan-lake/learn/coding-conventions/top-level-definitions.md
@@ -3,6 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Top-Level Definitions
 active: definitions
 permalink: /swan-lake/learn/coding-conventions/top-level-definitions/
+intro: The sections below include the coding conventions with respect to top-level definitions.
 redirect_from:
   - /swan-lake/learn/style-guide/definitions/
   - /swan-lake/learn/style-guide/definitions
@@ -10,7 +11,7 @@ redirect_from:
   - /swan-lake/learn/coding-conventions/top-level-definitions
 ---
 
-# Top-Level Definitions
+## General practices
 
 * Do not indent the top level definitions. 
   

--- a/swan-lake/learn/deployment/aws-lambda.md
+++ b/swan-lake/learn/deployment/aws-lambda.md
@@ -1,22 +1,16 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: AWS Lambda
 description: See how the Ballerina deployment in AWS Lambda works
 keywords: ballerina, programming language, serverless, cloud, AWS, Lambda
 permalink: /swan-lake/learn/deployment/aws-lambda/
 active: aws-lambda
+intro: The AWS Lambda extension provides the functionality to expose a Ballerina function as an AWS Lambda function.
 redirect_from:
   - /swan-lake/learn/deployment/aws-lambda
 ---
 
-# AWS Lambda
-
-The AWS Lambda extension provides the functionality to expose a Ballerina function as an AWS Lambda function. This is done by importing the `ballerinax/awslambda` module and simply annotating the Ballerina function with the `awslambda:Function` annotation. Also, the Ballerina function must have the following signature: `function (awslambda:Context, json) returns json|error`. 
-
-- [Writing a Function](#writing-a-function)
-- [Building the Function](#building-the-function)
-- [Deploying the Function](#deploying-the-function)
-- [Invoking the Function](#invoking-the-function)
+Exposing a Ballerina function as an AWS Lambda function is done by importing the `ballerinax/awslambda` module and simply annotating the Ballerina function with the `awslambda:Function` annotation. Also, the Ballerina function must have the following signature: `function (awslambda:Context, json) returns json|error`. 
 
 ## Writing a Function
 

--- a/swan-lake/learn/deployment/azure-functions.md
+++ b/swan-lake/learn/deployment/azure-functions.md
@@ -1,23 +1,16 @@
 ---
-layout: ballerina-left-nav-pages
+layout: ballerina-left-nav-pages-swanlake
 title: Azure Functions
 description: See how the Ballerina deployment in Azure Functions works
 keywords: ballerina, programming language, serverless, cloud, Azure, Functions
 permalink: /swan-lake/learn/deployment/azure-functions/
 active: azure-functions
+intro: The Azure Functions extension provides the functionality to expose a Ballerina function as a serverless function in the Azure Functions platform.
 redirect_from:
   - /swan-lake/learn/deployment/azure-functions
 ---
 
-# Azure Functions
-
-The Azure Functions extension provides the functionality to expose a Ballerina function as a serverless function in the Azure Functions platform. This is done by importing the `ballerinax/azure.functions` module and simply annotating the Ballerina function with the `functions:Function` annotation.
-
-- [Triggers and Bindings](#triggers-and-bindings)
-- [Writing a Function](#writing-a-function)
-- [Building the Function](#building-the-function)
-- [Deploying the Function](#deploying-the-function)
-- [Invoking the Function](#invoking-the-function)
+This is done by importing the `ballerinax/azure.functions` module and simply annotating the Ballerina function with the `functions:Function` annotation.
 
 ## Triggers and Bindings
 

--- a/swan-lake/learn/deployment/docker.md
+++ b/swan-lake/learn/deployment/docker.md
@@ -5,6 +5,7 @@ description: See how the Ballerina deployment in Docker works
 keywords: ballerina, programming language, services, cloud, docker
 permalink: /swan-lake/learn/deployment/docker/
 active: docker
+intro: Docker helps to package applications and their dependencies in a binary image, which can run in various locations whether on-premise, in a public cloud, or in a private cloud. 
 redirect_from:
   - /swan-lake/learn/deployment/docker
   - /swan-lake/learn/deploying-ballerina-programs-in-the-cloud
@@ -12,22 +13,9 @@ redirect_from:
   - /swan-lake/learn/deployment/
 ---
 
-# Docker
-
-Docker helps to package applications and their dependencies in a binary image, which can run in various locations whether on-premise, in a public cloud, or in a private cloud. To create a Docker image, you have to create a Dockerfile by choosing a suitable base image, bundling all dependencies, copying the application binary, and setting the execution command with proper permissions. To create optimized images, youhave to follow a set of [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/). Otherwise, the image that is built will be large in size, less secure, and have many other shortcomings. 
+To create a Docker image, you have to create a Dockerfile by choosing a suitable base image, bundling all dependencies, copying the application binary, and setting the execution command with proper permissions. To create optimized images, youhave to follow a set of [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/). Otherwise, the image that is built will be large in size, less secure, and have many other shortcomings. 
 
 The Ballerina compiler is capable of creating optimized Docker images out of the application source code. This guide includes step-by-step instructions on different use cases and executing the corresponding sample source code. 
-
-- [Enabling Docker support](#enabling-docker-support)
-- [Use cases](#use-cases)
-  - [Running a Ballerina service in a Docker container](#running-a-ballerina-service-in-a-docker-container)
-  - [Creating a custom Ballerina Docker image and pushing it automatically to the Docker registry](#creating-a-custom-ballerina-docker-image-and-pushing-it-automatically-to-the-Docker-registry)
-  - [Running a Ballerina HTTPS service in a Docker container](#running-a-ballerina-https-service-in-a-docker-container)
-  - [Copying additional files to the Ballerina Docker image](#copying-additional-files-to-the-ballerina-docker-image)
-  - [Using a custom base image to build Ballerina Docker images](#using-a-custom-base-image-to-build-ballerina-docker-images)
-  - [Overriding the CMD of the generated Ballerina Dockerfile](#overriding-the-cmd-of-the-generated-ballerina-dockerfile)
-  - [Creating multiple Docker images corresponding to modules of a Ballerina project](#creating-multiple-docker-images-corresponding-to-modules-of-a-ballerina-project)
-- [Troubleshooting](#troubleshooting)
 
 ## Enabling Docker support
 

--- a/swan-lake/learn/deployment/kubernetes.md
+++ b/swan-lake/learn/deployment/kubernetes.md
@@ -5,23 +5,12 @@ description: See how the Ballerina deployment in Kubernetes works
 keywords: ballerina, programming language, services, cloud, kubernetes
 permalink: /swan-lake/learn/deployment/kubernetes/
 active: kubernetes
+intro: The Kubernetes builder extension offers native support for running Ballerina programs on Kubernetes with the use of annotations that you can include as part of your service code.
 redirect_from:
   - /swan-lake/learn/deployment/kubernetes
 ---
 
-# Kubernetes
-
-The Kubernetes builder extension offers native support for running Ballerina programs on Kubernetes with the use of annotations that you can include as part of your service code. Also, it will take care of the creation of the Docker images, so you don't need to explicitly create Docker images prior to deployment on Kubernetes.
-
-- [Supported Configurations](#supported-configurations)
-- [Using Kubernetes Annotations](#using-kubernetes-annotations)
-- [Building the Deployed Service](#building-the-deployed-service)
-- [Creating the Kubernetes Deployment](#creating-the-kubernetes-deployment)
-    - [Accessing via Node Port](#accessing-via-node-port)
-    - [Accessing via Ingress](#accessing-via-ingress)
-    - [Accessing the Service](#accessing-the-service)
-- [Supported Kubernetes Annotations](#supported-kubernetes-annotations)
-- [Extending Ballerina Deployment and Annotations](#extending-ballerina-deployment-and-annotations)
+The Kubernetes builder extension takes care of the creation of the Docker images, so you don't need to explicitly create Docker images prior to deployment on Kubernetes.
 
 ## Supported Configurations
 

--- a/swan-lake/learn/documenting-ballerina-code.md
+++ b/swan-lake/learn/documenting-ballerina-code.md
@@ -5,25 +5,16 @@ description: Learn how to write unstructured documents with a bit of structure t
 keywords: ballerina, programming language, api documentation, api docs
 permalink: /swan-lake/learn/documenting-ballerina-code/
 active: documenting-ballerina-code
+intro: Ballerina has a built-in Ballerina Flavored Markdown (BFM) documentation framework named Docerina. The documentation framework allows you to write unstructured documents with a bit of structure to enable generating HTML content as API documentation.
 redirect_from:
   - /swan-lake/learn/how-to-document-ballerina-code
   - /swan-lake/learn/how-to-document-ballerina-code/
   - /swan-lake/learn/documenting-ballerina-code
 ---
 
-# Documenting Ballerina Code
-
-Ballerina has a built-in Ballerina Flavored Markdown (BFM) documentation framework named Docerina. The documentation framework allows you to write unstructured documents with a bit of structure to enable generating HTML content as API documentation.
+## Generating Documentation for Modules
 
 Developers can write the documentation inline with the Ballerina source code using the lightweight [markdown](https://daringfireball.net/projects/markdown/syntax) markup language. They can document special constructs such as parameters, return values, fields, etc. within the code using documentation attributes. Once the code is documented, developers can generate a basic HTML version of their Ballerina modules using the `ballerina doc` command. Developers are encouraged to have their custom themes and styles, to have a standard presentation of their Ballerina documentation.
-
-- [Generating Documentation for Modules](#generating-documentation-for-modules)
-- [Writing Ballerina Documentation](#writing-ballerina-documentation)
-  - [Sample Usage](#sample-usage)
-- [Documenting a Module](#documenting-a-module)
-- [Generating Ballerina Documentation](#generating-ballerina-documentation)
-
-## Generating Documentation for Modules
 
 Ballerina documentation design and usage is aligned with project and module semantics of Ballerina. You can generate documentation for modules using the `ballerina doc` command.
 

--- a/swan-lake/learn/extending-with-compiler-extensions.md
+++ b/swan-lake/learn/extending-with-compiler-extensions.md
@@ -5,24 +5,12 @@ description: Learn how to extend Ballerina using annotations, which can be used 
 keywords: ballerina, programming language, annotations, metadata, extend ballerina
 permalink: /swan-lake/learn/extending-with-compiler-extensions/
 active: extending-with-compiler-extensions
+intro: The sections below include information about extending with compiler extensions.
 redirect_from:
   - /swan-lake/learn/how-to-extend-ballerina
   - /swan-lake/learn/how-to-extend-ballerina/
   - /swan-lake/learn/extending-with-compiler-extensions
 ---
-
-# Extending with Compiler Extensions 
-
-- [Annotations](#annotations)
-- [Hello World: The Annotation Way](#hello-world-the-annotation-way)
-- [Defining a Custom Annotation](#defining-a-custom-annotation)
-    - [Creating the Annotation](#creating-the-annotation)
-    - [Verifying the Annotation](#verifying-the-annotation)
-- [Writing the Compiler Extension](#writing-the-compiler-extension)
-    - [Setting up the Project](#setting-up-the-project)
-    - [Adding the Code for the Extension](#adding-the-code-for-the-extension)
-- [Putting It All Together](#putting-it-all-together)
-- [Learning More About Writing Compiler Extensions](#learning-more-about-writing-compiler-extensions)
 
 ## Annotations
 

--- a/swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
+++ b/swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
@@ -5,6 +5,7 @@ description: The Protocol Buffers to Ballerina tool provides capabilities to gen
 keywords: ballerina, protocol buffers, programming language
 permalink: /swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions/
 active: generating-ballerina-code-for-protocol-buffer-definitions
+intro: The `Protocol Buffers to Ballerina` tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions.
 redirect_from:
   - /swan-lake/learn/how-to-generate-code-for-protocol-buffers
   - /swan-lake/learn/how-to-generate-code-for-protocol-buffers/
@@ -12,18 +13,12 @@ redirect_from:
   
 ---
 
-# Generating Ballerina Code for Protocol Buffer Definitions
+## Usage of the Tool
 
-The `Protocol Buffers` to Ballerina tool provides capabilities to generate Ballerina source code for the Protocol
-Buffer definition. The code generation tool can produce `ballerina stub` and `ballerina service/client template` files.
+The code generation tool can produce `ballerina stub` and `ballerina service/client template` files.
  
 > In Ballerina, Protocol Buffers serialization is only supported in the gRPC module. Therefore, you can only use
 > this tool to generate Ballerina source code for gRPC service definitions.
-
-- [CLI Command](#cli-command)
-  - [CLI Command Options](#cli-command-options)
-- [Sample](#sample)
-  - [Executing the Sample](#executing-the-sample)
 
 ## CLI Command
 

--- a/swan-lake/learn/installing-ballerina.md
+++ b/swan-lake/learn/installing-ballerina.md
@@ -5,6 +5,7 @@ description: Get started with the Ballerina programming language by following th
 keywords: ballerina, installing ballerina, programming language, ballerina installation
 permalink: /swan-lake/learn/installing-ballerina/
 active: installing-ballerina
+intro: The sections below include information about installing Ballerina.
 redirect_from:
   - /swan-lake/learn/getting-started
   - /swan-lake/learn/getting-started/
@@ -12,20 +13,6 @@ redirect_from:
   - /swan-lake/learn/installing-ballerina/#installing-from-source
   - /swan-lake/learn/installing-ballerina/#installing-from-source/
 ---
-
-# Installing Ballerina
-
-- [Installing Ballerina via Installers](#installing-ballerina-via-installers)
-    - [Installing on macOS](#installing-on-macos)
-    - [Installing on Windows](#installing-on-windows)
-    - [Installing on Linux](#installing-on-linux)
-- [Installing via the Ballerina Language ZIP File](#installing-via-the-ballerina-language-zip-file)
-- [Updating Ballerina](#updating-ballerina)
-- [Building from Source](#building-from-source)
-    - [Setting Up the Prerequisites](#setting-up-the-prerequisites)
-    - [Obtaining the Source Code](#obtaining-the-source-code)
-    - [Building the Source](#building-the-source)
-- [Uninstalling Ballerina](#uninstalling-ballerina)
 
 ## Installing Ballerina via Installers
 

--- a/swan-lake/learn/keeping-ballerina-up-to-date.md
+++ b/swan-lake/learn/keeping-ballerina-up-to-date.md
@@ -5,38 +5,20 @@ description: Learn how to maintain your Ballerina programming language installat
 keywords: ballerina, programming language, release, update
 permalink: /swan-lake/learn/keeping-ballerina-up-to-date/
 active: keeping-ballerina-up-to-date
+intro: This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases.
 redirect_from:
   - /swan-lake/learn/how-to-keep-ballerina-up-to-date
   - /swan-lake/learn/how-to-keep-ballerina-up-to-date/
   - /swan-lake/learn/keeping-ballerina-up-to-date
 ---
 
-# Keeping Ballerina Up to Date
-
-This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases. If you haven’t installed Ballerina yet, visit [installation guide](/swan-lake/learn/installing-ballerina/).
-
-- [Terminology](#terminology)
-  - [Ballerina tool](#ballerina-tool)
-  - [Ballerina distributions](#ballerina-distributions)
-  - [Release channels](#release-channels)
-    - [Patch release channel](#patch-release-channel)
-    - [Minor release channel](#minor-release-channel)
-    - [Release maintenance](#release-maintenance)
-- [Keeping Ballerina upto date](#keeping-ballerina-upto-date)
-  - [The “active” distribution](#the-active-distribution)
-  - [The `ballerina dist` command](#the-ballerina-dist-command)
-  - [Update to the latest patch version](#update-to-the-latest-patch-version)
-  - [List local and remote distributions](#list-local-and-remote-distributions)
-  - [Remove distributions](#remove-distributions)
-  - [Change the active distribution](#change-the-active-distribution)
-  - [Pull a specific distribution](#pull-a-specific-distribution)
-  - [Update the Ballerina tool](#update-the-ballerina-tool)
+If you haven’t installed Ballerina yet, visit [installation guide](/swan-lake/learn/installing-ballerina/).
 
 ## Terminology
 
 This section introduces various terms used throughout this guide. We recommend that you read this section before proceeding to the next.  
 
-### Ballerina tool
+### The Ballerina Tool
 
 **Ballerina** is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build, and run programs, etc.
 

--- a/swan-lake/learn/observing-ballerina-code.md
+++ b/swan-lake/learn/observing-ballerina-code.md
@@ -5,6 +5,7 @@ description: See how Ballerina supports observability by exposing itself via met
 keywords: ballerina, observability, metrics, tracing, logs
 permalink: /swan-lake/learn/observing-ballerina-code/
 active: how-to-observing-ballerina-code
+intro: Observability is a measure of how well internal states of a system can be inferred from knowledge of its external outputs.
 redirect_from:
   - /swan-lake/learn/how-to-observe-ballerina-code
   - /swan-lake/learn/how-to-observe-ballerina-code/
@@ -13,10 +14,9 @@ redirect_from:
   - /swan-lake/learn/observing-ballerina-code
 ---
 
-# Observing Ballerina Code
+## Providing observability in Ballerina
 
-Observability is a measure of how well internal states of a system can be inferred from knowledge of its external
-outputs. Monitoring, logging, and distributed tracing are key methods that reveal the internal state of the system to provide the observability. Ballerina becomes fully observable by exposing itself via these three methods to various external systems allowing to monitor metrics such as request count and response time statistics, analyze logs, and
+Monitoring, logging, and distributed tracing are key methods that reveal the internal state of the system to provide the observability. Ballerina becomes fully observable by exposing itself via these three methods to various external systems allowing to monitor metrics such as request count and response time statistics, analyze logs, and
 perform distributed tracing. 
 
 HTTP/HTTPS based Ballerina services and any client connectors are observable by default. HTTP/HTTPS and SQL client
@@ -25,32 +25,6 @@ connectors use semantic tags to make tracing and metrics monitoring more informa
 This guide focuses on enabling Ballerina service observability with some of its default supported systems.
 [Prometheus] and [Grafana] are used for metrics monitoring, and [Jaeger] is used for distributed tracing. 
 Ballerina logs can be fed to any external log monitoring system like [Elastic Stack] to perform log monitoring and analysis.
-
-- [Observing a Ballerina Service](#observing-a-ballerina-service)
-  - [Step 1 - Setting up the Prerequisites](#step-1---setting-up-the-prerequisites)
-  - [Step 2 - Installing and Configuring the External Systems](#step-2---installing-and-configuring-the-external-systems)
-  - [Step 3 - Creating a Hello World Ballerina Service](#step-3---creating-a-hello-world-ballerina-service)
-  - [Step 4 - Observing the Hello World Ballerina Service](#step-4---observing-the-hello-world-ballerina-service)
-    - [Starting the Service Using a Flag](#starting-the-service-using-a-flag)
-    - [Starting the Service Using a Configuration File](#starting-the-service-using-a-configuration-file)
-  - [Step 5 - Sending Few Requests](#step-5---sending-few-requests)
-  - [Step 6 - Viewing Tracing and Metrics in the Dashboard](#step-6---viewing-tracing-and-metrics-in-the-dashboard)
-  - [Step 7 - Visualizing the Logs](#step-7---visualizing-the-logs)
-- [Monitoring Metrics](#monitoring-metrics)
-  - [Configuring Advanced Metrics for Ballerina](#configuring-advanced-metrics-for-ballerina)
-  - [Setting Up the External Systems for Metrics](#setting-up-the-external-systems-for-metrics)
-    - [Setting Up Prometheus](#setting-up-prometheus)
-    - [Setting Up Grafana](#setting-up-grafana)
-- [Distributed Tracing](#distributed-tracing)
-  - [Configuring Advanced Tracing for Ballerina](#configuring-advanced-tracing-for-ballerina)
-    - [Using the Jaeger Client](#using-the-jaeger-client)
-    - [Using the Zipkin Client](#using-the-zipkin-client)
-  - [Setting Up the External Systems for Tracing](#setting-up-the-external-systems-for-tracing)
-    - [Setting Up the Jaeger Server](#setting-up-the-jaeger-server)
-    - [Setting Up the Zipkin Server](#setting-up-the-zipkin-server)
-- [Distributed Logging](#distributed-logging)
-  - [Setting Up the External Systems for Log Analytics](#setting-up-the-external-systems-for-log-analytics)
-    - [Setting Up Elastic Stack](#setting-up-elastic-stack)
 
 ## Observing a Ballerina Service
 

--- a/swan-lake/learn/publishing-modules-to-ballerina-central.md
+++ b/swan-lake/learn/publishing-modules-to-ballerina-central.md
@@ -5,19 +5,14 @@ description: Learn how to use the CLI tool in the Ballerina programming language
 keywords: ballerina, programming language, ballerina central, ballerina modules
 permalink: /swan-lake/learn/publishing-modules-to-ballerina-central/
 active: publishing-modules-to-ballerina-central
+intro: The sections below include information about publishing modules to Ballerina Central.
 redirect_from:
   - /swan-lake/learn/how-to-publish-modules
   - /swan-lake/learn/how-to-publish-modules/
   - /swan-lake/learn/publishing-modules-to-ballerina-central
 ---
 
-# Publishing Modules to Ballerina Central
-
-- [CLI Command](#cli-command)
-- [Setting Up](#setting-up)
-- [Organizations](#organizations)
-
-## CLI Command
+## The CLI command
 
 Pushing a module uploads it to [Ballerina Central](https://central.ballerina.io/).
 
@@ -25,7 +20,7 @@ Pushing a module uploads it to [Ballerina Central](https://central.ballerina.io/
 ballerina push <module-name>
 ```
 
-## Setting Up
+## Setting up
 
 Before you push your module, you must enter your Ballerina Central access token in `Settings.toml` in your home repository (`<USER_HOME>/.ballerina/`).
 

--- a/swan-lake/learn/quick-tour.md
+++ b/swan-lake/learn/quick-tour.md
@@ -5,25 +5,18 @@ description: A quick tour of the Ballerina programming language, including writi
 keywords: ballerina, quick tour, programming language, http service
 permalink: /swan-lake/learn/quick-tour/
 active: quick-tour
+intro: Now, that you know a little bit of Ballerina, let's take it for a spin!
 redirect_from:
   - /swan-lake/learn/quick-tour
 ---
 
-# Quick Tour
-
-Now, that you know a little bit of Ballerina, let's take it for a spin!
-
-- [Install Ballerina](#install-ballerina)
-- [Write a Service, Run It, and Invoke It](#write-a-service-run-it-and-invoke-it)
-- [Use a Client to Interact with a Network-Accessible Service](#use-a-client-to-interact-with-a-network-accessible-service)
-
-## Install Ballerina
+## Installing Ballerina
 
 1. [Download](https://ballerina.io/downloads) Ballerina based on the Operating System you are using. 
 1. Follow the instructions given on the [Getting Started](/swan-lake/learn/getting-started) page to set it up. 
 1. Follow the instructions given on the [Visual Studio Code Plugin](/swan-lake/learn/tools-ides/vscode-plugin) page or the [IntelliJ IDEA Plugin](/swan-lake/learn/tools-ides/intellij-plugin) page to set up your preferred editor for Ballerina.
 
-## Write a Service, Run It, and Invoke It
+## Writing a service, running it, and invoking it
 
 Write a simple Hello World HTTP service in a file with the `.bal` extension.
 
@@ -79,7 +72,7 @@ Hello Ballerina!
 
 Alternatively, you can use a Ballerina HTTP client to invoke the service.
 
-## Use a Client to Interact with a Network-Accessible Service
+## Using a client to interact with a network-accessible service
 
 A Ballerina client is a component, which interacts with a network-accessible service. It aggregates one or more actions that can be executed on the network-accessible service and accepts configuration parameters related to the network-accessible service.
 
@@ -179,7 +172,7 @@ $ ballerina run sunrise_client.bal
 
 This should print out the sunrise/sunset details.
 
-## What's Next?
+## What's next?
 
 Now, that you have taken Ballerina around for a quick tour, you can explore Ballerina more.
 

--- a/swan-lake/learn/running-ballerina-code.md
+++ b/swan-lake/learn/running-ballerina-code.md
@@ -5,6 +5,7 @@ description: Learn how to run Ballerina programs and services using the CLI tool
 keywords: ballerina, programming language, services
 permalink: /swan-lake/learn/running-ballerina-code/
 active: running-ballerina-code
+intro: The sections below include information on running Ballerina programs.
 redirect_from:
   - /swan-lake/learn/how-to-deploy-and-run-ballerina-programs
   - /swan-lake/learn/how-to-run-ballerina-programs/
@@ -12,7 +13,7 @@ redirect_from:
   - /swan-lake/learn/running-ballerina-code
 ---
 
-# Running Ballerina Code
+## Understanding the structure
 
 A Ballerina application can have:
 

--- a/swan-lake/learn/set-up-ballerina-sdk.md
+++ b/swan-lake/learn/set-up-ballerina-sdk.md
@@ -3,18 +3,10 @@ layout: ballerina-left-nav-pages-swanlake
 title: Setting up Ballerina SDK
 permalink: /swan-lake/learn/set-up-ballerina-sdk/
 active: set-up-ballerina-sdk
+intro: After installing the IntelliJ Ballerina plugin, you need to set up Ballerina SDK for your Ballerina projects to activate all the capabilities of the plugin. Click on the below links for instructions on how to set up Ballerina SDK.
 redirect_from:
   - /swan-lake/learn/set-up-ballerina-sdk
 ---
-
-# Setting up Ballerina SDK
-
-After [installing the IntelliJ Ballerina plugin](intellij-plugin-doc.md), you need to set up Ballerina SDK for your Ballerina projects to activate all the capabilities of the plugin. 
-
-Click on the below links for instructions on how to set up Ballerina SDK.
-
-- [Setting up for a new project](#setting-up-for-a-new-project)
-- [Setting up for an existing project](#setting-up-for-an-existing-project)
 
 ## Setting up for a new project
 

--- a/swan-lake/learn/structuring-ballerina-code.md
+++ b/swan-lake/learn/structuring-ballerina-code.md
@@ -5,48 +5,18 @@ description: Learn how to develop a Ballerina project, structure code, and use t
 keywords: ballerina, programming language, ballerina modules, structure code
 permalink: /swan-lake/learn/structuring-ballerina-code/
 active: structuring-ballerina-code
+intro: This document demonstrates the development of a Ballerina project and shows how to use the `Ballerina Tool` to fetch, build, and install Ballerina modules.
 redirect_from:
   - /swan-lake/learn/how-to-structure-ballerina-code
   - /swan-lake/learn/how-to-structure-ballerina-code/
   - /swan-lake/learn/structuring-ballerina-code
 ---
 
-# Structuring Ballerina Code
-This document demonstrates the development of a Ballerina project and shows how to use the `Ballerina Tool` to fetch, 
-build, and install Ballerina modules. These commands work with repositories that are both local and remote.
-
-Ballerina Central is a globally hosted module management system that is used to discover, download, and publish modules.
-
-- [Organizing Your Code](#organizing-your-code)
-- [Programs](#programs)
-    - [Building and Running Programs](#building-and-running-programs)
-- [Modules](#modules)
-    - [Importing Modules](#importing-modules)
-    - [Module Version Dependency](#module-version-dependency)
-    - [ Compiled Modules](#compiled-modules)
-    - [Running Compiled Modules](#running-compiled-modules)
-- [Projects](#projects)
-    - [Creating a Project](#creating-a-project)
-    - [Adding a Module](#adding-a-module)
-    - [Project Structure](#project-structure)
-    - [Building a Project](#building-a-project)
-    - [Building a Module](#building-a-module)
-    - [Compiling a Project](#compiling-a-project)
-    - [Compiling a Module](#compiling-a-module)
-    - [Versioning a Module](#versioning-a-module)
-    - [Assigning an Organization Name to a Module](#assigning-an-organization-name-to-a-module)
-- [Module Caches](#module-caches)
-    - [Caches](#caches)
-        - [BALO Cache](#balo-cache)
-        - [BIR Cache](#bir-cache)
-        - [JAR Cache](#jar-cache)
-    - [Module Repository - Ballerina Central](#module-repository---ballerina-central)
-        - [Organizations](#organizations)
-        - [Pulling Remote Modules](#pulling-remote-modules)
-        - [Pushing Modules](#pushing-modules)
-        - [Configuring Ballerina Central Access](#configuring-ballerina-central-access)
-
 ## Organizing Your Code
+
+> These commands work with repositories that are both local and remote.
+
+Ballerina Central is a globally hosted module management system that is used to discover, download, and publish modules
 
 The `Ballerina Tool` requires you to organize your code in a specific way. This document explains the simplest way to get it up and running with a Ballerina installation.
 

--- a/swan-lake/learn/testing-ballerina-code/executing-tests.md
+++ b/swan-lake/learn/testing-ballerina-code/executing-tests.md
@@ -5,15 +5,10 @@ description: Learn how to use different options for executing Ballerina tests.
 keywords: ballerina, programming language, testing
 permalink: /swan-lake/learn/testing-ballerina-code/executing-tests/
 active: executing-tests
+intro: The sections below include information about executing tests in Ballerina.
 redirect_from:
   - /swan-lake/learn/testing-ballerina-code/executing-tests
 ---
-
-# Executing Tests
-
-- [Executing Tests Using CLI Commands](#executing-tests-using-cli-commands)
-- [Test Report](#test-report)
-- [Code Coverage Report](#code-coverage-report)
 
 ## Executing Tests Using CLI Commands
 

--- a/swan-lake/learn/testing-ballerina-code/mocking.md
+++ b/swan-lake/learn/testing-ballerina-code/mocking.md
@@ -6,29 +6,14 @@ description: Learn how to use Ballerina's built-in mocking API provided by the t
 keywords: ballerina, programming language, testing, mocking
 permalink: /swan-lake/learn/testing-ballerina-code/mocking/
 active: mocking
+intro: Mocking is useful to control the behavior of functions and objects to control the communication with other modules and external endpoints. A mock can be created by defining return values or replacing the entire object or function with a user-defined equivalent. This feature will help you to test the Ballerina code independently from other modules and external endpoints.
 redirect_from:
   - /swan-lake/learn/testing-ballerina-code/mocking
 ---
 
-# Mocking
-
-Mocking is useful to control the behavior of functions and objects to control the communication with other modules and external endpoints. A mock can be created by defining return values or replacing the entire object or function with a user-defined equivalent. This feature will help you to test the Ballerina code independently from other modules and external endpoints.
-
-- [Mocking Objects](#mocking-objects)
-    - [Creating a Test Double](#creating-a-test-double)
-    - [Stubbing Member Functions and Variables of an Object](#stubbing-member-functions-and-variables-of-an-object)
-        - [Stubbing to Return a Specific Value](#stubbing-to-return-a-specific-value)
-        - [Stubbing with Multiple Values to Return Sequentially for Each Function Call](#stubbing-with-multiple-values-to-return-sequentially-for-each-function-call)
-        - [Stubbing a Member Variable](#stubbing-a-member-variable)
-        - [Stubbing to Do Nothing](#stubbing-to-do-nothing)
-- [Mocking Functions](#mocking-functions)
-    - [Stubbing to Return a Specific Value](#stubbing-to-return-a-specific-value)
-    - [Stubbing to Invoke Another Function in Place of the Real](#stubbing-to-invoke-another-function-in-place-of-the-real)
-
-
 ## Mocking Objects
 
-The test module provides capabilities to mock an object for unit testing. This allows you to control the behavior of the object member functions and values of member fields via stubbing or replacing the entire object with a user-defined equivalent. This feature will help you to test the Ballerina code independently from other modules and external endpoints.
+The `Test` module provides capabilities to mock an object for unit testing. This allows you to control the behavior of the object member functions and values of member fields via stubbing or replacing the entire object with a user-defined equivalent. This feature will help you to test the Ballerina code independently from other modules and external endpoints.
 
 Mocking of objects can be done in two ways.
 

--- a/swan-lake/learn/testing-ballerina-code/testing-quick-start.md
+++ b/swan-lake/learn/testing-ballerina-code/testing-quick-start.md
@@ -5,6 +5,7 @@ description: Learn how to use Ballerina's built-in test framework to write testa
 keywords: ballerina, programming language, testing
 permalink: /swan-lake/learn/testing-ballerina-code/testing-quick-start/
 active: testing-quick-start
+intro: The Ballerina Language has a built-in robust test framework, which allows you to achieve multiple levels of the test pyramid including unit testing, integration testing, and end to end testing.  It provides features such as assertions, data providers, mocking, and code coverage, which enable the programmers to write comprehensive tests.
 redirect_from:
   - /swan-lake/learn/how-to-test-ballerina-code/
   - /swan-lake/learn/how-to-test-ballerina-code
@@ -13,9 +14,7 @@ redirect_from:
   - /swan-lake/learn/testing-ballerina-code
 ---
 
-# Testing Quick Start
-
-The Ballerina Language has a built-in robust test framework, which allows you to achieve multiple levels of the test pyramid including unit testing, integration testing, and end to end testing.  It provides features such as assertions, data providers, mocking, and code coverage, which enable the programmers to write comprehensive tests.
+## Writing a simple function
 
 To get started, let's write a simple Ballerina function and test it.
 

--- a/swan-lake/learn/testing-ballerina-code/writing-tests.md
+++ b/swan-lake/learn/testing-ballerina-code/writing-tests.md
@@ -6,20 +6,10 @@ description: Learn how to use Ballerina's built-in test framework to write tests
 keywords: ballerina, programming language, testing
 permalink: /swan-lake/learn/testing-ballerina-code/writing-tests/
 active: writing-tests
+ntro: The sections below include information about writing tests in Ballerina.
 redirect_from:
   - /swan-lake/learn/testing-ballerina-code/writing-tests
 ---
-
-# Writing Tests
-
-- [Project Structure](#project-structure)
-- [Test Source Files](#test-source-files)
-- [Test Resources](#test-resources)
-- [Defining a Test](#defining-a-test)
-- [Visibility of Symbols](#visibility-of-symbols)
-- [Using Assertions](#using-assertions)
-- [Setup and Teardown](#setup-and-teardown)
-- [Test Configurations](#test-configurations)
 
 ## Project Structure
 

--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea.md
@@ -3,6 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Setting up IntelliJ IDEA
 permalink: /swan-lake/learn/setting-up-intellij-idea/
 active: setting-up-intellij-idea
+intro: The IntelliJ Ballerina plugin provides the Ballerina development capabilities in IntelliJ IDEA. The below sections include instructions on how to download, install, and use the features of the IntelliJ plugin.
 redirect_from:
   - /swan-lake/learn/tools-ides/intellij-plugin
   - /swan-lake/learn/tools-ides/intellij-plugin/
@@ -13,22 +14,7 @@ redirect_from:
   - /swan-lake/learn/setting-up-intellij-idea
 ---
 
-# Setting up IntelliJ IDEA
-
-The IntelliJ Ballerina plugin provides the Ballerina development capabilities in IntelliJ IDEA. The below sections include instructions on how to download, install, and use the features of the IntelliJ plugin.
-
-- [Prerequisites](#prerequisites)
-- [Installing the Plugin](#installing-the-plugin)
-  - [Installing via the IntelliJ IDE](#installing-via-the-intellij-ide)
-  - [Installing Using the ZIP File](#installing-using-the-zip-file)
-    - [Obtaining the ZIP File](#obtaining-the-zip-file)
-    - [Downloading from the JetBrains Plugin Repository](#downloading-from-the-jetbrains-plugin-repository)
-    - [Building from the Source](#building-from-the-source)
-    - [Installing the ZIP File via the IDE](#installing-the-zip-file-via-the-ide)
-- [Using the Plugin](#using-the-plugin)
-- [Using the Features of the Plugin](#using-the-features-of-the-plugin)
-
-## Prerequisites
+## Setting up the prerequisites
 
 You need [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) installed.
 

--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
@@ -3,6 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Using the features of the IntelliJ plugin
 permalink: /swan-lake/learn/setting-up-intellij-idea/using-intellij-plugin-features/
 active: using-intellij-plugin-features
+intro: The sections below include information on the various capabilities that are facilitated by the IntelliJ Ballerina plugin for the development process.
 redirect_from:
   - /swan-lake/learn/tools-ides/intellij-plugin/using-intellij-plugin-features
   - /swan-lake/learn/tools-ides/intellij-plugin/using-intellij-plugin-features/
@@ -15,33 +16,11 @@ redirect_from:
   - /swan-lake/learn/using-intellij-plugin-features/
 ---
 
-# Using the Features of the IntelliJ Plugin
-
-The below sections include information on the various capabilities that are facilitated by the IntelliJ Ballerina plugin for the development process.
-
-- [Running Ballerina Programs](#running-ballerina-programs)
-    - [Running the Main Method](#running-the-main-method)
-    - [Running Ballerina Services](#running-ballerina-services)
-- [Debugging Ballerina Programs](#debugging-ballerina-programs)
-    - [Troubleshooting](#troubleshooting)
-- [Viewing the Sequence Diagram](#viewing-the-sequence-diagram)
-- [Importing Modules on the Fly](#importing-modules-on-the-fly)
-- [Importing Unambiguous Modules](#importing-unambiguous-modules)
-- [Formatting Ballerina Codes](#formatting-ballerina-codes)
-- [Viewing Documentation](#viewing-documentation)
-- [Adding Annotation Fields via Suggestions](#adding-annotation-fields-via-suggestions)
-- [Using File Templates](#using-file-templates)
-- [Using Code Snippet Templates](#using-code-snippet-templates)
-- [Checking Spellings](#checking-spellings)
-- [Analyzing Semantics](#analyzing-semantics)
-- [Code Folding](#code-folding)
-- [Go to Definition](#go-to-definition)
-
 ## Running Ballerina Programs
 
 You can run Ballerina main/service programs with a single click without adding or changing any configurations.
 
-The below sections include instructions on how to run different elements of a Ballerina file.
+The sections below include instructions on how to run different elements of a Ballerina file.
 
 - [Running the main method](#running-the-main-method)
 - [Running Ballerina services](#running-ballerina-services)

--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
@@ -3,6 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Using the IntelliJ Ballerina Plugin
 permalink: /swan-lake/learn/setting-up-intellij-idea/using-the-intellij-plugin/
 active: using-the-intellij-plugin
+intro: The sections below include information to start using the IntelliJ Ballerina plugin after installing it.
 redirect_from:
   - /swan-lake/learn/tools-ides/intellij-plugin/using-the-intellij-plugin
   - /swan-lake/learn/tools-ides/intellij-plugin/using-the-intellij-plugin/
@@ -16,18 +17,6 @@ redirect_from:
   - /swan-lake/learn/using-the-intellij-plugin
   - /swan-lake/learn/using-the-intellij-plugin/
 ---
-
-# Using the IntelliJ Ballerina Plugin
-
-The below sections include information to start using the IntelliJ Ballerina plugin after [installing it](/swan-lake/learn/intellij-plugin).
-
-- [Creating a New Ballerina Project](#creating-a-new-ballerina-project)
-- [Setting Up Ballerina SDK for an Existing Project](#setting-up-ballerina-sdk-for-an-existing-project)
-- [Creating a New Ballerina File](#creating-a-new-ballerina-file)
-- [Configuring the Plugin Settings](#configuring-the-plugin-settings)
-    - [Ballerina Home Auto Detection](#ballerina-home-auto-detection)
-    - [Experimental Features](#experimental-features)
-    - [Language Server Debug Logs](#language-server-debug-logs)
 
 ## Creating a New Ballerina Project
 

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code.md
@@ -3,6 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Setting Up Visual Studio Code
 permalink: /swan-lake/learn/setting-up-visual-studio-code/
 active: setting-up-visual-studio-code
+intro: The VS Code Ballerina extension provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code extension.
 redirect_from:
   - /swan-lake/learn/tools-ides/vscode-plugin
   - /swan-lake/learn/tools-ides/vscode-plugin/
@@ -12,16 +13,6 @@ redirect_from:
   - /swan-lake/learn/tools-ides/setting-up-visual-studio-code/
   - /swan-lake/learn/setting-up-visual-studio-code
 ---
-
-# Setting Up Visual Studio Code 
-
-The VS Code Ballerina extension provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code extension.
-
-- [Downloading VS Code](#downloading-vs-code)
-- [Installing the Extension](#installing-the-extension)
-  - [Installing via the VS Code Editor](#installing-via-the-vs-code-editor)
-  - [Installing via the Command Line](#installing-via-the-command-line)
-- [Using the Extension](#using-the-extension)
 
 ## Downloading VS Code 
 

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
@@ -3,6 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Documentation Viewer
 permalink: /swan-lake/learn/setting-up-visual-studio-code/documentation-viewer/
 active: documentation-viewer
+intro: The VS Code Ballerina extension is shipped with a Documentation Viewer. You can add documentation for the functions and other public entities in your module for the reference of other users of it. 
 redirect_from:
   - /swan-lake/learn/tools-ides/vscode-plugin/documentation-viewer
   - /swan-lake/learn/tools-ides/vscode-plugin/documentation-viewer/
@@ -15,9 +16,7 @@ redirect_from:
   - /swan-lake/learn/documentation-viewer/
 ---
 
-# Documentation Viewer
-
-The VS Code Ballerina extension is shipped with a Documentation Viewer. You can add documentation for the functions and other public entities in your module for the reference of other users of it. 
+## Launching the Documentation Viewer
 
 The Documentation Viewer represents the documented entities in a file in an organized manner. Follow the steps below to launch the Documentation Viewer.
 

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
@@ -3,6 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Graphical View
 permalink: /swan-lake/learn/setting-up-visual-studio-code/graphical-editor/
 active: graphical-editor
+intro: A rich set of visualization tools will immensely enhance your development experience especially in the integration space.The Graphical Editor of the VS Code Ballerina extension allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. The sections below discuss how to use the Graphical Editor and explore its capabilities.
 redirect_from:
   - /swan-lake/learn/tools-ides/vscode-plugin/graphical-editor
   - /swan-lake/learn/tools-ides/vscode-plugin/graphical-editor/
@@ -14,21 +15,6 @@ redirect_from:
   - /swan-lake/learn/graphical-editor
   - /swan-lake/learn/graphical-editor/
 ---
-
-# Graphical View
-
-A rich set of visualization tools will immensely enhance your development experience especially in the integration space. 
-
-The Graphical Editor of the VS Code Ballerina extension allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. 
-
-The bellow sections discuss how to use the Graphical Editor and explore its capabilities.
-
-- [Launching the Graphical View](#launching-the-graphical-view)
-  - [Launching the Project Overview](#launching-the-project-overview)
-  - [Launching the File Overview](#launching-the-file-overview)
-- [Exploring the Features of the Graphical View](#exploring-the-features-of-the-graphical-view)
-  - [Viewing the Source](#viewing-the-source)
-  - [Expanding the Diagram View](#expanding-the-diagram-view)
 
 ## Launching the Graphical View
 

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
@@ -3,6 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Language Intelligence
 permalink: /swan-lake/learn/setting-up-visual-studio-code/language-intelligence/
 active: language-intelligence
+intro: The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency. Language intelligence is built in to the extension via a Language Server implementation, which consists of the below language intelligence options.
 redirect_from:
   - /swan-lake/learn/tools-ides/vscode-plugin/language-intelligence
   - /swan-lake/learn/tools-ides/vscode-plugin/language-intelligence/
@@ -14,18 +15,6 @@ redirect_from:
   - /swan-lake/learn/language-intelligence
   - /swan-lake/learn/language-intelligence/
 ---
-
-# Language Intelligence
-
-The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency.
-
-Language intelligence is built in to the extension via a Language Server implementation, which consists of the below language intelligence options.
-
-- [Semantic and syntactic diagnostics](#semantic-and-syntactic-diagnostics)
-- [Suggestions and auto completion](#suggestions-and-auto-completion)
-- [Code actions](#code-actions)
-- [Hover support](#hover-support)
-- [Go to definition](#go-to-definition)
 
 ## Semantic and syntactic diagnostics
 

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
@@ -3,6 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Run all Tests
 permalink: /swan-lake/learn/setting-up-visual-studio-code/run-all-tests/
 active: run-all-tests
+intro: This option allows you to run all the tests that belong to multiple modules of your project. 
 redirect_from:
   - /swan-lake/learn/tools-ides/vscode-plugin/run-all-tests
   - /swan-lake/learn/tools-ides/vscode-plugin/run-all-tests/
@@ -15,9 +16,9 @@ redirect_from:
   - /swan-lake/learn/run-all-tests/
 ---
 
-# Run all Tests
+## Running all tests 
 
-This option allows you to run all the tests that belong to multiple modules of your project. Follow the steps below to do this.
+Follow the steps below to do this.
 
 1. Click **View** in the top menu and click **Command Palette**.
 2. In the search box, type "Ballerina" and click **Ballerina: Run All Tests**.

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
@@ -3,6 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Run and Debug
 permalink: /swan-lake/learn/setting-up-visual-studio-code/run-and-debug/
 active: run-and-debug
+intro: The VS Code Ballerina extension gives you the  same debugging experience as the conventional VS Code Debugger. Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
 redirect_from:
   - /swan-lake/learn/tools-ides/vscode-plugin/run-and-debug
   - /swan-lake/learn/tools-ides/vscode-plugin/run-and-debug/
@@ -14,15 +15,6 @@ redirect_from:
   - /swan-lake/learn/run-and-debug
   - /swan-lake/learn/run-and-debug/
 ---
-
-# Run and Debug
-
-The VS Code Ballerina extension gives you the  same debugging experience as the conventional VS Code Debugger.
-
-Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
-
-- [Starting a Debug Session](#starting-a-debug-session)
-- [Troubleshooting](#troubleshooting)
 
 ## Starting a Debug Session
 

--- a/swan-lake/learn/using-the-cli-tools.md
+++ b/swan-lake/learn/using-the-cli-tools.md
@@ -5,27 +5,22 @@ description: Learn all the command line interface (CLI) commands need to get sta
 keywords: ballerina, cli, command line interface, programming language
 permalink: /swan-lake/learn/using-the-cli-tools/
 active: using-the-cli-tools
+intro: The `ballerina` command is your one-stop-shop for all the things you do in Ballerina. 
 redirect_from:
   - /swan-lake/learn/cli-commands
   - /swan-lake/learn/cli-commands/
   - /swan-lake/learn/using-the-cli-tools
 ---
 
-# Using the CLI Tools
-
-The `ballerina` command is your one-stop-shop for all the things you do in Ballerina. You can use it in the below format.
-
-> `ballerina <THE-COMMAND> <ITS-ARGUEMENTS>`
+## Using the `ballerina` command
 
 In the CLI, execute the `ballerina help` command to view all the actions you can perform with it as shown below:
 
 ![CLI commands](/swan-lake/learn/images/cli-commands.png)
 
-- [Core commands](#core-commands)
-- [Module commands](#module-commands)
-- [Project commands](#project-commands)
-- [Other commands](#other-commands)
-- [Update commands](#update-commands)
+You can use it in the below format.
+
+> `ballerina <THE-COMMAND> <ITS-ARGUEMENTS>`
 
 > **Tip:** You can view details of any of the commands below by executing `ballerina help <COMMAND>`. For example, the below is the output of the `ballerina help pull` command.
 

--- a/swan-lake/learn/using-the-openapi-tools.md
+++ b/swan-lake/learn/using-the-openapi-tools.md
@@ -5,6 +5,7 @@ description: Check out how the Ballerina OpenAPI tooling makes it easy for users
 keywords: ballerina, programming language, openapi, open api, restful api
 permalink: /learn/using-the-openapi-tools/
 active: using-the-openapi-tools
+intro: OpenAPI Specification is a specification that creates a RESTFUL contract for APIs, detailing all of its resources and operations in a human and machine-readable format for easy development, discovery, and integration. Ballerina OpenAPI tooling will make it easy for users to start development of a service documented in OpenAPI contract in Ballerina by generating Ballerina service and client skeletons.
 redirect_from:
   - /v1-2/learn/how-to-use-openapi-tools
   - /v1-2/learn/how-to-use-openapi-tools/
@@ -13,12 +14,9 @@ redirect_from:
   - /learn/using-the-openapi-tools
 ---
 
-# Ballerina OpenAPI Tools
+## Using the capabilities of the OpenAPI Tools
 
-The OpenAPI Specification is a specification, which creates a RESTFUL contract for APIs detailing all of its resources 
-and operations in a human and machine readable format for easy development, discovery, and integration. Ballerina
- OpenAPI tooling will make it easy for users to start development of a service documented in the OpenAPI contract 
-  by generating the Ballerina service and client skeletons. The OpenAPI tools provide the following capabilities.
+The OpenAPI tools provide the following capabilities.
  
  1. Generate the Ballerina service or client code for a given OpenAPI definition. 
  2. Export the OpenAPI definition of a Ballerina service.
@@ -28,18 +26,7 @@ The `openapi` command in Ballerina is used for OpenAPI to Ballerina and Ballerin
 Code generation from OpenAPI to Ballerina can produce `ballerina service stubs` and `ballerina client stubs`.
 The OpenAPI compiler plugin will allow you to validate a service implementation against an OpenAPI contract during
  compile time. 
-This plugin ensures that the implementation of a service does not deviate from its OpenAPI contract.
-
-- [OpenAPI to Ballerina](#openAPI-to-ballerina)
-    - [Generate Service and Client Stub from OpenAPI Contract](#generate-service-and-client-stub-from-openapi-contract)
-        - [Modes](#modes)
-- [Ballerina to OpenAPI](#ballerina-to-openAPI)    
-    - [Service to OpenAPI Export](#service-to-openapi-export)
-- [Samples](#samples)
-    - [Generate Service and Client Stub from OpenAPI](#generate-service-and-client-stub-from-openAPI)
-    - [Generate OpenAPI contract from Service](#generate-openAPI-contract-from-service)
-- [OpenAPI Validator Compiler Plugin](#openAPI-validator-compiler-plugin)
-     
+This plugin ensures that the implementation of a service does not deviate from its OpenAPI contract.   
 
 ### OpenAPI to Ballerina
 #### Generate Service and Client stub from OpenAPI Contract

--- a/swan-lake/learn/writing-secure-ballerina-code.md
+++ b/swan-lake/learn/writing-secure-ballerina-code.md
@@ -5,45 +5,12 @@ description: Check out the different security features and controls available wi
 keywords: ballerina, programming language, security, secure ballerina code
 permalink: /swan-lake/learn/writing-secure-ballerina-code/
 active: writing-secure-ballerina-code
+intro: The sections below include information on the different security features and controls available within Ballerina. Also, they provide guidelines on writing secure Ballerina programs.
 redirect_from:
   - /swan-lake/learn/how-to-write-secure-ballerina-code
   - /swan-lake/learn/how-to-write-secure-ballerina-code/
   - /swan-lake/learn/writing-secure-ballerina-code
 ---
-
-# Writing Secure Ballerina Code
-
-This document demonstrates different security features and controls available within Ballerina, and serves the purpose of providing guidelines on writing secure Ballerina programs.
-
-*   [Secure by Design](#secure-by-design)
-    *   [Ensuring Security of Ballerina Standard Libraries](#ensuring-security-of-ballerina-standard-libraries)
-    *   [Securely Using Tainted Data with Security-Sensitive Parameters](#securely-using-tainted-data-with-security-sensitive-parameters)
-*   [Securing Passwords and Secrets](#securing-passwords-and-secrets)
-*   [Authentication and Authorization](#authentication-and-authorization)
-    *   [Inbound Authentication and Authorization](#inbound-authentication-and-authorization)
-        *   [Inbound Advanced Use Cases](#inbound-advanced-use-cases)
-            *   [Using Multiple Auth Handlers](#using-multiple-auth-handlers)
-            *   [Using Multiple Scopes](#using-multiple-scopes)
-            *   [Per-Resource and Per-Service Customization](#per-resource-and-per-service-customization)
-            *   [Implementing Inbound Custom Authentication Mechanism](#implementing-inbound-custom-authentication-mechanism)
-            *   [Disable HTTPS Enforcement](#disable-https-enforcement)
-            *   [Modify Authentication or Authorization Filter Index](#modify-authorization-or-authentication-filter-index)
-        *   [JWT Inbound Authentication and Authorization](#jwt-inbound-authentication-and-authorization)
-        *   [OAuth2 Inbound Authentication and Authorization](#oauth2-inbound-authentication-and-authorization)
-        *   [LDAP Inbound Authentication and Authorization](#ldap-inbound-authentication-and-authorization)
-        *   [Basic Auth Inbound Authentication and Authorization](#basic-auth-inbound-authentication-and-authorization)
-    *   [Outbound Authentication and Authorization](#outbound-authentication-and-authorization)
-        *   [Outbound Advanced Use Cases](#outbound-advanced-use-cases)
-            *   [Implementing Outbound Custom Authentication Mechanism](#implementing-outbound-custom-authentication-mechanism)
-        *   [JWT Outbound Authentication](#jwt-outbound-authentication)
-        *   [OAuth2 Outbound Authentication](#oauth2-outbound-authentication)
-            *   [Client Credentials Grant Type](#client-credentials-grant-type)
-            *   [Password Grant Type](#password-grant-type)
-            *   [Direct Token Mode](#direct-token-mode)
-        *   [Basic Auth Outbound Authentication](#basic-auth-outbound-authentication)
-        *   [Token Propagation for Outbound Authentication](#token-propagation-for-outbound-authentication)
-            *   [Example One](#example-one)
-            *   [Example Two](#example-two)
 
 ## Secure by Design
 


### PR DESCRIPTION
## Purpose
Add TOCs to Swan Lake Learn pages.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
