### PR TITLE
Add Java 11 Changes in Azure Docs for SLP5

### DIFF
--- a/swan-lake/learn/deployment/azure-functions.md
+++ b/swan-lake/learn/deployment/azure-functions.md
@@ -65,7 +65,7 @@ Generating executables
 In order to deploy a Ballerina function in Azure Functions, the following prerequisites must be met.
 
 * Create an Azure [Function App](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-function-app-portal) with the given resource group with the following requirements:
-   - Runtime stack - `Java 8`
+   - Runtime stack - `Java 11`
    - Hosting operating system - `Windows` (default; Linux is not supported in Azure for custom handlers at the moment)
 * Install the [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
 


### PR DESCRIPTION
## Purpose
Add Java 11 changes in Azure Docs for SLP5.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
