### PR TITLE
Fix Swan Lake Broken Links

### DIFF
--- a/learn/api-docs/ballerina/docker/records/FileConfigs.html
+++ b/learn/api-docs/ballerina/docker/records/FileConfigs.html
@@ -172,7 +172,7 @@
             <li>
                 <p>
                     
-                    <p>Array of <a href="docker.html#FileConfig">FileConfig</a></p>
+                    <p>Array of FileConfig</p>
 
                 </p>
             </li>

--- a/swan-lake/learn/api-docs/ballerina/observe/index.html
+++ b/swan-lake/learn/api-docs/ballerina/observe/index.html
@@ -137,7 +137,7 @@ Ballerina supports Observability out of the box. This module provides user api's
 Ballerina supports Observability out of the box. This module provides user api's to make Ballerina Observability more flexible for the user.</p>
 <p>To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service.
 i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true'
-For more information on Ballerina Observability visit <a href="https://ballerina.io/swan-lake/learn/how-to-observe-ballerina-code/">How to Observe Ballerina Services</a>.</p>
+For more information on Ballerina Observability visit <a href="/swan-lake/learn/observing-ballerina-code/">Observing Ballerina Code</a>.</p>
 <h2>Tracing</h2>
 <p>Tracing provides information regarding the roundtrip of a service invocation based on the concept of spans, which are
 structured in a hierarchy based on the cause and effect concept. The tracing API allows users to tap into that


### PR DESCRIPTION
## Purpose
Fix Swan Lake broken links.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
