### PR TITLE
Make the "Ballerina Tool" Wording Consistent in Docs

### DIFF
--- a/1.0/learn/cli-commands/index.html
+++ b/1.0/learn/cli-commands/index.html
@@ -211,7 +211,7 @@
                               <div class="section">
                                  <h1 id="cli-commands">CLI Commands</h1>
 
-<p>The “ballerina” command is your one-stop-shop for all the things you do in Ballerina. You can use it in the below format.</p>
+<p>The Ballerina Tool is your one-stop-shop for all the things you do in Ballerina. You can use it in the below format.</p>
 
 <p><code class="highlighter-rouge">ballerina &lt;THE-COMMAND&gt; &lt;ITS-ARGUEMENTS&gt;</code></p>
 

--- a/1.0/learn/how-to-generate-code-for-protocol-buffers/index.html
+++ b/1.0/learn/how-to-generate-code-for-protocol-buffers/index.html
@@ -211,7 +211,7 @@
                               <div class="section">
                                  <h1 id="how-to-generate-ballerina-code-for-protocol-buffer-definition">How to generate Ballerina code for Protocol Buffer Definition</h1>
 
-<p>The <code class="highlighter-rouge">Protocol Buffers</code> to Ballerina tool provides capabilities to generate Ballerina source code for the Protocol
+<p>The <code class="highlighter-rouge">Protocol Buffers</code> to Ballerina Tool provides capabilities to generate Ballerina source code for the Protocol
 Buffer definition. The code generation tool can produce <code class="highlighter-rouge">ballerina stub</code> and <code class="highlighter-rouge">ballerina service/client template</code> files.</p>
 
 <blockquote>

--- a/1.0/learn/how-to-generate-code-for-protocol-buffers/index.html
+++ b/1.0/learn/how-to-generate-code-for-protocol-buffers/index.html
@@ -211,7 +211,7 @@
                               <div class="section">
                                  <h1 id="how-to-generate-ballerina-code-for-protocol-buffer-definition">How to generate Ballerina code for Protocol Buffer Definition</h1>
 
-<p>The <code class="highlighter-rouge">Protocol Buffers</code> to Ballerina Tool provides capabilities to generate Ballerina source code for the Protocol
+<p>The <code class="highlighter-rouge">'Protocol Buffers</code> to Ballerina' tool provides capabilities to generate Ballerina source code for the Protocol
 Buffer definition. The code generation tool can produce <code class="highlighter-rouge">ballerina stub</code> and <code class="highlighter-rouge">ballerina service/client template</code> files.</p>
 
 <blockquote>

--- a/1.1/learn/cli-commands/index.html
+++ b/1.1/learn/cli-commands/index.html
@@ -221,7 +221,7 @@
                               <div class="section">
                                  <h1 id="cli-commands">CLI Commands</h1>
 
-<p>The “ballerina” command is your one-stop-shop for all the things you do in Ballerina. You can use it in the below format.</p>
+<p>The Ballerina Tool is your one-stop-shop for all the things you do in Ballerina. You can use it in the below format.</p>
 
 <p><code class="highlighter-rouge">ballerina &lt;THE-COMMAND&gt; &lt;ITS-ARGUEMENTS&gt;</code></p>
 

--- a/1.1/learn/how-to-generate-code-for-protocol-buffers/index.html
+++ b/1.1/learn/how-to-generate-code-for-protocol-buffers/index.html
@@ -221,7 +221,7 @@
                               <div class="section">
                                  <h1 id="how-to-generate-ballerina-code-for-protocol-buffer-definition">How to generate Ballerina code for Protocol Buffer Definition</h1>
 
-<p>The <code class="highlighter-rouge">Protocol Buffers</code> to Ballerina Tool provides capabilities to generate Ballerina source code for the Protocol
+<p>The <code class="highlighter-rouge">'Protocol Buffers</code> to Ballerina' tool provides capabilities to generate Ballerina source code for the Protocol
 Buffer definition. The code generation tool can produce <code class="highlighter-rouge">ballerina stub</code> and <code class="highlighter-rouge">ballerina service/client template</code> files.</p>
 
 <blockquote>

