### PR TITLE
Update vscode extension download links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,5 +49,6 @@ exclude: ["downloads/RELEASE_NOTE.md","vendor","0.991/","v1-2","v1-1","v1-0","v0
 #   - vendor/gems/
 #   - vendor/ruby/
 dist_server: http://dist-dev.ballerina.io
+plugin_vscode_repo: https://github.com/ballerina-platform/plugin-vscode
 
 

--- a/downloads.html
+++ b/downloads.html
@@ -185,10 +185,10 @@ redirect_from:
                   </tr>
                   <tr>
                      <td style="width: 50%">Visual Studio Code Plugin (vsix)</td>
-                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/downloads/{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a></td>
-                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/downloads/{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.md5">md5</a></td>
-                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/downloads/{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.sha1">SHA-1</a></td>
-                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/downloads/{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.asc">asc</a></td>
+                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a></td>
+                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.md5">md5</a></td>
+                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.sha1">SHA-1</a></td>
+                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.asc">asc</a></td>
                   </tr>
                </table>
             </div>


### PR DESCRIPTION
## Purpose
Update vscode extension download links on website for preview releases.

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
