### PR TITLE
Fix the SQL Module Link in the Java JDBC Module

### DIFF
--- a/swan-lake/learn/api-docs/ballerina/java.jdbc/clients/Client.html
+++ b/swan-lake/learn/api-docs/ballerina/java.jdbc/clients/Client.html
@@ -416,7 +416,7 @@ can be accessed as <code>(&lt;sql:BatchExecuteError&gt; result).detail()?.execut
         <span class="method-types">
             <p>(<span class="builtin-type">string</span> | <a href="../../sql/abstractobjects/ParameterizedCallQuery.html">ParameterizedCallQuery</a> sqlQuery, <span class="array-type"><span class="builtin-type">typedesc</span>[]</span> rowTypes)</p>
             
-                <b> returns </b><a href="../../sql/abstractobjects/ProcedureCallResult.html">ProcedureCallResult</a> | <a href="../../sql/types.html#Error">Error</a> 
+                <b> returns </b><a href="../../sql/classes/ProcedureCallResult.html">ProcedureCallResult</a> | <a href="../../sql/types.html#Error">Error</a> 
             
         </span>
     </div>
@@ -472,7 +472,7 @@ the default column names of the query result set be used for the record attribut
         
         <div class="returns-listing">
             <ul>
-                <li> <h3 class="type">Return Type</h3> (<span class="type"><a href="../../sql/abstractobjects/ProcedureCallResult.html">ProcedureCallResult</a> | <a href="../../sql/types.html#Error">Error</a></span>)</li>
+                <li> <h3 class="type">Return Type</h3> (<span class="type"><a href="../../sql/classes/ProcedureCallResult.html">ProcedureCallResult</a> | <a href="../../sql/types.html#Error">Error</a></span>)</li>
                 <li><p>Summary of the execution is returned in <code>ProcedureCallResult</code> or <code>sql:Error</code></p>
 </li>
             </ul>


### PR DESCRIPTION
## Purpose
Fix the SQL Module link in the Java JDBC module.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