--- a/1.1/learn/how-to-generate-code-for-protocol-buffers/index.html
+++ b/1.1/learn/how-to-generate-code-for-protocol-buffers/index.html
@@ -221,7 +221,7 @@
                               <div class="section">
                                  <h1 id="how-to-generate-ballerina-code-for-protocol-buffer-definition">How to generate Ballerina code for Protocol Buffer Definition</h1>
 
-<p>The <code class="highlighter-rouge">Protocol Buffers</code> to Ballerina tool provides capabilities to generate Ballerina source code for the Protocol
+<p>The <code class="highlighter-rouge">Protocol Buffers</code> to Ballerina Tool provides capabilities to generate Ballerina source code for the Protocol
 Buffer definition. The code generation tool can produce <code class="highlighter-rouge">ballerina stub</code> and <code class="highlighter-rouge">ballerina service/client template</code> files.</p>
 
 <blockquote>

--- a/1.1/learn/how-to-keep-ballerina-up-to-date/index.html
+++ b/1.1/learn/how-to-keep-ballerina-up-to-date/index.html
@@ -246,7 +246,7 @@
       <li><a href="#remove-distributions">Remove distributions</a></li>
       <li><a href="#change-the-active-distribution">Change the active distribution</a></li>
       <li><a href="#pull-a-specific-distribution">Pull a specific distribution</a></li>
-      <li><a href="#update-the-ballerina-tool">Update the Ballerina tool</a></li>
+      <li><a href="#update-the-ballerina-tool">Update the Ballerina Tool</a></li>
     </ul>
   </li>
 </ul>

