### PR TITLE
Fix Broken Links After SLP7

### DIFF
--- a/swan-lake/learn/deployment/aws-lambda.md
+++ b/swan-lake/learn/deployment/aws-lambda.md
@@ -26,7 +26,7 @@ public function hash(awslambda:Context ctx, json input) returns json|error {
 }
 ```
 
-The first parameter with the [awslambda:Context](/swan-lake/learn/api-docs/ballerina/awslambda/classes/Context.html) object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time. 
+The first parameter with the [awslambda:Context](/swan-lake/learn/api-docs/ballerina/#/awslambda/classes/Context) object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time. 
 
 The second parameter with the `json` value contains the input request data. This input value format will vary depending on the source, which invoked the function e.g., an AWS S3 bucket update event. The return type of the function is `json|error`, which means in a successful scenario, the function can return a `json` value with the response or else in an error situation, the function will return an `error` value, which provides information on the error to the system.
 

--- a/swan-lake/learn/deployment/azure-functions.md
+++ b/swan-lake/learn/deployment/azure-functions.md
@@ -17,12 +17,12 @@ This is done by importing the `ballerinax/azure.functions` module and simply ann
 An Azure Function consists of a trigger and optional bindings. A trigger defines how a function is invoked. A binding is an approach in which you can declaratively connect other resources to the function. There are *input* and *output* bindings. An input binding is a source of data into the function. An output binding allows to output data from the function out to an external resource. For more information, go to [Azure Functions triggers and bindings concepts](https://docs.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings).
 
 The following Azure Functions triggers and bindings are currently supported in Ballerina:
-- HTTP [trigger](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#HTTPTrigger) and [output](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#HTTPOutput) binding
-- Queue [trigger](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#QueueTrigger) and [output](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#QueueOutput) binding
-- Blob [trigger](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#BlobTrigger), [input](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#BlobInput) binding, and [output](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#BlobOutput) binding
-- Twilio SMS [output](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#TwilioSmsOutput) binding
-- CosmosDB [trigger](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#CosmosDBTrigger), [input](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#CosmosDBInput) binding, and [output](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#CosmosDBOutput) binding
-- Timer [trigger](/swan-lake/learn/api-docs/ballerina/azure.functions/annotations.html#TimerTrigger)
+- HTTP [trigger](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#HTTPTrigger) and [output](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#HTTPOutput) binding
+- Queue [trigger](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#QueueTrigger) and [output](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#QueueOutput) binding
+- Blob [trigger](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#BlobTrigger), [input](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#BlobInput) binding, and [output](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#BlobOutput) binding
+- Twilio SMS [output](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#TwilioSmsOutput) binding
+- CosmosDB [trigger](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#CosmosDBTrigger), [input](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#CosmosDBInput) binding, and [output](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#CosmosDBOutput) binding
+- Timer [trigger](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#TimerTrigger)
 
 ## Writing a Function
 


### PR DESCRIPTION
## Purpose
Fix broken links after SLP7.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
