### PR TITLE
Fix JRE 11 changes in c2c learn and Lambda BBE  

### DIFF
--- a/swan-lake/learn/by-example/aws-lambda-deployment.html
+++ b/swan-lake/learn/by-example/aws-lambda-deployment.html
@@ -391,7 +391,7 @@ Compiling source
 
                                 <td class="code leading cOutput">
                                     <div class="highlight"><pre><code class=shell-session>	Run the following command to deploy each Ballerina AWS Lambda function:
-	aws lambda create-function --function-name $FUNCTION_NAME --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.$FUNCTION_NAME --runtime provided --role $LAMBDA_ROLE_ARN --layers arn:aws:lambda:$REGION_ID:141896495686:layer:ballerina:2 --memory-size 512 --timeout 10
+	aws lambda create-function --function-name $FUNCTION_NAME --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.$FUNCTION_NAME --runtime provided --role $LAMBDA_ROLE_ARN --layers arn:aws:lambda:$REGION_ID:141896495686:layer:ballerina-jre11:1 --memory-size 512 --timeout 10
 </code></pre></div>
 
                                 </td>
@@ -418,11 +418,11 @@ Compiling source
                                 <td class="code leading cOutput">
                                     <div class="highlight"><pre><code class=shell-session># Execute the AWS CLI commands to create and publish the functions; and set your respective AWS $LAMBDA_ROLE_ARN, $REGION_ID, and $FUNCTION_NAME values; following are some examples:-
 $ aws lambda create-function --function-name echo --zip-file fileb://aws-ballerina-lambda-functions.zip --handler aws_lambda_deployment.echo --runtime provided --role arn:aws:iam::908363916111:role/lambda-role
- --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina:2 --memory-size 512 --timeout 10
+ --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina-jre11:1 --memory-size 512 --timeout 10
 $ aws lambda create-function --function-name uuid --zip-file fileb://aws-ballerina-lambda-functions.zip --handler aws_lambda_deployment.uuid --runtime provided --role arn:aws:iam::908363916111:role/lambda-role
- --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina:2 --memory-size 512 --timeout 10
+ --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina-jre11:1 --memory-size 512 --timeout 10
 $ aws lambda create-function --function-name ctxinfo --zip-file fileb://aws-ballerina-lambda-functions.zip --handler aws_lambda_deployment.ctxinfo --runtime provided --role arn:aws:iam::908363916111:role/lambda-role
- --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina:2 --memory-size 512 --timeout 10
+ --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina-jre11:1 --memory-size 512 --timeout 10
 </code></pre></div>
 
                                 </td>

--- a/swan-lake/learn/deployment/aws-lambda.md
+++ b/swan-lake/learn/deployment/aws-lambda.md
@@ -45,7 +45,7 @@ Generating executables
 
 	Run the following commands to deploy each Ballerina AWS Lambda function:
 	aws lambda create-function --function-name <FUNCTION_NAME> --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.<FUNCTION_NAME> --runtime provided --role <LAMBDA_ROLE_ARN> --timeout 10 --memory-size 1024
-	aws lambda update-function-configuration --function-name <FUNCTION_NAME> --layers arn:aws:lambda:<REGION_ID>:141896495686:layer:ballerina:2
+	aws lambda update-function-configuration --function-name <FUNCTION_NAME> --layers arn:aws:lambda:<REGION_ID>:141896495686:layer:ballerina-jre11:1
 
 	Run the following command to re-deploy an updated Ballerina AWS Lambda function:
 	aws lambda update-function-code --function-name <FUNCTION_NAME> --zip-file fileb://aws-ballerina-lambda-functions.zip
