### PR TITLE
Fix the Open API Page Redirections for Swan Lake

### DIFF
--- a/js/redirections.js
+++ b/js/redirections.js
@@ -89,7 +89,6 @@ let redirections = {
     "/1.1/learn/keeping-ballerina-up-to-date":"/1.1/learn/how-to-keep-ballerina-up-to-date",
     "/1.0/learn/keeping-ballerina-up-to-date":"/1.0/page-not-available.html",
     "/0.991/learn/keeping-ballerina-up-to-date":"/0.991/page-not-available.html",
-    "/swan-lake/learn/using-the-openapi-tools":"/swan-lake/learn/how-to-use-openapi-tools",
     "/1.1/learn/using-the-openapi-tools":"/1.1/learn/how-to-use-openapi-tools",
     "/1.0/learn/using-the-openapi-tools":"/1.0/learn/how-to-use-openapi-tools/",
     "/0.991/learn/using-the-openapi-tools":"/0.991/page-not-available.html",

--- a/learn/using-the-openapi-tools.md
+++ b/learn/using-the-openapi-tools.md
@@ -7,6 +7,8 @@ permalink: /learn/using-the-openapi-tools/
 active: using-the-openapi-tools
 intro: OpenAPI Specification is a specification that creates a RESTFUL contract for APIs, detailing all of its resources and operations in a human and machine-readable format for easy development, discovery, and integration. Ballerina OpenAPI tooling will make it easy for users to start development of a service documented in OpenAPI contract in Ballerina by generating Ballerina service and client skeletons.
 redirect_from:
+  - /v1-2/learn/how-to-use-openapi-tools
+  - /v1-2/learn/how-to-use-openapi-tools/
   - /learn/how-to-use-openapi-tools
   - /learn/how-to-use-openapi-tools/
   - /learn/using-the-openapi-tools

--- a/swan-lake/learn/using-the-openapi-tools.md
+++ b/swan-lake/learn/using-the-openapi-tools.md
@@ -3,15 +3,13 @@ layout: ballerina-left-nav-pages
 title: Using the OpenAPI Tools
 description: Check out how the Ballerina OpenAPI tooling makes it easy for users to start developing a service documented in the OpenAPI contract.
 keywords: ballerina, programming language, openapi, open api, restful api
-permalink: /learn/using-the-openapi-tools/
+permalink: /swan-lake/learn/using-the-openapi-tools/
 active: using-the-openapi-tools
 intro: OpenAPI Specification is a specification that creates a RESTFUL contract for APIs, detailing all of its resources and operations in a human and machine-readable format for easy development, discovery, and integration. Ballerina OpenAPI tooling will make it easy for users to start development of a service documented in OpenAPI contract in Ballerina by generating Ballerina service and client skeletons.
 redirect_from:
-  - /v1-2/learn/how-to-use-openapi-tools
-  - /v1-2/learn/how-to-use-openapi-tools/
-  - /learn/how-to-use-openapi-tools/
-  - /learn/how-to-use-openapi-tools
-  - /learn/using-the-openapi-tools
+  - /swan-lake/learn/how-to-use-openapi-tools/
+  - /swan-lake/learn/how-to-use-openapi-tools
+  - /swan-lake/learn/using-the-openapi-tools
 ---
 
 ## Using the Capabilities of the OpenAPI Tools


### PR DESCRIPTION
## Purpose
Fix the Open API page redirections for Swan Lake.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
