### PR TITLE
Change the label of the "Go to top" option to "Back to Top"

### DIFF
--- a/_layouts/ballerina-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-left-nav-pages-swanlake.html
@@ -44,7 +44,7 @@
                            </div>
                         </div>
                      </div>
-                     <a class="cTopLink" href="#table-of-content">Go to top &#x2934;</a>
+                     <a class="cTopLink" href="#table-of-content">Back to Top &#x2934;</a>
                   </div>
                </div>
             </div>

--- a/_layouts/ballerina-left-nav-pages.html
+++ b/_layouts/ballerina-left-nav-pages.html
@@ -50,7 +50,7 @@
                            </div>
                         </div>
                      </div>
-                     <a class="cTopLink" href="#table-of-content">Go to top &#x2934;</a>
+                     <a class="cTopLink" href="#table-of-content">Back to Top &#x2934;</a>
                   </div>
                </div>
             </div>


### PR DESCRIPTION
## Purpose
Change the label of the "Go to top" option to "Back to Top".
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
