### PR TITLE
Fix the syntax highlighting of the TOML file in the C2C Learn Page

### DIFF
--- a/swan-lake/learn/deployment/code-to-cloud/code-to-cloud-samples.md
+++ b/swan-lake/learn/deployment/code-to-cloud/code-to-cloud-samples.md
@@ -50,7 +50,7 @@ redirect_from:
 
     ***Kubernetes.toml***
 
-    ```bash
+    ```toml
     [container.image]
     repository="wso2inc"
     name="hello"
@@ -312,7 +312,7 @@ Auto scaling policies allow the container to scale seamlessly without overloadin
 
     ***Kubernetes.toml***
 
-    ```bash
+    ```toml
     [container.image]
     repository="wso2inc"
     name="scaling-sample"


### PR DESCRIPTION
## Purpose
Fix the syntax highlighting of the TOML file in the C2C Learn page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