--- a/1.1/learn/how-to-keep-ballerina-up-to-date/index.html
+++ b/1.1/learn/how-to-keep-ballerina-up-to-date/index.html
@@ -465,7 +465,7 @@ Downloading ballerina-tool-0.8.1 100% <span class="o">[=========================
 
 Updated to latest tool version: 0.8.1
 Cleaning old files...
-Ballerina tool updated successfully
+Ballerina Tool updated successfully
 </code></pre></div></div>
 
                               </div>

--- a/1.1/learn/how-to-keep-ballerina-up-to-date/index.html
+++ b/1.1/learn/how-to-keep-ballerina-up-to-date/index.html
@@ -226,7 +226,7 @@
 <ul>
   <li><a href="#terminology">Terminology</a>
     <ul>
-      <li><a href="#ballerina-tool">Ballerina tool</a></li>
+      <li><a href="#ballerina-tool">Ballerina Tool</a></li>
       <li><a href="#ballerina-distributions">Ballerina distributions</a></li>
       <li><a href="#release-channels">Release channels</a>
         <ul>
@@ -255,7 +255,7 @@
 
 <p>This section introduces various terms used throughout this guide. We recommend that you read this section before proceeding to the next.</p>
 
-<h3 id="ballerina-tool">Ballerina tool</h3>
+<h3 id="ballerina-tool">Ballerina Tool</h3>
 
 <p><strong>Ballerina</strong> is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build and run programs, etc.</p>
 
@@ -334,13 +334,13 @@
 
 <ul>
   <li>One only distribution from the above list can be active at a given time.</li>
-  <li>Ballerina tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke <code class="highlighter-rouge">ballerina build</code>, the Ballerina tool dispatches this request to the active distribution.</li>
+  <li>Ballerina tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke <code class="highlighter-rouge">ballerina build</code>, the Ballerina Tool dispatches this request to the active distribution.</li>
   <li>You can change the active distribution at any time. Refer the <a href="#Change-the-active-distribution">Change the active distribution</a> section for more details.</li>
 </ul>
 
 <h3 id="the-ballerina-dist-command">The <code class="highlighter-rouge">ballerina dist</code> command</h3>
 
-<p>Ballerina tool comes with various subcommands to help you manage Ballerina source code. The <code class="highlighter-rouge">ballerina dist</code> and <code class="highlighter-rouge">ballerina update</code> commands are the ones that will be explained in this guide. The <code class="highlighter-rouge">ballerina dist</code> command allows you to manage Ballerina distributions whereas the <code class="highlighter-rouge">ballerina update</code> command updates the tool itself.</p>
+<p>Ballerina Tool comes with various subcommands to help you manage Ballerina source code. The <code class="highlighter-rouge">ballerina dist</code> and <code class="highlighter-rouge">ballerina update</code> commands are the ones that will be explained in this guide. The <code class="highlighter-rouge">ballerina dist</code> command allows you to manage Ballerina distributions whereas the <code class="highlighter-rouge">ballerina update</code> command updates the tool itself.</p>
 
 <p>The dist command has few other subcommands. Here is the output of <code class="highlighter-rouge">ballerina help dist</code>.</p>
 
@@ -452,10 +452,10 @@ Fetching the <span class="s1">'jballerina-1.0.3'</span> distribution from the re
 Downloading jballerina-1.0.3 100% <span class="o">[==================================]</span> 96/96 MB <span class="s1">'jballerina-1.0.3'</span> successfully <span class="nb">set </span>as the active distribution
 </code></pre></div></div>
 
-<h3 id="update-the-ballerina-tool">Update the Ballerina tool</h3>
+<h3 id="update-the-ballerina-tool">Update the Ballerina Tool</h3>
 
 <ul>
-  <li>The <code class="highlighter-rouge">ballerina update</code> command updates the Ballerina tool itself to the latest version. Ballerina tool versions are independent from distribution versions. We expect these tool updates to be rare compared to distribution releases.</li>
+  <li>The <code class="highlighter-rouge">ballerina update</code> command updates the Ballerina Tool itself to the latest version. Ballerina tool versions are independent from distribution versions. We expect these tool updates to be rare compared to distribution releases.</li>
 </ul>
 
 <div class="language-sh highlighter-rouge"><div class="highlight"><pre class="highlight"><code>→ ballerina update

--- a/1.1/learn/how-to-keep-ballerina-up-to-date/index.html
+++ b/1.1/learn/how-to-keep-ballerina-up-to-date/index.html
@@ -334,7 +334,7 @@
 
 <ul>
   <li>One only distribution from the above list can be active at a given time.</li>
-  <li>The Ballerina tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke <code class="highlighter-rouge">ballerina build</code>, the Ballerina Tool dispatches this request to the active distribution.</li>
+  <li>The Ballerina Tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke <code class="highlighter-rouge">ballerina build</code>, the Ballerina Tool dispatches this request to the active distribution.</li>
   <li>You can change the active distribution at any time. Refer the <a href="#Change-the-active-distribution">Change the active distribution</a> section for more details.</li>
 </ul>
 
@@ -455,7 +455,7 @@ Downloading jballerina-1.0.3 100% <span class="o">[=============================
 <h3 id="update-the-ballerina-tool">Update the Ballerina Tool</h3>
 
 <ul>
-  <li>The <code class="highlighter-rouge">ballerina update</code> command updates the Ballerina Tool itself to the latest version. The Ballerina tool versions are independent from distribution versions. We expect these tool updates to be rare compared to distribution releases.</li>
+  <li>The <code class="highlighter-rouge">ballerina update</code> command updates the Ballerina Tool itself to the latest version. The Ballerina Tool versions are independent from distribution versions. We expect these tool updates to be rare compared to distribution releases.</li>
 </ul>
 
 <div class="language-sh highlighter-rouge"><div class="highlight"><pre class="highlight"><code>→ ballerina update

--- a/1.1/learn/how-to-keep-ballerina-up-to-date/index.html
+++ b/1.1/learn/how-to-keep-ballerina-up-to-date/index.html
@@ -226,7 +226,7 @@
 <ul>
   <li><a href="#terminology">Terminology</a>
     <ul>
-      <li><a href="#ballerina-tool">Ballerina Tool</a></li>
+      <li><a href="#ballerina-tool">The Ballerina Tool</a></li>
       <li><a href="#ballerina-distributions">Ballerina distributions</a></li>
       <li><a href="#release-channels">Release channels</a>
         <ul>
@@ -255,7 +255,7 @@
 
 <p>This section introduces various terms used throughout this guide. We recommend that you read this section before proceeding to the next.</p>
 
-<h3 id="ballerina-tool">Ballerina Tool</h3>
+<h3 id="ballerina-tool">The Ballerina Tool</h3>
 
 <p><strong>Ballerina</strong> is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build and run programs, etc.</p>
 
@@ -334,13 +334,13 @@
 
 <ul>
   <li>One only distribution from the above list can be active at a given time.</li>
-  <li>Ballerina tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke <code class="highlighter-rouge">ballerina build</code>, the Ballerina Tool dispatches this request to the active distribution.</li>
+  <li>The Ballerina tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke <code class="highlighter-rouge">ballerina build</code>, the Ballerina Tool dispatches this request to the active distribution.</li>
   <li>You can change the active distribution at any time. Refer the <a href="#Change-the-active-distribution">Change the active distribution</a> section for more details.</li>
 </ul>
 
 <h3 id="the-ballerina-dist-command">The <code class="highlighter-rouge">ballerina dist</code> command</h3>
 
-<p>Ballerina Tool comes with various subcommands to help you manage Ballerina source code. The <code class="highlighter-rouge">ballerina dist</code> and <code class="highlighter-rouge">ballerina update</code> commands are the ones that will be explained in this guide. The <code class="highlighter-rouge">ballerina dist</code> command allows you to manage Ballerina distributions whereas the <code class="highlighter-rouge">ballerina update</code> command updates the tool itself.</p>
+<p>The Ballerina Tool comes with various subcommands to help you manage Ballerina source code. The <code class="highlighter-rouge">ballerina dist</code> and <code class="highlighter-rouge">ballerina update</code> commands are the ones that will be explained in this guide. The <code class="highlighter-rouge">ballerina dist</code> command allows you to manage Ballerina distributions whereas the <code class="highlighter-rouge">ballerina update</code> command updates the tool itself.</p>
 
 <p>The dist command has few other subcommands. Here is the output of <code class="highlighter-rouge">ballerina help dist</code>.</p>
 
@@ -455,7 +455,7 @@ Downloading jballerina-1.0.3 100% <span class="o">[=============================
 <h3 id="update-the-ballerina-tool">Update the Ballerina Tool</h3>
 
 <ul>
-  <li>The <code class="highlighter-rouge">ballerina update</code> command updates the Ballerina Tool itself to the latest version. Ballerina tool versions are independent from distribution versions. We expect these tool updates to be rare compared to distribution releases.</li>
+  <li>The <code class="highlighter-rouge">ballerina update</code> command updates the Ballerina Tool itself to the latest version. The Ballerina tool versions are independent from distribution versions. We expect these tool updates to be rare compared to distribution releases.</li>
 </ul>
 
 <div class="language-sh highlighter-rouge"><div class="highlight"><pre class="highlight"><code>→ ballerina update

--- a/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
+++ b/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
@@ -5,7 +5,7 @@ description: The `Protocol Buffers to Ballerina` Tool provides capabilities to g
 keywords: ballerina, protocol buffers, programming language
 permalink: /learn/generating-ballerina-code-for-protocol-buffer-definitions/
 active: generating-ballerina-code-for-protocol-buffer-definitions
-intro: The `Protocol Buffers to Ballerina` tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions. 
+intro: The `Protocol Buffers to Ballerina` Tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions. 
 redirect_from:
   - /learn/how-to-generate-code-for-protocol-buffers
   - /learn/how-to-generate-code-for-protocol-buffers/

--- a/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
+++ b/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
@@ -1,11 +1,11 @@
 ---
 layout: ballerina-left-nav-pages
 title: Generating Ballerina Code for Protocol Buffer Definitions
-description: The `Protocol Buffers to Ballerina` Tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions.
+description: The 'Protocol Buffers to Ballerina' tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions.
 keywords: ballerina, protocol buffers, programming language
 permalink: /learn/generating-ballerina-code-for-protocol-buffer-definitions/
 active: generating-ballerina-code-for-protocol-buffer-definitions
-intro: The `Protocol Buffers to Ballerina` Tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions. 
+intro: The 'Protocol Buffers to Ballerina' tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions. 
 redirect_from:
   - /learn/how-to-generate-code-for-protocol-buffers
   - /learn/how-to-generate-code-for-protocol-buffers/
@@ -16,7 +16,7 @@ redirect_from:
 
 ## Usage of the Tool
 
-The code generation Tool can produce `ballerina stub` and `ballerina service/client template` files.
+The code generation tool can produce `ballerina stub` and `ballerina service/client template` files.
 
 > In Ballerina, Protocol Buffers serialization is only supported in the gRPC module. Therefore, you can only use this tool to generate Ballerina source code for gRPC service definitions.
 

--- a/learn/keeping-ballerina-up-to-date.md
+++ b/learn/keeping-ballerina-up-to-date.md
@@ -87,7 +87,7 @@ Now that you are familiar with the terminology, let’s look at how you can keep
 ### The "active" Distribution
 
 - One only distribution from the above list can be active at a given time.
-- Ballerina Tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke `ballerina build`, the Ballerina Tool dispatches this request to the active distribution.
+- The Ballerina Tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke `ballerina build`, the Ballerina Tool dispatches this request to the active distribution.
 - You can change the active distribution at any time. Refer the [Change the active distribution](#change-the-active-distribution) section for more details.  
 
 ### The 'ballerina dist' Command

--- a/learn/keeping-ballerina-up-to-date.md
+++ b/learn/keeping-ballerina-up-to-date.md
@@ -87,12 +87,12 @@ Now that you are familiar with the terminology, let’s look at how you can keep
 ### The "active" Distribution
 
 - One only distribution from the above list can be active at a given time.
-- Ballerina tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke `ballerina build`, the Ballerina tool dispatches this request to the active distribution.
+- Ballerina Tool delegates most of the user requests to the active distribution. The commands such as build, test, run, pull, and push are delegated to the active distribution, while the commands such as dist and version are handled by the tool itself.  E.g., when you invoke `ballerina build`, the Ballerina Tool dispatches this request to the active distribution.
 - You can change the active distribution at any time. Refer the [Change the active distribution](#change-the-active-distribution) section for more details.  
 
 ### The 'ballerina dist' Command
 
-Ballerina tool comes with various subcommands to help you manage Ballerina source code. The `ballerina dist` and `ballerina update` commands are the ones that will be explained in this guide. The `ballerina dist` command allows you to manage Ballerina distributions whereas the `ballerina update` command updates the tool itself.
+The Ballerina Tool comes with various subcommands to help you manage Ballerina source code. The `ballerina dist` and `ballerina update` commands are the ones that will be explained in this guide. The `ballerina dist` command allows you to manage Ballerina distributions whereas the `ballerina update` command updates the tool itself.
 
 The dist command has few other subcommands. Here is the output of `ballerina help dist`.
 
@@ -220,7 +220,7 @@ Downloading jballerina-1.2.4 100% [==================================] 96/96 MB 
 
 ### Update the Ballerina Tool
 
-- The `ballerina update` command updates the Ballerina tool itself to the latest version. Ballerina tool versions are independent from distribution versions. We expect these tool updates to be rare compared to distribution releases.
+- The `ballerina update` command updates the Ballerina Tool itself to the latest version. Ballerina Tool versions are independent from distribution versions. We expect these tool updates to be rare compared to distribution releases.
 
 ```sh
 → ballerina update
@@ -230,5 +230,5 @@ Downloading ballerina-tool-0.8.1 100% [====================================] 1/1
 
 Updated to latest tool version: 0.8.1
 Cleaning old files...
-Ballerina tool updated successfully
+Ballerina Tool updated successfully
 ```

--- a/learn/using-the-cli-tools.md
+++ b/learn/using-the-cli-tools.md
@@ -146,7 +146,7 @@ These powerful supporting tools extend Ballerina to various ecosystem technologi
 </tr>
 <tr>
 <td class="cCommand">update</td>
-<td class="cDescription">Update the Ballerina tool. For more information, see <a href="/learn/keeping-ballerina-up-to-date/">Keeping Ballerina Up to Date</a>.
+<td class="cDescription">Update the Ballerina Tool. For more information, see <a href="/learn/keeping-ballerina-up-to-date/">Keeping Ballerina Up to Date</a>.
 </td>
 </tr>
 </table>

--- a/learn/using-the-cli-tools.md
+++ b/learn/using-the-cli-tools.md
@@ -5,7 +5,7 @@ description: Learn all the command line interface (CLI) commands need to get sta
 keywords: ballerina, cli, command line interface, programming language
 permalink: /learn/using-the-cli-tools/
 active: using-the-cli-tools
-intro: The `ballerina` command is your one-stop-shop for all the things you do in Ballerina. 
+intro: The Ballerina Tool is your one-stop-shop for all the things you do in Ballerina. 
 redirect_from:
   - /v1-2/learn/cli-commands
   - /v1-2/learn/cli-commands/
@@ -14,7 +14,7 @@ redirect_from:
   - /learn/using-the-cli-tools
 ---
 
-## Using the 'ballerina' Command
+## Using the Ballerina Tool
 
 In the CLI, execute the `ballerina help` command to view all the actions you can perform with it as shown below.
 

--- a/swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
+++ b/swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
@@ -1,11 +1,11 @@
 ---
 layout: ballerina-left-nav-pages-swanlake
 title: Generating Ballerina Code for Protocol Buffer Definitions
-description: The Protocol Buffers to Ballerina tool provides capabilities to generate Ballerina source code for the Protocol Buffer definition.
+description: The Protocol Buffers to Ballerina Tool provides capabilities to generate Ballerina source code for the Protocol Buffer definition.
 keywords: ballerina, protocol buffers, programming language
 permalink: /swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions/
 active: generating-ballerina-code-for-protocol-buffer-definitions
-intro: The `Protocol Buffers to Ballerina` tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions.
+intro: The `Protocol Buffers to Ballerina` Tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions.
 redirect_from:
   - /swan-lake/learn/how-to-generate-code-for-protocol-buffers
   - /swan-lake/learn/how-to-generate-code-for-protocol-buffers/

--- a/swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
+++ b/swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
@@ -1,11 +1,11 @@
 ---
 layout: ballerina-left-nav-pages-swanlake
 title: Generating Ballerina Code for Protocol Buffer Definitions
-description: The Protocol Buffers to Ballerina Tool provides capabilities to generate Ballerina source code for the Protocol Buffer definition.
+description: The 'Protocol Buffers to Ballerina' tool provides capabilities to generate Ballerina source code for the Protocol Buffer definition.
 keywords: ballerina, protocol buffers, programming language
 permalink: /swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions/
 active: generating-ballerina-code-for-protocol-buffer-definitions
-intro: The `Protocol Buffers to Ballerina` Tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions.
+intro: The 'Protocol Buffers to Ballerina' tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions.
 redirect_from:
   - /swan-lake/learn/how-to-generate-code-for-protocol-buffers
   - /swan-lake/learn/how-to-generate-code-for-protocol-buffers/

--- a/swan-lake/learn/keeping-ballerina-up-to-date.md
+++ b/swan-lake/learn/keeping-ballerina-up-to-date.md
@@ -71,15 +71,15 @@ Once the installation is complete, you would see the directory structure below i
 
 The `distributions` is the directory, in which all your installed distributions are maintained. Only one distribution from the above list can be active at a given time. 
 
-> **Note:** The Ballerina tool delegates most of the user requests to the active distribution. The commands such as `build`, `test`, `run`, `pull`, and `push` are delegated to the active distribution, while the commands such as `dist` and `version` are handled by the tool itself.
+> **Note:** The Ballerina Tool delegates most of the user requests to the active distribution. The commands such as `build`, `test`, `run`, `pull`, and `push` are delegated to the active distribution, while the commands such as `dist` and `version` are handled by the tool itself.
   
-  E.g., when you invoke `ballerina build`, the Ballerina tool dispatches this request to the active distribution.
+  E.g., when you invoke `ballerina build`, the Ballerina Tool dispatches this request to the active distribution.
 
 You can [change this active distribution](#changing-the-active-distribution) at any time or manage it using the Ballerina Tool. However, first, you need to update the Ballerina Tool to its latest version.
 
 ### Updating the Ballerina Tool
 
-The `ballerina update` command updates the Ballerina Tool itself to the latest version. Ballerina Tool versions are independent from the Ballerina distribution versions. These tool updates are expected to be rare compared to distribution releases.
+The `ballerina update` command updates the Ballerina Ttool itself to the latest version. Ballerina Tool versions are independent from the Ballerina distribution versions. These tool updates are expected to be rare compared to distribution releases.
 
 ```sh
 → ballerina update
@@ -89,7 +89,7 @@ Downloading ballerina-tool-0.8.8 100% [====================================] 1/1
 
 Updated to latest tool version: 0.8.8
 Cleaning old files...
-Ballerina tool updated successfully
+Ballerina Tool updated successfully
 ```
 
 ## Managing your Ballerina Distributions

--- a/swan-lake/learn/keeping-ballerina-up-to-date.md
+++ b/swan-lake/learn/keeping-ballerina-up-to-date.md
@@ -79,7 +79,7 @@ You can [change this active distribution](#changing-the-active-distribution) at 
 
 ### Updating the Ballerina Tool
 
-The `ballerina update` command updates the Ballerina Ttool itself to the latest version. Ballerina Tool versions are independent from the Ballerina distribution versions. These tool updates are expected to be rare compared to distribution releases.
+The `ballerina update` command updates the Ballerina Tool itself to the latest version. Ballerina Tool versions are independent from the Ballerina distribution versions. These tool updates are expected to be rare compared to distribution releases.
 
 ```sh
 → ballerina update
@@ -229,4 +229,3 @@ The `ballerina dist use <distribution>` command sets a particular distribution v
 → ballerina dist use 1.2.5
 '1.2.5' is the current active distribution version
 ```
-

--- a/swan-lake/learn/using-the-cli-tools.md
+++ b/swan-lake/learn/using-the-cli-tools.md
@@ -12,13 +12,13 @@ redirect_from:
   - /swan-lake/learn/using-the-cli-tools
 ---
 
-## Using the 'ballerina' Tool
+## Using the Ballerina Tool
 
-**Ballerina** is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build, and run programs, etc.
+**`ballerina`** is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build, and run programs, etc.
 
 It also enables you to easily install, update, and switch among Ballerina distributions. 
 
-In the CLI, execute the `ballerina help` command to view all the actions you can perform with the `ballerina` Tool as shown below:
+In the CLI, execute the `ballerina help` command to view all the actions you can perform with the Ballerina Tool as shown below:
 
 ![CLI commands](/swan-lake/learn/images/cli-commands.png)
 
@@ -148,7 +148,7 @@ These powerful supporting tools extend Ballerina to various ecosystem technologi
 </tr>
 <tr>
 <td class="cCommand">update</td>
-<td class="cDescription">Update the Ballerina tool. For more information, see <a href="/swan-lake/learn/keeping-ballerina-up-to-date/">Keeping Ballerina Up to Date</a>.
+<td class="cDescription">Update the Ballerina Tool. For more information, see <a href="/swan-lake/learn/keeping-ballerina-up-to-date/">Keeping Ballerina Up to Date</a>.
 </td>
 </tr>
 </table>

--- a/swan-lake/learn/using-the-cli-tools.md
+++ b/swan-lake/learn/using-the-cli-tools.md
@@ -12,7 +12,7 @@ redirect_from:
   - /swan-lake/learn/using-the-cli-tools
 ---
 
-## Using the 'ballerina' Command
+## Using the Ballerina Tool
 
 **`Ballerina`** is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build, and run programs, etc.
 

--- a/swan-lake/learn/using-the-cli-tools.md
+++ b/swan-lake/learn/using-the-cli-tools.md
@@ -14,7 +14,7 @@ redirect_from:
 
 ## Using the Ballerina Tool
 
-**`Ballerina`** is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build, and run programs, etc.
+The Ballerina Tool is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build, and run programs, etc.
 
 It also enables you to easily install, update, and switch among Ballerina distributions. 
 

--- a/swan-lake/learn/using-the-cli-tools.md
+++ b/swan-lake/learn/using-the-cli-tools.md
@@ -5,16 +5,16 @@ description: Learn all the command line interface (CLI) commands need to get sta
 keywords: ballerina, cli, command line interface, programming language
 permalink: /swan-lake/learn/using-the-cli-tools/
 active: using-the-cli-tools
-intro: The `ballerina` Tool is your one-stop-shop for all the things you do in Ballerina. 
+intro: The Ballerina Tool is your one-stop-shop for all the things you do in Ballerina. 
 redirect_from:
   - /swan-lake/learn/cli-commands
   - /swan-lake/learn/cli-commands/
   - /swan-lake/learn/using-the-cli-tools
 ---
 
-## Using the Ballerina Tool
+## Using the 'ballerina' Command
 
-**`ballerina`** is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build, and run programs, etc.
+**`Ballerina`** is a command-line tool for managing Ballerina source code. It helps you to manage Ballerina projects and modules, test, build, and run programs, etc.
 
 It also enables you to easily install, update, and switch among Ballerina distributions. 
 


### PR DESCRIPTION
## Purpose
Make the "Ballerina Tool" wording consistent in Docs.

> Fixes #1563

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