@@ -58,7 +58,7 @@ Ballerina's AWS Lambda functionality is implemented as a custom AWS Lambda layer
 A sample execution to deploy the hash function as an AWS Lambda is shown below. 
 
 ```bash
-$ aws lambda create-function --function-name hash --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.hash --runtime provided --role arn:aws:iam::908363916138:role/lambda-role --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina:2
+$ aws lambda create-function --function-name hash --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.hash --runtime provided --role arn:aws:iam::908363916138:role/lambda-role --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina-jre11:1
 {
     "FunctionName": "hash",
     "FunctionArn": "arn:aws:lambda:us-west-1:908363916138:function:hash",
@@ -78,7 +78,7 @@ $ aws lambda create-function --function-name hash --zip-file fileb://aws-balleri
     "RevisionId": "d5400f01-f3b8-478b-9269-73c44f4537aa",
     "Layers": [
         {
-            "Arn": "arn:aws:lambda:us-west-1:141896495686:layer:ballerina:2",
+            "Arn": "arn:aws:lambda:us-west-1:141896495686:layer:ballerina-jre11:1",
             "CodeSize": 697
         }
     ]

--- a/swan-lake/learn/deployment/docker.md
+++ b/swan-lake/learn/deployment/docker.md
@@ -92,7 +92,7 @@ service hello on new http:Listener(9090){
 
     ```
     # Auto Generated Dockerfile
-    FROM ballerina/jre8:v1
+    FROM ballerina/jre11:v1
 
     LABEL maintainer="dev@ballerina.io"
 
