### PR TITLE
Fix Broken Links for the 1.2.11 Release

### DIFF
--- a/swan-lake/learn/api-docs/ballerina/kubernetes/index.html
+++ b/swan-lake/learn/api-docs/ballerina/kubernetes/index.html
@@ -132,11 +132,9 @@
     <div>Version : 1.0.0</div>
     
     <h2>Module Overview</h2>
-<p>This module offers an annotation based Kubernetes extension implementation for Ballerina.</p>
-<ul>
-<li>For more information on the deployment, see the <a href="/swan-lake/learn/deployment/kubernetes/">Kubernetes Deployment Guide</a>.</li>
-<li>For examples on the usage of the operations, see the <a href="/swan-lake/learn/by-example/kubernetes-deployment.html">AWS Lambda Deployment Example</a>.</li>
-</ul>
+<p>This module offers an annotation based Kubernetes extension implementation for Ballerina. For examples on the usage of the operations, see the <a href="/swan-lake/learn/by-example/kubernetes-deployment.html">Kubernetes Deployment Example</a>.
+</p>
+
 <h3>Annotation Usage Sample:</h3>
 <pre><code class="language-ballerina">import ballerina/http;
 import ballerina/log;

--- a/swan-lake/learn/api-docs/ballerina/observe/index.html
+++ b/swan-lake/learn/api-docs/ballerina/observe/index.html
@@ -135,9 +135,7 @@ Ballerina supports Observability out of the box. This module provides user api's
     <h2>Module Overview</h2>
 <p>This module provides apis for observing Ballerina services.
 Ballerina supports Observability out of the box. This module provides user api's to make Ballerina Observability more flexible for the user.</p>
-<p>To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service.
-i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true'
-For more information on Ballerina Observability visit <a href="/swan-lake/learn/observing-ballerina-code/">Observing Ballerina Code</a>.</p>
+<p>To observe Ballerina code, the '--b7a.observability.enabled=true' property should be given when starting the service (i.e. `ballerina run hello_world.bal --b7a.observability.enabled=true').</p>
 <h2>Tracing</h2>
 <p>Tracing provides information regarding the roundtrip of a service invocation based on the concept of spans, which are
 structured in a hierarchy based on the cause and effect concept. The tracing API allows users to tap into that

--- a/swan-lake/learn/quick-tour.md
+++ b/swan-lake/learn/quick-tour.md
@@ -9,6 +9,8 @@ intro: Now, that you know a little bit of Ballerina, let's take it for a spin!
 redirect_from:
   - /swan-lake/learn/quick-tour
   - /swan-lake/learn/quick-tour/
+  - /swan-lake/learn/getting-started/
+  - /swan-lake/learn/getting-started
 ---
 
 ## Installing Ballerina


### PR DESCRIPTION
## Purpose
Fix broken links for the 1.2.11 release.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
