### PR TITLE
Add Redirections to the FTP Module

### DIFF
--- a/js/redirections.js
+++ b/js/redirections.js
@@ -242,4 +242,7 @@ let redirections = {
     "/learn/by-example/websocket-cookie.html":"/page-not-available.html",
     "/1.1/learn/by-example/websocket-cookie.html":"/1.1/page-not-available.html",
     "/1.0/learn/by-example/websocket-cookie.html":"/1.0/page-not-available.html",
+    "/learn/api-docs/ballerina/ftp/index.html":"/page-not-available.html",
+    "/1.1/learn/api-docs/ballerina/ftp/index.html":"/1.1/page-not-available.html",
+    "/1.0/learn/api-docs/ballerina/ftp/index.html":"/1.0/page-not-available.html"
 };


### PR DESCRIPTION
## Purpose
The FTP module is added in the SLP5 release. 

Therefore, we need to add "Page not available" error message pages for previous releases to avoid broken links in the version navigation.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
