### PR TITLE
Change Camel Case Back to All Caps in Titles of the "Downloads" Page

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -139,11 +139,11 @@ redirect_from:
                   and for installation instructions, see <a href="/learn/installing-ballerina/">Installing Ballerina</a>.
                </p>
                </p>
-               <h2>Preview Release: {{ site.data.swanlake-latest.metadata.version | camelCase }} <span id="versionInfo">({{ site.data.swanlake-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2>
+               <h2>Preview Release: {{ site.data.swanlake-latest.metadata.version | capitalize_all }} <span id="versionInfo">({{ site.data.swanlake-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2>
                <div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;" >
                   <p>If you already have jBallerina installed, you can use the <a href="/swan-lake/learn/keeping-ballerina-up-to-date/">Ballerina Update Tool</a> to update it to the Swan Lake channel. To do this, first, execute the command below to get the Update Tool updated to its latest version. </p>
                   <pre>ballerina update</pre>
-                  <p>Next, execute the command below to update to {{ site.data.swanlake-latest.metadata.version | camelCase }}.</p>
+                  <p>Next, execute the command below to update to {{ site.data.swanlake-latest.metadata.version | capitalize_all }}.</p>
                   <pre>ballerina dist pull {{ site.data.swanlake-latest.metadata.version | replace: "swan-lake-preview", "slp" }}</pre>
                   <p>For further details, see the <a href="/downloads/swan-lake-release-notes">Release Note</a>. </p>
                </div>


### PR DESCRIPTION
## Purpose
Change camel case back to all caps in titles of the "Downloads" page.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