@@ -325,7 +325,7 @@ service hello on helloWorldEP {
 
     ```
     # Auto Generated Dockerfile
-    FROM ballerina/jre8:v1
+    FROM ballerina/jre11:v1
 
     LABEL maintainer="dev@ballerina.io"
 
@@ -517,7 +517,7 @@ target = "java8"
 
     ```
     # Auto Generated Dockerfile
-    FROM ballerina/jre8:v1
+    FROM ballerina/jre11:v1
 
     LABEL maintainer="dev@ballerina.io"
 
@@ -582,7 +582,7 @@ target = "java8"
 
 ### Using a Custom Base Image to Build Ballerina Docker Images
 
-Ballerina ships a base image (e.g., `ballerina/jre8:v1`) with some security hardening. It is used to build Docker images with the user's application code. However, sometimes, you might need to use your own Docker base image depending on your company policies or any additional requirements. This use case shows how to use a custom Docker base image to build Ballerina Docker images with the application code. 
+Ballerina ships a base image (e.g., `ballerina/jre11:v1`) with some security hardening. It is used to build Docker images with the user's application code. However, sometimes, you might need to use your own Docker base image depending on your company policies or any additional requirements. This use case shows how to use a custom Docker base image to build Ballerina Docker images with the application code. 
 
 #### Setting Up the Prerequisites
 
@@ -598,7 +598,7 @@ import ballerina/docker;
  
 @docker:Config {
    name: "helloworld_custom_baseimage",
-   baseImage: "openjdk:8-jre-alpine"
+   baseImage: "openjdk:11-jre-slim"
 }
 service hello on new http:Listener(9090){
  
@@ -608,7 +608,7 @@ service hello on new http:Listener(9090){
 }
 ```
 
-> **Note:** This sample uses `openjdk:8-jre-alpine` as the custom Docker image by using the `baseImage` property in the `@docker:Config` annotation.
+> **Note:** This sample uses `openjdk:11-jre-slim` as the custom Docker image by using the `baseImage` property in the `@docker:Config` annotation.
 
 #### Steps to Run
 
@@ -648,7 +648,7 @@ service hello on new http:Listener(9090){
 
     ```
     # Auto Generated Dockerfile
-    FROM openjdk:8-jre-alpine
+    FROM openjdk:11-jre-slim
 
     LABEL maintainer="dev@ballerina.io"
 
@@ -774,7 +774,7 @@ This sample enables HTTP trace logs by overriding the CMD value of the generated
 
     ```
     # Auto Generated Dockerfile
-    FROM ballerina/jre8:v1
+    FROM ballerina/jre11:v1
 
     LABEL maintainer="dev@ballerina.io"
 

--- a/swan-lake/learn/deployment/docker.md
+++ b/swan-lake/learn/deployment/docker.md
@@ -95,20 +95,26 @@ service hello on new http:Listener(9090){
     FROM ballerina/jre11:v1
 
     LABEL maintainer="dev@ballerina.io"
+   
+    WORKDIR /home/ballerina
+   
+    COPY ballerina-lang.float-1.0.0.jar /home/ballerina/jars/ 
+    COPY ballerina-lang.__internal-0.1.0.jar /home/ballerina/jars/ 
+    COPY ballerina-lang.int-1.1.0.jar /home/ballerina/jars/ 
+    COPY hello_world_docker.jar /home/ballerina/jars/ 
+    ...
 
     RUN addgroup troupe \
-        && adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina \
-        && apk add --update --no-cache bash \
-        && chown -R ballerina:troupe /usr/bin/java \
-        && rm -rf /var/cache/apk/*
-
-    WORKDIR /home/ballerina
+    && adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina \
+    && apk add --update --no-cache bash \
+    && chown -R ballerina:troupe /usr/bin/java \
+    && rm -rf /var/cache/apk/*
 
     COPY hello_world_docker.jar /home/ballerina
 
     USER ballerina
 
-    CMD java -jar hello_world_docker.jar
+    CMD java -Xdiag -cp "hello_world_docker.jar:jars/*" '$_init'
 
     ```
 
@@ -329,21 +335,26 @@ service hello on helloWorldEP {
 
     LABEL maintainer="dev@ballerina.io"
 
-    RUN addgroup troupe \
-        && adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina \
-        && apk add --update --no-cache bash \
-        && chown -R ballerina:troupe /usr/bin/java \
-        && rm -rf /var/cache/apk/*
-
     WORKDIR /home/ballerina
-
+   
+    COPY ballerina-lang.float-1.0.0.jar /home/ballerina/jars/ 
+    COPY ballerina-lang.__internal-0.1.0.jar /home/ballerina/jars/ 
+    COPY ballerina-lang.int-1.1.0.jar /home/ballerina/jars/ 
+    COPY https_service_in_docker.jar /home/ballerina/jars/ 
+    ...
     COPY https_service_in_docker.jar /home/ballerina
     COPY ballerinaKeystore.p12 ./ballerinaKeystore.p12
 
+    RUN addgroup troupe \
+    && adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina \
+    && apk add --update --no-cache bash \
+    && chown -R ballerina:troupe /usr/bin/java \
+    && rm -rf /var/cache/apk/*
+
     EXPOSE  9095
     USER ballerina
-
-    CMD java -jar https_service_in_docker.jar
+    
+    CMD java -Xdiag -cp "https_service_in_docker.jar:jars/*" '$_init'
 
     ```
 
@@ -521,21 +532,26 @@ target = "java8"
 
     LABEL maintainer="dev@ballerina.io"
 
-    RUN addgroup troupe \
-        && adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina \
-        && apk add --update --no-cache bash \
-        && chown -R ballerina:troupe /usr/bin/java \
-        && rm -rf /var/cache/apk/*
-
     WORKDIR /home/ballerina
-
+   
+    COPY ballerina-lang.float-1.0.0.jar /home/ballerina/jars/ 
+    COPY ballerina-lang.__internal-0.1.0.jar /home/ballerina/jars/ 
+    COPY ballerina-lang.int-1.1.0.jar /home/ballerina/jars/ 
+    COPY copy_file.jar /home/ballerina/jars/ 
+    ...
     COPY copy_file.jar /home/ballerina
     COPY name.txt /home/ballerina/name.txt
 
+    RUN addgroup troupe \
+    && adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina \
+    && apk add --update --no-cache bash \
+    && chown -R ballerina:troupe /usr/bin/java \
+    && rm -rf /var/cache/apk/*
+
     EXPOSE  9090
     USER ballerina
-
-    CMD java -jar copy_file.jar
+   
+    CMD java -Xdiag -cp "copy_file.jar:jars/*" '$_init'
     ```
 
 3. Verify that the Docker image is created.
@@ -651,13 +667,18 @@ service hello on new http:Listener(9090){
     FROM openjdk:11-jre-slim
 
     LABEL maintainer="dev@ballerina.io"
-
+     
     WORKDIR /home/ballerina
-
+    
+    COPY ballerina-lang.float-1.0.0.jar /home/ballerina/jars/ 
+    COPY ballerina-lang.__internal-0.1.0.jar /home/ballerina/jars/ 
+    COPY ballerina-lang.int-1.1.0.jar /home/ballerina/jars/ 
+    COPY base_image.jar /home/ballerina/jars/ 
+    ...
     COPY base_image.jar /home/ballerina
 
     EXPOSE  9090
-    CMD java -jar base_image.jar
+    CMD java -Xdiag -cp "base_image.jar:jars/*" '$_init'
     ```
 
 2. Verify that the Docker image is created.
@@ -724,7 +745,7 @@ import ballerina/docker;
  
 @docker:Config {
    name: "custome_cmd",
-   cmd: "CMD java -jar ${APP} --b7a.http.accesslog.console=true"
+   cmd:    cmd: "CMD java -Xdiag -cp \"${APP}:jars/*\" '$_init' --b7a.http.accesslog.console=true"
 }
 service hello on new http:Listener(9090){
  
@@ -778,20 +799,27 @@ This sample enables HTTP trace logs by overriding the CMD value of the generated
 
     LABEL maintainer="dev@ballerina.io"
 
-    RUN addgroup troupe \
-        && adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina \
-        && apk add --update --no-cache bash \
-        && chown -R ballerina:troupe /usr/bin/java \
-        && rm -rf /var/cache/apk/*
-
     WORKDIR /home/ballerina
+   
+    COPY ballerina-lang.float-1.0.0.jar /home/ballerina/jars/ 
+    COPY ballerina-lang.__internal-0.1.0.jar /home/ballerina/jars/ 
+    COPY ballerina-lang.int-1.1.0.jar /home/ballerina/jars/ 
+    COPY docker_cmd.jar /home/ballerina/jars/ 
+    ...
+    COPY docker_cmd.jar /home/ballerina 
+   
+    RUN addgroup troupe \
+    && adduser -S -s /bin/bash -g 'ballerina' -G troupe -D ballerina \
+    && apk add --update --no-cache bash \
+    && chown -R ballerina:troupe /usr/bin/java \
+    && rm -rf /var/cache/apk/*
 
     COPY docker_cmd.jar /home/ballerina
 
     EXPOSE  9090
     USER ballerina
-
-    CMD java -jar docker_cmd.jar --b7a.http.accesslog.console=true
+    
+    CMD java -Xdiag -cp "docker_cmd.jar:jars/*" '$_init' --b7a.http.accesslog.console=true
     ```
 
 2. Verify that the Docker image is created.

--- a/swan-lake/learn/deployment/kubernetes.md
+++ b/swan-lake/learn/deployment/kubernetes.md
@@ -270,7 +270,7 @@ $ curl -kv https://ballerina.guides.io/users/jane
 |registry|Docker registry URL|null|
 |username|Username for the Docker registry|null|
 |password|Password for the Docker registry|null|
-|baseImage|Base image to create the Docker image|ballerina/jre8:v1|
+|baseImage|Base image to create the Docker image|ballerina/jre11:v1|
 |image|Docker image with tag|<OUTPUT_FILE_NAME>:latest. If field `registry` is set ,then it will be prepended to the Docker image name as <registry>/<OUTPUT_FILE_NAME>:latest|
 |buildImage|Building the Docker image|true|
 |push|Push the Docker image to registry. This will be effective if the `buildImage` field of the image is true|false|
@@ -382,7 +382,7 @@ $ curl -kv https://ballerina.guides.io/users/jane
 |registry|Docker registry URL|null|
 |username|Username for the Docker registry|null|
 |password|Password for the Docker registry|null|
-|baseImage|Base image to create the Docker image|ballerina/jre8:v1|
+|baseImage|Base image to create the Docker image|ballerina/jre11:v1|
 |image|Docker image with tag|<OUTPUT_FILE_NAME>:latest. If field `registry` is set, then it will be prepended to the Docker image name as <registry>/<OUTPUT_FILE_NAME>:latest|
 |buildImage|Building the Docker image|true|
 |push|Push the Docker image to registry. This will be effective if the `buildImage` field of the image is true|false|


### PR DESCRIPTION
## Purpose
Lambda - Changes ballerina:2 to ballerina-jre11:1 in AWS learn page and BBE.
Docker - Changes ballerina/jre8:v1 of the Dockerfile to ballerina/jre11:v1.
Custom docker image in learn page.    baseImage: "openjdk:8-jre-alpine" -> baseImage: "openjdk:11-jre-slim".
Kubernetes - Changes ballerina/jre8:v1 of the Dockerfile to ballerina/jre11:v1.

~~Note - In the New Dockerfile it uses separate jars instead of one fat jar. Learn pages contains sample output of the generated dockerfile. In this PR, I didn't update it to the latest because inline jars takes lot of unnecessary space in the page. This should be discussed before merging this PR.~~

Edit -: Updated the PR with Several Copy commands.

@anuruddhal  @hemikak @praneesha 


## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
