### PR TITLE
Update AWS BBE/Learn layer to JDK 11

### DIFF
--- a/swan-lake/learn/by-example/aws-lambda-deployment.html
+++ b/swan-lake/learn/by-example/aws-lambda-deployment.html
@@ -391,7 +391,7 @@ Compiling source
 
                                 <td class="code leading cOutput">
                                     <div class="highlight"><pre><code class=shell-session>	Run the following command to deploy each Ballerina AWS Lambda function:
-	aws lambda create-function --function-name $FUNCTION_NAME --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.$FUNCTION_NAME --runtime provided --role $LAMBDA_ROLE_ARN --layers arn:aws:lambda:$REGION_ID:141896495686:layer:ballerina:2 --memory-size 512 --timeout 10
+	aws lambda create-function --function-name $FUNCTION_NAME --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.$FUNCTION_NAME --runtime provided --role $LAMBDA_ROLE_ARN --layers arn:aws:lambda:$REGION_ID:134633749276:layer:ballerina-jre11:1 --memory-size 512 --timeout 10
 </code></pre></div>
 
                                 </td>
@@ -418,11 +418,11 @@ Compiling source
                                 <td class="code leading cOutput">
                                     <div class="highlight"><pre><code class=shell-session># Execute the AWS CLI commands to create and publish the functions; and set your respective AWS $LAMBDA_ROLE_ARN, $REGION_ID, and $FUNCTION_NAME values; following are some examples:-
 $ aws lambda create-function --function-name echo --zip-file fileb://aws-ballerina-lambda-functions.zip --handler aws_lambda_deployment.echo --runtime provided --role arn:aws:iam::908363916111:role/lambda-role
- --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina:2 --memory-size 512 --timeout 10
+ --layers arn:aws:lambda:us-west-1:134633749276:layer:ballerina-jre11:1 --memory-size 512 --timeout 10
 $ aws lambda create-function --function-name uuid --zip-file fileb://aws-ballerina-lambda-functions.zip --handler aws_lambda_deployment.uuid --runtime provided --role arn:aws:iam::908363916111:role/lambda-role
- --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina:2 --memory-size 512 --timeout 10
+ --layers arn:aws:lambda:us-west-1:134633749276:layer:ballerina-jre11:1 --memory-size 512 --timeout 10
 $ aws lambda create-function --function-name ctxinfo --zip-file fileb://aws-ballerina-lambda-functions.zip --handler aws_lambda_deployment.ctxinfo --runtime provided --role arn:aws:iam::908363916111:role/lambda-role
- --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina:2 --memory-size 512 --timeout 10
+ --layers arn:aws:lambda:us-west-1:134633749276:layer:ballerina-jre11:1 --memory-size 512 --timeout 10
 </code></pre></div>
 
                                 </td>

--- a/swan-lake/learn/deployment/aws-lambda.md
+++ b/swan-lake/learn/deployment/aws-lambda.md
@@ -45,7 +45,7 @@ Generating executables
 
 	Run the following commands to deploy each Ballerina AWS Lambda function:
 	aws lambda create-function --function-name <FUNCTION_NAME> --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.<FUNCTION_NAME> --runtime provided --role <LAMBDA_ROLE_ARN> --timeout 10 --memory-size 1024
-	aws lambda update-function-configuration --function-name <FUNCTION_NAME> --layers arn:aws:lambda:<REGION_ID>:141896495686:layer:ballerina-jre11:1
+	aws lambda update-function-configuration --function-name <FUNCTION_NAME> --layers arn:aws:lambda:<REGION_ID>:134633749276:layer:ballerina-jre11:1
 
 	Run the following command to re-deploy an updated Ballerina AWS Lambda function:
 	aws lambda update-function-code --function-name <FUNCTION_NAME> --zip-file fileb://aws-ballerina-lambda-functions.zip
@@ -58,7 +58,7 @@ Ballerina's AWS Lambda functionality is implemented as a custom AWS Lambda layer
 A sample execution to deploy the hash function as an AWS Lambda is shown below. 
 
 ```bash
-$ aws lambda create-function --function-name hash --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.hash --runtime provided --role arn:aws:iam::908363916138:role/lambda-role --layers arn:aws:lambda:us-west-1:141896495686:layer:ballerina-jre11:1
+$ aws lambda create-function --function-name hash --zip-file fileb://aws-ballerina-lambda-functions.zip --handler functions.hash --runtime provided --role arn:aws:iam::908363916138:role/lambda-role --layers arn:aws:lambda:us-west-1:134633749276:layer:ballerina-jre11:1
 {
     "FunctionName": "hash",
     "FunctionArn": "arn:aws:lambda:us-west-1:908363916138:function:hash",
@@ -78,7 +78,7 @@ $ aws lambda create-function --function-name hash --zip-file fileb://aws-balleri
     "RevisionId": "d5400f01-f3b8-478b-9269-73c44f4537aa",
     "Layers": [
         {
-            "Arn": "arn:aws:lambda:us-west-1:141896495686:layer:ballerina-jre11:1",
+            "Arn": "arn:aws:lambda:us-west-1:134633749276:layer:ballerina-jre11:1",
             "CodeSize": 697
         }
     ]


### PR DESCRIPTION
## Purpose
## Purpose
$Subject. 
Fixes the overriding issue occurred from #1419
AWS Repo PR - ballerina-platform/module-ballerinax-aws.lambda#220
