### PR TITLE
Fix the Liquid Syntax Links Manually in 1.2.x Release Notes

### DIFF
--- a/downloads/release-notes/1.2.7/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.7/RELEASE_NOTE.md
@@ -3,7 +3,7 @@ layout: ballerina-blank-page
 title: Release Note
 ---
 ### Overview of jBallerina 1.2.7
-The jBallerina 1.2.7 patch release improves upon the 1.2.6} release by introducing the features listed below and addressing a number of [bugs](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.7%22+label%3AType%2FBug+is%3Aclosed) and [improvements](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.7%22+is%3Aclosed+label%3AType%2FImprovement).
+The jBallerina 1.2.7 patch release improves upon the 1.2.6 release by introducing the features listed below and addressing a number of [bugs](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.7%22+label%3AType%2FBug+is%3Aclosed) and [improvements](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.7%22+is%3Aclosed+label%3AType%2FImprovement).
 
 You can use the update tool to update to jBallerina 1.2.7 as follows.
 

--- a/downloads/release-notes/1.2.7/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.7/RELEASE_NOTE.md
@@ -2,20 +2,20 @@
 layout: ballerina-blank-page
 title: Release Note
 ---
-### Overview of jBallerina {{ site.data.stable-latest.metadata.version }}
-The jBallerina {{ site.data.stable-latest.metadata.version }} patch release improves upon the {{ site.data.stable-latest.metadata.version }} release by introducing the features listed below and addressing a number of [bugs](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+{{ site.data.stable-latest.metadata.version }}%22+label%3AType%2FBug+is%3Aclosed) and [improvements](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+{{ site.data.stable-latest.metadata.version }}%22+is%3Aclosed+label%3AType%2FImprovement).
+### Overview of jBallerina 1.2.7
+The jBallerina 1.2.7 patch release improves upon the 1.2.6} release by introducing the features listed below and addressing a number of [bugs](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.7%22+label%3AType%2FBug+is%3Aclosed) and [improvements](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.7%22+is%3Aclosed+label%3AType%2FImprovement).
 
-You can use the update tool to update to jBallerina {{ site.data.stable-latest.metadata.version }} as follows.
+You can use the update tool to update to jBallerina 1.2.7 as follows.
 
 **For existing users:**
 
 If you are already using jBallerina version 1.2.0, or above, you can directly update your distribution to jBallerina {{ site.data.stable-latest.metadata.version }} by executing the following command:
 
-> $ ballerina dist update
+> ballerina dist update
 
 However, you need to use the following commands instead of the above if you have installed:
 
-- jBallerina 1.2.0 but switched to a previous version: `$ ballerina dist pull jballerina-{{ site.data.stable-latest.metadata.version }}`
+- jBallerina 1.2.0 but switched to a previous version: `ballerina dist pull jballerina-1.2.7`
 - a jBallerina version below 1.1.0: install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/release-notes/1.2.8/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.8/RELEASE_NOTE.md
@@ -2,21 +2,21 @@
 layout: ballerina-blank-page
 title: Release Note
 ---
-### Overview of jBallerina {{ site.data.stable-latest.metadata.version }}
+### Overview of jBallerina 1.2.8
 
-The jBallerina {{ site.data.stable-latest.metadata.version }} patch release improves upon the {{ site.data.stable-latest.metadata.version }} release by introducing the features listed below and addressing a number of [bugs](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+{{ site.data.stable-latest.metadata.version }}%22+label%3AType%2FBug+is%3Aclosed) and [improvements](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+{{ site.data.stable-latest.metadata.version }}%22+is%3Aclosed+label%3AType%2FImprovement).
+The jBallerina 1.2.8 patch release improves upon the 1.2.7 release by introducing the features listed below and addressing a number of [bugs](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.8%22+label%3AType%2FBug+is%3Aclosed) and [improvements](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.8%22+is%3Aclosed+label%3AType%2FImprovement).
 
-You can use the [update tool](/learn/keeping-ballerina-up-to-date/) to update to jBallerina {{ site.data.stable-latest.metadata.version }} as follows.
+You can use the [update tool](/learn/keeping-ballerina-up-to-date/) to update to jBallerina 1.2.8 as follows.
 
 **For existing users:**
 
-If you are already using jBallerina version 1.2.0, or above, you can directly update your distribution to jBallerina {{ site.data.stable-latest.metadata.version }} by executing the following command:
+If you are already using jBallerina version 1.2.0, or above, you can directly update your distribution to jBallerina 1.2.8 by executing the following command:
 
-> $ ballerina dist update
+> ballerina dist update
 
 However, you need to use the following commands instead of the above if you have installed:
 
-- jBallerina 1.2.0 but switched to a previous version: `$ ballerina dist pull jballerina-{{ site.data.stable-latest.metadata.version }}`
+- jBallerina 1.2.0 but switched to a previous version: `ballerina dist pull jballerina-1.2.8`
 - a jBallerina version below 1.1.0: install via the [installers](/downloads/)
 
 **For new users:**

--- a/downloads/release-notes/1.2.9/RELEASE_NOTE.md
+++ b/downloads/release-notes/1.2.9/RELEASE_NOTE.md
@@ -2,21 +2,21 @@
 layout: ballerina-blank-page
 title: Release Note
 ---
-### Overview of jBallerina {{ site.data.stable-latest.metadata.version }}
+### Overview of jBallerina 1.2.9
 
-The jBallerina {{ site.data.stable-latest.metadata.version }} patch release improves upon the {{ site.data.stable-latest.metadata.version }} release by introducing the features listed below and addressing a number of [bugs](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+{{ site.data.stable-latest.metadata.version }}%22+label%3AType%2FBug+is%3Aclosed) and [improvements](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+{{ site.data.stable-latest.metadata.version }}%22+is%3Aclosed+label%3AType%2FImprovement).
+The jBallerina 1.2.9 patch release improves upon the 1.2.8 release by introducing the features listed below and addressing a number of [bugs](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.9%22+label%3AType%2FBug+is%3Aclosed) and [improvements](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.9%22+is%3Aclosed+label%3AType%2FImprovement).
 
-You can use the [update tool](/learn/keeping-ballerina-up-to-date/) to update to jBallerina {{ site.data.stable-latest.metadata.version }} as follows.
+You can use the [update tool](/learn/keeping-ballerina-up-to-date/) to update to jBallerina 1.2.9 as follows.
 
 **For existing users:**
 
-If you are already using jBallerina version 1.2.0, or above, you can directly update your distribution to jBallerina {{ site.data.stable-latest.metadata.version }} by executing the following command:
+If you are already using jBallerina version 1.2.0, or above, you can directly update your distribution to jBallerina 1.2.9 by executing the following command:
 
-> $ ballerina dist update
+> ballerina dist update
 
 However, you need to use the following commands instead of the above if you have installed:
 
-- jBallerina 1.2.0 but switched to a previous version: `$ ballerina dist pull jballerina-{{ site.data.stable-latest.metadata.version }}`
+- jBallerina 1.2.0 but switched to a previous version: `ballerina dist pull 1.2.9`
 - a jBallerina version below 1.1.0: install via the [installers](/downloads/)
 
 **For new users:**


### PR DESCRIPTION
## Purpose
Fix the liquid syntax links (i.e., `{{ site.data.stable-latest.metadata.version }}`) manually in 1.2.x release notes.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
