### PR TITLE
Fix Broken Links in the Dev Site for SLP5

### DIFF
--- a/js/redirections.js
+++ b/js/redirections.js
@@ -238,5 +238,8 @@ let redirections = {
     "/1.0/learn/by-example/readonly-objects.html":"/1.0/page-not-available.html",
     "/swan-lake/learn/api-docs/ballerina/*/objects/*":"/swan-lake/learn/api-docs/ballerina/*/classes/*",
     "/swan-lake/learn/observing-ballerina-code/":"/swan-lake/page-not-available.html",
-    "/swan-lake/learn/extending-with-compiler-extensions/":"/swan-lake/page-not-available.html"
+    "/swan-lake/learn/extending-with-compiler-extensions/":"/swan-lake/page-not-available.html",
+    "/learn/by-example/websocket-cookie.html":"/page-not-available.html",
+    "/1.1/learn/by-example/websocket-cookie.html":"/1.1/page-not-available.html",
+    "/1.0/learn/by-example/websocket-cookie.html":"/1.0/page-not-available.html",
 };

--- a/swan-lake/learn/api-docs/ballerina/ftp/index.html
+++ b/swan-lake/learn/api-docs/ballerina/ftp/index.html
@@ -300,7 +300,7 @@ service ftpServerConnector on remoteServer {
     }
 }
 </code></pre>
-<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operation, see the <a href="https://ballerina.io/swan-lake/learn/by-example/execute-ftp-operations.html">Execute FTP Operations Example</a>.</p>
+<p>For information on the operations, which you can perform with this module, see the <a href="#records"><strong>Records</strong></a> below.</p>
 
 
     

--- a/swan-lake/learn/by-example/websocket-cookie.html
+++ b/swan-lake/learn/by-example/websocket-cookie.html
@@ -979,7 +979,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/objects/Response.html#getCookies">Gets cookies from the <code>http:Response</code></a></p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getCookies">Gets cookies from the <code>http:Response</code></a></p>
 
                                         </div>
                                     </div>


### PR DESCRIPTION
## Purpose
Fix Broken Links in the Dev Site for SLP5.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
