### PR TITLE
Fix Case Issues in Titles of All Learn Pages

### DIFF
--- a/learn/calling-java-code-from-ballerina.md
+++ b/learn/calling-java-code-from-ballerina.md
@@ -224,7 +224,7 @@ public class SnakeYamlSample {
 }
 ```
 
-#### Creating the `FileInputStream`
+#### Creating the 'FileInputStream'
 Our goal here is to create a new `java.io.FileInputStream` instance from the filename. In step 3, we generated bindings for the required Java classes. The following is the code snippet that does the job. 
 
 ```ballerina
@@ -308,7 +308,7 @@ In this section, we explained how to use the `bindgen` tool to generate Ballerin
 
 The next sections provide more details on various aspects related to Java interoperability in Ballerina. 
 
-## The `bindgen` Tool
+## The 'bindgen' Tool
 
 The following subsections explain how the `bindgen` tool works.
 
@@ -335,7 +335,7 @@ The following subsections explain how the `bindgen` tool works.
 
 The `bindgen` is a CLI tool, which generates Ballerina bindings for Java classes.
 
-### The `bindgen` Command
+### The 'bindgen' Command
 
 ```sh
 ballerina bindgen [(-cp|--classpath) <classpath>...]
@@ -808,7 +808,7 @@ function newArrayDequeWithCollection(handle c) returns handle = @java:Constructo
 } external;
 ```
 
-##### The `paramTypes` Field
+##### The 'paramTypes' Field
 You can use the `paramTypes` field to resolve the exact overloaded method. This field is defined as follows.
 
 ```ballerina

--- a/learn/coding-conventions.md
+++ b/learn/coding-conventions.md
@@ -16,13 +16,13 @@ redirect_from:
 
 > You can follow your own coding style when writing Ballerina source code. Also, plugins and tools can be configured to match your coding style.
 
-## Indentation and line length
+## Indentation and Line Length
 * Use four spaces (not tabs) for each level of indentation.
 * Keep the maximum length of a line to 120 characters. 
 
 > **Note:** You can configure tools and plugins to use tabs when indenting and to change the number of maximum characters of the line length.
 
-## Line spacing
+## Line Spacing
 
 * Use only a single space to separate keywords, types, and identifiers. 
    
@@ -79,7 +79,7 @@ function foo(string name, int id) {}
 service hello on ep1, ep2 {...}
 ```
 
-## Blank lines
+## Blank Lines
 
 Separate both statements and top level definitions by zero or one blank lines.
 
@@ -189,7 +189,7 @@ setValue("value");
 int|() result = getResult();
 ```
   
-## Line breaks
+## Line Breaks
 
 * Have only one statement in a line.
 * When splitting lines, which contains operator(s), split them right before an operator.
@@ -281,7 +281,7 @@ table<Employee> employee = table {
     };
 ```
 
-## Top Level Definitions
+## Top-Level Definitions
 
 For style guidelines on imports, service definition, object definition, record definition, referencing record or abstract object, etc., see [Top Level Definitions](/learn/style-guide/definitions).
 

--- a/learn/coding-conventions/top-level-definitions.md
+++ b/learn/coding-conventions/top-level-definitions.md
@@ -13,7 +13,7 @@ redirect_from:
   - /learn/coding-conventions/top-level-definitions
 ---
 
-## General practices
+## General Practices
 
 * Do not indent the top level definitions. 
   
