### PR TITLE
Fix docerina learn page

### DIFF
--- a/swan-lake/learn/documenting-ballerina-code.md
+++ b/swan-lake/learn/documenting-ballerina-code.md
@@ -139,12 +139,63 @@ Next, move into the project directory and execute `ballerina add <module-name>` 
 
 ```bash
 $ cd myproject/
-$ ballerina add math -t service
+$ ballerina add math
 Added new ballerina module at 'src/math'
-$ ballerina add time -t service
-Added new ballerina module at 'src/time'
+$ ballerina add world
+Added new ballerina module at 'src/world'
 ```
+Now, let's add a function to the `math` module to be documented. Copy and paste the following code in to the `myproject/src/math/main.bal` file.
 
+```ballerina
+# Calculates the value of the 'a' raised to the power of 'b'.
+# ```ballerina
+# float aPowerB = math:pow(3.2, 2.4);
+# ```
+# 
+# + a - Base value
+# + b - Exponential value
+# + return - Calculated exponential value
+public isolated function pow(float a, float b) returns float {
+    return 0;
+}
+```
+Add the follwoing class definition to the `world` module. Copy and paste the following code in to the `myproject/src/world/main.bal/` file.
+
+```ballerina
+# Represents a person object.
+#
+# + name - Name of the person
+# + age - Age of the person in years
+# + address - Address of the person
+# + wealth - Account balance of the person
+public class Person {
+    public string name = "";
+    public int age;
+    public string address;
+    public float wealth = 0;
+
+    # Gets invoked to initialize the `Person` object.
+    #
+    # + name - Name of the person for the constructor
+    # + age - Age of the person for the constructor
+    public function init(string name, int age) {
+    }
+
+    # Get the address of the person.
+    #
+    # + return - New address of the person
+    public function getAddress() returns string {
+        return self.address ;
+    }
+
+    # Add wealth of the person.
+    #
+    # + amt - Amount to be added
+    # + rate - Interest rate
+    public function addWealth(int[] amt, float rate=1.5) {
+    }
+}
+```
 Now, let's generate documentation of the project:
 ```bash
 $ ballerina doc -a
@@ -152,22 +203,22 @@ $ ballerina doc -a
 Output:
 ```bash
 Compiling source
-        foo/time:0.1.0
         foo/math:0.1.0
+        foo/world:0.1.0
 
 Generating API Documentation
         target/apidocs
 ```
 
-The `target/apidocs/` folder would contain following;
+`target/apidocs/` folder would contain following;
 ```bash
 $ ls target/apidocs/
-index.html  math  time  ...
+index.html  math  world  ...
 ```
 
 * `index.html`  - contains an index page of all the modules in the Ballerina project 
 * `math` - contains the documentation of the module named `math`
-* `time` - contains the documentation of the module named `time`
+* `world` - contains the documentation of the module named `world`
 
 If you want to generate documentation for a selected Ballerina module, then you can execute the following command from the Ballerina project root directory:
 


### PR DESCRIPTION
## Purpose
> Since Docerina doesn't support services, the current learn page has wrong information at the end. This PR fixes the issue with a custom function and a class definition.

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
