### PR TITLE
Change "User Guides" to "User Guide"

### DIFF
--- a/learn-2.md
+++ b/learn-2.md
@@ -9,7 +9,7 @@ permalink: /learn-2/
 <div class="col-sm-6 col-md-6 cLearnPageContentCol">
 <a class="cBoxLink" href="/learn/installing-ballerina/">
 
-<h2>Ballerina User Guides</h2>
+<h2>Ballerina User Guide</h2>
 
 <p>Gear yourself up by setting up Ballerina and learn about all the features of the language and its platform capabilities.</p>
 


### PR DESCRIPTION
## Purpose
Change "User Guides" to "User Guide".
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