@@ -48,13 +48,6 @@ service hello on ep1 {
         
 ```
 
-- [Imports](#imports)
-- [Function Definition](#function-definition)
-- [Service Definition](#service-definition)
-- [Object Definition](#object-definition)
-- [Record Definition](#record-definition)
-- [Referencing Record or Abstract Object](#referencing-record-or-abstract-object)
-
 ## Imports
 
 * Do not keep spaces between the organization name, divider `/`, and module name.
@@ -67,7 +60,7 @@ import ballerina/http;
 
 * Imports should be sorted alphabetically, first by the organization name and then by the module name.
 
-## Function definition
+## Function Definition
 * Do not keep spaces between the function name and the open parentheses `(` of the function signature.
 
 **Example,**
@@ -120,7 +113,7 @@ function getAddress(int value, string name) returns
 }          
 ```
 
-## Service definition
+## Service Definition
 
 * Keep the listener inline with the service signature.
   
@@ -153,7 +146,7 @@ service hello on ep1, ep2 {
 
 * Block indent each function definition, resource definition, and field definition inside a service definition.
  
-## Object definition
+## Object Definition
 
 * Block indent each field definition and each function definition on their own line.
 * Init function should be placed before all the other functions. 
@@ -189,7 +182,7 @@ type Person object {
 }
 ```
 
-## Record definition
+## Record Definition
 Block indent each of the field definitions (including the Rest field) in their own line.
 
 **Example,**
@@ -208,7 +201,7 @@ type Person record {|
 |}
 ```
 
-## Referencing record or abstract object 
+## Referencing Record or Abstract Object 
 * Do not keep spaces between the `*`, the abstract object name, or the record name.
   
 **Example,**

--- a/learn/deployment/docker.md
+++ b/learn/deployment/docker.md
@@ -584,7 +584,7 @@ target = "java8"
 
 Ballerina ships a base image (e.g., `ballerina/jre8:v1`) with some security hardening. It is used to build Docker images with the user's application code. However, sometimes, you might need to use your own Docker base image depending on your company policies or any additional requirements. This use case shows how to use a custom Docker base image to build Ballerina Docker images with the application code. 
 
-#### Setting UP The Prerequisites
+#### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 

--- a/learn/deployment/docker.md
+++ b/learn/deployment/docker.md
@@ -17,7 +17,7 @@ To create a Docker image, you have to create a Dockerfile by choosing a suitable
 
 The Ballerina compiler is capable of creating optimized Docker images out of the application source code. This guide includes step-by-step instructions on different use cases and executing the corresponding sample source code. 
 
-## Enabling Docker support
+## Enabling Docker Support
 
 Docker support is inbuilt and comes by default in any Ballerina distribution. You can enable Docker artifact generation by adding annotations to your Ballerina code. Follow the steps below to enable Docker support.
 
@@ -27,17 +27,17 @@ Docker support is inbuilt and comes by default in any Ballerina distribution. Yo
 
 3. Build the Ballerina source file/project (e.g., `ballerina build source.bal`).
 
-## Use cases
+## Use Cases
 
-### Running a Ballerina service in a Docker container
+### Running a Ballerina Service in a Docker Container
 
 This use case shows how to run a Ballerina service in a Docker container. The sample below demonstrates running a simple Ballerina hello world service in a Docker container. 
 
-#### Prerequisites
+#### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code 
+#### Sample Source Code 
 
 `hello_world_docker.bal`
 ```ballerina 
@@ -55,7 +55,7 @@ service hello on new http:Listener(9090){
 
 ```
 
-#### Steps to run
+#### Steps to Run
 
 1. Compile the `hello_world_docker.bal` file.
 
@@ -163,16 +163,16 @@ service hello on new http:Listener(9090){
     > docker rmi e48123737a65
   ```
 
-### Creating a custom Ballerina Docker image and pushing it automatically to the Docker registry
+### Creating a Custom Ballerina Docker Image and Pushing it Automatically to the Docker Registry
 
 This use case shows how to run a simple Ballerina hello world service in a Docker container with annotation configurations, which can be used to create a Docker image with a custom image-name and tag, and then automatically push the created image to the Docker registry.
 
-#### Prerequisites
+#### Setting Up the Prerequisites
 
 - A machine with [Docker](https://docs.docker.com/get-docker/) installed
 - A [Docker Hub](https://hub.docker.com/) account
 
-#### Sample source code
+#### Sample Source Code
 
 `custom_docker_name.bal`
 
@@ -207,7 +207,7 @@ In this sample, the following properties are set in the `@docker:Config` annotat
 
 > The `$env` variable is used to read the environment variable values from the system.
 
-#### Steps to run
+#### Steps to Run
 
 1. Export the username and password of Docker (registry).
 
@@ -246,15 +246,15 @@ In this sample, the following properties are set in the `@docker:Config` annotat
 
     ![Docker Hub](/learn/images/docker-hub.png)
 
-### Running a Ballerina HTTPS service in a Docker container
+### Running a Ballerina HTTPS Service in a Docker Container
 
 An HTTP endpoint can be configured to communicate through HTTPS as well. To secure an endpoint using HTTPS, it needs to be configured with a keystore, a certificate, and a private key for the endpoint. When running this HTTPS service as a Docker container, it is required to copy the keystore with the custom certificate that is used to configure the HTTPS endpoint. 
 
-#### Prerequisites
+#### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code
+#### Sample Source Code
 
 The sample below uses a separate listener endpoint and it is configured with a custom keystore. In addition to the `@docker:Config` annotation, the `@docker:Expose` annotation is used with the listener endpoint object, which helps to expose the correct service ports when creating the Docker container. 
 
@@ -286,7 +286,7 @@ service hello on helloWorldEP {
 }
 ```
 
-#### Steps to run
+#### Steps to Run
 
 1. Compile the `https_service_in_docker.bal` file.
 
@@ -393,15 +393,15 @@ service hello on helloWorldEP {
     Untagged: https-helloworld:latest
     ```
 
-### Copying additional files to the Ballerina Docker image
+### Copying Additional Files to the Ballerina Docker Image
 
 In some use cases, you need to process files in your applications. When these applications are run in a Docker container, you might need to copy these additional files into the image or mount them as external volume. This use case shows how to copy additional files into the Docker image while compiling the Ballerina source code.
 
-#### Prerequisites
+#### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code
+#### Sample Source Code
 
 `copy_file.bal`
 
@@ -473,7 +473,7 @@ target = "java8"
     path = "/path/to/mysql-connector-java-8.0.17.jar"
 ```
 
-#### Steps to run
+#### Steps to Run
 
 1. Create a `name.txt` file in the same directory in which the `copy_file.bal` file resides.
 
@@ -580,15 +580,15 @@ target = "java8"
     > docker rmi cc198c0af86e
     ```
 
-### Using a custom base image to build Ballerina Docker images
+### Using a Custom Base Image to Build Ballerina Docker Images
 
 Ballerina ships a base image (e.g., `ballerina/jre8:v1`) with some security hardening. It is used to build Docker images with the user's application code. However, sometimes, you might need to use your own Docker base image depending on your company policies or any additional requirements. This use case shows how to use a custom Docker base image to build Ballerina Docker images with the application code. 
 
-#### Prerequisites
+#### Setting UP The Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code
+#### Sample Source Code
 
 `base_image.bal`
 
@@ -610,7 +610,7 @@ service hello on new http:Listener(9090){
 
 > **Note:** This sample uses `openjdk:8-jre-alpine` as the custom Docker image by using the `baseImage` property in the `@docker:Config` annotation.
 
-#### Steps to run
+#### Steps to Run
 
 1.  Compile the `base_image.bal` file.
 
@@ -705,15 +705,15 @@ service hello on new http:Listener(9090){
     Untagged: helloworld_custom_baseimage:latest
     ```
 
-### Overriding the CMD of the generated Ballerina Dockerfile
+### Overriding the CMD of the Generated Ballerina Dockerfile
 
 The Ballerina Docker image builder uses the generic CMD command to execute the created JAR file. However, sometimes, you might need to override the default CMD command. This use case shows how to override the default CMD command.
 
-### Prerequisites
+### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code
+#### Sample Source Code
 
 `docker_cmd.bal`
 
@@ -736,7 +736,7 @@ service hello on new http:Listener(9090){
 
 This sample enables HTTP trace logs by overriding the CMD value of the generated Dockerfile. The cmd field will be as `CMD java -jar ${APP} --b7a.http.accesslog.console=true` in the `@docker:Config{}` annotation.
 
-### Steps to run
+### Steps to Run
 
 1. Compile the `base_image.bal` file.
 
@@ -847,15 +847,15 @@ This sample enables HTTP trace logs by overriding the CMD value of the generated
     Untagged: custome_cmd:latest
     ```
 
-### Creating multiple Docker images corresponding to modules of a Ballerina project
+### Creating Multiple Docker Images Corresponding to Modules of a Ballerina Project
 
 This use case shows how to add the Docker annotation to a Ballerina project to create the corresponding Docker images.
 
-### Prerequisites
+### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code
+#### Sample Source Code
 
 1. Ballerina project to call the restaurant:
 
@@ -916,7 +916,7 @@ You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
     }
     ```
 
-#### Steps to run
+#### Steps to Run
 
 1. Compile the Ballerina project.
 

--- a/learn/deployment/kubernetes.md
+++ b/learn/deployment/kubernetes.md
@@ -256,7 +256,7 @@ $ curl -kv https://ballerina.guides.io/users/jane
 {"name":"Jane Doe", "email":"jane@ballerina.com"}
 ```   
     
-##### Supported Kubernetes Annotations
+#### Supported Kubernetes Annotations
 
 **@kubernetes:Deployment{}**
 - Supported with Ballerina services, listeners and functions.

--- a/learn/documenting-ballerina-code.md
+++ b/learn/documenting-ballerina-code.md
@@ -93,7 +93,7 @@ public function foo(int i, string s) returns boolean {
 public function submit(@sensitive string httpVerb, string path, Request request) returns HttpFuture|error;
 ```
 
-## Documenting A Module
+## Documenting a Module
 
 A Ballerina module can have a `Module.md` file, which describes the module and its usage.
 

--- a/learn/extending-with-compiler-extensions.md
+++ b/learn/extending-with-compiler-extensions.md
@@ -172,7 +172,7 @@ Each of the `process()` methods correspond to annotable constructs of the langua
 
 The extension will read the salutation field of the `@hello:Greeting` annotation and write its value to a file in the `/target` directory. 
 
-### Setting up the Project
+### Setting Up the Project
 
 Start by creating a Java project for the extension. It needs two classes: `HelloPlugin` and `HelloModel`. Also, create a resource file named `org.ballerinalang.compiler.plugins.CompilerPlugin` in the `resources/META-INF/services` directory. This file should contain the fully-qualified class name of the extension class (which in this case, is `xyz.foo.hello.HelloPlugin`).
 ```
@@ -343,7 +343,7 @@ class HelloModel {
 
 Finally, build the extension and place the resulting JAR file inside the `<BALLERINA_HOME>/distributions/jballerina-<BALLERINA_VERSION>/bre/lib/` directory. 
 
-## Putting It All Together
+## Putting it All Together
 
 Now, build your hello world project again. You should see an additional step logged in the console for generating the greeting.
 

--- a/learn/keeping-ballerina-up-to-date.md
+++ b/learn/keeping-ballerina-up-to-date.md
@@ -26,7 +26,7 @@ This section introduces various terms used throughout this guide. We recommend t
 
 It also enables you to easily install, update and switch among Ballerina distributions. The main focus of this guide is to teach you how, but first, let’s talk about Ballerina distributions.
 
-### Ballerina distributions
+### Ballerina Distributions
 
 - The language specification defines the syntax and semantics of Ballerina programming language. Ballerina compiler is a software program that validates the Ballerina source code and translates it to an executable program. There exist a production-ready official compiler called  jBallerina. We also have a plan to do a native compiler called nBallerina.
 - jBallerina
@@ -38,30 +38,30 @@ It also enables you to easily install, update and switch among Ballerina distrib
 
 Ballerina distribution is a term that we use to refer to jBallerina and nBallerina compilers.
 
-### Release channels
+### Release Channels
 
 Ballerina distributions are released on two different release channels at the moment: patch releases and minor releases. Both these channels distribute stable versions. We don’t yet have a release channel for nightly builds that give you access to the latest, perhaps unstable features. 
 
 Ballerina distribution releases strictly follow [SemVer](https://semver.org/) with major.minor.patch version numbers. 
 
-#### Patch release channel
+#### Patch Release Channel
 
 This channel gives you access to patch releases of Ballerina distributions that contain bug fixes and fixes for critical stability and security issues. These releases are strictly time-bound and happen every two weeks. Occasionally,  you would see on-demand patch releases as well. 
 
 *Example patch releases: jballerina-1.0.6, jballerina-1.1.5, jballerina-1.1.10*
 
-#### Minor release channel
+#### Minor Release Channel
 
 This channel gives you access to feature releases of Ballerina distributions. Ballerina programs that you’ve written today should continue to work on these minor releases. There will be four minor releases a year. You will get access to a minor release on the 3rd Wednesday of the 3rd month of every quarter. 
 
 *Example minor releases: jballerina 1.1.0, jballerina 1.2.0, jballerina 1.3.0*
 
-#### Release maintenance
+#### Release Maintenance
 
 - We maintain a minor release 1.x.0 by issuing a series of patch releases 1.x.y. The maintenance of a particular minor release stops when there are two newer minor releases available.
 - In other words, patch releases for jBallerina 1.x.0 stop when jBallerina 1.(x+2).0 is released. E.g., when jBallerina 1.2 is available, we stop maintaining jBallerina 1.0.0.
 
-## Keeping Ballerina upto date
+## Keeping Ballerina Upto Date
 
 Now that you are familiar with the terminology, let’s look at how you can keep your Ballerina distributions up to date.
 
@@ -84,13 +84,13 @@ Now that you are familiar with the terminology, let’s look at how you can keep
 
 “distributions” is the directory where we maintain all your installed distributions.
 
-### The "active" distribution
+### The "active" Distribution
 
 - One only distribution from the above list can be active at a given time.
 - Ballerina tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke `ballerina build`, the Ballerina tool dispatches this request to the active distribution.
 - You can change the active distribution at any time. Refer the [Change the active distribution](#change-the-active-distribution) section for more details.  
 
-### The `ballerina dist` command
+### The 'ballerina dist' Command
 
 Ballerina tool comes with various subcommands to help you manage Ballerina source code. The `ballerina dist` and `ballerina update` commands are the ones that will be explained in this guide. The `ballerina dist` command allows you to manage Ballerina distributions whereas the `ballerina update` command updates the tool itself.
 
@@ -131,7 +131,7 @@ Use 'ballerina help dist <command>' for more information on a specific command.
 
 Most of these subcommands are self-explanatory. Therefore, the following sections introduce them briefly.
 
-### Update to the latest patch version
+### Update to the Latest Patch Version
 
 The `ballerina dist update` command updates your active distribution to the latest patch version.
 
@@ -145,7 +145,7 @@ Downloading jballerina-1.0.5 100% [=============================================
 Successfully set the latest patch distribution 'jballerina-1.0.5' as the active distribution
 ```
 
-### List local and remote distributions
+### List Local and Remote Distributions
 
 The `ballerina dist list` command lists the installed distributions in your local environment. It also lists the distributions available for you to download.
 
@@ -171,7 +171,7 @@ Use 'ballerina help dist' for more information on specific commands.
 
 The star (*) indicates the active distribution.
 
-### Remove distributions
+### Remove Distributions
 
 The `ballerina dist remove <distribution>` command allows you to delete a particular distribution from your local environment. If you’ve been updating Ballerina regularly, you may have accumulated many unused distribution versions. This command helps you to clean them up. 
 
@@ -180,7 +180,7 @@ The `ballerina dist remove <distribution>` command allows you to delete a partic
 Distribution 'jballerina-1.0.5' successfully removed
 ```
 
-### Change the active distribution
+### Change the Active Distribution
 
 The `ballerina dist use <distribution>` command sets a particular distribution version as the active one.  See the following workflow. 
 
@@ -198,11 +198,11 @@ Distributions available locally:
 …
 ```
 
-### Pull a specific distribution
+### Pull a Specific Distribution
 
 The `ballerina dist pull <distribution>` command downloads a particular distribution and stores it in your local environment. It also sets the fetched distribution as the active distribution.
 
-#### For jBallerina 1.2.5 and above (for update tool version 0.8.8 and above):
+#### For jBallerina 1.2.5 and Above (For Update Tool Version 0.8.8 and Above):
 
 ```sh
 → sudo ballerina dist pull 1.2.6
@@ -210,7 +210,7 @@ Fetching the 'jballerina-1.2.6' distribution from the remote server...
 Downloading jballerina-1.2.6 100% [==================================] 96/96 MB 'jballerina-1.2.6' successfully set as the active distribution
 ```
 
-#### For versions below jBallerina 1.2.5 (for update tool versions below 0.8.8):
+#### For Versions Below jBallerina 1.2.5 (for Update Tool Versions Below 0.8.8):
 
 ```sh
 → sudo ballerina dist pull jballerina-1.2.4
@@ -218,7 +218,7 @@ Fetching the 'jballerina-1.2.4' distribution from the remote server...
 Downloading jballerina-1.2.4 100% [==================================] 96/96 MB 'jballerina-1.2.4' successfully set as the active distribution
 ```
 
-### Update the Ballerina tool
+### Update the Ballerina Tool
 
 - The `ballerina update` command updates the Ballerina tool itself to the latest version. Ballerina tool versions are independent from distribution versions. We expect these tool updates to be rare compared to distribution releases.
 

--- a/learn/keeping-ballerina-up-to-date.md
+++ b/learn/keeping-ballerina-up-to-date.md
@@ -202,7 +202,7 @@ Distributions available locally:
 
 The `ballerina dist pull <distribution>` command downloads a particular distribution and stores it in your local environment. It also sets the fetched distribution as the active distribution.
 
-#### For jBallerina 1.2.5 and Above (For Update Tool Version 0.8.8 and Above):
+#### For jBallerina 1.2.5 and Above (for Update Tool Version 0.8.8 and Above):
 
 ```sh
 → sudo ballerina dist pull 1.2.6

--- a/learn/observing-ballerina-code.md
+++ b/learn/observing-ballerina-code.md
@@ -16,7 +16,7 @@ redirect_from:
   - /learn/observing-ballerina-code
 ---
 
-## Providing observability in Ballerina
+## Providing Observability in Ballerina
 
 Monitoring, logging, and distributed tracing are key methods that reveal the internal state of the system to provide the observability. Ballerina becomes fully observable by exposing itself via these three methods to various external systems allowing to monitor metrics such as request count and response time statistics, analyze logs, and
 perform distributed tracing. 
@@ -33,7 +33,7 @@ Ballerina logs can be fed to any external log monitoring system like [Elastic St
 
 Follow the steps below to observe a sample Ballerina service.
 
-### Step 1 - Setting up the Prerequisites
+### Step 1 - Setting Up the Prerequisites
 
 Make sure you have already installed [Docker](https://www.docker.com/) to setup external products such as Jaeger,
 Prometheus, etc. You can follow [Docker documentation](https://docs.docker.com/install/) to install Docker.
@@ -45,7 +45,7 @@ Prometheus, etc. You can follow [Docker documentation](https://docs.docker.com/i
 * Setup Jaeger analyze tracing as mentioned in section [Setting up Jaeger](#jaeger-server)
 * Setup Elastic Stack only if you are interested in analysing logs by following section on [Setting up Elastic Stack](#elastic-stack)
 
-### Step 3 - Creating a Hello World Ballerina Service
+### Step 3 - Creating a 'Hello World' Ballerina Service
  
 Create a Service as shown below and save it as `hello_world_service.bal`.
 
@@ -67,7 +67,7 @@ service hello on new http:Listener(9090) {
 }
 ```
 
-### Step 4 - Observing the Hello World Ballerina Service
+### Step 4 - Observing the 'Hello World' Ballerina Service
 
 Observability is disabled by default and can be enabled by using the `--b7a.observability.enabled=true` flag or updating the configurations.
 

--- a/learn/publishing-modules-to-ballerina-central.md
+++ b/learn/publishing-modules-to-ballerina-central.md
@@ -14,7 +14,7 @@ redirect_from:
   - /learn/publishing-modules-to-ballerina-central
 ---
 
-## The CLI command
+## The CLI Command
 
 Pushing a module uploads it to [Ballerina Central](https://central.ballerina.io/).
 
@@ -22,7 +22,7 @@ Pushing a module uploads it to [Ballerina Central](https://central.ballerina.io/
 ballerina push <module-name>
 ```
 
-## Setting up
+## Setting Up
 
 Before you push your module, you must enter your Ballerina Central access token in `Settings.toml` in your home repository (`<USER_HOME>/.ballerina/`).
 

--- a/learn/quick-tour.md
+++ b/learn/quick-tour.md
@@ -74,7 +74,7 @@ Hello Ballerina!
 
 Alternatively, you can use a Ballerina HTTP client to invoke the service.
 
-## Using a Client to Interact With a Network-Accessible Service
+## Using a Client to Interact with a Network-Accessible Service
 
 A Ballerina client is a component, which interacts with a network-accessible service. It aggregates one or more actions that can be executed on the network-accessible service and accepts configuration parameters related to the network-accessible service.
 

--- a/learn/quick-tour.md
+++ b/learn/quick-tour.md
@@ -18,7 +18,7 @@ redirect_from:
 1. Follow the instructions given on the [Getting Started](/learn/getting-started) page to set it up. 
 1. Follow the instructions given on the [Visual Studio Code Plugin](/learn/tools-ides/vscode-plugin) page or the [IntelliJ IDEA Plugin](/learn/tools-ides/intellij-plugin) page to set up your preferred editor for Ballerina.
 
-## Writing a service, running it, and invoking it
+## Writing a Service, Running It, and Invoking It
 
 Write a simple Hello World HTTP service in a file with the `.bal` extension.
 
@@ -74,7 +74,7 @@ Hello Ballerina!
 
 Alternatively, you can use a Ballerina HTTP client to invoke the service.
 
-## Using a client to interact with a network-accessible service
+## Using a Client to Interact With a Network-Accessible Service
 
 A Ballerina client is a component, which interacts with a network-accessible service. It aggregates one or more actions that can be executed on the network-accessible service and accepts configuration parameters related to the network-accessible service.
 

--- a/learn/running-ballerina-code.md
+++ b/learn/running-ballerina-code.md
@@ -15,7 +15,7 @@ redirect_from:
   - /learn/running-ballerina-code
 ---
 
-## Understanding the structure
+## Understanding the Structure
 
 A Ballerina application can have:
 

--- a/learn/tools-ides/setting-up-intellij-idea.md
+++ b/learn/tools-ides/setting-up-intellij-idea.md
@@ -18,7 +18,7 @@ redirect_from:
   - /learn/setting-up-intellij-idea
 ---
 
-## Setting up the prerequisites
+## Setting Up the Prerequisites
 
 You need [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) installed.
 

--- a/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
+++ b/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
@@ -29,7 +29,7 @@ The sections below include instructions on how to run different elements of a Ba
 - [Running the main method](#running-the-main-method)
 - [Running Ballerina services](#running-ballerina-services)
 
-### Running the Main Method
+### Running the 'Main' Method
 
 Follow the steps below to run the main function of a Ballerina file.
 

--- a/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/learn/tools-ides/setting-up-visual-studio-code.md
@@ -69,7 +69,7 @@ $ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 
 ## Troubleshooting
 
- If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
+ If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
 
 The sections below include information on the various capabilities that are facilitated by the VS Code Ballerina Extension for the development process.
 
@@ -78,4 +78,3 @@ The sections below include information on the various capabilities that are faci
 - [Graphical View](/learn/vscode-plugin/graphical-editor)
 - [Documentation Viewer](/learn/vscode-plugin/documentation-viewer)
 - [Run All Tests](/learn/vscode-plugin/run-all-tests)
-

--- a/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/learn/tools-ides/setting-up-visual-studio-code.md
@@ -67,9 +67,11 @@ $ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 
 > **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VS Code Extension, enable the Allow Experimental option in user settings.
 
-> **Troubleshooting**: If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
+## Troubleshooting
 
-The below sections include information on the various capabilities that are facilitated by the VS Code Ballerina Extension for the development process.
+ If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
+
+The sections below include information on the various capabilities that are facilitated by the VS Code Ballerina Extension for the development process.
 
 - [Language Intelligence](/learn/vscode-plugin/language-intelligence)
 - [Run and Debug](/learn/vscode-plugin/run-and-debug)

--- a/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
@@ -29,7 +29,7 @@ The Documentation Viewer represents the documented entities in a file in an orga
 
 ![Documentation Viewer](/learn/images/documentation-viewer.gif)
 
-## What's next?
+## What's Next?
 
  - For information on the next capability of the VS Code Ballerina plugin, see [Run All tests](/learn/vscode-plugin/run-all-tests).
  - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin).

--- a/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
@@ -20,7 +20,7 @@ redirect_from:
   - /learn/language-intelligence/
 ---
 
-## Semantic and syntactic diagnostics
+## Semantic and Syntactic Diagnostics
 
 When there are syntax or semantic errors in your code, you will be notified with appropriate diagnostics during the development time. 
 
@@ -28,7 +28,7 @@ When there are syntax or semantic errors in your code, you will be notified with
 
 ![Semantic and syntactic diagnostics](/learn/images/semantic-and-syntactic.gif)
 
-## Suggestions and auto completion
+## Suggestions and Auto Completion
 
 The extension provides you with suggestions on keywords, variables, and code snippets of language constructs (such as functions, services, and iterable constructs etc.).
 
@@ -36,7 +36,7 @@ The extension provides you with suggestions on keywords, variables, and code sni
 
 > **Tip**: You can use these suggestions to access the contents of the modules available in your Ballerina home repo as well as in the Ballerina distribution.
 
-## Code actions
+## Code Actions
 
 These allow you to perform the below tasks easily based on the diagnostics and the current scope where the cursor resides. 
 
@@ -50,7 +50,7 @@ For example, you can add documentation for a function as shown below.
 
  ![Code actions](/learn/images/code-actions.gif)
 
-## Hover support
+## Hover Support
 
  Hover support provides you quick access to information about a certain entity. 
  
@@ -66,7 +66,7 @@ This option allows you to view the definition of a selected variable, function, 
 
 ![Go to definition](/learn/images/go-to-definition-vscode.gif)
 
-## What's next?
+## What's Next?
 
  - For information on the next capability of the VS Code Ballerina extension, see [Run and Debug](/learn/vscode-plugin/run-and-debug).
  - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin).

--- a/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
@@ -20,7 +20,7 @@ redirect_from:
   - /learn/run-all-tests/
 ---
 
-## Running all tests 
+## Running All Tests 
 
 Follow the steps below to do this.
 
@@ -29,7 +29,7 @@ Follow the steps below to do this.
 
 ![Run all tests](/learn/images/run-all-tests.gif)
 
-## What's next?
+## What's Next?
 
 - For information on the Ballerina VSCode extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin/).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Setting up Ballerina](/learn/installing-ballerina/).

--- a/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
@@ -43,7 +43,7 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
 - There are some cases where stepping over gives unexpected behavior
     - Eg: When there are multiple workers and a wait expression waiting for them, even though step over hit and pass wait line in source, workers are not yet finished execution.
 
-## What's next?
+## What's Next?
 
  - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/learn/vscode-plugin/graphical-editor).
  - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin).

--- a/learn/using-the-cli-tools.md
+++ b/learn/using-the-cli-tools.md
@@ -14,7 +14,7 @@ redirect_from:
   - /learn/using-the-cli-tools
 ---
 
-## Using the `ballerina` command
+## Using the 'ballerina' Command
 
 In the CLI, execute the `ballerina help` command to view all the actions you can perform with it as shown below.
 
@@ -28,7 +28,7 @@ In the CLI, execute the `ballerina help` command to view all the actions you can
 
 ![Ballerina help output](/learn/images/ballerina-help-output.png)
 
-## Core commands
+## Core Commands
 
 These everyday commands are your best friends! They address the very basics of programming in Ballerina such as compiling, running, testing programs, and generating their documentation.
 
@@ -86,7 +86,7 @@ These commands allow you to work with the Ballerina Central to share Ballerina m
 </tr>
 </table>
 
-## Project commands
+## Project Commands
 
 Ballerina projects are the way to organize real world Ballerina development tasks. 
 
@@ -103,7 +103,7 @@ Ballerina projects are the way to organize real world Ballerina development task
 </tr>
 </table>
 
-## Other commands
+## Other Commands
 
 These powerful supporting tools extend Ballerina to various ecosystem technologies that are inherently cloud-native. This functionality will grow over time and will even be developer extensible in the future.
 
@@ -136,7 +136,7 @@ These powerful supporting tools extend Ballerina to various ecosystem technologi
 </tr>
 </table>
 
-## Update commands
+## Update Commands
 
 <table class="cComandTable">
 <tr>

--- a/learn/using-the-openapi-tools.md
+++ b/learn/using-the-openapi-tools.md
@@ -12,7 +12,7 @@ redirect_from:
   - /learn/using-the-openapi-tools
 ---
 
-## Using the capabilities of the OpenAPI Tools
+## Using the Capabilities of the OpenAPI Tools
 
 The OpenAPI tools provide the following capabilities.
 

--- a/swan-lake/learn/calling-java-code-from-ballerina.md
+++ b/swan-lake/learn/calling-java-code-from-ballerina.md
@@ -234,7 +234,7 @@ public class SnakeYamlSample {
 }
 ```
 
-#### Creating the `FileInputStream`
+#### Creating the 'FileInputStream'
 Our goal here is to create a new `java.io.FileInputStream` instance from the filename. In step 3, we generated bindings for the required Java classes. The following is the code snippet that does the job. 
 
 ```ballerina
@@ -324,7 +324,7 @@ In this section, we explained how to use the `bindgen` tool to generate Ballerin
 The next sections provide more details on various aspects related to Java interoperability in Ballerina. 
 
 
-## The `bindgen` Tool
+## The 'bindgen' Tool
 
 The following subsections explain how the `bindgen` tool works.
 
@@ -348,7 +348,7 @@ The following subsections explain how the `bindgen` tool works.
 
 The `bindgen` is a CLI tool, which generates Ballerina bindings for Java classes.
 
-### The `bindgen` Command
+### The 'bindgen' Command
 
 ```sh
 ballerina bindgen [(-cp|--classpath) <classpath>...]
@@ -704,7 +704,7 @@ function newArrayDequeWithCollection(handle c) returns handle = @java:Constructo
 } external;
 ```
 
-##### The `paramTypes` Field
+##### The 'paramTypes' Field
 You can use the `paramTypes` field to resolve the exact overloaded method. This field is defined as follows.
 
 ```ballerina
@@ -1094,7 +1094,7 @@ int | byte, char, short, int, long | Narrowing conversion when int -> byte, char
 float | byte, char, short, int, long, float, double | Narrowing conversion when float -> byte, char, short, int, long, float
 
 
-### Access/ or Mutate Java Fields
+### Access or Mutate Java Fields
 The `@java:FieldGet` and `@java:FieldSet` annotations allow you to read and update the value of a Java static or instance field respectively. The most common use case is to read a value of a Java static constant. 
 
 ```ballerina

--- a/swan-lake/learn/coding-conventions/statements.md
+++ b/swan-lake/learn/coding-conventions/statements.md
@@ -56,9 +56,9 @@ if (inProperSallaryRange) {
 }
 ```
 
-## Match statement
+## Match Statement
 
-### Match patterns clause
+### Match Patterns Clause
 
 * Block indent each pattern clause in its own line.
 * Keep a single space before and after the `=>` sign.
@@ -105,7 +105,7 @@ match x {
 }
 ```
 
-## Transaction statement
+## Transaction Statement
 
 * Start each optional clause (`onretry`, `committed`, and `aborted`) in the same line as the closing brace of the matching clause.
 * If `transaction`, `onretry`, `committed`, and `aborted` blocks are empty, add an empty line between the braces. 

--- a/swan-lake/learn/coding-conventions/top-level-definitions.md
+++ b/swan-lake/learn/coding-conventions/top-level-definitions.md
@@ -11,7 +11,7 @@ redirect_from:
   - /swan-lake/learn/coding-conventions/top-level-definitions
 ---
 
-## General practices
+## General Practices
 
 * Do not indent the top level definitions. 
   

--- a/swan-lake/learn/deployment/docker.md
+++ b/swan-lake/learn/deployment/docker.md
@@ -17,7 +17,7 @@ To create a Docker image, you have to create a Dockerfile by choosing a suitable
 
 The Ballerina compiler is capable of creating optimized Docker images out of the application source code. This guide includes step-by-step instructions on different use cases and executing the corresponding sample source code. 
 
-## Enabling Docker support
+## Enabling Docker Support
 
 Docker support is inbuilt and comes by default in any Ballerina distribution. You can enable Docker artifact generation by adding annotations to your Ballerina code. Follow the steps below to enable Docker support.
 
@@ -27,17 +27,17 @@ Docker support is inbuilt and comes by default in any Ballerina distribution. Yo
 
 3. Build the Ballerina source file/project (e.g., `ballerina build source.bal`).
 
-## Use cases
+## Use Cases
 
-### Running a Ballerina service in a Docker container
+### Running a Ballerina Service in a Docker Container
 
 This use case shows how to run a Ballerina service in a Docker container. The sample below demonstrates running a simple Ballerina hello world service in a Docker container. 
 
-#### Prerequisites
+#### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code 
+#### Sample Source Code 
 
 `hello_world_docker.bal`
 ```ballerina 
@@ -55,7 +55,7 @@ service hello on new http:Listener(9090){
 
 ```
 
-#### Steps to run
+#### Steps to Run
 
 1. Compile the `hello_world_docker.bal` file.
 
@@ -163,16 +163,16 @@ service hello on new http:Listener(9090){
     > docker rmi e48123737a65
   ```
 
-### Creating a custom Ballerina Docker image and pushing it automatically to the Docker registry
+### Creating a Custom Ballerina Docker Image and Pushing it Automatically to the Docker Registry
 
 This use case shows how to run a simple Ballerina hello world service in a Docker container with annotation configurations, which can be used to create a Docker image with a custom image-name and tag, and then automatically push the created image to the Docker registry.
 
-#### Prerequisites
+#### Setting Up the Prerequisites
 
 - A machine with [Docker](https://docs.docker.com/get-docker/) installed
 - A [Docker Hub](https://hub.docker.com/) account
 
-#### Sample source code
+#### Sample Source Code
 
 `custom_docker_name.bal`
 
@@ -207,7 +207,7 @@ In this sample, the following properties are set in the `@docker:Config` annotat
 
 > The `$env` variable is used to read the environment variable values from the system.
 
-#### Steps to run
+#### Steps to Run
 
 1. Export the username and password of Docker (registry).
 
@@ -246,15 +246,15 @@ In this sample, the following properties are set in the `@docker:Config` annotat
 
     ![Docker Hub](/swan-lake/learn/images/docker-hub.png)
 
-### Running a Ballerina HTTPS service in a Docker container
+### Running a Ballerina HTTPS Service in a Docker Container
 
 An HTTP endpoint can be configured to communicate through HTTPS as well. To secure an endpoint using HTTPS, it needs to be configured with a keystore, a certificate, and a private key for the endpoint. When running this HTTPS service as a Docker container, it is required to copy the keystore with the custom certificate that is used to configure the HTTPS endpoint. 
 
-#### Prerequisites
+#### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code
+#### Sample Source Code
 
 The sample below uses a separate listener endpoint and it is configured with a custom keystore. In addition to the `@docker:Config` annotation, the `@docker:Expose` annotation is used with the listener endpoint object, which helps to expose the correct service ports when creating the Docker container. 
 
@@ -286,7 +286,7 @@ service hello on helloWorldEP {
 }
 ```
 
-#### Steps to run
+#### Steps to Run
 
 1. Compile the `https_service_in_docker.bal` file.
 
@@ -393,15 +393,15 @@ service hello on helloWorldEP {
     Untagged: https-helloworld:latest
     ```
 
-### Copying additional files to the Ballerina Docker image
+### Copying Additional Files to the Ballerina Docker Image
 
 In some use cases, you need to process files in your applications. When these applications are run in a Docker container, you might need to copy these additional files into the image or mount them as external volume. This use case shows how to copy additional files into the Docker image while compiling the Ballerina source code.
 
-#### Prerequisites
+#### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code
+#### Sample Source Code
 
 `copy_file.bal`
 
@@ -473,7 +473,7 @@ target = "java8"
     path = "/path/to/mysql-connector-java-8.0.17.jar"
 ```
 
-#### Steps to run
+#### Steps to Run
 
 1. Create a `name.txt` file in the same directory in which the `copy_file.bal` file resides.
 
@@ -580,15 +580,15 @@ target = "java8"
     > docker rmi cc198c0af86e
     ```
 
-### Using a custom base image to build Ballerina Docker images
+### Using a Custom Base Image to Build Ballerina Docker Images
 
 Ballerina ships a base image (e.g., `ballerina/jre8:v1`) with some security hardening. It is used to build Docker images with the user's application code. However, sometimes, you might need to use your own Docker base image depending on your company policies or any additional requirements. This use case shows how to use a custom Docker base image to build Ballerina Docker images with the application code. 
 
-#### Prerequisites
+#### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code
+#### Sample Source Code
 
 `base_image.bal`
 
@@ -610,7 +610,7 @@ service hello on new http:Listener(9090){
 
 > **Note:** This sample uses `openjdk:8-jre-alpine` as the custom Docker image by using the `baseImage` property in the `@docker:Config` annotation.
 
-#### Steps to run
+#### Steps to Run
 
 1.  Compile the `base_image.bal` file.
 
@@ -705,15 +705,15 @@ service hello on new http:Listener(9090){
     Untagged: helloworld_custom_baseimage:latest
     ```
 
-### Overriding the CMD of the generated Ballerina Dockerfile
+### Overriding the CMD of the Generated Ballerina Dockerfile
 
 The Ballerina Docker image builder uses the generic CMD command to execute the created JAR file. However, sometimes, you might need to override the default CMD command. This use case shows how to override the default CMD command.
 
-### Prerequisites
+### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code
+#### Sample Source Code
 
 `docker_cmd.bal`
 
@@ -736,7 +736,7 @@ service hello on new http:Listener(9090){
 
 This sample enables HTTP trace logs by overriding the CMD value of the generated Dockerfile. The cmd field will be as `CMD java -jar ${APP} --b7a.http.accesslog.console=true` in the `@docker:Config{}` annotation.
 
-### Steps to run
+### Steps to Run
 
 1. Compile the `base_image.bal` file.
 
@@ -847,15 +847,15 @@ This sample enables HTTP trace logs by overriding the CMD value of the generated
     Untagged: custome_cmd:latest
     ```
 
-### Creating multiple Docker images corresponding to modules of a Ballerina project
+### Creating Multiple Docker Images Corresponding to Modules of a Ballerina Project
 
 This use case shows how to add the Docker annotation to a Ballerina project to create the corresponding Docker images.
 
-### Prerequisites
+### Setting Up the Prerequisites
 
 You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
 
-#### Sample source code
+#### Sample Source Code
 
 1. Ballerina project to call the restaurant:
 
@@ -916,7 +916,7 @@ You need a machine with [Docker](https://docs.docker.com/get-docker/) installed.
     }
     ```
 
-#### Steps to run
+#### Steps to Run
 
 1. Compile the Ballerina project.
 

--- a/swan-lake/learn/extending-with-compiler-extensions.md
+++ b/swan-lake/learn/extending-with-compiler-extensions.md
@@ -36,7 +36,7 @@ The `ballerina/docker` and `ballerina/kubernetes` modules make use of custom ann
 > 1. The Ballerina Compiler is written in Java 11. Therefore, you will need JDK 11.
 > 2. End users will have to install the extension manually.
 
-## Hello World: The Annotation Way
+## 'Hello World': The Annotation Way
 
 In this guide, we will take a look at how to create a custom annotation and how to write a compiler extension to read and act upon our custom annotation. The custom annotation (i.e. `@hello:Greeting`) is attachable to functions. It has an attribute called `salutation`, which will be read by the compiler extension and written to a file when building the program. The annotation can be shared with others by publishing it to [Ballerina Central](https://central.ballerina.io/). Currently, there isn’t a mechanism for sharing compiler extensions. The compiler extension has to be copied to the `<BALLERINA_HOME>/bre/lib` directory.
 
@@ -170,7 +170,7 @@ Each of the `process()` methods correspond to annotable constructs of the langua
 
 The extension will read the salutation field of the `@hello:Greeting` annotation and write its value to a file in the `/target` directory. 
 
-### Setting up the Project
+### Setting Up the Project
 
 Start by creating a Java project for the extension. It needs two classes: `HelloPlugin` and `HelloModel`. Also, create a resource file named `org.ballerinalang.compiler.plugins.CompilerPlugin` in the `resources/META-INF/services` directory. This file should contain the fully-qualified class name of the extension class (which in this case, is `xyz.foo.hello.HelloPlugin`).
 ```
@@ -341,7 +341,7 @@ class HelloModel {
 
 Finally, build the extension and place the resulting JAR file inside the `<BALLERINA_HOME>/distributions/jballerina-<BALLERINA_VERSION>/bre/lib/` directory. 
 
-## Putting It All Together
+## Putting it All Together
 
 Now, build your hello world project again. You should see an additional step logged in the console for generating the greeting.
 

--- a/swan-lake/learn/keeping-ballerina-up-to-date.md
+++ b/swan-lake/learn/keeping-ballerina-up-to-date.md
@@ -24,7 +24,7 @@ This section introduces various terms used throughout this guide. We recommend t
 
 It also enables you to easily install, update, and switch among Ballerina distributions. The main focus of this guide is to teach you how to perform these actions but first, let’s talk about Ballerina distributions.
 
-### Ballerina distributions
+### Ballerina Distributions
 
 - The language specification defines the syntax and semantics of Ballerina programming language. Ballerina compiler is a software program that validates the Ballerina source code and translates it to an executable program. There exist a production-ready official compiler called  jBallerina. We also have a plan to do a native compiler called nBallerina.
 - jBallerina
@@ -36,30 +36,30 @@ It also enables you to easily install, update, and switch among Ballerina distri
 
 Ballerina distribution is a term that we use to refer to jBallerina and nBallerina compilers.
 
-### Release channels
+### Release Channels
 
 Ballerina distributions are released on two different release channels at the moment: patch releases and minor releases. Both these channels distribute stable versions. Ballerina yet does not have a release channel for nightly builds that give you access to the latest perhaps unstable features.
 
 Ballerina distribution releases strictly follow [SemVer](https://semver.org/) with major.minor.patch version numbers.
 
-#### Patch release channel
+#### Patch Release Channel
 
 This channel gives you access to the patch releases of Ballerina distributions that contain bug fixes and fixes for critical stability and security related issues. These releases are strictly time-bound and happen every two weeks. Occasionally,  you would see on-demand patch releases as well.
 
 *Example patch releases: 1.0.6, 1.1.5, 1.1.10*
 
-#### Minor release channel
+#### Minor Release Channel
 
 This channel gives you access to feature releases of Ballerina distributions. Ballerina programs that you’ve written today should continue to work on these minor releases. There will be four minor releases a year. You will get access to a minor release on the 3rd Wednesday of the 3rd month of every quarter.
 
 *Example minor releases: 1.1.0, 1.2.0, 1.3.0*
 
-#### Release maintenance
+#### Release Maintenance
 
 - We maintain a minor release 1.x.0 by issuing a series of patch releases 1.x.y. The maintenance of a particular minor release stops when there are two newer minor releases available.
 - In other words, patch releases for 1.x.0 stop when jBallerina 1.(x+2).0 is released. E.g., when 1.2 is available, maintaining 1.0.0 will be stopped.
 
-## Keeping Ballerina upto date
+## Keeping Ballerina Upto Date
 
 Now that you are familiar with the terminology, let’s look at how you can keep your Ballerina distributions up to date.
 
@@ -82,13 +82,13 @@ Now that you are familiar with the terminology, let’s look at how you can keep
 
 “distributions” is the directory where we maintain all your installed distributions.
 
-### The "active" distribution
+### The 'active' Distribution
 
 - One only distribution from the above list can be active at a given time.
 - Ballerina tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke `ballerina build`, the Ballerina tool dispatches this request to the active distribution.
 - You can change the active distribution at any time. Refer the [Change the active distribution](#change-the-active-distribution) section for more details.  
 
-### The `ballerina dist` command
+### The 'ballerina dist' Command
 
 Ballerina tool comes with various subcommands to help you manage Ballerina source code. The `ballerina dist` and `ballerina update` commands are the ones that will be explained in this guide. The `ballerina dist` command allows you to manage Ballerina distributions whereas the `ballerina update` command updates the tool itself.
 
@@ -129,7 +129,7 @@ Use 'ballerina help dist <command>' for more information on a specific command.
 
 Most of these subcommands are self-explanatory. Therefore, the following sections introduce them briefly.
 
-### Update to the latest patch version
+### Update to the Latest Patch Version
 
 The `ballerina dist update` command updates your active distribution to the latest patch version.
 
@@ -143,7 +143,7 @@ Downloading 1.0.5 100% [========================================================
 Successfully set the latest patch distribution '1.0.5' as the active distribution
 ```
 
-### List local and remote distributions
+### List Local and Remote Distributions
 
 The `ballerina dist list` command lists the installed distributions in your local environment. It also lists the distributions available for you to download.
 
@@ -185,7 +185,7 @@ Use 'ballerina help dist' for more information on specific commands.
 
 The star (*) indicates the active distribution.
 
-### Remove distributions
+### Remove Distributions
 
 The `ballerina dist remove <distribution>` command allows you to delete a particular distribution from your local environment. If you’ve been updating Ballerina regularly, you may have accumulated many unused distribution versions. This command helps you to clean them up.
 
@@ -194,7 +194,7 @@ The `ballerina dist remove <distribution>` command allows you to delete a partic
 Distribution '1.0.5' successfully removed
 ```
 
-### Change the active distribution
+### Change the Active Distribution
 
 The `ballerina dist use <distribution>` command sets a particular distribution version as the active one.  See the following workflow.
 
@@ -213,11 +213,11 @@ Distributions available locally:
 …
 ```
 
-### Pull a specific distribution
+### Pull a Specific Distribution
 
 The `ballerina dist pull <distribution>` command downloads a particular distribution and stores it in your local environment. It also sets the fetched distribution as the active distribution.
 
-#### For jBallerina 1.2.5 and above (for update tool version 0.8.8 and above):
+#### For jBallerina 1.2.5 and above (for Update Tool Version 0.8.8 and above):
 
 ```sh
 → sudo ballerina dist pull 1.2.6
@@ -225,7 +225,7 @@ Fetching the 'jballerina-1.2.6' distribution from the remote server...
 Downloading jballerina-1.2.6 100% [==================================] 96/96 MB 'jballerina-1.2.6' successfully set as the active distribution
 ```
 
-#### For versions below jBallerina 1.2.5 (for update tool versions below 0.8.8):
+#### For Versions below jBallerina 1.2.5 (for Update Tool Versions below 0.8.8):
 
 ```sh
 → sudo ballerina dist pull jballerina-1.2.4
@@ -233,7 +233,7 @@ Fetching the 'jballerina-1.2.4' distribution from the remote server...
 Downloading jballerina-1.2.4 100% [==================================] 96/96 MB 'jballerina-1.2.4' successfully set as the active distribution
 ```
 
-### Update the Ballerina tool
+### Update the Ballerina Tool
 
 - The `ballerina update` command updates the Ballerina tool itself to the latest version. Ballerina tool versions are independent from distribution versions. We expect these tool updates to be rare compared to distribution releases.
 

--- a/swan-lake/learn/keeping-ballerina-up-to-date.md
+++ b/swan-lake/learn/keeping-ballerina-up-to-date.md
@@ -217,7 +217,7 @@ Distributions available locally:
 
 The `ballerina dist pull <distribution>` command downloads a particular distribution and stores it in your local environment. It also sets the fetched distribution as the active distribution.
 
-#### For jBallerina 1.2.5 and above (for Update Tool Version 0.8.8 and above):
+#### For jBallerina 1.2.5 and Above (for Update Tool Version 0.8.8 and Above):
 
 ```sh
 → sudo ballerina dist pull 1.2.6
@@ -225,7 +225,7 @@ Fetching the 'jballerina-1.2.6' distribution from the remote server...
 Downloading jballerina-1.2.6 100% [==================================] 96/96 MB 'jballerina-1.2.6' successfully set as the active distribution
 ```
 
-#### For Versions below jBallerina 1.2.5 (for Update Tool Versions below 0.8.8):
+#### For Versions Below jBallerina 1.2.5 (for Update Tool Versions Below 0.8.8):
 
 ```sh
 → sudo ballerina dist pull jballerina-1.2.4

--- a/swan-lake/learn/observing-ballerina-code.md
+++ b/swan-lake/learn/observing-ballerina-code.md
@@ -14,7 +14,7 @@ redirect_from:
   - /swan-lake/learn/observing-ballerina-code
 ---
 
-## Providing observability in Ballerina
+## Providing Observability in Ballerina
 
 Monitoring, logging, and distributed tracing are key methods that reveal the internal state of the system to provide the observability. Ballerina becomes fully observable by exposing itself via these three methods to various external systems allowing to monitor metrics such as request count and response time statistics, analyze logs, and
 perform distributed tracing. 
@@ -42,7 +42,7 @@ Prometheus, etc. You can follow [Docker documentation](https://docs.docker.com/i
 * Setup Jaeger analyze tracing as mentioned in section [Setting up Jaeger](#jaeger-server)
 * Setup Elastic Stack only if you are interested in analysing logs by following section on [Setting up Elastic Stack](#elastic-stack)
 
-### Step 3 - Creating a Hello World Ballerina Service
+### Step 3 - Creating a 'Hello World' Ballerina Service
  
 Create a Service as shown below and save it as `hello_world_service.bal`.
 
@@ -64,7 +64,7 @@ service hello on new http:Listener(9090) {
 }
 ```
 
-### Step 4 - Observing the Hello World Ballerina Service
+### Step 4 - Observing the 'Hello World' Ballerina Service
 
 Observability is disabled by default and can be enabled by using the `--b7a.observability.enabled=true` flag or updating the configurations.
 

--- a/swan-lake/learn/publishing-modules-to-ballerina-central.md
+++ b/swan-lake/learn/publishing-modules-to-ballerina-central.md
@@ -12,7 +12,7 @@ redirect_from:
   - /swan-lake/learn/publishing-modules-to-ballerina-central
 ---
 
-## The CLI command
+## The CLI Command
 
 Pushing a module uploads it to [Ballerina Central](https://central.ballerina.io/).
 
@@ -20,7 +20,7 @@ Pushing a module uploads it to [Ballerina Central](https://central.ballerina.io/
 ballerina push <module-name>
 ```
 
-## Setting up
+## Setting Up
 
 Before you push your module, you must enter your Ballerina Central access token in `Settings.toml` in your home repository (`<USER_HOME>/.ballerina/`).
 

--- a/swan-lake/learn/quick-tour.md
+++ b/swan-lake/learn/quick-tour.md
@@ -16,7 +16,7 @@ redirect_from:
 1. Follow the instructions given on the [Getting Started](/swan-lake/learn/getting-started) page to set it up. 
 1. Follow the instructions given on the [Visual Studio Code Plugin](/swan-lake/learn/tools-ides/vscode-plugin) page or the [IntelliJ IDEA Plugin](/swan-lake/learn/tools-ides/intellij-plugin) page to set up your preferred editor for Ballerina.
 
-## Writing a Service, Running it, and Invoking it
+## Writing a Service, Running It, and Invoking It
 
 Write a simple Hello World HTTP service in a file with the `.bal` extension.
 

--- a/swan-lake/learn/quick-tour.md
+++ b/swan-lake/learn/quick-tour.md
@@ -16,7 +16,7 @@ redirect_from:
 1. Follow the instructions given on the [Getting Started](/swan-lake/learn/getting-started) page to set it up. 
 1. Follow the instructions given on the [Visual Studio Code Plugin](/swan-lake/learn/tools-ides/vscode-plugin) page or the [IntelliJ IDEA Plugin](/swan-lake/learn/tools-ides/intellij-plugin) page to set up your preferred editor for Ballerina.
 
-## Writing a service, running it, and invoking it
+## Writing a Service, Running it, and Invoking it
 
 Write a simple Hello World HTTP service in a file with the `.bal` extension.
 
@@ -72,7 +72,7 @@ Hello Ballerina!
 
 Alternatively, you can use a Ballerina HTTP client to invoke the service.
 
-## Using a client to interact with a network-accessible service
+## Using a Client to Interact with a Network-Accessible Service
 
 A Ballerina client is a component, which interacts with a network-accessible service. It aggregates one or more actions that can be executed on the network-accessible service and accepts configuration parameters related to the network-accessible service.
 
@@ -172,7 +172,7 @@ $ ballerina run sunrise_client.bal
 
 This should print out the sunrise/sunset details.
 
-## What's next?
+## What's Next?
 
 Now, that you have taken Ballerina around for a quick tour, you can explore Ballerina more.
 

--- a/swan-lake/learn/running-ballerina-code.md
+++ b/swan-lake/learn/running-ballerina-code.md
@@ -13,7 +13,7 @@ redirect_from:
   - /swan-lake/learn/running-ballerina-code
 ---
 
-## Understanding the structure
+## Understanding the Structure
 
 A Ballerina application can have:
 
@@ -86,7 +86,7 @@ A Ballerina runtime can be configured using configuration parameters, which are 
 
 The configuration APIs accept a key and an optional default value. If a mapping does not exist for the specified key, the default value is returned as the configuration value. The default values of these optional configurations are the default values of the return types of the functions.
 
-### Sourcing Parameters Into Ballerina Programs
+### Sourcing Parameters into Ballerina Programs
 Configuration parameters for your programs and apps can be defined on the CLI, as an environment variable, or from a configuration file, with loading and override precedence in the same order.
 
 #### Sourcing CLI Parameters
@@ -172,7 +172,6 @@ $ echo 12345 > secret.txt
 $ ballerina run main.bal --b7a.config.file=ballerina.conf
 Hello, Ballerina !
 ```
-
 
 If the `secret.txt` file is not present, then CLI prompts the user for the secret. Enter secret `12345` when prompted.
 ```bash

--- a/swan-lake/learn/set-up-ballerina-sdk.md
+++ b/swan-lake/learn/set-up-ballerina-sdk.md
@@ -8,7 +8,7 @@ redirect_from:
   - /swan-lake/learn/set-up-ballerina-sdk
 ---
 
-## Setting up for a new project
+## Setting Up for a New Project
 
 Follow the steps below to set up Ballerina SDK when creating a new Ballerina project.
 
@@ -34,7 +34,7 @@ Now, you have successfully added the Ballerina SDK. Click **Next** and continue 
 
 ![The new Ballerina SDK](images/new-ballerina-sdk.png)
 
-## Setting up for an existing project
+## Setting Up for an Existing Project
 
 Follow the steps below to set up Ballerina SDK for an exisitng Ballerina project.
 

--- a/swan-lake/learn/testing-ballerina-code/testing-quick-start.md
+++ b/swan-lake/learn/testing-ballerina-code/testing-quick-start.md
@@ -14,7 +14,7 @@ redirect_from:
   - /swan-lake/learn/testing-ballerina-code
 ---
 
-## Writing a simple function
+## Writing a Simple Function
 
 To get started, let's write a simple Ballerina function and test it.
 

--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea.md
@@ -14,7 +14,7 @@ redirect_from:
   - /swan-lake/learn/setting-up-intellij-idea
 ---
 
-## Setting up the prerequisites
+## Setting Up the Prerequisites
 
 You need [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) installed.
 

--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
@@ -25,7 +25,7 @@ The sections below include instructions on how to run different elements of a Ba
 - [Running the main method](#running-the-main-method)
 - [Running Ballerina services](#running-ballerina-services)
 
-### Running the Main Method
+### Running the 'Main' Method
 
 Follow the steps below to run the main function of a Ballerina file.
 
@@ -70,7 +70,7 @@ You can debug Ballerina main/service programs with a few clicks.
 - There are some cases where stepping over gives unexpected behavior
     - Eg: When there are multiple workers and a wait expression waiting for them, even though step over hit and pass wait line in source, workers are not yet finished execution.
 
-## Viewing the Sequence Siagram
+## Viewing the Sequence Diagram
 
 The underlying language semantics of Ballerina were designed by modeling how independent parties communicate via structured interactions. Subsequently, every Ballerina program can be displayed as a sequence diagram of its flow including endpoints as well as synchronous and asynchronous calls.
 

--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
@@ -85,7 +85,7 @@ Now, you have successfully created a new Ballerina file with a **main** function
 
 ## Configuring the Plugin Settings
 
-### Ballerina Home Auto Detection
+### 'Ballerina Home' Auto Detection
 
 In order to automatically detect the Ballerina Home that is being used (without setting up a Ballerina SDK), enable the **Settings** **->** **Languages and Frameworks** **->** **Ballerina** **->** **Ballerina Home Auto Detection** option.
 

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code.md
@@ -50,7 +50,7 @@ $ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 
 ## Troubleshooting
 
-If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
+If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
 
 The sections below include information on the various capabilities that are facilitated by the VS Code Ballerina Extension for the development process.
 

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code.md
@@ -48,9 +48,11 @@ $ code --install-extension <BALLERINA-EXTENSION-DIRECTORY>
 
 > **Tip:** Ballerina Language Specification supports a set of experimental features such as transactions syntax. In order to be compatible with the experimental features and for supporting language intelligence in VS Code Extension, enable the Allow Experimental option in user settings.
 
-> **Troubleshooting**: If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
+## Troubleshooting
 
-The below sections include information on the various capabilities that are facilitated by the VS Code Ballerina Extension for the development process.
+If you installed a new Ballerina version recently, you might need to restart the VS Code Editor to pick the new Ballerina version. Herein, If you are using Mac OS, press 'Command+Q' keys to quit the app and reopen it.
+
+The sections below include information on the various capabilities that are facilitated by the VS Code Ballerina Extension for the development process.
 
 - [Language Intelligence](/swan-lake/learn/vscode-plugin/language-intelligence)
 - [Run and Debug](/swan-lake/learn/vscode-plugin/run-and-debug)

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
@@ -25,7 +25,7 @@ The Documentation Viewer represents the documented entities in a file in an orga
 
 ![Documentation Viewer](/swan-lake/learn/images/documentation-viewer.gif)
 
-## What's next?
+## What's Next?
 
  - For information on the next capability of the VS Code Ballerina plugin, see [Run All tests](/swan-lake/learn/vscode-plugin/run-all-tests).
  - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/swan-lake/learn/vscode-plugin).

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
@@ -16,7 +16,7 @@ redirect_from:
   - /swan-lake/learn/language-intelligence/
 ---
 
-## Semantic and syntactic diagnostics
+## Semantic and Syntactic Diagnostics
 
 When there are syntax or semantic errors in your code, you will be notified with appropriate diagnostics during the development time. 
 
@@ -24,7 +24,7 @@ When there are syntax or semantic errors in your code, you will be notified with
 
 ![Semantic and syntactic diagnostics](/swan-lake/learn/images/semantic-and-syntactic.gif)
 
-## Suggestions and auto completion
+## Suggestions and Auto Completion
 
 The extension provides you with suggestions on keywords, variables, and code snippets of language constructs (such as functions, services, and iterable constructs etc.).
 
@@ -32,7 +32,7 @@ The extension provides you with suggestions on keywords, variables, and code sni
 
 > **Tip**: You can use these suggestions to access the contents of the modules available in your Ballerina home repo as well as in the Ballerina distribution.
 
-## Code actions
+## Code Actions
 
 These allow you to perform the below tasks easily based on the diagnostics and the current scope where the cursor resides. 
 
@@ -52,7 +52,7 @@ For another example, you can add documentation for a function as shown below.
 
  ![Code actions](/swan-lake/learn/images/code-actions.gif)
 
-## Hover support
+## Hover Support
 
  Hover support provides you quick access to information about a certain entity. 
  
@@ -62,13 +62,13 @@ For another example, you can add documentation for a function as shown below.
  
  > **Tip**: Likewise, if you hover over an entity name of an object or a record, you can view the description of the object/record as well as descriptions of its fields.
 
-## Go to definition
+## Go to Definition
 
 This option allows you to view the definition of a selected variable, function, an object etc. within the same file, in a separate file, in the same module, or in a file of a different module, of the same project or of the [Standard Library](/learn/api-docs/ballerina/).
 
 ![Go to definition](/swan-lake/learn/images/go-to-definition-vscode.gif)
 
-## What's next?
+## What's Next?
 
  - For information on the next capability of the VS Code Ballerina extension, see [Run and Debug](/swan-lake/learn/vscode-plugin/run-and-debug).
  - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/swan-lake/learn/vscode-plugin).

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
@@ -16,7 +16,7 @@ redirect_from:
   - /swan-lake/learn/run-all-tests/
 ---
 
-## Running all tests 
+## Running All Tests 
 
 Follow the steps below to do this.
 
@@ -25,7 +25,7 @@ Follow the steps below to do this.
 
 ![Run all tests](/swan-lake/learn/images/run-all-tests.gif)
 
-## What's next?
+## What's Next?
 
 - For information on the Ballerina VSCode extension, see [The Visual Studio Code Ballerina Extension](/swan-lake/learn/vscode-plugin/).
 - For information on all the tools and IDEs that are supported by Ballerina, see [Setting up Ballerina](/swan-lake/learn/installing-ballerina/).

--- a/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
+++ b/swan-lake/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
@@ -39,7 +39,7 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
 - There are some cases where stepping over gives unexpected behavior
     - Eg: When there are multiple workers and a wait expression waiting for them, even though step over hit and pass wait line in source, workers are not yet finished execution.
 
-## What's next?
+## What's Next?
 
  - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/swan-lake/learn/vscode-plugin/graphical-editor).
  - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/swan-lake/learn/vscode-plugin).

--- a/swan-lake/learn/using-the-cli-tools.md
+++ b/swan-lake/learn/using-the-cli-tools.md
@@ -12,7 +12,7 @@ redirect_from:
   - /swan-lake/learn/using-the-cli-tools
 ---
 
-## Using the `ballerina` command
+## Using the 'ballerina' command
 
 In the CLI, execute the `ballerina help` command to view all the actions you can perform with it as shown below:
 
@@ -26,7 +26,7 @@ You can use it in the below format.
 
 ![Ballerina help output](/swan-lake/learn/images/ballerina-help-output.png)
 
-## Core commands
+## Core Commands
 
 These everyday commands are your best friends! They address the very basics of programming in Ballerina such as compiling, running, testing programs, and generating their documentation.
 
@@ -84,7 +84,7 @@ These commands allow you to work with the Ballerina Central to share Ballerina m
 </tr>
 </table>
 
-## Project commands
+## Project Commands
 
 Ballerina projects are the way to organize real world Ballerina development tasks. 
 
@@ -101,7 +101,7 @@ Ballerina projects are the way to organize real world Ballerina development task
 </tr>
 </table>
 
-## Other commands
+## Other Commands
 
 These powerful supporting tools extend Ballerina to various ecosystem technologies that are inherently cloud-native. This functionality will grow over time and will even be developer extensible in the future.
 
@@ -134,7 +134,7 @@ These powerful supporting tools extend Ballerina to various ecosystem technologi
 </tr>
 </table>
 
-## Update commands
+## Update Commands
 
 <table class="cComandTable">
 <tr>

--- a/swan-lake/learn/using-the-openapi-tools.md
+++ b/swan-lake/learn/using-the-openapi-tools.md
@@ -14,7 +14,7 @@ redirect_from:
   - /learn/using-the-openapi-tools
 ---
 
-## Using the capabilities of the OpenAPI Tools
+## Using the Capabilities of the OpenAPI Tools
 
 The OpenAPI tools provide the following capabilities.
  
@@ -29,7 +29,7 @@ The OpenAPI compiler plugin will allow you to validate a service implementation 
 This plugin ensures that the implementation of a service does not deviate from its OpenAPI contract.   
 
 ### OpenAPI to Ballerina
-#### Generate Service and Client stub from OpenAPI Contract
+#### Generate Service and Client Stub from an OpenAPI Contract
 
 ```bash
 ballerina openapi   -i <openapi-contract> 
@@ -98,7 +98,7 @@ The service generation process is complete. The following files were created.
 -- hello-client.bal
 -- schema.bal
 ```
-#### Generate OpenAPI contract from Service
+#### Generate OpenAPI Contract from Service
 
  ```bash
     ballerina openapi -i src/helloworld/helloService.bal
@@ -117,7 +117,7 @@ The Compiler Plugin is activated if a service has the `openapi:ServiceInfo` anno
 the service and the OpenAPI Contract and validates both against a pre-defined set of validation rules. 
 If any of the rules fail, the plugin will give the result as one or more compilation errors.
 
-### Annotation for validator Plugin 
+### Annotation for Validator Plugin 
 The `@openapi:ServiceInfo` annotation is used to bind the service with an OpenAPI Contract. You need to add 
 this annotation to the service file with the required values for enabling the validations.  
 The following is an example of the annotation usage.
@@ -134,7 +134,7 @@ service greet on new http:Listener(9090) {
     ...
 }
 ```
-#### Annotation support the following attributes:
+#### Annotation Support for the Following Attributes:
 - **Contract** (Required) : **string**  :
 Here, you can provide a path to the OpenAPI contract as a string and the OpenAPI file can either be `.yaml` or `.json`
 This is a required attribute.

--- a/swan-lake/learn/using-the-openapi-tools.md
+++ b/swan-lake/learn/using-the-openapi-tools.md
@@ -98,7 +98,7 @@ The service generation process is complete. The following files were created.
 -- hello-client.bal
 -- schema.bal
 ```
-#### Generate OpenAPI Contract from Service
+#### Generate an OpenAPI Contract from a Service
 
  ```bash
     ballerina openapi -i src/helloworld/helloService.bal


### PR DESCRIPTION
## Purpose
Fix case issues in titles of all Learn pages in both 1.2 and Swan Lake.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
