### PR TITLE
Fix links to api docs

### DIFF
--- a/swan-lake/learn/by-example/access-mutate-java-fields.html
+++ b/swan-lake/learn/by-example/access-mutate-java-fields.html
@@ -39,7 +39,7 @@ redirect_from:
  Similarly, the <code>@java:FieldSet</code> annotation can be used to create a Ballerina function with
  an external function that acts as a field setter.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/index.html">Java module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/">Java module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/arrays.html
+++ b/swan-lake/learn/by-example/arrays.html
@@ -97,7 +97,7 @@ redirect_from:
  of the same type.
  A fixed length array can be created by specifying the length of the array at the time of declaration.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/lang.array/index.html">lang.array module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/lang.array/">lang.array module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/base-path-and-path.html
+++ b/swan-lake/learn/by-example/base-path-and-path.html
@@ -13,17 +13,17 @@ redirect_from:
                 <div class="highlight"><pre><span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">http</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 
-<span class="c1">// The [basePath](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpServiceConfig.html) attribute</span>
+<span class="c1">// The [basePath](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpServiceConfig) attribute</span>
 <span class="c1">// associates a path to the service. When bound to a listener endpoint, the service will be accessible at the</span>
 <span class="c1">// specified path.</span>
 <span class="nd">@http:ServiceConfig {</span>
     <span class="nx">basePath</span><span class="p">:</span> <span class="s">&quot;/foo&quot;</span>
 <span class="p">}</span>
 <span class="kd">service</span> <span class="nx">echo</span> <span class="nx">on</span> <span class="nx">new</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span><span class="p">(</span><span class="mi">9090</span><span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// When the [methods](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpResourceConfig.html) attribute</span>
+    <span class="c1">// When the [methods](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpResourceConfig) attribute</span>
     <span class="c1">// is used, it confines the resource to the specified HTTP methods. In this instance, only `POST` requests are</span>
     <span class="c1">// allowed. The `path` attribute associates a subpath to the resource (i.e., relative to the `basePath` given in</span>
-    <span class="c1">// the [ServiceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpServiceConfig.html) annotation).</span>
+    <span class="c1">// the [ServiceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpServiceConfig) annotation).</span>
     <span class="nd">@http:ResourceConfig {</span>
         <span class="nx">methods</span><span class="p">:</span> <span class="p">[</span><span class="s">&quot;POST&quot;</span><span class="p">],</span>
         <span class="nx">path</span><span class="p">:</span> <span class="s">&quot;/bar&quot;</span>
@@ -59,7 +59,7 @@ redirect_from:
  You can use <code>BasePath</code>, <code>Path</code>, and HTTP verb annotations such as <code>POST</code> and <code>GET</code> to
  constrain your service in a RESTful manner.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -159,7 +159,7 @@ service echo on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpServiceConfig.html">basePath</a> attribute
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpServiceConfig">basePath</a> attribute
  associates a path to the service. When bound to a listener endpoint, the service will be accessible at the
  specified path.</p>
 
@@ -184,10 +184,10 @@ service echo on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>When the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpResourceConfig.html">methods</a> attribute
+                                            <p>When the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpResourceConfig">methods</a> attribute
  is used, it confines the resource to the specified HTTP methods. In this instance, only <code>POST</code> requests are
  allowed. The <code>path</code> attribute associates a subpath to the resource (i.e., relative to the <code>basePath</code> given in
- the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpServiceConfig.html">ServiceConfig</a> annotation).</p>
+ the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpServiceConfig">ServiceConfig</a> annotation).</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/basic-https-listener-client.html
+++ b/swan-lake/learn/by-example/basic-https-listener-client.html
@@ -53,7 +53,7 @@ redirect_from:
 <span class="c1">// This is a client endpoint configured to connect to the HTTPS service.</span>
 <span class="c1">// As this is a 1-way SSL connection, the client needs to provide</span>
 <span class="c1">// `trustStore` file `path` and its `password`.</span>
-<span class="c1">// [secureSocket](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ClientSecureSocket.html) record provides the SSL related configurations.</span>
+<span class="c1">// [secureSocket](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ClientSecureSocket) record provides the SSL related configurations.</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">ClientConfiguration</span> <span class="nx">clientEPConfig</span> <span class="p">=</span> <span class="p">{</span>
     <span class="nx">secureSocket</span><span class="p">:</span> <span class="p">{</span>
         <span class="nx">trustStore</span><span class="p">:</span> <span class="p">{</span>
@@ -89,7 +89,7 @@ redirect_from:
                             <p><p>This example demonstrates how the Ballerina https client can be configured to connect to an https listener through 1-way SSL connection (i.e., the server is verified by the client).
  This example uses the Ballerina https listener to host a service and the https client sends requests for that listener.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -383,7 +383,7 @@ import ballerina/log;
                                             <p>This is a client endpoint configured to connect to the HTTPS service.
  As this is a 1-way SSL connection, the client needs to provide
  <code>trustStore</code> file <code>path</code> and its <code>password</code>.
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ClientSecureSocket.html">secureSocket</a> record provides the SSL related configurations.</p>
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ClientSecureSocket">secureSocket</a> record provides the SSL related configurations.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/byte-io.html
+++ b/swan-lake/learn/by-example/byte-io.html
@@ -84,7 +84,7 @@ redirect_from:
                             <h2>Byte I/O</h2>
                             <p><p>This example demonstrates how bytes can be read and written through the I/O API.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/index.html">IO module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/">IO module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/cache.html
+++ b/swan-lake/learn/by-example/cache.html
@@ -75,7 +75,7 @@ redirect_from:
  LRU algorithm based eviction policy. The caching implementation can be customized by providing different
  storage mechanisms and eviction policies. <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/cache/index.html">Cache module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/cache/">Cache module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/config-api.html
+++ b/swan-lake/learn/by-example/config-api.html
@@ -51,7 +51,7 @@ redirect_from:
  optional configurations are the default values of the return types of
  the functions. <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/config/index.html">Config module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/config/">Config module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/content-based-routing.html
+++ b/swan-lake/learn/by-example/content-based-routing.html
@@ -18,7 +18,7 @@ redirect_from:
 <span class="p">}</span>
 <span class="kd">service</span> <span class="nx">contentBasedRouting</span> <span class="nx">on</span> <span class="nx">new</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span><span class="p">(</span><span class="mi">9090</span><span class="p">)</span> <span class="p">{</span>
 
-    <span class="c1">// Use [resourceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpResourceConfig.html) annotation to declare the HTTP method.</span>
+    <span class="c1">// Use [resourceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpResourceConfig) annotation to declare the HTTP method.</span>
     <span class="nd">@http:ResourceConfig {</span>
         <span class="nx">methods</span><span class="p">:</span> <span class="p">[</span><span class="s">&quot;POST&quot;</span><span class="p">],</span>
         <span class="nx">path</span><span class="p">:</span> <span class="s">&quot;/route&quot;</span>
@@ -36,7 +36,7 @@ redirect_from:
             <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span><span class="p">|</span><span class="nx">http</span><span class="p">:</span><span class="nx">Payload</span><span class="p">|</span><span class="nx">error</span> <span class="nx">response</span><span class="p">;</span>
             <span class="k">if</span> <span class="p">(</span><span class="nx">nameString</span> <span class="nx">is</span> <span class="kt">json</span><span class="p">)</span> <span class="p">{</span>
                 <span class="k">if</span> <span class="p">(</span><span class="nx">nameString</span><span class="p">.</span><span class="nx">toString</span><span class="p">()</span> <span class="o">==</span> <span class="s">&quot;sanFrancisco&quot;</span><span class="p">)</span> <span class="p">{</span>
-                    <span class="c1">// Here, [post](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post) remote function represents the POST operation of</span>
+                    <span class="c1">// Here, [post](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post) remote function represents the POST operation of</span>
                     <span class="c1">// the HTTP client.</span>
                     <span class="c1">// This routes the payload to the relevant service when the server</span>
                     <span class="c1">// accepts the enclosed entity.</span>
@@ -48,7 +48,7 @@ redirect_from:
                            <span class="nx">locationEP</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/v2/594e026c1100004011d6d39c&quot;</span><span class="p">,</span> <span class="p">());</span>
                 <span class="p">}</span>
 
-                <span class="c1">// Use the remote function [respond](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Caller.html#respond) to send the client response</span>
+                <span class="c1">// Use the remote function [respond](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Caller#respond) to send the client response</span>
                 <span class="c1">// back to the caller.</span>
                 <span class="k">if</span> <span class="p">(</span><span class="nx">response</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span><span class="p">)</span> <span class="p">{</span>
                     <span class="k">var</span> <span class="nx">result</span> <span class="p">=</span> <span class="nx">outboundEP</span><span class="o">-&gt;</span><span class="nx">respond</span><span class="p">(&lt;</span><span class="err">@</span><span class="nx">untainted</span><span class="p">&gt;</span><span class="nx">response</span><span class="p">);</span>
@@ -97,7 +97,7 @@ redirect_from:
                             <h2>Content-Based Routing</h2>
                             <p><p>The Content-Based Router service reads the content of a request and routes it to a specific recipient based on the content.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -225,7 +225,7 @@ service contentBasedRouting on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Use <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpResourceConfig.html">resourceConfig</a> annotation to declare the HTTP method.</p>
+                                            <p>Use <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpResourceConfig">resourceConfig</a> annotation to declare the HTTP method.</p>
 
                                         </div>
                                     </div>
@@ -317,7 +317,7 @@ service contentBasedRouting on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Here, <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post">post</a> remote function represents the POST operation of
+                                            <p>Here, <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post">post</a> remote function represents the POST operation of
  the HTTP client.
  This routes the payload to the relevant service when the server
  accepts the enclosed entity.</p>
@@ -371,7 +371,7 @@ service contentBasedRouting on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Use the remote function <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Caller.html#respond">respond</a> to send the client response
+                                            <p>Use the remote function <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Caller#respond">respond</a> to send the client response
  back to the caller.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/create-java-objects.html
+++ b/swan-lake/learn/by-example/create-java-objects.html
@@ -13,7 +13,7 @@ redirect_from:
                 <div class="highlight"><pre><span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">io</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">java</span><span class="p">;</span>
 
-<span class="c1">// The [@java:Constructor](https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/annotations.html#Constructor) </span>
+<span class="c1">// The [@java:Constructor](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/annotations#Constructor) </span>
 <span class="c1">// annotation links the default constructor of</span>
 <span class="c1">// the class `java.util.ArrayDeque` with this Ballerina function declaration.</span>
 <span class="kd">function</span> <span class="nx">newArrayDeque</span><span class="p">()</span> <span class="nx">returns</span> <span class="nx">handle</span> <span class="p">=</span> <span class="nd">@java:Constructor {</span>
@@ -60,7 +60,7 @@ redirect_from:
  the implementations of Ballerina functions that are marked as <code>external</code>.
  In this example, let&rsquo;s look at how to create Java objects by invoking their constructors from Ballerina.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/index.html">Java module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/">Java module</a>.</p>
 </p>
 
                         </td>
@@ -159,7 +159,7 @@ import ballerina/java;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/annotations.html#Constructor">@java:Constructor</a>
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/annotations#Constructor">@java:Constructor</a>
  annotation links the default constructor of
  the class <code>java.util.ArrayDeque</code> with this Ballerina function declaration.</p>
 

--- a/swan-lake/learn/by-example/crypto.html
+++ b/swan-lake/learn/by-example/crypto.html
@@ -22,7 +22,7 @@ redirect_from:
     <span class="kt">string</span> <span class="nx">input</span> <span class="p">=</span> <span class="s">&quot;Hello Ballerina!&quot;</span><span class="p">;</span>
     <span class="nx">byte</span><span class="p">[]</span> <span class="nx">inputArr</span> <span class="p">=</span> <span class="nx">input</span><span class="p">.</span><span class="nx">toBytes</span><span class="p">();</span>
 
-    <span class="c1">// Hashing input value using [MD5 hashing algorithm](https://ballerina.io/swan-lake/learn/api-docs/ballerina/crypto/functions.html#hashMd5), and printing hash value using Hex encoding.</span>
+    <span class="c1">// Hashing input value using [MD5 hashing algorithm](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/crypto/functions#hashMd5), and printing hash value using Hex encoding.</span>
     <span class="nx">byte</span><span class="p">[]</span> <span class="nx">output</span> <span class="p">=</span> <span class="nx">crypto</span><span class="p">:</span><span class="nx">hashMd5</span><span class="p">(</span><span class="nx">inputArr</span><span class="p">);</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Hex encoded hash with MD5: &quot;</span> <span class="o">+</span> <span class="nx">output</span><span class="p">.</span><span class="nx">toBase16</span><span class="p">());</span>
 
@@ -210,7 +210,7 @@ redirect_from:
  hashing, HMAC generation, checksum generation, encryption, decryption, digitally signing data and
  verifying digitally signed data.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/crypto/index.html">Crypto module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/crypto/">Crypto module</a>.</p>
 </p>
 
                         </td>
@@ -407,7 +407,7 @@ import ballerina/math;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Hashing input value using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/crypto/functions.html#hashMd5">MD5 hashing algorithm</a>, and printing hash value using Hex encoding.</p>
+                                            <p>Hashing input value using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/crypto/functions#hashMd5">MD5 hashing algorithm</a>, and printing hash value using Hex encoding.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/csv-io.html
+++ b/swan-lake/learn/by-example/csv-io.html
@@ -38,7 +38,7 @@ redirect_from:
 <span class="c1">//Specifies the location of the `.CSV` file.</span>
 <span class="nx">public</span> <span class="kd">function</span> <span class="nx">main</span><span class="p">()</span> <span class="nx">returns</span> <span class="nx">error</span><span class="err">?</span> <span class="p">{</span>
     <span class="kt">string</span> <span class="nx">srcFileName</span> <span class="p">=</span> <span class="s">&quot;./files/sample.csv&quot;</span><span class="p">;</span>
-    <span class="c1">// Opens a [CSV channel in the `write` mode](https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/classes/WritableCSVChannel.html)</span>
+    <span class="c1">// Opens a [CSV channel in the `write` mode](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/classes/WritableCSVChannel)</span>
     <span class="c1">// and writes some data to the `./files/sample.csv` file for later use.</span>
     <span class="c1">// The record separator of the `.CSV` file is a</span>
     <span class="c1">// new line and the field separator is a comma (,).</span>
@@ -49,7 +49,7 @@ redirect_from:
     <span class="p">[</span><span class="s">&quot;5&quot;</span><span class="p">,</span> <span class="s">&quot;Oliver&quot;</span><span class="p">,</span> <span class="s">&quot;1100000&quot;</span><span class="p">]];</span>
     <span class="nx">writeDataToCSVChannel</span><span class="p">(</span><span class="nx">wCsvChannel</span><span class="p">,</span> <span class="o">...</span><span class="nx">data</span><span class="p">);</span>
     <span class="nx">closeWritableCSVChannel</span><span class="p">(</span><span class="nx">wCsvChannel</span><span class="p">);</span>
-    <span class="c1">// Opens a [CSV channel in the `read` mode](https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/classes/ReadableCSVChannel.html),</span>
+    <span class="c1">// Opens a [CSV channel in the `read` mode](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/classes/ReadableCSVChannel),</span>
     <span class="c1">// which is the default mode.</span>
     <span class="nx">io</span><span class="p">:</span><span class="nx">ReadableCSVChannel</span> <span class="nx">rCsvChannel</span> <span class="p">=</span>
                         <span class="nx">check</span> <span class="nx">io</span><span class="p">:</span><span class="nx">openReadableCsvFile</span><span class="p">(</span><span class="nx">srcFileName</span><span class="p">);</span>
@@ -65,7 +65,7 @@ redirect_from:
     <span class="c1">// Opens a CSV channel in the `read` mode, which is the default mode.</span>
     <span class="nx">io</span><span class="p">:</span><span class="nx">ReadableCSVChannel</span> <span class="nx">rCsvChannel2</span> <span class="p">=</span>
                             <span class="nx">check</span> <span class="nx">io</span><span class="p">:</span><span class="nx">openReadableCsvFile</span><span class="p">(</span><span class="nx">srcFileName</span><span class="p">);</span>
-    <span class="c1">// Reads the `.CSV` file as a `table` using [getTable](https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/classes/ReadableCSVChannel.html#getTable) function.</span>
+    <span class="c1">// Reads the `.CSV` file as a `table` using [getTable](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/classes/ReadableCSVChannel#getTable) function.</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Reading  &quot;</span> <span class="o">+</span> <span class="nx">srcFileName</span> <span class="o">+</span> <span class="s">&quot; as a table&quot;</span><span class="p">);</span>
     <span class="k">var</span> <span class="nx">tblResult</span> <span class="p">=</span> <span class="nx">rCsvChannel2</span><span class="p">.</span><span class="nx">getTable</span><span class="p">(</span><span class="nx">Employee</span><span class="p">);</span>
     <span class="k">if</span> <span class="p">(</span><span class="nx">tblResult</span> <span class="nx">is</span> <span class="nx">table</span><span class="p">&lt;</span><span class="nx">record</span> <span class="p">{}&gt;)</span> <span class="p">{</span>
@@ -144,7 +144,7 @@ redirect_from:
                             <h2>CSV I/O</h2>
                             <p><p>This sample demonstrates how to read/write from/to a CSV file using the CSV channel of the I/O API.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/index.html">IO module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/">IO module</a>.</p>
 </p>
 
                         </td>
@@ -388,7 +388,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Opens a <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/classes/WritableCSVChannel.html">CSV channel in the <code>write</code> mode</a>
+                                            <p>Opens a <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/classes/WritableCSVChannel">CSV channel in the <code>write</code> mode</a>
  and writes some data to the <code>./files/sample.csv</code> file for later use.
  The record separator of the <code>.CSV</code> file is a
  new line and the field separator is a comma (,).</p>
@@ -418,7 +418,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Opens a <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/classes/ReadableCSVChannel.html">CSV channel in the <code>read</code> mode</a>,
+                                            <p>Opens a <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/classes/ReadableCSVChannel">CSV channel in the <code>read</code> mode</a>,
  which is the default mode.</p>
 
                                         </div>
@@ -487,7 +487,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Reads the <code>.CSV</code> file as a <code>table</code> using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/classes/ReadableCSVChannel.html#getTable">getTable</a> function.</p>
+                                            <p>Reads the <code>.CSV</code> file as a <code>table</code> using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/classes/ReadableCSVChannel#getTable">getTable</a> function.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/different-payload-types.html
+++ b/swan-lake/learn/by-example/different-payload-types.html
@@ -15,7 +15,7 @@ redirect_from:
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">mime</span><span class="p">;</span>
 
-<span class="c1">//[Client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html) endpoint.</span>
+<span class="c1">//[Client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client) endpoint.</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">Client</span> <span class="nx">clientEP</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="s">&quot;http://localhost:9091/backEndService&quot;</span><span class="p">);</span>
 
 <span class="c1">//Service to test HTTP client remote functions with different payload types.</span>
@@ -23,26 +23,26 @@ redirect_from:
 
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">messageUsage</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">)</span> <span class="p">{</span>
 
-        <span class="c1">//[GET](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#get) remote function without any payload.</span>
+        <span class="c1">//[GET](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#get) remote function without any payload.</span>
         <span class="k">var</span> <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">get</span><span class="p">(</span><span class="s">&quot;/greeting&quot;</span><span class="p">);</span>
         <span class="nx">handleResponse</span><span class="p">(</span><span class="nx">response</span><span class="p">);</span>
 
-        <span class="c1">//[GET](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#get) remote function with</span>
+        <span class="c1">//[GET](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#get) remote function with</span>
         <span class="c1">//the request given as a message.</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">request</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
         <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">get</span><span class="p">(</span><span class="s">&quot;/greeting&quot;</span><span class="p">,</span> <span class="kt">message</span> <span class="p">=</span> <span class="nx">request</span><span class="p">);</span>
         <span class="nx">handleResponse</span><span class="p">(</span><span class="nx">response</span><span class="p">);</span>
 
-        <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post) remote function without any payload.</span>
+        <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post) remote function without any payload.</span>
         <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/echo&quot;</span><span class="p">,</span> <span class="p">());</span>
         <span class="nx">handleResponse</span><span class="p">(</span><span class="nx">response</span><span class="p">);</span>
 
-        <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post) remote function with</span>
+        <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post) remote function with</span>
         <span class="c1">//text as the payload.</span>
         <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/echo&quot;</span><span class="p">,</span> <span class="s">&quot;Sample Text&quot;</span><span class="p">);</span>
         <span class="nx">handleResponse</span><span class="p">(</span><span class="nx">response</span><span class="p">);</span>
 
-        <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post) remote function with</span>
+        <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post) remote function with</span>
         <span class="c1">//`xml` as the payload.</span>
         <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/echo&quot;</span><span class="p">,</span> <span class="kt">xml</span> <span class="s">`&lt;yy&gt;Sample Xml&lt;/yy&gt;`</span><span class="p">);</span>
         <span class="nx">handleResponse</span><span class="p">(</span><span class="nx">response</span><span class="p">);</span>
@@ -51,32 +51,32 @@ redirect_from:
         <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/echo&quot;</span><span class="p">,</span> <span class="p">{</span><span class="nx">name</span><span class="p">:</span> <span class="s">&quot;apple&quot;</span><span class="p">,</span> <span class="nx">color</span><span class="p">:</span> <span class="s">&quot;red&quot;</span><span class="p">});</span>
         <span class="nx">handleResponse</span><span class="p">(</span><span class="nx">response</span><span class="p">);</span>
 
-        <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post) remote function with</span>
+        <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post) remote function with</span>
         <span class="c1">//`byte[]` as the payload.</span>
         <span class="kt">string</span> <span class="nx">textVal</span> <span class="p">=</span> <span class="s">&quot;Sample Text&quot;</span><span class="p">;</span>
         <span class="nx">byte</span><span class="p">[]</span> <span class="nx">binaryValue</span> <span class="p">=</span> <span class="nx">textVal</span><span class="p">.</span><span class="nx">toBytes</span><span class="p">();</span>
         <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/echo&quot;</span><span class="p">,</span> <span class="nx">binaryValue</span><span class="p">);</span>
         <span class="nx">handleResponse</span><span class="p">(</span><span class="nx">response</span><span class="p">);</span>
 
-        <span class="c1">//[Get a byte channel](https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/functions.html#openReadableFile) to a given file.</span>
+        <span class="c1">//[Get a byte channel](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/functions#openReadableFile) to a given file.</span>
         <span class="k">var</span> <span class="nx">bChannel</span> <span class="p">=</span> <span class="nx">io</span><span class="p">:</span><span class="nx">openReadableFile</span><span class="p">(</span><span class="s">&quot;./files/logo.png&quot;</span><span class="p">);</span>
 
         <span class="k">if</span> <span class="p">(</span><span class="nx">bChannel</span> <span class="nx">is</span> <span class="nx">io</span><span class="p">:</span><span class="nx">ReadableByteChannel</span><span class="p">)</span> <span class="p">{</span>
-            <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post) remote function</span>
+            <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post) remote function</span>
             <span class="c1">//with a byte channel as the payload. Since the file path is static,</span>
             <span class="c1">//`untaint` is used to denote that the byte channel is trusted.</span>
             <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/image&quot;</span><span class="p">,</span> <span class="p">&lt;</span><span class="err">@</span><span class="nx">untainted</span><span class="p">&gt;</span><span class="nx">bChannel</span><span class="p">);</span>
             <span class="nx">handleResponse</span><span class="p">(</span><span class="nx">response</span><span class="p">);</span>
 
-            <span class="c1">//[Create a JSON body part](https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#setJson).</span>
+            <span class="c1">//[Create a JSON body part](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#setJson).</span>
             <span class="nx">mime</span><span class="p">:</span><span class="nx">Entity</span> <span class="nx">part1</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
             <span class="nx">part1</span><span class="p">.</span><span class="nx">setJson</span><span class="p">({</span><span class="s">&quot;name&quot;</span><span class="p">:</span> <span class="s">&quot;Jane&quot;</span><span class="p">});</span>
 
-            <span class="c1">//[Create a text body part](https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#setText).</span>
+            <span class="c1">//[Create a text body part](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#setText).</span>
             <span class="nx">mime</span><span class="p">:</span><span class="nx">Entity</span> <span class="nx">part2</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
             <span class="nx">part2</span><span class="p">.</span><span class="nx">setText</span><span class="p">(</span><span class="s">&quot;Hello&quot;</span><span class="p">);</span>
 
-            <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post) remote function</span>
+            <span class="c1">//[POST](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post) remote function</span>
             <span class="c1">//with a body parts as the payload.</span>
             <span class="nx">mime</span><span class="p">:</span><span class="nx">Entity</span><span class="p">[]</span> <span class="nx">bodyParts</span> <span class="p">=</span> <span class="p">[</span><span class="nx">part1</span><span class="p">,</span> <span class="nx">part2</span><span class="p">];</span>
             <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/echo&quot;</span><span class="p">,</span> <span class="nx">bodyParts</span><span class="p">);</span>
@@ -296,7 +296,7 @@ redirect_from:
                             <p><p>Ballerina supports different payload types to be used directly with HTTP client actions
 (eg: POST, PUT, DELETE etc..) and service respond calls.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -439,7 +439,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html">Client</a> endpoint.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client">Client</a> endpoint.</p>
 
                                         </div>
                                     </div>
@@ -490,7 +490,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#get">GET</a> remote function without any payload.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#get">GET</a> remote function without any payload.</p>
 
                                         </div>
                                     </div>
@@ -511,7 +511,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#get">GET</a> remote function with
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#get">GET</a> remote function with
 the request given as a message.</p>
 
                                         </div>
@@ -532,7 +532,7 @@ the request given as a message.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post">POST</a> remote function without any payload.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post">POST</a> remote function without any payload.</p>
 
                                         </div>
                                     </div>
@@ -552,7 +552,7 @@ the request given as a message.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post">POST</a> remote function with
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post">POST</a> remote function with
 text as the payload.</p>
 
                                         </div>
@@ -573,7 +573,7 @@ text as the payload.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post">POST</a> remote function with
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post">POST</a> remote function with
 <code>xml</code> as the payload.</p>
 
                                         </div>
@@ -616,7 +616,7 @@ text as the payload.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post">POST</a> remote function with
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post">POST</a> remote function with
 <code>byte[]</code> as the payload.</p>
 
                                         </div>
@@ -636,7 +636,7 @@ text as the payload.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/functions.html#openReadableFile">Get a byte channel</a> to a given file.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/functions#openReadableFile">Get a byte channel</a> to a given file.</p>
 
                                         </div>
                                     </div>
@@ -668,7 +668,7 @@ text as the payload.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post">POST</a> remote function
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post">POST</a> remote function
 with a byte channel as the payload. Since the file path is static,
 <code>untaint</code> is used to denote that the byte channel is trusted.</p>
 
@@ -690,7 +690,7 @@ with a byte channel as the payload. Since the file path is static,
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#setJson">Create a JSON body part</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#setJson">Create a JSON body part</a>.</p>
 
                                         </div>
                                     </div>
@@ -710,7 +710,7 @@ with a byte channel as the payload. Since the file path is static,
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#setText">Create a text body part</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#setText">Create a text body part</a>.</p>
 
                                         </div>
                                     </div>
@@ -731,7 +731,7 @@ with a byte channel as the payload. Since the file path is static,
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post">POST</a> remote function
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post">POST</a> remote function
 with a body parts as the payload.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/directory-listener.html
+++ b/swan-lake/learn/by-example/directory-listener.html
@@ -57,7 +57,7 @@ redirect_from:
                             <p><p>The <code>Directory Listener</code> is used to listen to a directory in the local file system.
  It notifies when new files are created in the directory or when the existing files are deleted or modified.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/file/index.html">File module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/file/">File module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/file-io.html
+++ b/swan-lake/learn/by-example/file-io.html
@@ -123,7 +123,7 @@ redirect_from:
                             <h2>File I/O</h2>
                             <p><p>This example demonstrates how bytes can be read and written using the I/O APIs.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/index.html">IO module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/">IO module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/file.html
+++ b/swan-lake/learn/by-example/file.html
@@ -98,7 +98,7 @@ redirect_from:
                             <h2>File</h2>
                             <p><p>The Ballerina File API contains functions to perform file-system operations.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/file/index.html">File module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/file/">File module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/filepath.html
+++ b/swan-lake/learn/by-example/filepath.html
@@ -57,7 +57,7 @@ redirect_from:
                             <p><p>The Ballerina File API also contains utility functions to manipulate file paths in a way that is compatible with the
  target operating system.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/file/index.html">File module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/file/">File module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/grpc-bidirectional-streaming.html
+++ b/swan-lake/learn/by-example/grpc-bidirectional-streaming.html
@@ -135,7 +135,7 @@ redirect_from:
  operate when each of them sends a sequence of messages using a read-write stream.
  In such scenarios, the two streams operate independently. Therefore, clients and servers can read and write in any order.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/grpc/index.html">GRPC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/grpc/">GRPC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/grpc-client-streaming.html
+++ b/swan-lake/learn/by-example/grpc-client-streaming.html
@@ -119,7 +119,7 @@ redirect_from:
  This sample includes a gRPC client streaming service and non-blocking client. The client writes a sequence of messages and sends them to the server via a stream.
  Once the client has finished writing the messages, it waits for the server to read them and return a response.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/grpc/index.html">GRPC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/grpc/">GRPC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/grpc-secured-unary.html
+++ b/swan-lake/learn/by-example/grpc-secured-unary.html
@@ -93,7 +93,7 @@ redirect_from:
                             <p><p>The gRPC Server Connector is used to expose gRPC services over HTTP/2.
  This sample demonstrates how a gRPC secured unary service interacts with a gRPC secured blocking client.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/grpc/index.html">GRPC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/grpc/">GRPC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/grpc-server-streaming.html
+++ b/swan-lake/learn/by-example/grpc-server-streaming.html
@@ -97,7 +97,7 @@ redirect_from:
  This sample includes a gRPC server streaming service and a non-blocking client. The
  client sends a request to the server and gets a stream to read the messages until all the messages are read.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/grpc/index.html">GRPC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/grpc/">GRPC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/grpc-unary-blocking.html
+++ b/swan-lake/learn/by-example/grpc-unary-blocking.html
@@ -87,7 +87,7 @@ redirect_from:
  This sample demonstrates how the gRPC unary service interacts with the gRPC blocking client, and how
  header values are handled.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/grpc/index.html">GRPC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/grpc/">GRPC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/grpc-unary-non-blocking.html
+++ b/swan-lake/learn/by-example/grpc-unary-non-blocking.html
@@ -90,7 +90,7 @@ redirect_from:
                             <p><p>The gRPC Server Connector is used to expose gRPC services over HTTP/2.
  This sample demonstrates how the gRPC unary service interacts with the gRPC non-blocking client.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/grpc/index.html">GRPC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/grpc/">GRPC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/header-based-routing.html
+++ b/swan-lake/learn/by-example/header-based-routing.html
@@ -31,7 +31,7 @@ redirect_from:
 <span class="p">}</span>
 
 <span class="kd">service</span> <span class="nx">headerBasedRouting</span> <span class="nx">on</span> <span class="nx">new</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span><span class="p">(</span><span class="mi">9090</span><span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// [http:ResourceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpResourceConfig.html) annotation with &#39;GET&#39; method declares the</span>
+    <span class="c1">// [http:ResourceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpResourceConfig) annotation with &#39;GET&#39; method declares the</span>
     <span class="c1">// HTTP method.</span>
     <span class="nd">@http:ResourceConfig {</span>
         <span class="nx">methods</span><span class="p">:</span> <span class="p">[</span><span class="s">&quot;GET&quot;</span><span class="p">],</span>
@@ -58,19 +58,19 @@ redirect_from:
             <span class="p">}</span>
             <span class="k">return</span><span class="p">;</span>
         <span class="p">}</span>
-        <span class="c1">//[getHeader()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getHeader) returns header value of the specified header name.</span>
+        <span class="c1">//[getHeader()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getHeader) returns header value of the specified header name.</span>
         <span class="kt">string</span> <span class="nx">nameString</span> <span class="p">=</span> <span class="nx">req</span><span class="p">.</span><span class="nx">getHeader</span><span class="p">(</span><span class="s">&quot;x-type&quot;</span><span class="p">);</span>
 
         <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span><span class="p">|</span><span class="nx">http</span><span class="p">:</span><span class="nx">Payload</span><span class="p">|</span><span class="nx">error</span> <span class="nx">response</span><span class="p">;</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">nameString</span> <span class="o">==</span> <span class="s">&quot;location&quot;</span><span class="p">)</span> <span class="p">{</span>
-            <span class="c1">//[post()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post) remote function represents the &#39;POST&#39; operation</span>
+            <span class="c1">//[post()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post) remote function represents the &#39;POST&#39; operation</span>
             <span class="c1">// of the HTTP client.</span>
             <span class="c1">// Route payload to the relevant service.</span>
             <span class="nx">response</span> <span class="p">=</span> <span class="nx">locationEP</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/v2/5adddd66300000bd2a4b2912&quot;</span><span class="p">,</span>
                                         <span class="nx">newRequest</span><span class="p">);</span>
 
         <span class="p">}</span> <span class="k">else</span> <span class="p">{</span>
-            <span class="c1">//[get()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#get) remote function can be used to make an http GET call.</span>
+            <span class="c1">//[get()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#get) remote function can be used to make an http GET call.</span>
             <span class="nx">response</span> <span class="p">=</span>
                 <span class="nx">weatherEP</span><span class="o">-&gt;</span><span class="nx">get</span><span class="p">(</span><span class="s">&quot;/data/2.5/weather?lat=35&amp;lon=139&amp;appid=b1b1&quot;</span><span class="p">,</span>
                                  <span class="nx">newRequest</span><span class="p">);</span>
@@ -78,7 +78,7 @@ redirect_from:
         <span class="p">}</span>
 
         <span class="k">if</span> <span class="p">(</span><span class="nx">response</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span><span class="p">)</span> <span class="p">{</span>
-            <span class="c1">// [respond()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Caller.html#respond) sends back the inbound clientResponse to the caller</span>
+            <span class="c1">// [respond()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Caller#respond) sends back the inbound clientResponse to the caller</span>
             <span class="c1">// if no error occurs.</span>
 
             <span class="k">var</span> <span class="nx">result</span> <span class="p">=</span> <span class="nx">caller</span><span class="o">-&gt;</span><span class="nx">respond</span><span class="p">(&lt;</span><span class="err">@</span><span class="nx">untainted</span><span class="p">&gt;</span><span class="nx">response</span><span class="p">);</span>
@@ -110,7 +110,7 @@ redirect_from:
                             <h2>Header-Based Routing</h2>
                             <p><p>The Header-Based Router service reads a particular Header of a request and routes it to a specific recipient based on the Header value.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -297,7 +297,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpResourceConfig.html">http:ResourceConfig</a> annotation with &lsquo;GET&rsquo; method declares the
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpResourceConfig">http:ResourceConfig</a> annotation with &lsquo;GET&rsquo; method declares the
  HTTP method.</p>
 
                                         </div>
@@ -402,7 +402,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getHeader">getHeader()</a> returns header value of the specified header name.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getHeader">getHeader()</a> returns header value of the specified header name.</p>
 
                                         </div>
                                     </div>
@@ -435,7 +435,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#post">post()</a> remote function represents the &lsquo;POST&rsquo; operation
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#post">post()</a> remote function represents the &lsquo;POST&rsquo; operation
  of the HTTP client.
  Route payload to the relevant service.</p>
 
@@ -470,7 +470,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#get">get()</a> remote function can be used to make an http GET call.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#get">get()</a> remote function can be used to make an http GET call.</p>
 
                                         </div>
                                     </div>
@@ -511,7 +511,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Caller.html#respond">respond()</a> sends back the inbound clientResponse to the caller
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Caller#respond">respond()</a> sends back the inbound clientResponse to the caller
  if no error occurs.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/http-1-1-to-2-0-protocol-switch.html
+++ b/swan-lake/learn/by-example/http-1-1-to-2-0-protocol-switch.html
@@ -27,7 +27,7 @@ redirect_from:
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">http11Resource</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span>
                                      <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">clientRequest</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// Forward the [clientRequest](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html) to the `http2` service.</span>
+        <span class="c1">// Forward the [clientRequest](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request) to the `http2` service.</span>
         <span class="k">var</span> <span class="nx">clientResponse</span> <span class="p">=</span> <span class="nx">http2serviceClientEP</span><span class="o">-&gt;</span><span class="nx">forward</span><span class="p">(</span><span class="s">&quot;/http2service&quot;</span><span class="p">,</span>
                                                         <span class="nx">clientRequest</span><span class="p">);</span>
 
@@ -36,7 +36,7 @@ redirect_from:
             <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientResponse</span><span class="p">;</span>
         <span class="p">}</span> <span class="k">else</span> <span class="p">{</span>
             <span class="c1">// Handle the errors that are returned when invoking the</span>
-            <span class="c1">// [forward](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/HttpClient.html#forward) function.</span>
+            <span class="c1">// [forward](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/HttpClient#forward) function.</span>
             <span class="nx">response</span><span class="p">.</span><span class="nx">statusCode</span> <span class="p">=</span> <span class="mi">500</span><span class="p">;</span>
             <span class="nx">response</span><span class="p">.</span><span class="nx">setPayload</span><span class="p">(&lt;</span><span class="err">@</span><span class="nx">untainted</span><span class="p">&gt;(&lt;</span><span class="nx">error</span><span class="p">&gt;</span><span class="nx">clientResponse</span><span class="p">).</span><span class="kt">message</span><span class="p">());</span>
         <span class="p">}</span>
@@ -89,7 +89,7 @@ redirect_from:
                             <p><p>In this example, the Ballerina HTTP service receives a message over the HTTP/1.1 protocol and forwards it
  to another service over the HTTP/2.0 protocol.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -254,7 +254,7 @@ service http11Service on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Forward the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html">clientRequest</a> to the <code>http2</code> service.</p>
+                                            <p>Forward the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request">clientRequest</a> to the <code>http2</code> service.</p>
 
                                         </div>
                                     </div>
@@ -291,7 +291,7 @@ service http11Service on new http:Listener(9090) {
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>Handle the errors that are returned when invoking the
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/HttpClient.html#forward">forward</a> function.</p>
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/HttpClient#forward">forward</a> function.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/http-100-continue.html
+++ b/swan-lake/learn/by-example/http-100-continue.html
@@ -22,7 +22,7 @@ redirect_from:
         <span class="nx">path</span><span class="p">:</span> <span class="s">&quot;/&quot;</span>
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">hello</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">request</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// [Check if the client expects a 100-continue response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#expects100Continue).</span>
+        <span class="c1">// [Check if the client expects a 100-continue response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#expects100Continue).</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">request</span><span class="p">.</span><span class="nx">expects100Continue</span><span class="p">())</span> <span class="p">{</span>
             <span class="kt">string</span> <span class="nx">mediaType</span> <span class="p">=</span> <span class="nx">request</span><span class="p">.</span><span class="nx">getContentType</span><span class="p">();</span>
             <span class="k">if</span> <span class="p">(</span><span class="nx">mediaType</span><span class="p">.</span><span class="nx">toLowerAscii</span><span class="p">()</span> <span class="o">==</span> <span class="s">&quot;text/plain&quot;</span><span class="p">)</span> <span class="p">{</span>
@@ -79,7 +79,7 @@ redirect_from:
                             <p><p>Convenience functions are provided in the HTTP library for ease of use when handling 100-continue scenarios.
  100-continue indicates that the server has received the request headers and the client can proceed with sending the request.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -210,7 +210,7 @@ service helloWorld on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#expects100Continue">Check if the client expects a 100-continue response</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#expects100Continue">Check if the client expects a 100-continue response</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/http-2-0-server-push.html
+++ b/swan-lake/learn/by-example/http-2-0-server-push.html
@@ -28,7 +28,7 @@ redirect_from:
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">http2Resource</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">)</span> <span class="p">{</span>
 
-        <span class="c1">// [Send a Push Promise](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Caller.html#promise).</span>
+        <span class="c1">// [Send a Push Promise](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Caller#promise).</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">PushPromise</span> <span class="nx">promise1</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="nx">path</span> <span class="p">=</span> <span class="s">&quot;/resource1&quot;</span><span class="p">,</span> <span class="nx">method</span> <span class="p">=</span> <span class="s">&quot;GET&quot;</span><span class="p">);</span>
         <span class="k">var</span> <span class="nx">promiseResponse1</span> <span class="p">=</span> <span class="nx">caller</span><span class="o">-&gt;</span><span class="nx">promise</span><span class="p">(</span><span class="nx">promise1</span><span class="p">);</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">promiseResponse1</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
@@ -69,7 +69,7 @@ redirect_from:
         <span class="nx">msg</span> <span class="p">=</span> <span class="p">{</span><span class="s">&quot;push&quot;</span><span class="p">:</span> <span class="p">{</span><span class="s">&quot;name&quot;</span><span class="p">:</span> <span class="s">&quot;resource1&quot;</span><span class="p">}};</span>
         <span class="nx">push1</span><span class="p">.</span><span class="nx">setPayload</span><span class="p">(</span><span class="nx">msg</span><span class="p">);</span>
 
-        <span class="c1">// [Push promised resource1](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Caller.html#pushPromisedResponse).</span>
+        <span class="c1">// [Push promised resource1](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Caller#pushPromisedResponse).</span>
         <span class="k">var</span> <span class="nx">pushResponse1</span> <span class="p">=</span> <span class="nx">caller</span><span class="o">-&gt;</span><span class="nx">pushPromisedResponse</span><span class="p">(</span><span class="nx">promise1</span><span class="p">,</span> <span class="nx">push1</span><span class="p">);</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">pushResponse1</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
             <span class="nx">log</span><span class="p">:</span><span class="nx">printError</span><span class="p">(</span><span class="s">&quot;Error occurred while sending the promised &quot;</span> <span class="o">+</span>
@@ -104,7 +104,7 @@ redirect_from:
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">http</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 
-<span class="c1">// Create an [HTTP client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html) that can send HTTP/2 messages.</span>
+<span class="c1">// Create an [HTTP client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client) that can send HTTP/2 messages.</span>
 <span class="c1">// HTTP version is set to 2.0.</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">Client</span> <span class="nx">clientEP</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="s">&quot;http://localhost:7090&quot;</span><span class="p">,</span> <span class="p">{</span><span class="nx">httpVersion</span><span class="p">:</span> <span class="s">&quot;2.0&quot;</span><span class="p">});</span>
 
@@ -112,7 +112,7 @@ redirect_from:
 
     <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">serviceReq</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
     <span class="nx">http</span><span class="p">:</span><span class="nx">HttpFuture</span> <span class="nx">httpFuture</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
-    <span class="c1">// [Submit a request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#submit).</span>
+    <span class="c1">// [Submit a request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#submit).</span>
     <span class="k">var</span> <span class="nx">submissionResult</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">submit</span><span class="p">(</span><span class="s">&quot;GET&quot;</span><span class="p">,</span> <span class="s">&quot;/http2Service&quot;</span><span class="p">,</span> <span class="nx">serviceReq</span><span class="p">);</span>
 
     <span class="k">if</span> <span class="p">(</span><span class="nx">submissionResult</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">HttpFuture</span><span class="p">)</span> <span class="p">{</span>
@@ -125,12 +125,12 @@ redirect_from:
 
     <span class="nx">http</span><span class="p">:</span><span class="nx">PushPromise</span><span class="err">?</span><span class="p">[]</span> <span class="nx">promises</span> <span class="p">=</span> <span class="p">[];</span>
     <span class="kt">int</span> <span class="nx">promiseCount</span> <span class="p">=</span> <span class="mi">0</span><span class="p">;</span>
-    <span class="c1">// [Check if promises exists](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#hasPromise).</span>
+    <span class="c1">// [Check if promises exists](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#hasPromise).</span>
     <span class="kt">boolean</span> <span class="nx">hasPromise</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">hasPromise</span><span class="p">(</span><span class="nx">httpFuture</span><span class="p">);</span>
 
     <span class="k">while</span> <span class="p">(</span><span class="nx">hasPromise</span><span class="p">)</span> <span class="p">{</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">PushPromise</span> <span class="nx">pushPromise</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
-        <span class="c1">// [Get the next promise](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#getNextPromise).</span>
+        <span class="c1">// [Get the next promise](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#getNextPromise).</span>
         <span class="k">var</span> <span class="nx">nextPromiseResult</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">getNextPromise</span><span class="p">(</span><span class="nx">httpFuture</span><span class="p">);</span>
 
         <span class="k">if</span> <span class="p">(</span><span class="nx">nextPromiseResult</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">PushPromise</span><span class="p">)</span> <span class="p">{</span>
@@ -144,7 +144,7 @@ redirect_from:
 
         <span class="k">if</span> <span class="p">(</span><span class="nx">pushPromise</span><span class="p">.</span><span class="nx">path</span> <span class="o">==</span> <span class="s">&quot;/resource2&quot;</span><span class="p">)</span> <span class="p">{</span>
             <span class="c1">// The client is not interested in receiving `/resource2`.</span>
-            <span class="c1">// Therefore, [reject the promise](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#rejectPromise).</span>
+            <span class="c1">// Therefore, [reject the promise](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#rejectPromise).</span>
             <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">rejectPromise</span><span class="p">(</span><span class="nx">pushPromise</span><span class="p">);</span>
 
             <span class="nx">log</span><span class="p">:</span><span class="nx">printInfo</span><span class="p">(</span><span class="s">&quot;Push promise for resource2 rejected&quot;</span><span class="p">);</span>
@@ -158,7 +158,7 @@ redirect_from:
     <span class="p">}</span>
 
     <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span> <span class="nx">response</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
-    <span class="c1">// [Get the requested resource](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#getResponse).</span>
+    <span class="c1">// [Get the requested resource](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#getResponse).</span>
     <span class="k">var</span> <span class="nx">result</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">getResponse</span><span class="p">(</span><span class="nx">httpFuture</span><span class="p">);</span>
 
     <span class="k">if</span> <span class="p">(</span><span class="nx">result</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span><span class="p">)</span> <span class="p">{</span>
@@ -211,7 +211,7 @@ redirect_from:
                             <p><p>This example demonstrates sending and receiving HTTP/2 Server Push messages in Ballerina HTTP Library.
  HTTP/2 Server Push messages allow the server to send resources to the client before the client requests for it.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -382,7 +382,7 @@ service http2Service on http2ServiceEP {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Caller.html#promise">Send a Push Promise</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Caller#promise">Send a Push Promise</a>.</p>
 
                                         </div>
                                     </div>
@@ -518,7 +518,7 @@ service http2Service on http2ServiceEP {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Caller.html#pushPromisedResponse">Push promised resource1</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Caller#pushPromisedResponse">Push promised resource1</a>.</p>
 
                                         </div>
                                     </div>
@@ -771,7 +771,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Create an <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html">HTTP client</a> that can send HTTP/2 messages.
+                                            <p>Create an <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client">HTTP client</a> that can send HTTP/2 messages.
  HTTP version is set to 2.0.</p>
 
                                         </div>
@@ -816,7 +816,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#submit">Submit a request</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#submit">Submit a request</a>.</p>
 
                                         </div>
                                     </div>
@@ -866,7 +866,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#hasPromise">Check if promises exists</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#hasPromise">Check if promises exists</a>.</p>
 
                                         </div>
                                     </div>
@@ -898,7 +898,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#getNextPromise">Get the next promise</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#getNextPromise">Get the next promise</a>.</p>
 
                                         </div>
                                     </div>
@@ -949,7 +949,7 @@ import ballerina/log;
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>The client is not interested in receiving <code>/resource2</code>.
- Therefore, <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#rejectPromise">reject the promise</a>.</p>
+ Therefore, <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#rejectPromise">reject the promise</a>.</p>
 
                                         </div>
                                     </div>
@@ -1027,7 +1027,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#getResponse">Get the requested resource</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#getResponse">Get the requested resource</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/http-access-logs.html
+++ b/swan-lake/learn/by-example/http-access-logs.html
@@ -41,7 +41,7 @@ redirect_from:
                             <h2>Access Logs</h2>
                             <p><p>Ballerina supports HTTP access logs for HTTP services. The access log format used is the combined log format.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/http-caching-client.html
+++ b/swan-lake/learn/by-example/http-caching-client.html
@@ -14,16 +14,16 @@ redirect_from:
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 
 <span class="c1">// HTTP caching is enabled by default for client endpoints. Caching can be</span>
-<span class="c1">// disabled by setting `enabled=false` in the [cache config](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CacheConfig.html)</span>
+<span class="c1">// disabled by setting `enabled=false` in the [cache config](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CacheConfig)</span>
 <span class="c1">// of the client endpoint. In this example, the `isShared` field of the `cacheConfig` is set</span>
 <span class="c1">// to true, as the cache will be a public cache in this particular scenario.</span>
 <span class="c1">//</span>
 <span class="c1">// The default caching policy is to cache a response only if it contains a</span>
 <span class="c1">// `cache-control` header and either an `etag` header or a `last-modified`</span>
-<span class="c1">// header. The user can control this behaviour by setting the [policy](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/types.html#CachingPolicy)</span>
+<span class="c1">// header. The user can control this behaviour by setting the [policy](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/types#CachingPolicy)</span>
 <span class="c1">// field of the `cacheConfig`. Currently, there are only 2 policies:</span>
-<span class="c1">// [CACHE_CONTROL_AND_VALIDATORS](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#CACHE_CONTROL_AND_VALIDATORS)</span>
-<span class="c1">// (the default policy) and [RFC_7234](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#RFC_7234).</span>
+<span class="c1">// [CACHE_CONTROL_AND_VALIDATORS](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#CACHE_CONTROL_AND_VALIDATORS)</span>
+<span class="c1">// (the default policy) and [RFC_7234](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#RFC_7234).</span>
 
 <span class="nx">http</span><span class="p">:</span><span class="nx">Client</span> <span class="nx">cachingEP</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="s">&quot;http://localhost:8080&quot;</span><span class="p">,</span>
                              <span class="p">{</span><span class="nx">cache</span><span class="p">:</span> <span class="p">{</span><span class="nx">isShared</span><span class="p">:</span> <span class="kc">true</span><span class="p">}});</span>
@@ -74,8 +74,8 @@ redirect_from:
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">sayHello</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">)</span> <span class="p">{</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span> <span class="nx">res</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
 
-        <span class="c1">// The [ResponseCacheControl](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/ResponseCacheControl.html)</span>
-        <span class="c1">// object in the [Response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html) object can be</span>
+        <span class="c1">// The [ResponseCacheControl](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/ResponseCacheControl)</span>
+        <span class="c1">// object in the [Response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response) object can be</span>
         <span class="c1">// used for setting the cache control directives associated with the</span>
         <span class="c1">// response. In this example, the `max-age` directive is set to 15 seconds</span>
         <span class="c1">// indicating that the response will be fresh for 15 seconds. The</span>
@@ -91,12 +91,12 @@ redirect_from:
 
         <span class="nx">res</span><span class="p">.</span><span class="nx">cacheControl</span> <span class="p">=</span> <span class="nx">resCC</span><span class="p">;</span>
 
-        <span class="c1">// The [setETag()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#setETag)</span>
+        <span class="c1">// The [setETag()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#setETag)</span>
         <span class="c1">// function can be used for generating ETags for `string`, `json`, and `xml` types. This uses the `getCRC32()`</span>
         <span class="c1">// function from the `ballerina/crypto` module for generating the ETag.</span>
         <span class="nx">res</span><span class="p">.</span><span class="nx">setETag</span><span class="p">(</span><span class="nx">payload</span><span class="p">);</span>
 
-        <span class="c1">// The [setLastModified()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#setLastModified)</span>
+        <span class="c1">// The [setLastModified()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#setLastModified)</span>
         <span class="c1">// function sets the current time as the `last-modified` header.</span>
         <span class="nx">res</span><span class="p">.</span><span class="nx">setLastModified</span><span class="p">();</span>
 
@@ -104,7 +104,7 @@ redirect_from:
         <span class="c1">// When sending the response, if the `cacheControl` field of the</span>
         <span class="c1">// response is set, and the user has not already set a `cache-control`</span>
         <span class="c1">// header, a `cache-control` header will be set using the directives set</span>
-        <span class="c1">// in the [cacheControl](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/ResponseCacheControl.html) object.</span>
+        <span class="c1">// in the [cacheControl](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/ResponseCacheControl) object.</span>
 
         <span class="k">var</span> <span class="nx">result</span> <span class="p">=</span> <span class="nx">caller</span><span class="o">-&gt;</span><span class="nx">respond</span><span class="p">(</span><span class="nx">res</span><span class="p">);</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">result</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
@@ -124,7 +124,7 @@ redirect_from:
                             <p><p>HTTP caching is enabled by default in HTTP client endpoints.
  Users can configure caching using the <code>cache</code> field in the endpoint configurations.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -244,16 +244,16 @@ import ballerina/log;
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>HTTP caching is enabled by default for client endpoints. Caching can be
- disabled by setting <code>enabled=false</code> in the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CacheConfig.html">cache config</a>
+ disabled by setting <code>enabled=false</code> in the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CacheConfig">cache config</a>
  of the client endpoint. In this example, the <code>isShared</code> field of the <code>cacheConfig</code> is set
  to true, as the cache will be a public cache in this particular scenario.</p>
 
 <p>The default caching policy is to cache a response only if it contains a
  <code>cache-control</code> header and either an <code>etag</code> header or a <code>last-modified</code>
- header. The user can control this behaviour by setting the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/types.html#CachingPolicy">policy</a>
+ header. The user can control this behaviour by setting the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/types#CachingPolicy">policy</a>
  field of the <code>cacheConfig</code>. Currently, there are only 2 policies:
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#CACHE_CONTROL_AND_VALIDATORS">CACHE_CONTROL_AND_VALIDATORS</a>
- (the default policy) and <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#RFC_7234">RFC_7234</a>.</p>
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#CACHE_CONTROL_AND_VALIDATORS">CACHE_CONTROL_AND_VALIDATORS</a>
+ (the default policy) and <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#RFC_7234">RFC_7234</a>.</p>
 
                                         </div>
                                     </div>
@@ -434,8 +434,8 @@ service helloWorld on new http:Listener(8080) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/ResponseCacheControl.html">ResponseCacheControl</a>
- object in the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html">Response</a> object can be
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/ResponseCacheControl">ResponseCacheControl</a>
+ object in the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response">Response</a> object can be
  used for setting the cache control directives associated with the
  response. In this example, the <code>max-age</code> directive is set to 15 seconds
  indicating that the response will be fresh for 15 seconds. The
@@ -474,7 +474,7 @@ service helloWorld on new http:Listener(8080) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#setETag">setETag()</a>
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#setETag">setETag()</a>
  function can be used for generating ETags for <code>string</code>, <code>json</code>, and <code>xml</code> types. This uses the <code>getCRC32()</code>
  function from the <code>ballerina/crypto</code> module for generating the ETag.</p>
 
@@ -495,7 +495,7 @@ service helloWorld on new http:Listener(8080) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#setLastModified">setLastModified()</a>
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#setLastModified">setLastModified()</a>
  function sets the current time as the <code>last-modified</code> header.</p>
 
                                         </div>
@@ -528,7 +528,7 @@ service helloWorld on new http:Listener(8080) {
                                             <p>When sending the response, if the <code>cacheControl</code> field of the
  response is set, and the user has not already set a <code>cache-control</code>
  header, a <code>cache-control</code> header will be set using the directives set
- in the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/ResponseCacheControl.html">cacheControl</a> object.</p>
+ in the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/ResponseCacheControl">cacheControl</a> object.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/http-circuit-breaker.html
+++ b/swan-lake/learn/by-example/http-circuit-breaker.html
@@ -143,7 +143,7 @@ redirect_from:
                             <h2>Circuit Breaker</h2>
                             <p><p>The Circuit Breaker is used to gracefully handle network related errors, which occur when using the HTTP Client.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/http-client-data-binding.html
+++ b/swan-lake/learn/by-example/http-client-data-binding.html
@@ -28,7 +28,7 @@ redirect_from:
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">bindCheck</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">request</span><span class="p">)</span>
                                                     <span class="nx">returns</span> <span class="nd">@tainted error? {</span>
-        <span class="c1">// The `string` typedesc is being passed to the `get` [client remote function](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#get)</span>
+        <span class="c1">// The `string` typedesc is being passed to the `get` [client remote function](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#get)</span>
         <span class="c1">// as the `targetType` expecting the payload to be bound to a string value.</span>
         <span class="k">var</span> <span class="nx">result</span> <span class="p">=</span> <span class="nx">backendClient</span><span class="o">-&gt;</span>
                         <span class="nx">get</span><span class="p">(</span><span class="s">&quot;/backend/getString&quot;</span><span class="p">,</span> <span class="nx">targetType</span> <span class="p">=</span> <span class="kt">string</span><span class="p">);</span>
@@ -40,7 +40,7 @@ redirect_from:
             <span class="k">return</span> <span class="nx">result</span><span class="p">;</span>
         <span class="p">}</span>
 
-        <span class="c1">// If the type test of the error becomes false, it implies that the [payload type](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/types.html#Payload)</span>
+        <span class="c1">// If the type test of the error becomes false, it implies that the [payload type](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/types#Payload)</span>
         <span class="c1">// is string.</span>
         <span class="nx">log</span><span class="p">:</span><span class="nx">printInfo</span><span class="p">(</span><span class="s">&quot;String payload: &quot;</span> <span class="o">+</span> <span class="p">&lt;</span><span class="kt">string</span><span class="p">&gt;</span><span class="nx">result</span><span class="p">);</span>
 
@@ -74,7 +74,7 @@ redirect_from:
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">handle500</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">request</span><span class="p">)</span> <span class="p">{</span>
         <span class="k">var</span> <span class="nx">res</span> <span class="p">=</span> <span class="nx">backendClient</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/backend/get5XX&quot;</span><span class="p">,</span> <span class="s">&quot;want 500&quot;</span><span class="p">,</span> <span class="kt">json</span><span class="p">);</span>
         <span class="c1">// When the data binding is expected to happen and if the `post` remote function gets a 5XX response from the</span>
-        <span class="c1">// backend, the response will be returned as an [http:RemoteServerError](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/errors.html#RemoteServerError)</span>
+        <span class="c1">// backend, the response will be returned as an [http:RemoteServerError](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/errors#RemoteServerError)</span>
         <span class="c1">// including the error message and status code.</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">res</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">RemoteServerError</span><span class="p">)</span> <span class="p">{</span>
             <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span> <span class="nx">resp</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
@@ -91,7 +91,7 @@ redirect_from:
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">handle404</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">request</span><span class="p">)</span> <span class="p">{</span>
         <span class="c1">// When the data binding is expected to happen and if the client remote function gets a 4XX response from the</span>
-        <span class="c1">// backend, the response will be returned as an [http:ClientRequestError](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/errors.html#ClientRequestError)</span>
+        <span class="c1">// backend, the response will be returned as an [http:ClientRequestError](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/errors#ClientRequestError)</span>
         <span class="c1">// including the error message and status code.</span>
         <span class="k">var</span> <span class="nx">res</span> <span class="p">=</span> <span class="nx">backendClient</span><span class="o">-&gt;</span><span class="nx">post</span><span class="p">(</span><span class="s">&quot;/backend/err&quot;</span><span class="p">,</span> <span class="s">&quot;want 400&quot;</span><span class="p">,</span> <span class="kt">json</span><span class="p">);</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">res</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">ClientRequestError</span><span class="p">)</span> <span class="p">{</span>
@@ -159,7 +159,7 @@ redirect_from:
  client remote operation. Since the default <code>targetType</code> is <code>http:Response</code>, the user still has the option to access
  the complete response to explore more.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -347,7 +347,7 @@ type Person record {|
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <code>string</code> typedesc is being passed to the <code>get</code> <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#get">client remote function</a>
+                                            <p>The <code>string</code> typedesc is being passed to the <code>get</code> <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#get">client remote function</a>
  as the <code>targetType</code> expecting the payload to be bound to a string value.</p>
 
                                         </div>
@@ -390,7 +390,7 @@ type Person record {|
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>If the type test of the error becomes false, it implies that the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/types.html#Payload">payload type</a>
+                                            <p>If the type test of the error becomes false, it implies that the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/types#Payload">payload type</a>
  is string.</p>
 
                                         </div>
@@ -533,7 +533,7 @@ type Person record {|
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>When the data binding is expected to happen and if the <code>post</code> remote function gets a 5XX response from the
- backend, the response will be returned as an <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/errors.html#RemoteServerError">http:RemoteServerError</a>
+ backend, the response will be returned as an <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/errors#RemoteServerError">http:RemoteServerError</a>
  including the error message and status code.</p>
 
                                         </div>
@@ -579,7 +579,7 @@ type Person record {|
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>When the data binding is expected to happen and if the client remote function gets a 4XX response from the
- backend, the response will be returned as an <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/errors.html#ClientRequestError">http:ClientRequestError</a>
+ backend, the response will be returned as an <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/errors#ClientRequestError">http:ClientRequestError</a>
  including the error message and status code.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/http-client-endpoint.html
+++ b/swan-lake/learn/by-example/http-client-endpoint.html
@@ -40,7 +40,7 @@ redirect_from:
     <span class="c1">// which will be a request or a payload.</span>
     <span class="nx">response</span> <span class="p">=</span> <span class="nx">clientEndpoint</span><span class="o">-&gt;</span><span class="nx">get</span><span class="p">(</span><span class="s">&quot;/get&quot;</span><span class="p">,</span> <span class="nx">req</span><span class="p">);</span>
     <span class="k">if</span> <span class="p">(</span><span class="nx">response</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// [Get the content type](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getContentType) from the response.</span>
+        <span class="c1">// [Get the content type](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#getContentType) from the response.</span>
         <span class="kt">string</span> <span class="nx">contentType</span> <span class="p">=</span> <span class="nx">response</span><span class="p">.</span><span class="nx">getContentType</span><span class="p">();</span>
         <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Content-Type: &quot;</span> <span class="o">+</span> <span class="nx">contentType</span><span class="p">);</span>
 
@@ -56,7 +56,7 @@ redirect_from:
 <span class="c1">//The below function handles the response received from the remote HTTP endpoint.</span>
 <span class="kd">function</span> <span class="nx">handleResponse</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Response</span><span class="p">|</span><span class="nx">http</span><span class="p">:</span><span class="nx">Payload</span><span class="p">|</span><span class="nx">error</span> <span class="nx">response</span><span class="p">)</span> <span class="p">{</span>
     <span class="k">if</span> <span class="p">(</span><span class="nx">response</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// [Get the JSON payload](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getJsonPayload) from the response.</span>
+        <span class="c1">// [Get the JSON payload](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#getJsonPayload) from the response.</span>
         <span class="k">var</span> <span class="nx">msg</span> <span class="p">=</span> <span class="nx">response</span><span class="p">.</span><span class="nx">getJsonPayload</span><span class="p">();</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">msg</span> <span class="nx">is</span> <span class="kt">json</span><span class="p">)</span> <span class="p">{</span>
             <span class="c1">// Prints the received `JSON` response.</span>
@@ -80,7 +80,7 @@ redirect_from:
                             <h2>Client Endpoint</h2>
                             <p><p>The HTTP Client Connector can be used to connect to and interact with an HTTP server.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -394,7 +394,7 @@ import ballerina/io;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getContentType">Get the content type</a> from the response.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#getContentType">Get the content type</a> from the response.</p>
 
                                         </div>
                                     </div>
@@ -463,7 +463,7 @@ import ballerina/io;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getJsonPayload">Get the JSON payload</a> from the response.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#getJsonPayload">Get the JSON payload</a> from the response.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/http-compression.html
+++ b/swan-lake/learn/by-example/http-compression.html
@@ -15,10 +15,10 @@ redirect_from:
 
 <span class="nx">listener</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span> <span class="nx">listenerEndpoint</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="mi">9090</span><span class="p">);</span>
 
-<span class="c1">// Since compression behavior of the service is set as [COMPRESSION_AUTO](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_AUTO),</span>
+<span class="c1">// Since compression behavior of the service is set as [COMPRESSION_AUTO](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_AUTO),</span>
 <span class="c1">// entity body compression is done according to the scheme indicated in the `Accept-Encoding` request header.</span>
 <span class="c1">// Compression is not performed when the header is not present or when the header value is &quot;identity&quot;.</span>
-<span class="c1">// [compression](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CompressionConfig.html) annotation</span>
+<span class="c1">// [compression](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CompressionConfig) annotation</span>
 <span class="c1">// provides the related configurations.</span>
 <span class="nd">@http:ServiceConfig {</span>
     <span class="nx">compression</span><span class="p">:</span> <span class="p">{</span>
@@ -38,7 +38,7 @@ redirect_from:
     <span class="p">}</span>
 <span class="p">}</span>
 
-<span class="c1">// [COMPRESSION_ALWAYS](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_ALWAYS)</span>
+<span class="c1">// [COMPRESSION_ALWAYS](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_ALWAYS)</span>
 <span class="c1">// guarantees a compressed response entity body. Compression scheme is set to the</span>
 <span class="c1">// value indicated in Accept-Encoding request header. When a particular header is not present or the header</span>
 <span class="c1">// value is &quot;identity&quot;, encoding is done using the &quot;gzip&quot; scheme.</span>
@@ -70,13 +70,13 @@ redirect_from:
     <span class="p">}</span>
 <span class="p">}</span>
 
-<span class="c1">// The HTTP client can indicate the [compression](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/types.html#Compression)</span>
+<span class="c1">// The HTTP client can indicate the [compression](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/types#Compression)</span>
 <span class="c1">// behavior (&quot;AUTO&quot;, &quot;ALWAYS&quot;, &quot;NEVER&quot;) for content negotiation.</span>
 <span class="c1">// Depending on the compression option values, the `Accept-Encoding` header is sent along with the request.</span>
-<span class="c1">// In this example, the client compression behavior is set as [COMPRESSION_ALWAYS](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_ALWAYS). If you have not specified</span>
+<span class="c1">// In this example, the client compression behavior is set as [COMPRESSION_ALWAYS](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_ALWAYS). If you have not specified</span>
 <span class="c1">// an `Accept-Encoding` header, the client specifies it with &quot;deflate, gzip&quot;. Alternatively, the existing header is sent.</span>
-<span class="c1">// When compression is specified as [COMPRESSION_AUTO](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_AUTO), only the user-specified `Accept-Encoding` header is sent.</span>
-<span class="c1">// If the behavior is set as [COMPRESSION_NEVER](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_NEVER), the client makes sure not to send the `Accept-Encoding` header.</span>
+<span class="c1">// When compression is specified as [COMPRESSION_AUTO](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_AUTO), only the user-specified `Accept-Encoding` header is sent.</span>
+<span class="c1">// If the behavior is set as [COMPRESSION_NEVER](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_NEVER), the client makes sure not to send the `Accept-Encoding` header.</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">Client</span> <span class="nx">clientEndpoint</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="s">&quot;http://localhost:9090&quot;</span><span class="p">,</span> <span class="p">{</span>
         <span class="nx">compression</span><span class="p">:</span> <span class="nx">http</span><span class="p">:</span><span class="nx">COMPRESSION_ALWAYS</span>
     <span class="p">}</span>
@@ -103,7 +103,7 @@ redirect_from:
     <span class="p">}</span>
 <span class="p">}</span>
 
-<span class="c1">// The compression behavior of the service is inferred by [COMPRESSION_AUTO](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_AUTO), which is the default value</span>
+<span class="c1">// The compression behavior of the service is inferred by [COMPRESSION_AUTO](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_AUTO), which is the default value</span>
 <span class="c1">// of the compression config.</span>
 <span class="kd">service</span> <span class="nx">backend</span> <span class="nx">on</span> <span class="nx">listenerEndpoint</span> <span class="p">{</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">echo</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">)</span> <span class="p">{</span>
@@ -136,7 +136,7 @@ redirect_from:
  the particular header is not present or the header value is &ldquo;identity&rdquo;, the server does not perform any compression. Compression
  is disabled when the option is set to <code>COMPRESSION_NEVER</code>.&rdquo;<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -265,10 +265,10 @@ service autoCompress on listenerEndpoint {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Since compression behavior of the service is set as <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_AUTO">COMPRESSION_AUTO</a>,
+                                            <p>Since compression behavior of the service is set as <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_AUTO">COMPRESSION_AUTO</a>,
  entity body compression is done according to the scheme indicated in the <code>Accept-Encoding</code> request header.
  Compression is not performed when the header is not present or when the header value is &ldquo;identity&rdquo;.
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CompressionConfig.html">compression</a> annotation
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CompressionConfig">compression</a> annotation
  provides the related configurations.</p>
 
                                         </div>
@@ -310,7 +310,7 @@ service alwaysCompress on listenerEndpoint {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_ALWAYS">COMPRESSION_ALWAYS</a>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_ALWAYS">COMPRESSION_ALWAYS</a>
  guarantees a compressed response entity body. Compression scheme is set to the
  value indicated in Accept-Encoding request header. When a particular header is not present or the header
  value is &ldquo;identity&rdquo;, encoding is done using the &ldquo;gzip&rdquo; scheme.
@@ -389,13 +389,13 @@ service alwaysCompress on listenerEndpoint {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The HTTP client can indicate the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/types.html#Compression">compression</a>
+                                            <p>The HTTP client can indicate the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/types#Compression">compression</a>
  behavior (&ldquo;AUTO&rdquo;, &ldquo;ALWAYS&rdquo;, &ldquo;NEVER&rdquo;) for content negotiation.
  Depending on the compression option values, the <code>Accept-Encoding</code> header is sent along with the request.
- In this example, the client compression behavior is set as <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_ALWAYS">COMPRESSION_ALWAYS</a>. If you have not specified
+ In this example, the client compression behavior is set as <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_ALWAYS">COMPRESSION_ALWAYS</a>. If you have not specified
  an <code>Accept-Encoding</code> header, the client specifies it with &ldquo;deflate, gzip&rdquo;. Alternatively, the existing header is sent.
- When compression is specified as <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_AUTO">COMPRESSION_AUTO</a>, only the user-specified <code>Accept-Encoding</code> header is sent.
- If the behavior is set as <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_NEVER">COMPRESSION_NEVER</a>, the client makes sure not to send the <code>Accept-Encoding</code> header.</p>
+ When compression is specified as <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_AUTO">COMPRESSION_AUTO</a>, only the user-specified <code>Accept-Encoding</code> header is sent.
+ If the behavior is set as <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_NEVER">COMPRESSION_NEVER</a>, the client makes sure not to send the <code>Accept-Encoding</code> header.</p>
 
                                         </div>
                                     </div>
@@ -454,7 +454,7 @@ service alwaysCompress on listenerEndpoint {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The compression behavior of the service is inferred by <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#COMPRESSION_AUTO">COMPRESSION_AUTO</a>, which is the default value
+                                            <p>The compression behavior of the service is inferred by <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#COMPRESSION_AUTO">COMPRESSION_AUTO</a>, which is the default value
  of the compression config.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/http-cookies.html
+++ b/swan-lake/learn/by-example/http-cookies.html
@@ -38,7 +38,7 @@ redirect_from:
                 <span class="c1">// Check the password value.</span>
                 <span class="k">if</span> <span class="p">(</span><span class="nx">password</span> <span class="o">==</span> <span class="s">&quot;p@ssw0rd&quot;</span><span class="p">)</span> <span class="p">{</span>
 
-                    <span class="c1">// [Create a new cookie](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Cookie.html) by setting `name` as the `username`</span>
+                    <span class="c1">// [Create a new cookie](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Cookie) by setting `name` as the `username`</span>
                     <span class="c1">// and `value` as the logged-in user&#39;s name.</span>
                     <span class="nx">http</span><span class="p">:</span><span class="nx">Cookie</span> <span class="nx">cookie</span> <span class="p">=</span> <span class="nx">new</span><span class="p">(</span><span class="s">&quot;username&quot;</span><span class="p">,</span> <span class="nx">name</span><span class="p">.</span><span class="nx">toString</span><span class="p">());</span>
 
@@ -48,7 +48,7 @@ redirect_from:
 
                     <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span> <span class="nx">response</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
 
-                    <span class="c1">// [Add the created cookie to the response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#addCookie).</span>
+                    <span class="c1">// [Add the created cookie to the response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#addCookie).</span>
                     <span class="nx">response</span><span class="p">.</span><span class="nx">addCookie</span><span class="p">(</span><span class="nx">cookie</span><span class="p">);</span>
 
                     <span class="c1">// Set a message payload to inform that the login has</span>
@@ -68,7 +68,7 @@ redirect_from:
         <span class="nx">path</span><span class="p">:</span> <span class="s">&quot;/welcome&quot;</span>
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">welcome</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// [Retrieve cookies from the request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getCookies).</span>
+        <span class="c1">// [Retrieve cookies from the request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getCookies).</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">Cookie</span><span class="p">[]</span> <span class="nx">cookies</span> <span class="p">=</span> <span class="nx">req</span><span class="p">.</span><span class="nx">getCookies</span><span class="p">();</span>
 
         <span class="c1">// Get the cookie value of the `username`.</span>
@@ -96,7 +96,7 @@ redirect_from:
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">http</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 
-<span class="c1">// HTTP client configurations associated with [enabling cookies](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CookieConfig.html).</span>
+<span class="c1">// HTTP client configurations associated with [enabling cookies](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CookieConfig).</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">ClientConfiguration</span> <span class="nx">clientEPConfig</span> <span class="p">=</span> <span class="p">{</span>
     <span class="nx">cookieConfig</span><span class="p">:</span> <span class="p">{</span>
         <span class="nx">enabled</span><span class="p">:</span> <span class="kc">true</span>
@@ -149,7 +149,7 @@ redirect_from:
                             <h2>HTTP Cookies</h2>
                             <p><p>This example demonstrates how to handle HTTP cookies in a Ballerina service and client.
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -404,7 +404,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Cookie.html">Create a new cookie</a> by setting <code>name</code> as the <code>username</code>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Cookie">Create a new cookie</a> by setting <code>name</code> as the <code>username</code>
  and <code>value</code> as the logged-in user&rsquo;s name.</p>
 
                                         </div>
@@ -456,7 +456,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#addCookie">Add the created cookie to the response</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#addCookie">Add the created cookie to the response</a>.</p>
 
                                         </div>
                                     </div>
@@ -519,7 +519,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getCookies">Retrieve cookies from the request</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getCookies">Retrieve cookies from the request</a>.</p>
 
                                         </div>
                                     </div>
@@ -756,7 +756,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>HTTP client configurations associated with <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CookieConfig.html">enabling cookies</a>.</p>
+                                            <p>HTTP client configurations associated with <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CookieConfig">enabling cookies</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/http-cors.html
+++ b/swan-lake/learn/by-example/http-cors.html
@@ -13,7 +13,7 @@ redirect_from:
                 <div class="highlight"><pre><span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">http</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 
-<span class="c1">// Service-level [CORS config](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CorsConfig.html) applies</span>
+<span class="c1">// Service-level [CORS config](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CorsConfig) applies</span>
 <span class="c1">// globally to each `resource`.</span>
 <span class="nd">@http:ServiceConfig {</span>
     <span class="nx">cors</span><span class="p">:</span> <span class="p">{</span>
@@ -26,7 +26,7 @@ redirect_from:
 <span class="p">}</span>
 <span class="kd">service</span> <span class="nx">crossOriginService</span> <span class="nx">on</span> <span class="nx">new</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span><span class="p">(</span><span class="mi">9092</span><span class="p">)</span> <span class="p">{</span>
 
-    <span class="c1">// Resource-level [CORS config](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CorsConfig.html)</span>
+    <span class="c1">// Resource-level [CORS config](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CorsConfig)</span>
     <span class="c1">// overrides the service-level CORS headers.</span>
     <span class="nd">@http:ResourceConfig {</span>
         <span class="nx">methods</span><span class="p">:</span> <span class="p">[</span><span class="s">&quot;GET&quot;</span><span class="p">],</span>
@@ -76,7 +76,7 @@ redirect_from:
 CORS headers can be applied in both the service-level and the resource-level. Service-level CORS headers apply to all the resources
 unless there are headers configured at the resource-level. Ballerina CORS supports both simple and pre-flight requests.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -178,7 +178,7 @@ service crossOriginService on new http:Listener(9092) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Service-level <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CorsConfig.html">CORS config</a> applies
+                                            <p>Service-level <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CorsConfig">CORS config</a> applies
  globally to each <code>resource</code>.</p>
 
                                         </div>
@@ -215,7 +215,7 @@ service crossOriginService on new http:Listener(9092) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Resource-level <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CorsConfig.html">CORS config</a>
+                                            <p>Resource-level <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CorsConfig">CORS config</a>
  overrides the service-level CORS headers.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/http-data-binding.html
+++ b/swan-lake/learn/by-example/http-data-binding.html
@@ -22,7 +22,7 @@ redirect_from:
 <span class="nd">@http:ServiceConfig {</span><span class="p">}</span>
 <span class="kd">service</span> <span class="nx">hello</span> <span class="nx">on</span> <span class="nx">new</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span><span class="p">(</span><span class="mi">9090</span><span class="p">)</span> <span class="p">{</span>
 
-    <span class="c1">// The `body` annotation in the [ResourceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpResourceConfig.html)</span>
+    <span class="c1">// The `body` annotation in the [ResourceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpResourceConfig)</span>
     <span class="c1">// represents the entity body of the inbound request.</span>
     <span class="nd">@http:ResourceConfig {</span>
         <span class="nx">methods</span><span class="p">:</span> <span class="p">[</span><span class="s">&quot;POST&quot;</span><span class="p">],</span>
@@ -98,7 +98,7 @@ redirect_from:
  parameter name should be declared in the resource config under the <code>body</code> annotation. <code>string</code>, <code>json</code>, <code>xml</code>,
  <code>byte[]</code>, record, and record[] are supported as parameter types.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -239,7 +239,7 @@ service hello on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <code>body</code> annotation in the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpResourceConfig.html">ResourceConfig</a>
+                                            <p>The <code>body</code> annotation in the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpResourceConfig">ResourceConfig</a>
  represents the entity body of the inbound request.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/http-disable-chunking.html
+++ b/swan-lake/learn/by-example/http-disable-chunking.html
@@ -13,12 +13,12 @@ redirect_from:
                 <div class="highlight"><pre><span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">http</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 
-<span class="c1">// The HTTP client&#39;s chunking behavior can be configured as [CHUNKING_AUTO](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#CHUNKING_AUTO),</span>
-<span class="c1">// [CHUNKING_ALWAYS](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#CHUNKING_ALWAYS),</span>
-<span class="c1">// or [CHUNKING_NEVER](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#CHUNKING_NEVER).</span>
+<span class="c1">// The HTTP client&#39;s chunking behavior can be configured as [CHUNKING_AUTO](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#CHUNKING_AUTO),</span>
+<span class="c1">// [CHUNKING_ALWAYS](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#CHUNKING_ALWAYS),</span>
+<span class="c1">// or [CHUNKING_NEVER](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#CHUNKING_NEVER).</span>
 <span class="c1">// In this example, it is set to `CHUNKING_NEVER`, which means that chunking never happens irrespective of how it is</span>
 <span class="c1">// specified in the request. When chunking is set to `CHUNKING_AUTO`, chunking is done as specified in the request.</span>
-<span class="c1">// [http1Settings](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html) annotation</span>
+<span class="c1">// [http1Settings](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ClientHttp1Settings) annotation</span>
 <span class="c1">// provides the chunking-related configurations.</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">Client</span> <span class="nx">clientEndpoint</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="s">&quot;http://localhost:9090&quot;</span><span class="p">,</span>
                                     <span class="p">{</span><span class="nx">http1Settings</span><span class="p">:</span>
@@ -111,7 +111,7 @@ redirect_from:
                             <p><p>This sample demonstrates how to configure the chunking behavior of an HTTP client endpoint. By default, the HTTP client sends messages with the <code>content-length</code> header.
 If the message size is larger than the buffer size (8K), messages are chunked. Chunking can be disabled using the connector options.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -223,12 +223,12 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The HTTP client&rsquo;s chunking behavior can be configured as <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#CHUNKING_AUTO">CHUNKING_AUTO</a>,
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#CHUNKING_ALWAYS">CHUNKING_ALWAYS</a>,
- or <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/constants.html#CHUNKING_NEVER">CHUNKING_NEVER</a>.
+                                            <p>The HTTP client&rsquo;s chunking behavior can be configured as <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#CHUNKING_AUTO">CHUNKING_AUTO</a>,
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#CHUNKING_ALWAYS">CHUNKING_ALWAYS</a>,
+ or <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/constants#CHUNKING_NEVER">CHUNKING_NEVER</a>.
  In this example, it is set to <code>CHUNKING_NEVER</code>, which means that chunking never happens irrespective of how it is
  specified in the request. When chunking is set to <code>CHUNKING_AUTO</code>, chunking is done as specified in the request.
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html">http1Settings</a> annotation
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ClientHttp1Settings">http1Settings</a> annotation
  provides the chunking-related configurations.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/http-failover.html
+++ b/swan-lake/learn/by-example/http-failover.html
@@ -114,7 +114,7 @@ redirect_from:
                             <p><p>Ballerina users can configure multiple HTTP clients in a given failover group.
  If one of the HTTP clients (dependencies) fails, Ballerina automatically fails over to another endpoint.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/http-filters.html
+++ b/swan-lake/learn/by-example/http-filters.html
@@ -18,11 +18,11 @@ redirect_from:
 <span class="c1">// Header value to be set to the request in the filter.</span>
 <span class="nx">final</span> <span class="kt">string</span> <span class="nx">filter_name_header_value</span> <span class="p">=</span> <span class="s">&quot;RequestFilter&quot;</span><span class="p">;</span>
 
-<span class="c1">// The [Request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html) implementation.</span>
+<span class="c1">// The [Request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request) implementation.</span>
 <span class="c1">// It intercepts the request and adds a new header to the request before it is dispatched to the HTTP resource.</span>
 <span class="nx">public</span> <span class="nx">class</span> <span class="nx">RequestFilter</span> <span class="p">{</span>
     <span class="o">*</span><span class="nx">http</span><span class="p">:</span><span class="nx">RequestFilter</span><span class="p">;</span>
-    <span class="c1">// [Intercepts the request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#filterRequest).</span>
+    <span class="c1">// [Intercepts the request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#filterRequest).</span>
     <span class="nx">public</span> <span class="nx">isolated</span> <span class="kd">function</span> <span class="nx">filterRequest</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span>
                         <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">request</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">FilterContext</span> <span class="nx">context</span><span class="p">)</span>
                         <span class="nx">returns</span> <span class="kt">boolean</span> <span class="p">{</span>
@@ -36,11 +36,11 @@ redirect_from:
 <span class="c1">// Creates a new RequestFilter.</span>
 <span class="nx">RequestFilter</span> <span class="nx">requestFilter</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
 
-<span class="c1">// The [response(https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html) implementation.</span>
+<span class="c1">// The [response(https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response) implementation.</span>
 <span class="c1">// It intercepts the response in the response path and adds a new header to the response.</span>
 <span class="nx">public</span> <span class="nx">class</span> <span class="nx">ResponseFilter</span> <span class="p">{</span>
     <span class="o">*</span><span class="nx">http</span><span class="p">:</span><span class="nx">ResponseFilter</span><span class="p">;</span>
-    <span class="c1">// [Intercepts the response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#filterResponse).</span>
+    <span class="c1">// [Intercepts the response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#filterResponse).</span>
     <span class="nx">public</span> <span class="nx">isolated</span> <span class="kd">function</span> <span class="nx">filterResponse</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Response</span> <span class="nx">response</span><span class="p">,</span> 
                         <span class="nx">http</span><span class="p">:</span><span class="nx">FilterContext</span> <span class="nx">context</span><span class="p">)</span> <span class="nx">returns</span> <span class="kt">boolean</span> <span class="p">{</span>
         <span class="c1">// Sets a header to the response inside the filter.</span>
@@ -50,10 +50,10 @@ redirect_from:
     <span class="p">}</span>
 <span class="p">}</span>
 
-<span class="c1">// Creates a new [Response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html).</span>
+<span class="c1">// Creates a new [Response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response).</span>
 <span class="nx">ResponseFilter</span> <span class="nx">responseFilter</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
 
-<span class="c1">// Creates an HTTP listener and assigns the [filters as a config parameter](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ListenerConfiguration.html).</span>
+<span class="c1">// Creates an HTTP listener and assigns the [filters as a config parameter](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ListenerConfiguration).</span>
 <span class="nx">listener</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span> <span class="nx">echoListener</span> <span class="p">=</span> <span class="nx">new</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span><span class="p">(</span><span class="mi">9090</span><span class="p">,</span>
                     <span class="nx">config</span> <span class="p">=</span> <span class="p">{</span><span class="nx">filters</span><span class="p">:</span> <span class="p">[</span><span class="nx">requestFilter</span><span class="p">,</span> <span class="nx">responseFilter</span><span class="p">]});</span>
 
@@ -91,7 +91,7 @@ redirect_from:
  The request will go through the filter logic before its dispatched to the
  actual resource in the target service.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -249,7 +249,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html">Request</a> implementation.
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request">Request</a> implementation.
  It intercepts the request and adds a new header to the request before it is dispatched to the HTTP resource.</p>
 
                                         </div>
@@ -271,7 +271,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#filterRequest">Intercepts the request</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#filterRequest">Intercepts the request</a>.</p>
 
                                         </div>
                                     </div>
@@ -350,7 +350,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The [response(<a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html">https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html</a>) implementation.
+                                            <p>The [response(<a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response.html">https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response</a>) implementation.
  It intercepts the response in the response path and adds a new header to the response.</p>
 
                                         </div>
@@ -371,7 +371,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#filterResponse">Intercepts the response</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#filterResponse">Intercepts the response</a>.</p>
 
                                         </div>
                                     </div>
@@ -430,7 +430,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Creates a new <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html">Response</a>.</p>
+                                            <p>Creates a new <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response">Response</a>.</p>
 
                                         </div>
                                     </div>
@@ -450,7 +450,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Creates an HTTP listener and assigns the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ListenerConfiguration.html">filters as a config parameter</a>.</p>
+                                            <p>Creates an HTTP listener and assigns the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ListenerConfiguration">filters as a config parameter</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/http-load-balancer.html
+++ b/swan-lake/learn/by-example/http-load-balancer.html
@@ -125,7 +125,7 @@ redirect_from:
                             <p><p>An HTTP load balancing endpoint is used when the request load needs to be load balanced across a given
  set of target endpoints.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/http-redirects.html
+++ b/swan-lake/learn/by-example/http-redirects.html
@@ -14,7 +14,7 @@ redirect_from:
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 
 <span class="c1">// Creates an HTTP client to interact with a remote endpoint.</span>
-<span class="c1">// [followRedirects](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/FollowRedirects.html) record provides configurations associated with HTTP redirects.</span>
+<span class="c1">// [followRedirects](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/FollowRedirects) record provides configurations associated with HTTP redirects.</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">Client</span> <span class="nx">clientEndpoint</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="s">&quot;http://localhost:9092&quot;</span><span class="p">,</span> <span class="p">{</span>
         <span class="nx">followRedirects</span><span class="p">:</span> <span class="p">{</span><span class="nx">enabled</span><span class="p">:</span> <span class="kc">true</span><span class="p">,</span> <span class="nx">maxCount</span><span class="p">:</span> <span class="mi">5</span><span class="p">}</span>
     <span class="p">}</span>
@@ -107,7 +107,7 @@ redirect_from:
  To follow redirects when calling an external HTTP server using the Ballerina HTTP client connector, set <code>followRedirect</code>
  to true.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -220,7 +220,7 @@ import ballerina/log;
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>Creates an HTTP client to interact with a remote endpoint.
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/FollowRedirects.html">followRedirects</a> record provides configurations associated with HTTP redirects.</p>
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/FollowRedirects">followRedirects</a> record provides configurations associated with HTTP redirects.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/http-retry.html
+++ b/swan-lake/learn/by-example/http-retry.html
@@ -125,7 +125,7 @@ redirect_from:
                             <h2>Retry</h2>
                             <p><p>The HTTP retry client tries sending over the same request to the backend service when there is a network level failure.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/http-streaming.html
+++ b/swan-lake/learn/by-example/http-streaming.html
@@ -15,7 +15,7 @@ redirect_from:
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">mime</span><span class="p">;</span>
 
-<span class="c1">// Creates an endpoint for the [client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html).</span>
+<span class="c1">// Creates an endpoint for the [client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client).</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">Client</span> <span class="nx">clientEndpoint</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="s">&quot;http://localhost:9090&quot;</span><span class="p">);</span>
 
 <span class="nd">@http:ServiceConfig {</span>
@@ -31,7 +31,7 @@ redirect_from:
                                          <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">clientRequest</span><span class="p">)</span> <span class="p">{</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">request</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
 
-        <span class="c1">//[Sets the file](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#setFileAsPayload) as the request payload.</span>
+        <span class="c1">//[Sets the file](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#setFileAsPayload) as the request payload.</span>
         <span class="nx">request</span><span class="p">.</span><span class="nx">setFileAsPayload</span><span class="p">(</span><span class="s">&quot;./files/BallerinaLang.pdf&quot;</span><span class="p">,</span>
             <span class="nx">contentType</span> <span class="p">=</span> <span class="nx">mime</span><span class="p">:</span><span class="nx">APPLICATION_PDF</span><span class="p">);</span>
 
@@ -67,7 +67,7 @@ redirect_from:
         <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span> <span class="nx">res</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
         <span class="k">var</span> <span class="nx">payload</span> <span class="p">=</span> <span class="nx">clientRequest</span><span class="p">.</span><span class="nx">getByteChannel</span><span class="p">();</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">payload</span> <span class="nx">is</span> <span class="nx">io</span><span class="p">:</span><span class="nx">ReadableByteChannel</span><span class="p">)</span> <span class="p">{</span>
-            <span class="c1">//Writes the incoming stream to a file. First, [get the destination channel](https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/functions.html#openWritableFile)</span>
+            <span class="c1">//Writes the incoming stream to a file. First, [get the destination channel](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/functions#openWritableFile)</span>
             <span class="c1">//by providing the file name to which the content should be written to.</span>
             <span class="k">var</span> <span class="nx">destinationChannel</span> <span class="p">=</span>
                 <span class="nx">io</span><span class="p">:</span><span class="nx">openWritableFile</span><span class="p">(</span><span class="s">&quot;./files/ReceivedFile.pdf&quot;</span><span class="p">);</span>
@@ -105,7 +105,7 @@ redirect_from:
     <span class="c1">// The below example shows how to read all the content from</span>
     <span class="c1">// the source and copy it to the destination.</span>
     <span class="k">while</span> <span class="p">(</span><span class="kc">true</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// The operation attempts to [read](https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/classes/ReadableByteChannel.html#read) a maximum of 1000 bytes and returns</span>
+        <span class="c1">// The operation attempts to [read](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/classes/ReadableByteChannel#read) a maximum of 1000 bytes and returns</span>
         <span class="c1">// with the available content, which could be &lt; 1000.</span>
         <span class="nx">byte</span><span class="p">[]|</span><span class="nx">io</span><span class="p">:</span><span class="nx">Error</span> <span class="nx">result</span> <span class="p">=</span> <span class="nx">src</span><span class="p">.</span><span class="nx">read</span><span class="p">(</span><span class="mi">1000</span><span class="p">);</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">result</span> <span class="nx">is</span> <span class="nx">io</span><span class="p">:</span><span class="nx">EofError</span><span class="p">)</span> <span class="p">{</span>
@@ -113,7 +113,7 @@ redirect_from:
         <span class="p">}</span> <span class="k">else</span> <span class="k">if</span> <span class="p">(</span><span class="nx">result</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
             <span class="k">return</span> <span class="p">&lt;</span><span class="err">@</span><span class="nx">untainted</span><span class="p">&gt;</span><span class="nx">result</span><span class="p">;</span>
         <span class="p">}</span> <span class="k">else</span> <span class="p">{</span>
-            <span class="c1">// The operation [writes](https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/classes/WritableByteChannel.html#write) the given content into the channel.</span>
+            <span class="c1">// The operation [writes](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/classes/WritableByteChannel#write) the given content into the channel.</span>
             <span class="kt">int</span> <span class="nx">i</span> <span class="p">=</span> <span class="mi">0</span><span class="p">;</span>
             <span class="k">while</span> <span class="p">(</span><span class="nx">i</span> <span class="p">&lt;</span> <span class="nx">result</span><span class="p">.</span><span class="nx">length</span><span class="p">())</span> <span class="p">{</span>
                 <span class="k">var</span> <span class="nx">result2</span> <span class="p">=</span> <span class="nx">dst</span><span class="p">.</span><span class="nx">write</span><span class="p">(</span><span class="nx">result</span><span class="p">,</span> <span class="nx">i</span><span class="p">);</span>
@@ -149,7 +149,7 @@ redirect_from:
                             <h2>HTTP Streaming</h2>
                             <p><p>Ballerina supports HTTP input and output streaming capability through io:ReadableByteChannel.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -268,7 +268,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Creates an endpoint for the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html">client</a>.</p>
+                                            <p>Creates an endpoint for the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client">client</a>.</p>
 
                                         </div>
                                     </div>
@@ -321,7 +321,7 @@ service HTTPStreamingService on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#setFileAsPayload">Sets the file</a> as the request payload.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#setFileAsPayload">Sets the file</a> as the request payload.</p>
 
                                         </div>
                                     </div>
@@ -410,7 +410,7 @@ service HTTPStreamingService on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Writes the incoming stream to a file. First, <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/functions.html#openWritableFile">get the destination channel</a>
+                                            <p>Writes the incoming stream to a file. First, <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/functions#openWritableFile">get the destination channel</a>
 by providing the file name to which the content should be written to.</p>
 
                                         </div>
@@ -528,7 +528,7 @@ by providing the file name to which the content should be written to.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The operation attempts to <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/classes/ReadableByteChannel.html#read">read</a> a maximum of 1000 bytes and returns
+                                            <p>The operation attempts to <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/classes/ReadableByteChannel#read">read</a> a maximum of 1000 bytes and returns
  with the available content, which could be &lt; 1000.</p>
 
                                         </div>
@@ -560,7 +560,7 @@ by providing the file name to which the content should be written to.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The operation <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/classes/WritableByteChannel.html#write">writes</a> the given content into the channel.</p>
+                                            <p>The operation <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/classes/WritableByteChannel#write">writes</a> the given content into the channel.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/http-timeout.html
+++ b/swan-lake/learn/by-example/http-timeout.html
@@ -95,7 +95,7 @@ redirect_from:
                             <h2>Timeout</h2>
                             <p><p>The Timeout is used to gracefully handle network timeouts, which occur when using the HTTP Client.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/http-to-websocket-upgrade.html
+++ b/swan-lake/learn/by-example/http-to-websocket-upgrade.html
@@ -19,7 +19,7 @@ redirect_from:
 <span class="p">}</span>
 <span class="kd">service</span> <span class="nx">httpService</span> <span class="nx">on</span> <span class="nx">new</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span><span class="p">(</span><span class="mi">9090</span><span class="p">)</span> <span class="p">{</span>
     <span class="c1">// This is an HTTP to WebSocket upgrade resource. This is defined using the WebSocket upgrade resource config.</span>
-    <span class="c1">// Here you have access to the [http:Request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html), query, and path params where applicable.</span>
+    <span class="c1">// Here you have access to the [http:Request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request), query, and path params where applicable.</span>
     <span class="nd">@http:ResourceConfig {</span>
         <span class="nx">webSocketUpgrade</span><span class="p">:</span> <span class="p">{</span>
             <span class="nx">upgradePath</span><span class="p">:</span> <span class="s">&quot;/ws&quot;</span><span class="p">,</span>
@@ -34,7 +34,7 @@ redirect_from:
 
 <span class="c1">// Note: When a WebSocket upgrade path is defined in the HTTP resource configuration. &lt;br&gt;</span>
 <span class="c1">// - Without service configuration for WebSocketService default values are taken for sub protocols, idle timeout etc.&lt;br&gt;</span>
-<span class="c1">// - If [WebSocketServiceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/annotations.html#WebSocketServiceConfig) is defined without the path, sub protocols, idle timeout etc. can be configured.&lt;br&gt;</span>
+<span class="c1">// - If [WebSocketServiceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/annotations#WebSocketServiceConfig) is defined without the path, sub protocols, idle timeout etc. can be configured.&lt;br&gt;</span>
 <span class="c1">// - If path is defined in the `WebSocketServiceConfig` it shall be ignored.&lt;br&gt;</span>
 <span class="c1">// - This service can also be bound to a different `Listener` in which case the path configuration becomes useful.</span>
 <span class="kd">service</span> <span class="nx">wsService</span> <span class="p">=</span> <span class="nd">@http:WebSocketServiceConfig {</span><span class="nx">subProtocols</span><span class="p">:</span> <span class="p">[</span><span class="s">&quot;xml, json&quot;</span><span class="p">]</span>
@@ -67,7 +67,7 @@ redirect_from:
                             <h2>HTTP To WebSocket Upgrade</h2>
                             <p><p>This sample demonstrates how an HTTP endpoint is updated to a WebSocket endpoint using an upgrade resource.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -191,7 +191,7 @@ service httpService on new http:Listener(9090) {
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>This is an HTTP to WebSocket upgrade resource. This is defined using the WebSocket upgrade resource config.
- Here you have access to the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html">http:Request</a>, query, and path params where applicable.</p>
+ Here you have access to the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request">http:Request</a>, query, and path params where applicable.</p>
 
                                         </div>
                                     </div>
@@ -226,7 +226,7 @@ service httpService on new http:Listener(9090) {
                                         <div>
                                             <p>Note: When a WebSocket upgrade path is defined in the HTTP resource configuration. <br>
  - Without service configuration for WebSocketService default values are taken for sub protocols, idle timeout etc.<br>
- - If <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/annotations.html#WebSocketServiceConfig">WebSocketServiceConfig</a> is defined without the path, sub protocols, idle timeout etc. can be configured.<br>
+ - If <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/annotations#WebSocketServiceConfig">WebSocketServiceConfig</a> is defined without the path, sub protocols, idle timeout etc. can be configured.<br>
  - If path is defined in the <code>WebSocketServiceConfig</code> it shall be ignored.<br>
  - This service can also be bound to a different <code>Listener</code> in which case the path configuration becomes useful.</p>
 

--- a/swan-lake/learn/by-example/http-trace-logs.html
+++ b/swan-lake/learn/by-example/http-trace-logs.html
@@ -22,7 +22,7 @@ redirect_from:
         <span class="nx">path</span><span class="p">:</span> <span class="s">&quot;/&quot;</span>
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">sayHello</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// Create a new [http:Client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html).</span>
+        <span class="c1">// Create a new [http:Client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client).</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">Client</span> <span class="nx">clientEP</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="s">&quot;http://httpstat.us&quot;</span><span class="p">);</span>
         <span class="c1">// Forward incoming requests to the remote backend.</span>
         <span class="k">var</span> <span class="nx">resp</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">forward</span><span class="p">(</span><span class="s">&quot;/200&quot;</span><span class="p">,</span> <span class="nx">req</span><span class="p">);</span>
@@ -49,7 +49,7 @@ redirect_from:
                             <h2>Trace Logs</h2>
                             <p><p>The HTTP trace logs can be used to monitor the HTTP traffic that goes in and out of Ballerina.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -166,7 +166,7 @@ service helloWorld on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Create a new <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html">http:Client</a>.</p>
+                                            <p>Create a new <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client">http:Client</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/https-listener.html
+++ b/swan-lake/learn/by-example/https-listener.html
@@ -17,7 +17,7 @@ redirect_from:
 <span class="c1">// An HTTP endpoint can be configured to communicate through HTTPS as well.</span>
 <span class="c1">// To secure an endpoint using HTTPS, the endpoint needs to be configured with</span>
 <span class="c1">// a keystore and its `password` for the endpoint.</span>
-<span class="c1">// The [secureSocket](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html) record provides the SSL-related listener configurations.</span>
+<span class="c1">// The [secureSocket](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ListenerSecureSocket) record provides the SSL-related listener configurations.</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">ListenerConfiguration</span> <span class="nx">helloWorldEPConfig</span> <span class="p">=</span> <span class="p">{</span>
     <span class="nx">secureSocket</span><span class="p">:</span> <span class="p">{</span>
         <span class="nx">keyStore</span><span class="p">:</span> <span class="p">{</span>
@@ -60,7 +60,7 @@ redirect_from:
                             <p><p>You can use the HTTPS Listener to connect or interact with an HTTPS client.
  Provide the Secure Socket configuration to the server to expose an HTTPS connection.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -169,7 +169,7 @@ import ballerina/log;
                                             <p>An HTTP endpoint can be configured to communicate through HTTPS as well.
  To secure an endpoint using HTTPS, the endpoint needs to be configured with
  a keystore and its <code>password</code> for the endpoint.
- The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html">secureSocket</a> record provides the SSL-related listener configurations.</p>
+ The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ListenerSecureSocket">secureSocket</a> record provides the SSL-related listener configurations.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/invoke-java-methods.html
+++ b/swan-lake/learn/by-example/invoke-java-methods.html
@@ -48,7 +48,7 @@ redirect_from:
     <span class="k">var</span> <span class="nx">arrayDeque</span> <span class="p">=</span> <span class="nx">newArrayDeque</span><span class="p">();</span>
 
     <span class="c1">// Ballerina strings are different from Java strings. </span>
-    <span class="c1">// The [fromString](https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/functions.html#fromString) function in </span>
+    <span class="c1">// The [fromString](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/functions#fromString) function in </span>
     <span class="c1">// `ballerina/java` module converts a Ballerina string value to a Java String representation.</span>
     <span class="c1">// Java String is a reference type; hence,</span>
     <span class="c1">// this method returns a handle value referring to the created to Java string.</span>
@@ -57,7 +57,7 @@ redirect_from:
     <span class="nx">_</span> <span class="p">=</span> <span class="nx">offer</span><span class="p">(</span><span class="nx">arrayDeque</span><span class="p">,</span> <span class="nx">java</span><span class="p">:</span><span class="nx">fromString</span><span class="p">(</span><span class="s">&quot;Peter&quot;</span><span class="p">));</span>
 
     <span class="k">var</span> <span class="nx">nextInLineHandle</span> <span class="p">=</span> <span class="nx">poll</span><span class="p">(</span><span class="nx">arrayDeque</span><span class="p">);</span>
-    <span class="c1">// The [toString](https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/functions.html#toString) function in </span>
+    <span class="c1">// The [toString](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/functions#toString) function in </span>
     <span class="c1">// `ballerina/java` module creates a Ballerina string</span>
     <span class="c1">// representation of the Java reference value.</span>
     <span class="kt">string</span><span class="p">? nextInLine = java:toString(</span><span class="nx">nextInLineHandle</span><span class="p">);</span>
@@ -75,7 +75,7 @@ redirect_from:
                             <p><p>The <code>Method</code> annotation in <code>ballerina/java</code> module allows you to link a Java method (static or instance) with a
  Ballerina function with an external function body.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/index.html">Java module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/">Java module</a>.</p>
 </p>
 
                         </td>
@@ -326,7 +326,7 @@ import ballerina/java;
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>Ballerina strings are different from Java strings.
- The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/functions.html#fromString">fromString</a> function in
+ The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/functions#fromString">fromString</a> function in
  <code>ballerina/java</code> module converts a Ballerina string value to a Java String representation.
  Java String is a reference type; hence,
  this method returns a handle value referring to the created to Java string.</p>
@@ -362,7 +362,7 @@ import ballerina/java;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/functions.html#toString">toString</a> function in
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/functions#toString">toString</a> function in
  <code>ballerina/java</code> module creates a Ballerina string
  representation of the Java reference value.</p>
 

--- a/swan-lake/learn/by-example/java-arrays.html
+++ b/swan-lake/learn/by-example/java-arrays.html
@@ -47,7 +47,7 @@ redirect_from:
                             <p><p>Java arrays are represented by the <code>handle</code> type in Ballerina. They can be manipulated using the
  <code>get</code>, <code>set</code>, and <code>getLength</code> methods provided by the <code>ballerina/java.arrays</code> module.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/java.arrays/index.html">java.arrays module</a></p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java.arrays/">java.arrays module</a></p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/java-exceptions.html
+++ b/swan-lake/learn/by-example/java-exceptions.html
@@ -65,7 +65,7 @@ redirect_from:
  should have the <code>error</code> type in its return signature.
  Let&rsquo;s look at how to handle Java exceptions in Ballerina.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/index.html">Java module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/">Java module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/java-varargs.html
+++ b/swan-lake/learn/by-example/java-varargs.html
@@ -40,7 +40,7 @@ redirect_from:
  If there are overloaded Java methods and you want to remove the ambiguity, the <code>paramTypes</code> field can be used
  to specify the element class type and dimension.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/index.html">Java module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/">Java module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/jdbc-batch-execute-operation.html
+++ b/swan-lake/learn/by-example/jdbc-batch-execute-operation.html
@@ -162,7 +162,7 @@ redirect_from:
  default into the Ballerina distribution. Therefore, it is not required to
  copy the driver JAR for H2 databases.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/jdbc/index.html">JDBC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/jdbc/">JDBC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/jdbc-complex-type-queries.html
+++ b/swan-lake/learn/by-example/jdbc-complex-type-queries.html
@@ -227,7 +227,7 @@ redirect_from:
  Ballerina distribution. Therefore, it is not required to copy the driver JAR
  for the H2 database.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/jdbc/index.html">JDBC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/jdbc/">JDBC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/jdbc-execute-operation.html
+++ b/swan-lake/learn/by-example/jdbc-execute-operation.html
@@ -115,7 +115,7 @@ redirect_from:
  default into the Ballerina distribution. Therefore, it is not required to
  copy the driver JAR for H2 databases.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/jdbc/index.html">JDBC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/jdbc/">JDBC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/jdbc-init-options.html
+++ b/swan-lake/learn/by-example/jdbc-init-options.html
@@ -108,7 +108,7 @@ redirect_from:
  default in the Ballerina distribution. Therefore, it is not required to copy
  the driver JAR for H2 databases.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/jdbc/index.html">JDBC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/jdbc/">JDBC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/jdbc-parameterized-query.html
+++ b/swan-lake/learn/by-example/jdbc-parameterized-query.html
@@ -150,7 +150,7 @@ redirect_from:
  driver JAR is included by default into the Ballerina distribution.
  Therefore, it is not required to copy the driver JAR for H2 databases.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/jdbc/index.html">JDBC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/jdbc/">JDBC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/jdbc-query-operation.html
+++ b/swan-lake/learn/by-example/jdbc-query-operation.html
@@ -161,7 +161,7 @@ redirect_from:
  default in the Ballerina distribution. Therefore, it is not required to copy
  the driver JAR for H2 databases.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/jdbc/index.html">JDBC module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/jdbc/">JDBC module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/json-io.html
+++ b/swan-lake/learn/by-example/json-io.html
@@ -96,7 +96,7 @@ redirect_from:
                             <p><p>This sample demonstrates how to read JSON content from a file and write JSON content
  to a file using the character channel, <code>readJson()</code>, and <code>writeJson()</code> of the I/O API.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/index.html">IO module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/">IO module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/jwt-issue-validate.html
+++ b/swan-lake/learn/by-example/jwt-issue-validate.html
@@ -163,7 +163,7 @@ redirect_from:
                             <h2>JWT Issue/Validate</h2>
                             <p><p>This example demonstrates how to issue and validate a JWT.
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/jwt/index.html">JWT module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/jwt/">JWT module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/kafka-authentication-sasl-plain-consumer.html
+++ b/swan-lake/learn/by-example/kafka-authentication-sasl-plain-consumer.html
@@ -61,7 +61,7 @@ redirect_from:
  and it should be configured to use the SASL/PLAIN authentication mechanism.
  <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/kafka/index.html">Kafka module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/kafka/">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/kafka-authentication-sasl-plain-producer.html
+++ b/swan-lake/learn/by-example/kafka-authentication-sasl-plain-producer.html
@@ -56,7 +56,7 @@ redirect_from:
  and it should be configured to use the SASL/PLAIN authentication mechanism.
  <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/kafka/index.html">Kafka module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/kafka/">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/kafka-consumer-client.html
+++ b/swan-lake/learn/by-example/kafka-consumer-client.html
@@ -75,7 +75,7 @@ redirect_from:
  this example to work properly, an active Kafka broker should be present.
  <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/kafka/index.html">Kafka module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/kafka/">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/kafka-consumer-group-service.html
+++ b/swan-lake/learn/by-example/kafka-consumer-group-service.html
@@ -73,7 +73,7 @@ redirect_from:
  values. For this example to work properly, an active Kafka broker should be
  present.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/kafka/index.html">Kafka module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/kafka/">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/kafka-consumer-service.html
+++ b/swan-lake/learn/by-example/kafka-consumer-service.html
@@ -92,7 +92,7 @@ redirect_from:
  builtin <code>string</code> deserializer for the values. For this example to work
  properly, an active Kafka broker should be present.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/kafka/index.html">Kafka module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/kafka/">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/kafka-producer-transactional.html
+++ b/swan-lake/learn/by-example/kafka-producer-transactional.html
@@ -72,7 +72,7 @@ redirect_from:
  this example to work properly, an active Kafka broker should be present.
  <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/kafka/index.html">Kafka module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/kafka/">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/kafka-producer.html
+++ b/swan-lake/learn/by-example/kafka-producer.html
@@ -65,7 +65,7 @@ redirect_from:
  values and <code>int</code> keys. For this example to work properly, an active Kafka
  broker should be present.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/kafka/index.html">Kafka module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/kafka/">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/local-transactions-with-handlers.html
+++ b/swan-lake/learn/by-example/local-transactions-with-handlers.html
@@ -80,7 +80,7 @@ redirect_from:
  system in a consistent state. This example demonstrates how to use
  transaction util methods and the various usages of them.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/lang.transaction/index.html">Transactions module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/lang.transaction/">Transactions module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/local-transactions.html
+++ b/swan-lake/learn/by-example/local-transactions.html
@@ -76,7 +76,7 @@ redirect_from:
  system in a consistent state. This sample uses an H2 database, which is
  created when running the sample. <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/lang.transaction/index.html">Transactions module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/lang.transaction/">Transactions module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/log-api.html
+++ b/swan-lake/learn/by-example/log-api.html
@@ -45,7 +45,7 @@ redirect_from:
                         <td class="cLeftTD">
                             <h2>Log</h2>
                             <p><p>The Ballerina Log API contains the application log handling
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/log/index.html#functions">functions</a>.<br/><br/>
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/log/#functions">functions</a>.<br/><br/>
  To set the log level of the API, use the following CLI parameter: <br>
  <code>--b7a.log.level=[LOG_LEVEL]</code></p>
 
@@ -63,7 +63,7 @@ redirect_from:
 
 <p>E.g., <code>--foo.loglevel=DEBUG</code> <br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/log/index.html">Log module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/log/">Log module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/maps.html
+++ b/swan-lake/learn/by-example/maps.html
@@ -130,7 +130,7 @@ redirect_from:
                             <p><p>The <code>map</code> type in Ballerina defines a mutable mapping from keys (that are strings) to values of the type specified as
  the map&rsquo;s constraint type.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/lang.map/index.html">lang.map module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/lang.map/">lang.map module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/math-functions.html
+++ b/swan-lake/learn/by-example/math-functions.html
@@ -18,37 +18,37 @@ redirect_from:
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Value of PI: &quot;</span><span class="p">,</span> <span class="nx">math</span><span class="p">:</span><span class="nx">PI</span><span class="p">);</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Value of E: &quot;</span><span class="p">,</span> <span class="nx">math</span><span class="p">:</span><span class="nx">E</span><span class="p">);</span>
 
-    <span class="c1">// The [absFloat](https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#absFloat) function returns</span>
+    <span class="c1">// The [absFloat](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#absFloat) function returns</span>
     <span class="c1">// the absolute value of a `float` value.</span>
     <span class="kt">float</span> <span class="nx">absoluteFloatValue</span> <span class="p">=</span> <span class="nx">math</span><span class="p">:</span><span class="nx">absFloat</span><span class="p">(</span><span class="o">-</span><span class="mf">152.2544</span><span class="p">);</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Absolute value of -152.2544: &quot;</span><span class="p">,</span> <span class="nx">absoluteFloatValue</span><span class="p">);</span>
 
-    <span class="c1">// The [absInt](https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#absInt) function returns</span>
+    <span class="c1">// The [absInt](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#absInt) function returns</span>
     <span class="c1">// the absolute value of an `int` value.</span>
     <span class="kt">int</span> <span class="nx">absoluteIntValue</span> <span class="p">=</span> <span class="nx">math</span><span class="p">:</span><span class="nx">absInt</span><span class="p">(</span><span class="o">-</span><span class="mi">152</span><span class="p">);</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Absolute value of -152: &quot;</span><span class="p">,</span> <span class="nx">absoluteIntValue</span><span class="p">);</span>
 
-    <span class="c1">// The [acos](https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#acos) function</span>
+    <span class="c1">// The [acos](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#acos) function</span>
     <span class="c1">// returns the arc cosine of a value.</span>
     <span class="kt">float</span> <span class="nx">acosValue</span> <span class="p">=</span> <span class="nx">math</span><span class="p">:</span><span class="nx">acos</span><span class="p">(</span><span class="mf">0.027415567780803774</span><span class="p">);</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Arc cosine of 0.027415567780803774: &quot;</span><span class="p">,</span> <span class="nx">acosValue</span><span class="p">);</span>
 
-    <span class="c1">// The [asin](https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#asin) function</span>
+    <span class="c1">// The [asin](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#asin) function</span>
     <span class="c1">// returns the arc sine of a value.</span>
     <span class="kt">float</span> <span class="nx">arcSineValue</span> <span class="p">=</span> <span class="nx">math</span><span class="p">:</span><span class="nx">asin</span><span class="p">(</span><span class="mf">0.027415567780803774</span><span class="p">);</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Arc sine of 0.027415567780803774: &quot;</span><span class="p">,</span> <span class="nx">arcSineValue</span><span class="p">);</span>
 
-    <span class="c1">// The [atan](https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#atan) function</span>
+    <span class="c1">// The [atan](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#atan) function</span>
     <span class="c1">// returns the arc tangent of a value.</span>
     <span class="kt">float</span> <span class="nx">arcTangent</span> <span class="p">=</span> <span class="nx">math</span><span class="p">:</span><span class="nx">atan</span><span class="p">(</span><span class="mf">0.027415567780803774</span><span class="p">);</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Arc tangent of 0.027415567780803774: &quot;</span><span class="p">,</span> <span class="nx">arcTangent</span><span class="p">);</span>
 
-    <span class="c1">// The [cbrt](https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#cbrt) function</span>
+    <span class="c1">// The [cbrt](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#cbrt) function</span>
     <span class="c1">// returns the cube root of a `float` value.</span>
     <span class="kt">float</span> <span class="nx">cubeRoot</span> <span class="p">=</span> <span class="nx">math</span><span class="p">:</span><span class="nx">cbrt</span><span class="p">(</span><span class="o">-</span><span class="mf">27.0</span><span class="p">);</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Cube root of -27.0: &quot;</span><span class="p">,</span> <span class="nx">cubeRoot</span><span class="p">);</span>
 
-    <span class="c1">// There are over 40 [functions](https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/index.html#functions) in the</span>
+    <span class="c1">// There are over 40 [functions](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/#functions) in the</span>
     <span class="c1">// ballerina math API that can be used to perform numeric operations.</span>
 <span class="p">}</span>
 </pre></div>
@@ -62,7 +62,7 @@ redirect_from:
                             <h2>Math</h2>
                             <p><p>The Ballerina Math API contains methods to perform various numerical operations.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/index.html">Math module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/">Math module</a>.</p>
 </p>
 
                         </td>
@@ -193,7 +193,7 @@ import ballerina/math;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#absFloat">absFloat</a> function returns
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#absFloat">absFloat</a> function returns
  the absolute value of a <code>float</code> value.</p>
 
                                         </div>
@@ -214,7 +214,7 @@ import ballerina/math;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#absInt">absInt</a> function returns
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#absInt">absInt</a> function returns
  the absolute value of an <code>int</code> value.</p>
 
                                         </div>
@@ -235,7 +235,7 @@ import ballerina/math;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#acos">acos</a> function
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#acos">acos</a> function
  returns the arc cosine of a value.</p>
 
                                         </div>
@@ -256,7 +256,7 @@ import ballerina/math;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#asin">asin</a> function
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#asin">asin</a> function
  returns the arc sine of a value.</p>
 
                                         </div>
@@ -277,7 +277,7 @@ import ballerina/math;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#atan">atan</a> function
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#atan">atan</a> function
  returns the arc tangent of a value.</p>
 
                                         </div>
@@ -298,7 +298,7 @@ import ballerina/math;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/functions.html#cbrt">cbrt</a> function
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/functions#cbrt">cbrt</a> function
  returns the cube root of a <code>float</code> value.</p>
 
                                         </div>
@@ -318,7 +318,7 @@ import ballerina/math;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>There are over 40 <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/math/index.html#functions">functions</a> in the
+                                            <p>There are over 40 <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/math/#functions">functions</a> in the
  ballerina math API that can be used to perform numeric operations.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/mutual-ssl.html
+++ b/swan-lake/learn/by-example/mutual-ssl.html
@@ -16,7 +16,7 @@ redirect_from:
 
 <span class="c1">// Create an HTTP listener configuration, which will configure a listener to</span>
 <span class="c1">// accept new connections that are secured via mutual SSL.</span>
-<span class="c1">// [secureSocket](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html) record provides the SSL related listener configurations.</span>
+<span class="c1">// [secureSocket](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ListenerSecureSocket) record provides the SSL related listener configurations.</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">ListenerConfiguration</span> <span class="nx">helloWorldEPConfig</span> <span class="p">=</span> <span class="p">{</span>
     <span class="nx">secureSocket</span><span class="p">:</span> <span class="p">{</span>
         <span class="nx">keyStore</span><span class="p">:</span> <span class="p">{</span>
@@ -69,7 +69,7 @@ redirect_from:
 <span class="c1">// Create a client configuration to be passed to the client endpoint.</span>
 <span class="c1">// Configure the `keyStore` file `path` and `password`, `truststore`</span>
 <span class="c1">// file `path` and `password`, which are required to enable mutual SSL.</span>
-<span class="c1">// [secureSocket](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ClientSecureSocket.html) record provides the SSL related configurations.</span>
+<span class="c1">// [secureSocket](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ClientSecureSocket) record provides the SSL related configurations.</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">ClientConfiguration</span> <span class="nx">clientEPConfig</span> <span class="p">=</span> <span class="p">{</span>
     <span class="nx">secureSocket</span><span class="p">:</span> <span class="p">{</span>
         <span class="nx">keyStore</span><span class="p">:</span> <span class="p">{</span>
@@ -115,7 +115,7 @@ redirect_from:
 server) authenticate each other by verifying the digital certificates. It ensures that both parties are assured of
 each other&rsquo;s identity.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -234,7 +234,7 @@ import ballerina/log;
                                         <div>
                                             <p>Create an HTTP listener configuration, which will configure a listener to
  accept new connections that are secured via mutual SSL.
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html">secureSocket</a> record provides the SSL related listener configurations.</p>
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ListenerSecureSocket">secureSocket</a> record provides the SSL related listener configurations.</p>
 
                                         </div>
                                     </div>
@@ -516,7 +516,7 @@ import ballerina/log;
                                             <p>Create a client configuration to be passed to the client endpoint.
  Configure the <code>keyStore</code> file <code>path</code> and <code>password</code>, <code>truststore</code>
  file <code>path</code> and <code>password</code>, which are required to enable mutual SSL.
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/ClientSecureSocket.html">secureSocket</a> record provides the SSL related configurations.</p>
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/ClientSecureSocket">secureSocket</a> record provides the SSL related configurations.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/mysql-batch-execute-operation.html
+++ b/swan-lake/learn/by-example/mysql-batch-execute-operation.html
@@ -194,7 +194,7 @@ redirect_from:
  properties from MySQL version 8.0.x onwards. Therefore, it is
  recommended to use a MySQL driver version greater than 8.0.x.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mysql/index.html">MySQL module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mysql/">MySQL module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/mysql-call-stored-procedures.html
+++ b/swan-lake/learn/by-example/mysql-call-stored-procedures.html
@@ -211,7 +211,7 @@ redirect_from:
  properties from MySQL version 8.0.x onwards. Therefore, it is
  recommended to use a MySQL driver version greater than 8.0.x.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mysql/index.html">MySQL module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mysql/">MySQL module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/mysql-complex-type-queries.html
+++ b/swan-lake/learn/by-example/mysql-complex-type-queries.html
@@ -185,7 +185,7 @@ redirect_from:
  onwards. Therefore, it is recommended to use a MySQL driver version greater
  than 8.0.x.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mysql/index.html">MySQL module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mysql/">MySQL module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/mysql-execute-operation.html
+++ b/swan-lake/learn/by-example/mysql-execute-operation.html
@@ -141,7 +141,7 @@ redirect_from:
  properties from MySQL version 8.0.x onwards. Therefore, it is
  recommended to use a MySQL driver version greater than 8.0.x.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mysql/index.html">MySQL module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mysql/">MySQL module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/mysql-init-options.html
+++ b/swan-lake/learn/by-example/mysql-init-options.html
@@ -141,7 +141,7 @@ redirect_from:
  database properties from MySQL version 8.0.x onwards. Therefore, it is
  recommended to use a MySQL driver version greater than 8.0.x.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mysql/index.html">MySQL module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mysql/">MySQL module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/mysql-parameterized-query.html
+++ b/swan-lake/learn/by-example/mysql-parameterized-query.html
@@ -180,7 +180,7 @@ redirect_from:
  version 8.0.x onwards. Therefore, it is recommended to use a MySQL driver
  version greater than 8.0.x.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mysql/index.html">MySQL module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mysql/">MySQL module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/mysql-query-operation.html
+++ b/swan-lake/learn/by-example/mysql-query-operation.html
@@ -171,7 +171,7 @@ redirect_from:
  database properties from MySQL version 8.0.x onwards. Therefore, it is
  recommended to use a MySQL driver version greater than 8.0.x.<br><br>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mysql/index.html">MySQL module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mysql/">MySQL module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/nats-basic-client.html
+++ b/swan-lake/learn/by-example/nats-basic-client.html
@@ -70,7 +70,7 @@ redirect_from:
  For instructions on installing the NATS server,
  go to <a href="https://docs.nats.io/nats-server/installation">NATS Server Installation</a>.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/nats/index.html">NATS module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/nats/">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/nats-streaming-client.html
+++ b/swan-lake/learn/by-example/nats-streaming-client.html
@@ -73,7 +73,7 @@ redirect_from:
  In order to run this sample, a NATS Streaming server should be
  running on the corresponding port used in the sample.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/nats/index.html">NATS module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/nats/">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/nats-streaming-consumer-with-data-binding.html
+++ b/swan-lake/learn/by-example/nats-streaming-consumer-with-data-binding.html
@@ -72,7 +72,7 @@ redirect_from:
  services to bind the data in the incoming message to
  a user-provided compatible type.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/nats/index.html">NATS module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/nats/">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/nats-streaming-durable-subscriptions.html
+++ b/swan-lake/learn/by-example/nats-streaming-durable-subscriptions.html
@@ -86,7 +86,7 @@ redirect_from:
  disconnects, the position is lost. Durable subscriptions
  remember their position even if the client is disconnected.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/nats/index.html">NATS module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/nats/">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/nats-streaming-queue-group.html
+++ b/swan-lake/learn/by-example/nats-streaming-queue-group.html
@@ -139,7 +139,7 @@ redirect_from:
  to receive the message. Although queue groups have multiple subscribers,
  each message is consumed by only one.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/nats/index.html">NATS module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/nats/">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/nats-streaming-start-position.html
+++ b/swan-lake/learn/by-example/nats-streaming-start-position.html
@@ -191,7 +191,7 @@ redirect_from:
     (e.g., the last 30 seconds).
  4. A specific message sequence number<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/nats/index.html">NATS module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/nats/">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/overloaded-methods-constructors.html
+++ b/swan-lake/learn/by-example/overloaded-methods-constructors.html
@@ -68,7 +68,7 @@ redirect_from:
  parameters, then you need to specify the parameter types of the exact constructor or the method using the
  <code>paramTypes</code> annotation field.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/java/index.html">Java module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/java/">Java module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/passthrough.html
+++ b/swan-lake/learn/by-example/passthrough.html
@@ -23,7 +23,7 @@ redirect_from:
         <span class="nx">path</span><span class="p">:</span> <span class="s">&quot;/&quot;</span>
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">passthrough</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// When [forward()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#forward) is called on the backend client endpoint, it forwards the request that the passthrough</span>
+        <span class="c1">// When [forward()](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#forward) is called on the backend client endpoint, it forwards the request that the passthrough</span>
         <span class="c1">// resource received to the backend. When forwarding, the request is made using the same HTTP method that was</span>
         <span class="c1">// used to invoke the passthrough resource. The `forward()` function returns the response from the backend if</span>
         <span class="c1">// there are no errors.</span>
@@ -59,7 +59,7 @@ redirect_from:
         <span class="nx">path</span><span class="p">:</span> <span class="s">&quot;/&quot;</span>
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">helloResource</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// [Send the response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Caller.html#respond) back to the caller.</span>
+        <span class="c1">// [Send the response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Caller#respond) back to the caller.</span>
         <span class="k">var</span> <span class="nx">result</span> <span class="p">=</span> <span class="nx">caller</span><span class="o">-&gt;</span><span class="nx">respond</span><span class="p">(</span><span class="s">&quot;Hello World!&quot;</span><span class="p">);</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">result</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
             <span class="nx">log</span><span class="p">:</span><span class="nx">printError</span><span class="p">(</span><span class="s">&quot;Error sending response&quot;</span><span class="p">,</span> <span class="nx">result</span><span class="p">);</span>
@@ -77,7 +77,7 @@ redirect_from:
                             <h2>Passthrough</h2>
                             <p><p>The passthrough sample exhibits the process of an HTTP client connector. The &lsquo;Echo Service&rsquo; is used as a sample backend.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -231,7 +231,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>When <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Client.html#forward">forward()</a> is called on the backend client endpoint, it forwards the request that the passthrough
+                                            <p>When <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Client#forward">forward()</a> is called on the backend client endpoint, it forwards the request that the passthrough
  resource received to the backend. When forwarding, the request is made using the same HTTP method that was
  used to invoke the passthrough resource. The <code>forward()</code> function returns the response from the backend if
  there are no errors.</p>
@@ -371,7 +371,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/Caller.html#respond">Send the response</a> back to the caller.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/Caller#respond">Send the response</a> back to the caller.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/proto-to-ballerina.html
+++ b/swan-lake/learn/by-example/proto-to-ballerina.html
@@ -33,7 +33,7 @@ redirect_from:
  <code>--mode</code> The mode (client or server) to generate code samples.
  If no value is specified for this parameter, only the stub file will be generated.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/grpc/index.html">GRPC module</a> and
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/grpc/">GRPC module</a> and
  <a href="https://ballerina.io/swan-lake/learn/how-to-generate-code-for-protocol-buffers/">How to generate Ballerina code for Protocol Buffer Definition</a>.</p>
 </p>
 

--- a/swan-lake/learn/by-example/query-path-matrix-param.html
+++ b/swan-lake/learn/by-example/query-path-matrix-param.html
@@ -22,11 +22,11 @@ redirect_from:
     <span class="c1">// The `PathParam` and `QueryParam` parameters extract values from the request URI.</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">params</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">,</span>
                                 <span class="kt">string</span> <span class="nx">foo</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// Get the [QueryParam](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getQueryParamValue)</span>
+        <span class="c1">// Get the [QueryParam](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getQueryParamValue)</span>
         <span class="c1">// value for a given parameter key.</span>
         <span class="k">var</span> <span class="nx">bar</span> <span class="p">=</span> <span class="nx">req</span><span class="p">.</span><span class="nx">getQueryParamValue</span><span class="p">(</span><span class="s">&quot;bar&quot;</span><span class="p">);</span>
 
-        <span class="c1">// Get the [MatrixParams](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getMatrixParams).</span>
+        <span class="c1">// Get the [MatrixParams](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getMatrixParams).</span>
         <span class="kt">map</span><span class="p">&lt;</span><span class="kt">any</span><span class="p">&gt;</span> <span class="nx">pathMParams</span> <span class="p">=</span> <span class="nx">req</span><span class="p">.</span><span class="nx">getMatrixParams</span><span class="p">(</span><span class="s">&quot;/sample/path&quot;</span><span class="p">);</span>
         <span class="k">var</span> <span class="nx">a</span> <span class="p">=</span> <span class="p">&lt;</span><span class="kt">string</span><span class="p">&gt;</span><span class="nx">pathMParams</span><span class="p">[</span><span class="s">&quot;a&quot;</span><span class="p">];</span>
         <span class="k">var</span> <span class="nx">b</span> <span class="p">=</span> <span class="p">&lt;</span><span class="kt">string</span><span class="p">&gt;</span><span class="nx">pathMParams</span><span class="p">[</span><span class="s">&quot;b&quot;</span><span class="p">];</span>
@@ -65,7 +65,7 @@ redirect_from:
                             <h2>Query Path Matrix Param</h2>
                             <p><p>Ballerina supports extracting values using the <code>PathParam</code>, <code>QueryParam</code> and <code>MatrixParam</code> parameters.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -217,7 +217,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Get the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getQueryParamValue">QueryParam</a>
+                                            <p>Get the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getQueryParamValue">QueryParam</a>
  value for a given parameter key.</p>
 
                                         </div>
@@ -245,7 +245,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Get the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getMatrixParams">MatrixParams</a>.</p>
+                                            <p>Get the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getMatrixParams">MatrixParams</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html
+++ b/swan-lake/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html
@@ -64,7 +64,7 @@ redirect_from:
  By default, the ackMode is rabbitmq:AUTO_ACK, which will automatically acknowledge
  all messages once consumed.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/rabbitmq/index.html">RabbitMQ module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/rabbitmq/">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/rabbitmq-consumer-with-data-binding.html
+++ b/swan-lake/learn/by-example/rabbitmq-consumer-with-data-binding.html
@@ -72,7 +72,7 @@ redirect_from:
  <code>string</code>, <code>json</code>, <code>xml</code>, <code>byte[]</code>, <code>record</code>, <code>float</code> and <code>int</code> are
  supported as parameter types.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/rabbitmq/index.html">RabbitMQ module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/rabbitmq/">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/rabbitmq-consumer-with-qos-settings.html
+++ b/swan-lake/learn/by-example/rabbitmq-consumer-with-qos-settings.html
@@ -76,7 +76,7 @@ redirect_from:
  To apply the settings per consumer service, they should be specified in the
  service config annotation.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/rabbitmq/index.html">RabbitMQ module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/rabbitmq/">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/rabbitmq-consumer.html
+++ b/swan-lake/learn/by-example/rabbitmq-consumer.html
@@ -58,7 +58,7 @@ redirect_from:
  Multiple services consuming messages from the same queue or from
  different queues can be attached to the same Listener.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/rabbitmq/index.html">RabbitMQ module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/rabbitmq/">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/rabbitmq-producer.html
+++ b/swan-lake/learn/by-example/rabbitmq-producer.html
@@ -79,7 +79,7 @@ redirect_from:
                             <p><p>In this example, messages are sent to two different queues,
  to one queue using the same channel and to the other using two different channels.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/rabbitmq/index.html">RabbitMQ module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/rabbitmq/">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/rabbitmq-transaction-consumer.html
+++ b/swan-lake/learn/by-example/rabbitmq-transaction-consumer.html
@@ -64,7 +64,7 @@ redirect_from:
  Messages will not be re-queued in the case of a rollback
  automatically unless negatively acknowledged by the user.
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/rabbitmq/index.html">RabbitMQ module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/rabbitmq/">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/rabbitmq-transaction-producer.html
+++ b/swan-lake/learn/by-example/rabbitmq-transaction-producer.html
@@ -50,7 +50,7 @@ redirect_from:
  Upon successful execution of the transaction block,
  the channel will commit and rollback in the case of any error.
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/rabbitmq/index.html">RabbitMQ module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/rabbitmq/">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/record-io.html
+++ b/swan-lake/learn/by-example/record-io.html
@@ -143,7 +143,7 @@ redirect_from:
                             <h2>Record I/O</h2>
                             <p><p>This example demonstrates how to read and write records using I/O APIs.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/index.html">IO module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/">IO module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/request-with-multiparts.html
+++ b/swan-lake/learn/by-example/request-with-multiparts.html
@@ -29,7 +29,7 @@ redirect_from:
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">multipartReceiver</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span>
                                         <span class="nx">request</span><span class="p">)</span> <span class="p">{</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span> <span class="nx">response</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
-        <span class="c1">// [Extracts bodyparts](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getBodyParts) from the request.</span>
+        <span class="c1">// [Extracts bodyparts](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getBodyParts) from the request.</span>
         <span class="k">var</span> <span class="nx">bodyParts</span> <span class="p">=</span> <span class="nx">request</span><span class="p">.</span><span class="nx">getBodyParts</span><span class="p">();</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">bodyParts</span> <span class="nx">is</span> <span class="nx">mime</span><span class="p">:</span><span class="nx">Entity</span><span class="p">[])</span> <span class="p">{</span>
             <span class="nx">foreach</span> <span class="k">var</span> <span class="nx">part</span> <span class="nx">in</span> <span class="nx">bodyParts</span> <span class="p">{</span>
@@ -69,7 +69,7 @@ redirect_from:
         <span class="c1">// Create an array to hold all the body parts.</span>
         <span class="nx">mime</span><span class="p">:</span><span class="nx">Entity</span><span class="p">[]</span> <span class="nx">bodyParts</span> <span class="p">=</span> <span class="p">[</span><span class="nx">jsonBodyPart</span><span class="p">,</span> <span class="nx">xmlFilePart</span><span class="p">];</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">request</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
-        <span class="c1">// [Set the body parts](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#setBodyParts) to the request.</span>
+        <span class="c1">// [Set the body parts](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#setBodyParts) to the request.</span>
         <span class="c1">// Here the content-type is set as multipart form data.</span>
         <span class="c1">// This also works with any other multipart media type.</span>
         <span class="c1">// eg:- `multipart/mixed`, `multipart/related` etc.</span>
@@ -96,12 +96,12 @@ redirect_from:
 
 <span class="c1">// The content logic that handles the body parts vary based on your requirement.</span>
 <span class="kd">function</span> <span class="nx">handleContent</span><span class="p">(</span><span class="nx">mime</span><span class="p">:</span><span class="nx">Entity</span> <span class="nx">bodyPart</span><span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// [Get the media type](https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/functions.html#getMediaType) from the body part retrieved from the request.</span>
+    <span class="c1">// [Get the media type](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/functions#getMediaType) from the body part retrieved from the request.</span>
     <span class="k">var</span> <span class="nx">mediaType</span> <span class="p">=</span> <span class="nx">mime</span><span class="p">:</span><span class="nx">getMediaType</span><span class="p">(</span><span class="nx">bodyPart</span><span class="p">.</span><span class="nx">getContentType</span><span class="p">());</span>
     <span class="k">if</span> <span class="p">(</span><span class="nx">mediaType</span> <span class="nx">is</span> <span class="nx">mime</span><span class="p">:</span><span class="nx">MediaType</span><span class="p">)</span> <span class="p">{</span>
         <span class="kt">string</span> <span class="nx">baseType</span> <span class="p">=</span> <span class="nx">mediaType</span><span class="p">.</span><span class="nx">getBaseType</span><span class="p">();</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">mime</span><span class="p">:</span><span class="nx">APPLICATION_XML</span> <span class="o">==</span> <span class="nx">baseType</span> <span class="o">||</span> <span class="nx">mime</span><span class="p">:</span><span class="nx">TEXT_XML</span> <span class="o">==</span> <span class="nx">baseType</span><span class="p">)</span> <span class="p">{</span>
-            <span class="c1">//[Extracts `xml` data](https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getXml) from the body part.</span>
+            <span class="c1">//[Extracts `xml` data](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getXml) from the body part.</span>
             <span class="k">var</span> <span class="nx">payload</span> <span class="p">=</span> <span class="nx">bodyPart</span><span class="p">.</span><span class="nx">getXml</span><span class="p">();</span>
             <span class="k">if</span> <span class="p">(</span><span class="nx">payload</span> <span class="nx">is</span> <span class="kt">xml</span><span class="p">)</span> <span class="p">{</span>
                 <span class="nx">log</span><span class="p">:</span><span class="nx">printInfo</span><span class="p">(</span><span class="nx">payload</span><span class="p">.</span><span class="nx">toString</span><span class="p">());</span>
@@ -109,7 +109,7 @@ redirect_from:
                 <span class="nx">log</span><span class="p">:</span><span class="nx">printError</span><span class="p">(</span><span class="nx">payload</span><span class="p">.</span><span class="kt">message</span><span class="p">());</span>
             <span class="p">}</span>
         <span class="p">}</span> <span class="k">else</span> <span class="k">if</span> <span class="p">(</span><span class="nx">mime</span><span class="p">:</span><span class="nx">APPLICATION_JSON</span> <span class="o">==</span> <span class="nx">baseType</span><span class="p">)</span> <span class="p">{</span>
-            <span class="c1">//[Extracts `json` data](https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getJson) from the body part.</span>
+            <span class="c1">//[Extracts `json` data](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getJson) from the body part.</span>
             <span class="k">var</span> <span class="nx">payload</span> <span class="p">=</span> <span class="nx">bodyPart</span><span class="p">.</span><span class="nx">getJson</span><span class="p">();</span>
             <span class="k">if</span> <span class="p">(</span><span class="nx">payload</span> <span class="nx">is</span> <span class="kt">json</span><span class="p">)</span> <span class="p">{</span>
                 <span class="nx">log</span><span class="p">:</span><span class="nx">printInfo</span><span class="p">(</span><span class="nx">payload</span><span class="p">.</span><span class="nx">toJsonString</span><span class="p">());</span>
@@ -117,7 +117,7 @@ redirect_from:
                 <span class="nx">log</span><span class="p">:</span><span class="nx">printError</span><span class="p">(</span><span class="nx">payload</span><span class="p">.</span><span class="kt">message</span><span class="p">());</span>
             <span class="p">}</span>
         <span class="p">}</span> <span class="k">else</span> <span class="k">if</span> <span class="p">(</span><span class="nx">mime</span><span class="p">:</span><span class="nx">TEXT_PLAIN</span> <span class="o">==</span> <span class="nx">baseType</span><span class="p">)</span> <span class="p">{</span>
-            <span class="c1">//[Extracts text data](https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getText) from the body part.</span>
+            <span class="c1">//[Extracts text data](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getText) from the body part.</span>
             <span class="k">var</span> <span class="nx">payload</span> <span class="p">=</span> <span class="nx">bodyPart</span><span class="p">.</span><span class="nx">getText</span><span class="p">();</span>
             <span class="k">if</span> <span class="p">(</span><span class="nx">payload</span> <span class="nx">is</span> <span class="kt">string</span><span class="p">)</span> <span class="p">{</span>
                 <span class="nx">log</span><span class="p">:</span><span class="nx">printInfo</span><span class="p">(</span><span class="nx">payload</span><span class="p">);</span>
@@ -148,7 +148,7 @@ redirect_from:
  When you request multiparts from the HTTP inbound request, you get an array of body parts (an array of entities).
  You can loop through this array and handle the received body parts according to your requirement.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/index.html">Mime module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/">Mime module</a>.</p>
 </p>
 
                         </td>
@@ -348,7 +348,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getBodyParts">Extracts bodyparts</a> from the request.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getBodyParts">Extracts bodyparts</a> from the request.</p>
 
                                         </div>
                                     </div>
@@ -486,7 +486,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#setBodyParts">Set the body parts</a> to the request.
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#setBodyParts">Set the body parts</a> to the request.
  Here the content-type is set as multipart form data.
  This also works with any other multipart media type.
  eg:- <code>multipart/mixed</code>, <code>multipart/related</code> etc.
@@ -531,7 +531,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/functions.html#getMediaType">Get the media type</a> from the body part retrieved from the request.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/functions#getMediaType">Get the media type</a> from the body part retrieved from the request.</p>
 
                                         </div>
                                     </div>
@@ -556,7 +556,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getXml">Extracts <code>xml</code> data</a> from the body part.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getXml">Extracts <code>xml</code> data</a> from the body part.</p>
 
                                         </div>
                                     </div>
@@ -581,7 +581,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getJson">Extracts <code>json</code> data</a> from the body part.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getJson">Extracts <code>json</code> data</a> from the body part.</p>
 
                                         </div>
                                     </div>
@@ -608,7 +608,7 @@ import ballerina/mime;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getText">Extracts text data</a> from the body part.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getText">Extracts text data</a> from the body part.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/response-with-multiparts.html
+++ b/swan-lake/learn/by-example/response-with-multiparts.html
@@ -46,7 +46,7 @@ redirect_from:
             <span class="nx">contentType</span> <span class="p">=</span> <span class="nx">mime</span><span class="p">:</span><span class="nx">TEXT_XML</span><span class="p">);</span>
         <span class="c1">// Creates an array to hold the child parts.</span>
         <span class="nx">mime</span><span class="p">:</span><span class="nx">Entity</span><span class="p">[]</span> <span class="nx">childParts</span> <span class="p">=</span> <span class="p">[</span><span class="nx">childPart1</span><span class="p">,</span> <span class="nx">childPart2</span><span class="p">];</span>
-        <span class="c1">// [Sets the child parts to the parent part](https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#setBodyParts).</span>
+        <span class="c1">// [Sets the child parts to the parent part](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#setBodyParts).</span>
         <span class="nx">parentPart</span><span class="p">.</span><span class="nx">setBodyParts</span><span class="p">(</span><span class="nx">childParts</span><span class="p">,</span>
             <span class="nx">contentType</span> <span class="p">=</span> <span class="nx">mime</span><span class="p">:</span><span class="nx">MULTIPART_MIXED</span><span class="p">);</span>
         <span class="c1">// Creates an array to hold the parent part and set it to the response.</span>
@@ -77,7 +77,7 @@ redirect_from:
         <span class="k">var</span> <span class="nx">returnResult</span> <span class="p">=</span> <span class="nx">clientEP</span><span class="o">-&gt;</span><span class="nx">get</span><span class="p">(</span><span class="s">&quot;/multiparts/encode_out_response&quot;</span><span class="p">);</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span> <span class="nx">res</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">returnResult</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span><span class="p">)</span> <span class="p">{</span>
-            <span class="c1">// [Extracts the body parts from the response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getBodyParts).</span>
+            <span class="c1">// [Extracts the body parts from the response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#getBodyParts).</span>
             <span class="k">var</span> <span class="nx">parentParts</span> <span class="p">=</span> <span class="nx">returnResult</span><span class="p">.</span><span class="nx">getBodyParts</span><span class="p">();</span>
             <span class="k">if</span> <span class="p">(</span><span class="nx">parentParts</span> <span class="nx">is</span> <span class="nx">mime</span><span class="p">:</span><span class="nx">Entity</span><span class="p">[])</span> <span class="p">{</span>
                 <span class="c1">//Loops through body parts.</span>
@@ -119,7 +119,7 @@ redirect_from:
 <span class="kd">function</span> <span class="nx">handleContent</span><span class="p">(</span><span class="nx">mime</span><span class="p">:</span><span class="nx">Entity</span> <span class="nx">bodyPart</span><span class="p">)</span> <span class="p">{</span>
     <span class="kt">string</span> <span class="nx">baseType</span> <span class="p">=</span> <span class="nx">getBaseType</span><span class="p">(</span><span class="nx">bodyPart</span><span class="p">.</span><span class="nx">getContentType</span><span class="p">());</span>
     <span class="k">if</span> <span class="p">(</span><span class="nx">mime</span><span class="p">:</span><span class="nx">APPLICATION_XML</span> <span class="o">==</span> <span class="nx">baseType</span> <span class="o">||</span> <span class="nx">mime</span><span class="p">:</span><span class="nx">TEXT_XML</span> <span class="o">==</span> <span class="nx">baseType</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// [Extracts `xml` data]((https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getXml) from the body part.</span>
+        <span class="c1">// [Extracts `xml` data]((https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getXml) from the body part.</span>
         <span class="k">var</span> <span class="nx">payload</span> <span class="p">=</span> <span class="nx">bodyPart</span><span class="p">.</span><span class="nx">getXml</span><span class="p">();</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">payload</span> <span class="nx">is</span> <span class="kt">xml</span><span class="p">)</span> <span class="p">{</span>
             <span class="kt">string</span> <span class="nx">strValue</span> <span class="p">=</span> <span class="nx">io</span><span class="p">:</span><span class="nx">sprintf</span><span class="p">(</span><span class="s">&quot;%s&quot;</span><span class="p">,</span> <span class="nx">payload</span><span class="p">);</span>
@@ -128,7 +128,7 @@ redirect_from:
              <span class="nx">log</span><span class="p">:</span><span class="nx">printError</span><span class="p">(</span><span class="s">&quot;Error in parsing XML data&quot;</span><span class="p">,</span> <span class="nx">payload</span><span class="p">);</span>
         <span class="p">}</span>
     <span class="p">}</span> <span class="k">else</span> <span class="k">if</span> <span class="p">(</span><span class="nx">mime</span><span class="p">:</span><span class="nx">APPLICATION_JSON</span> <span class="o">==</span> <span class="nx">baseType</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// [Extracts `json` data](https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getJson) from the body part.</span>
+        <span class="c1">// [Extracts `json` data](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getJson) from the body part.</span>
         <span class="k">var</span> <span class="nx">payload</span> <span class="p">=</span> <span class="nx">bodyPart</span><span class="p">.</span><span class="nx">getJson</span><span class="p">();</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">payload</span> <span class="nx">is</span> <span class="kt">json</span><span class="p">)</span> <span class="p">{</span>
             <span class="nx">log</span><span class="p">:</span><span class="nx">printInfo</span><span class="p">(</span><span class="s">&quot;JSON data: &quot;</span> <span class="o">+</span> <span class="nx">payload</span><span class="p">.</span><span class="nx">toJsonString</span><span class="p">());</span>
@@ -136,7 +136,7 @@ redirect_from:
              <span class="nx">log</span><span class="p">:</span><span class="nx">printError</span><span class="p">(</span><span class="s">&quot;Error in parsing JSON data&quot;</span><span class="p">,</span> <span class="nx">payload</span><span class="p">);</span>
         <span class="p">}</span>
     <span class="p">}</span> <span class="k">else</span> <span class="k">if</span> <span class="p">(</span><span class="nx">mime</span><span class="p">:</span><span class="nx">TEXT_PLAIN</span> <span class="o">==</span> <span class="nx">baseType</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// [Extracts text data](https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getText) from the body part.</span>
+        <span class="c1">// [Extracts text data](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getText) from the body part.</span>
         <span class="k">var</span> <span class="nx">payload</span> <span class="p">=</span> <span class="nx">bodyPart</span><span class="p">.</span><span class="nx">getText</span><span class="p">();</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">payload</span> <span class="nx">is</span> <span class="kt">string</span><span class="p">)</span> <span class="p">{</span>
             <span class="nx">log</span><span class="p">:</span><span class="nx">printInfo</span><span class="p">(</span><span class="s">&quot;Text data: &quot;</span> <span class="o">+</span> <span class="nx">payload</span><span class="p">);</span>
@@ -144,7 +144,7 @@ redirect_from:
             <span class="nx">log</span><span class="p">:</span><span class="nx">printError</span><span class="p">(</span><span class="s">&quot;Error in parsing text data&quot;</span><span class="p">,</span> <span class="nx">payload</span><span class="p">);</span>
         <span class="p">}</span>
     <span class="p">}</span> <span class="k">else</span> <span class="k">if</span> <span class="p">(</span><span class="nx">mime</span><span class="p">:</span><span class="nx">APPLICATION_PDF</span> <span class="o">==</span> <span class="nx">baseType</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// [Extracts byte channel](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getByteChannel) from the body part and save it as a file.</span>
+        <span class="c1">// [Extracts byte channel](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#getByteChannel) from the body part and save it as a file.</span>
         <span class="k">var</span> <span class="nx">payload</span> <span class="p">=</span> <span class="nx">bodyPart</span><span class="p">.</span><span class="nx">getByteChannel</span><span class="p">();</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">payload</span> <span class="nx">is</span> <span class="nx">io</span><span class="p">:</span><span class="nx">ReadableByteChannel</span><span class="p">)</span> <span class="p">{</span>
             <span class="nx">io</span><span class="p">:</span><span class="nx">WritableByteChannel</span> <span class="nx">destinationChannel</span> <span class="p">=</span>
@@ -221,7 +221,7 @@ redirect_from:
  When you request multiparts from an HTTP inbound response, you get an array of the parts of the body (an array of
  entities). If the received parts contain nested parts, you can loop through the parent parts and get the child parts.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/index.html">Mime module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/">Mime module</a>.</p>
 </p>
 
                         </td>
@@ -519,7 +519,7 @@ absolute file path instead.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#setBodyParts">Sets the child parts to the parent part</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#setBodyParts">Sets the child parts to the parent part</a>.</p>
 
                                         </div>
                                     </div>
@@ -617,7 +617,7 @@ service multipartResponseDecoder on multipartEP {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getBodyParts">Extracts the body parts from the response</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#getBodyParts">Extracts the body parts from the response</a>.</p>
 
                                         </div>
                                     </div>
@@ -731,7 +731,7 @@ vary based on your requirement.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>[Extracts <code>xml</code> data]((<a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getXml">https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getXml</a>) from the body part.</p>
+                                            <p>[Extracts <code>xml</code> data]((<a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity.html#getXml">https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getXml</a>) from the body part.</p>
 
                                         </div>
                                     </div>
@@ -756,7 +756,7 @@ vary based on your requirement.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getJson">Extracts <code>json</code> data</a> from the body part.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getJson">Extracts <code>json</code> data</a> from the body part.</p>
 
                                         </div>
                                     </div>
@@ -781,7 +781,7 @@ vary based on your requirement.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/mime/classes/Entity.html#getText">Extracts text data</a> from the body part.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/mime/classes/Entity#getText">Extracts text data</a> from the body part.</p>
 
                                         </div>
                                     </div>
@@ -815,7 +815,7 @@ vary based on your requirement.</p>
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getByteChannel">Extracts byte channel</a> from the body part and save it as a file.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#getByteChannel">Extracts byte channel</a> from the body part and save it as a file.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/restrict-by-media-type.html
+++ b/swan-lake/learn/by-example/restrict-by-media-type.html
@@ -14,7 +14,7 @@ redirect_from:
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 
 <span class="kd">service</span> <span class="nx">infoService</span> <span class="nx">on</span> <span class="nx">new</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span><span class="p">(</span><span class="mi">9092</span><span class="p">)</span> <span class="p">{</span>
-    <span class="c1">// The `consumes` and `produces` annotations of the [resource configuration](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpResourceConfig.html)</span>
+    <span class="c1">// The `consumes` and `produces` annotations of the [resource configuration](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpResourceConfig)</span>
     <span class="c1">// contain MIME types as an array of strings. The resource can only consume/accept `text/json` and</span>
     <span class="c1">// `application/json` media types. Therefore, the `Content-Type` header</span>
     <span class="c1">// of the request must be in one of these two types. The resource can produce</span>
@@ -58,7 +58,7 @@ redirect_from:
                             <p><p>You can configure resources of HTTP services to restrict the types of media they consume and produce.
  This is done through the &lsquo;consumes&rsquo; and &lsquo;produces&rsquo; annotation attributes of the ResourceConfig annotation, which is used with resources.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -175,7 +175,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <code>consumes</code> and <code>produces</code> annotations of the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/HttpResourceConfig.html">resource configuration</a>
+                                            <p>The <code>consumes</code> and <code>produces</code> annotations of the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/HttpResourceConfig">resource configuration</a>
  contain MIME types as an array of strings. The resource can only consume/accept <code>text/json</code> and
  <code>application/json</code> media types. Therefore, the <code>Content-Type</code> header
  of the request must be in one of these two types. The resource can produce

--- a/swan-lake/learn/by-example/retry-transactions.html
+++ b/swan-lake/learn/by-example/retry-transactions.html
@@ -97,7 +97,7 @@ redirect_from:
  retries. This sample uses an H2 database, which is
  created when running the sample. <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/lang.transaction/index.html">Transactions module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/lang.transaction/">Transactions module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/secured-client-with-basic-auth.html
+++ b/swan-lake/learn/by-example/secured-client-with-basic-auth.html
@@ -103,7 +103,7 @@ redirect_from:
  The <code>authHandler</code> field is defined inside the <code>auth</code> field with the value of
  it being the reference of the created <code>http:BearerAuthHandler</code>.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/auth/index.html">Auth module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/auth/">Auth module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/secured-client-with-jwt-auth.html
+++ b/swan-lake/learn/by-example/secured-client-with-jwt-auth.html
@@ -131,7 +131,7 @@ redirect_from:
  The <code>authHandler</code> field is defined inside the <code>auth</code> field with the value
  of it being the reference of the created <code>http:BearerAuthHandler</code>.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/jwt/index.html">JWT module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/jwt/">JWT module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/secured-client-with-oauth2.html
+++ b/swan-lake/learn/by-example/secured-client-with-oauth2.html
@@ -186,7 +186,7 @@ redirect_from:
  The <code>authHandler</code> field is defined inside the <code>auth</code> field with the
  value of it being the reference of the created <code>http:BearerAuthHandler</code>.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/oauth2/index.html">OAuth2 module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/oauth2/">OAuth2 module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/secured-service-with-basic-auth.html
+++ b/swan-lake/learn/by-example/secured-service-with-basic-auth.html
@@ -111,7 +111,7 @@ redirect_from:
 <p>There are two users defined - Alice and Bob. Each user has a password and
  assigned scopes.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/auth/index.html">Auth module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/auth/">Auth module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/secured-service-with-jwt-auth.html
+++ b/swan-lake/learn/by-example/secured-service-with-jwt-auth.html
@@ -127,7 +127,7 @@ redirect_from:
  In the authorization phase, the scopes of the resource are compared against
  the scopes mapped to the user for at least one match between the two sets.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/jwt/index.html">JWT module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/jwt/">JWT module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/secured-service-with-ldap.html
+++ b/swan-lake/learn/by-example/secured-service-with-ldap.html
@@ -86,7 +86,7 @@ redirect_from:
  configured LDAP server. The result returned from the LDAP
  server is used for authentication and authorization.
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/ldap/index.html">LDAP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/ldap/">LDAP module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/secured-service-with-oauth2.html
+++ b/swan-lake/learn/by-example/secured-service-with-oauth2.html
@@ -68,7 +68,7 @@ redirect_from:
  the introspection response and the scopes of the resource are compared
  against those for at least one match between the two sets.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/oauth2/index.html">OAuth2 module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/oauth2/">OAuth2 module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/send-and-receive-emails.html
+++ b/swan-lake/learn/by-example/send-and-receive-emails.html
@@ -140,7 +140,7 @@ redirect_from:
  sending and receiving emails with default configurations over SSL using
  default ports.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/email/index.html">Email module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/email/">Email module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/streams.html
+++ b/swan-lake/learn/by-example/streams.html
@@ -147,7 +147,7 @@ redirect_from:
  The stream type provides methods similar to lists such as <code>map</code>, <code>foreach</code>, <code>filter</code>, <code>reduce</code>, and <code>iterator</code>.
  The stream type does not provide a length method. This is a preview feature.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/lang.stream/index.html">lang.stream module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/lang.stream/">lang.stream module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/strings.html
+++ b/swan-lake/learn/by-example/strings.html
@@ -98,7 +98,7 @@ redirect_from:
                             <h2>String</h2>
                             <p><p>Ballerina contains a comprehensive set of functions to manipulate strings.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/lang.string/index.html">lang.string module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/lang.string/">lang.string module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/table.html
+++ b/swan-lake/learn/by-example/table.html
@@ -122,7 +122,7 @@ redirect_from:
  members in order but does not provide random access to a member using its position in this order. The built-in
  functions enable inserting, accessing, deleting data, and applying functions on members of a <code>table</code>.
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/lang.table/index.html">lang.table module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/lang.table/">lang.table module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/task-scheduler-appointment.html
+++ b/swan-lake/learn/by-example/task-scheduler-appointment.html
@@ -18,7 +18,7 @@ redirect_from:
 
 <span class="nx">public</span> <span class="kd">function</span> <span class="nx">main</span><span class="p">()</span> <span class="nx">returns</span> <span class="nx">error</span><span class="err">?</span> <span class="p">{</span>
 
-    <span class="c1">// The [`task:AppointmentConfiguration`](https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html) record of the task scheduler.</span>
+    <span class="c1">// The [`task:AppointmentConfiguration`](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/records/AppointmentConfiguration) record of the task scheduler.</span>
     <span class="nx">task</span><span class="p">:</span><span class="nx">AppointmentConfiguration</span> <span class="nx">appointmentConfiguration</span> <span class="p">=</span> <span class="p">{</span>
         <span class="c1">// This CRON expression will schedule the appointment every two second.</span>
         <span class="nx">cronExpression</span><span class="p">:</span> <span class="s">&quot;0/2 * * ? * * *&quot;</span>
@@ -68,7 +68,7 @@ redirect_from:
  Then, the scheduler can be started using the <code>start()</code> method. When the scheduler
  needs to be cancelled, the <code>stop()</code> method can be called.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/index.html">Task module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/">Task module</a>.</p>
 </p>
 
                         </td>
@@ -206,7 +206,7 @@ import ballerina/task;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html"><code>task:AppointmentConfiguration</code></a> record of the task scheduler.</p>
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/records/AppointmentConfiguration"><code>task:AppointmentConfiguration</code></a> record of the task scheduler.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/task-scheduler-timer.html
+++ b/swan-lake/learn/by-example/task-scheduler-timer.html
@@ -71,10 +71,10 @@ redirect_from:
  method and the listener can be started using the <code>start()</code> method.
  The service that is being attached must contain the <code>onTrigger()</code> resource function.
  Additionally, a user can pass a set of <code>any</code> values to the resource using
- the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/classes/Scheduler.html#attach"><code>attach()</code></a> method, which then can be used inside the <code>onTrigger()</code>
+ the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/classes/Scheduler#attach"><code>attach()</code></a> method, which then can be used inside the <code>onTrigger()</code>
  function. The Listener can be stopped by calling the <code>stop()</code> method.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/index.html">Task module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/">Task module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/task-service-appointment.html
+++ b/swan-lake/learn/by-example/task-service-appointment.html
@@ -13,7 +13,7 @@ redirect_from:
                 <div class="highlight"><pre><span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">io</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">task</span><span class="p">;</span>
 
-<span class="c1">// The [`task:AppointmentConfiguration`](https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html) record of the task listener.</span>
+<span class="c1">// The [`task:AppointmentConfiguration`](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/records/AppointmentConfiguration) record of the task listener.</span>
 <span class="nx">task</span><span class="p">:</span><span class="nx">AppointmentConfiguration</span> <span class="nx">appointmentConfiguration</span> <span class="p">=</span> <span class="p">{</span>
     <span class="c1">// This CRON expression will schedule the appointment every second.</span>
     <span class="nx">cronExpression</span><span class="p">:</span> <span class="s">&quot;* * * * * ?&quot;</span><span class="p">,</span>
@@ -50,7 +50,7 @@ redirect_from:
  <code>noOfRecurrences</code> field that can be used to provide the maximum number of times
  the appointment should run before shutting down.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/index.html">Task module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/">Task module</a>.</p>
 </p>
 
                         </td>
@@ -153,7 +153,7 @@ import ballerina/task;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html"><code>task:AppointmentConfiguration</code></a> record of the task listener.</p>
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/records/AppointmentConfiguration"><code>task:AppointmentConfiguration</code></a> record of the task listener.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/task-service-timer.html
+++ b/swan-lake/learn/by-example/task-service-timer.html
@@ -13,7 +13,7 @@ redirect_from:
                 <div class="highlight"><pre><span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">io</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">task</span><span class="p">;</span>
 
-<span class="c1">// The [`task:TimerConfiguration`](https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/records/TimerConfiguration.html) record to configure the task listener.</span>
+<span class="c1">// The [`task:TimerConfiguration`](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/records/TimerConfiguration) record to configure the task listener.</span>
 <span class="nx">task</span><span class="p">:</span><span class="nx">TimerConfiguration</span> <span class="nx">timerConfiguration</span> <span class="p">=</span> <span class="p">{</span>
     <span class="nx">intervalInMillis</span><span class="p">:</span> <span class="mi">1000</span><span class="p">,</span>
     <span class="nx">initialDelayInMillis</span><span class="p">:</span> <span class="mi">3000</span><span class="p">,</span>
@@ -52,7 +52,7 @@ redirect_from:
  <code>noOfRecurrences</code> field can be used to provide the maximum number of times
  the timer should run before shutting down.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/index.html">Task module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/">Task module</a>.</p>
 </p>
 
                         </td>
@@ -155,7 +155,7 @@ import ballerina/task;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/task/records/TimerConfiguration.html"><code>task:TimerConfiguration</code></a> record to configure the task listener.</p>
+                                            <p>The <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/task/records/TimerConfiguration"><code>task:TimerConfiguration</code></a> record to configure the task listener.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/tcp-socket-listener-client.html
+++ b/swan-lake/learn/by-example/tcp-socket-listener-client.html
@@ -144,7 +144,7 @@ redirect_from:
  The TCP Client is used to connect to a remote TCP server.
  This sample demonstrates how the TCP socket listener service interacts with the TCP client.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/socket/index.html">Socket module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/socket/">Socket module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/testerina-assertions.html
+++ b/swan-lake/learn/by-example/testerina-assertions.html
@@ -202,7 +202,7 @@ redirect_from:
  assert an outcome against an expected outcome.
  This example illustrates how to use different assertions.<br/><br/>
  For more information, see <a href="https://ballerina.io/swan-lake/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a>
- and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/test/">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/testerina-before-and-after-each.html
+++ b/swan-lake/learn/by-example/testerina-before-and-after-each.html
@@ -58,7 +58,7 @@ redirect_from:
  the function specified with the <code>AfterEach</code> annotation is executed after every test within the test suite.
  This can be used for repeatedly initializing and tearing down test level aspects before every test function.<br/><br/>
  For more information, see <a href="https://ballerina.io/swan-lake/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a>
- and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/test/">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/testerina-before-and-after-groups.html
+++ b/swan-lake/learn/by-example/testerina-before-and-after-groups.html
@@ -53,7 +53,7 @@ redirect_from:
  specified group is executed and the function specified with the <code>AfterGroups</code> annotation is executed once after all
  the tests belonging to the specified group is executed.<br/><br/>
  For more information, see <a href="https://ballerina.io/swan-lake/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a>
- and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/test/">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/testerina-before-and-after-suite.html
+++ b/swan-lake/learn/by-example/testerina-before-and-after-suite.html
@@ -52,7 +52,7 @@ redirect_from:
  setting up prerequisites before executing a test suite.
  Similarly, the <code>AfterSuite</code> annotation can be used to execute a function after a test suite.<br/><br/>
  For more information, see <a href="https://ballerina.io/swan-lake/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a>
- and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/test/">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/testerina-before-and-after-test.html
+++ b/swan-lake/learn/by-example/testerina-before-and-after-test.html
@@ -47,7 +47,7 @@ redirect_from:
  This capability can be used for setting up prerequisites that need to be executed before executing a test.
  Similarly, the <code>after</code> attribute can be used to execute a function after a test function.<br/><br/>
  For more information, see <a href="https://ballerina.io/swan-lake/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a>
- and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/test/">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/testerina-data-driven-tests.html
+++ b/swan-lake/learn/by-example/testerina-data-driven-tests.html
@@ -65,7 +65,7 @@ redirect_from:
  You can provide a function as a data-provider. The function returns a
  set of data values and the system will iterate the same test over the returned dataset.<br/><br/>
  For more information, see <a href="https://ballerina.io/swan-lake/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a>
- and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/test/">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/testerina-group-tests.html
+++ b/swan-lake/learn/by-example/testerina-group-tests.html
@@ -48,7 +48,7 @@ redirect_from:
  test groups that are to be executed when you run tests.
  Likewise, you can exclude executing selected tests as well.<br/><br/>
  For more information, see <a href="https://ballerina.io/swan-lake/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a>
- and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/test/">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/testerina-guarantee-test-execution-order.html
+++ b/swan-lake/learn/by-example/testerina-guarantee-test-execution-order.html
@@ -49,7 +49,7 @@ redirect_from:
  function depends on. These functions will be executed before the test execution.
  This allows you to ensure that the tests are being executed in the expected order.<br/><br/>
  For more information, see <a href="https://ballerina.io/swan-lake/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a>
- and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/test/">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/testerina-mocking-functions.html
+++ b/swan-lake/learn/by-example/testerina-mocking-functions.html
@@ -77,7 +77,7 @@ redirect_from:
  This allows you to isolate your tests from other modules. Function mocks can be stubbed with return
  values or with a user-defined function, which has the same signature as the real function.<br/><br/>
  For more information, see <a href="https://ballerina.io/swan-lake/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a>
- and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/test/">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/testerina-mocking-objects.html
+++ b/swan-lake/learn/by-example/testerina-mocking-objects.html
@@ -158,7 +158,7 @@ redirect_from:
  throughout all tests whereas stubbing is ideal when defining different behaviors for
  different test cases is required.<br/><br/>
  For more information, see <a href="https://ballerina.io/swan-lake/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a>
- and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ and the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/test/">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/time.html
+++ b/swan-lake/learn/by-example/time.html
@@ -92,7 +92,7 @@ redirect_from:
                             <p><p>The Ballerina time API provides operations to work with
  date and time.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/time/index.html">Time module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/time/">Time module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/udp-socket-client.html
+++ b/swan-lake/learn/by-example/udp-socket-client.html
@@ -75,7 +75,7 @@ redirect_from:
                             <p><p>The UDP Client is used to connect to a remote UDP host.
  This sample demonstrates how to send data to a remote server and print the echoed response.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/socket/index.html">Socket module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/socket/">Socket module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/url-encode-decode.html
+++ b/swan-lake/learn/by-example/url-encode-decode.html
@@ -49,7 +49,7 @@ redirect_from:
                             <h2>URL Encode/Decode Operations</h2>
                             <p><p>Ballerina encoding API supports encoding/decoding content using different URL encoding mechanisms and algorithms.
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/encoding/index.html">Encoding module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/encoding/">Encoding module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/websocket-basic-sample.html
+++ b/swan-lake/learn/by-example/websocket-basic-sample.html
@@ -73,7 +73,7 @@ redirect_from:
     <span class="p">}</span>
 
     <span class="c1">// This `resource` is triggered when a ping message is received from the client. If this resource is not implemented,</span>
-    <span class="c1">// a pong message is automatically sent to the connected [http:WebSocketCaller](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketCaller.html) when a ping is received.</span>
+    <span class="c1">// a pong message is automatically sent to the connected [http:WebSocketCaller](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketCaller) when a ping is received.</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">onPing</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">WebSocketCaller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">byte</span><span class="p">[]</span> <span class="nx">data</span><span class="p">)</span> <span class="p">{</span>
         <span class="k">var</span> <span class="nx">err</span> <span class="p">=</span> <span class="nx">caller</span><span class="o">-&gt;</span><span class="nx">pong</span><span class="p">(</span><span class="nx">data</span><span class="p">);</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">err</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">WebSocketError</span><span class="p">)</span> <span class="p">{</span>
@@ -87,7 +87,7 @@ redirect_from:
     <span class="p">}</span>
 
     <span class="c1">// This resource is triggered when a particular client reaches the idle timeout that is defined in the</span>
-    <span class="c1">// [http:WebSocketServiceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/annotations.html#WebSocketServiceConfig) annotation.</span>
+    <span class="c1">// [http:WebSocketServiceConfig](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/annotations#WebSocketServiceConfig) annotation.</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">onIdleTimeout</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">WebSocketCaller</span> <span class="nx">caller</span><span class="p">)</span> <span class="p">{</span>
         <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;\nReached idle timeout&quot;</span><span class="p">);</span>
         <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Closing connection &quot;</span> <span class="o">+</span> <span class="nx">caller</span><span class="p">.</span><span class="nx">getConnectionId</span><span class="p">());</span>
@@ -122,7 +122,7 @@ redirect_from:
                             <h2>Basic Server Functionalities</h2>
                             <p><p>This example explains the basic functions of a WebSocket server.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -362,7 +362,7 @@ service basic on new http:Listener(9090) {
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>This <code>resource</code> is triggered when a ping message is received from the client. If this resource is not implemented,
- a pong message is automatically sent to the connected <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketCaller.html">http:WebSocketCaller</a> when a ping is received.</p>
+ a pong message is automatically sent to the connected <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketCaller">http:WebSocketCaller</a> when a ping is received.</p>
 
                                         </div>
                                     </div>
@@ -411,7 +411,7 @@ service basic on new http:Listener(9090) {
                                     <div class="cCodeDesription">
                                         <div>
                                             <p>This resource is triggered when a particular client reaches the idle timeout that is defined in the
- <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/annotations.html#WebSocketServiceConfig">http:WebSocketServiceConfig</a> annotation.</p>
+ <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/annotations#WebSocketServiceConfig">http:WebSocketServiceConfig</a> annotation.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/websocket-chat-application.html
+++ b/swan-lake/learn/by-example/websocket-chat-application.html
@@ -30,7 +30,7 @@ redirect_from:
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">upgrader</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">,</span>
     <span class="kt">string</span> <span class="nx">name</span><span class="p">)</span> <span class="p">{</span>
-        <span class="c1">// Retrieve query parameters from the [http:Request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html).</span>
+        <span class="c1">// Retrieve query parameters from the [http:Request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request).</span>
         <span class="kt">map</span><span class="p">&lt;</span><span class="kt">string</span><span class="p">[]&gt;</span> <span class="nx">queryParams</span> <span class="p">=</span> <span class="nx">req</span><span class="p">.</span><span class="nx">getQueryParams</span><span class="p">();</span>
         <span class="c1">// Cancel the handshake by sending a 400 status code if the age parameter is missing in the request.</span>
         <span class="k">if</span> <span class="p">(!</span><span class="nx">queryParams</span><span class="p">.</span><span class="nx">hasKey</span><span class="p">(</span><span class="s">&quot;age&quot;</span><span class="p">))</span> <span class="p">{</span>
@@ -119,7 +119,7 @@ redirect_from:
                             <h2>Chat Application</h2>
                             <p><p>This example explains how to write a simple chat application using Ballerina.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -286,7 +286,7 @@ service chatAppUpgrader on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Retrieve query parameters from the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html">http:Request</a>.</p>
+                                            <p>Retrieve query parameters from the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request">http:Request</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/websocket-client.html
+++ b/swan-lake/learn/by-example/websocket-client.html
@@ -14,10 +14,10 @@ redirect_from:
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">io</span><span class="p">;</span>
 
 <span class="nx">public</span> <span class="kd">function</span> <span class="nx">main</span><span class="p">()</span> <span class="p">{</span>
-    <span class="c1">// Creates a new [WebSocket client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketClient.html) with the backend URL and assigns a callback service.</span>
+    <span class="c1">// Creates a new [WebSocket client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketClient) with the backend URL and assigns a callback service.</span>
     <span class="nx">http</span><span class="p">:</span><span class="nx">WebSocketClient</span> <span class="nx">wsClientEp</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span><span class="s">&quot;ws://echo.websocket.org&quot;</span><span class="p">,</span>
                             <span class="nx">config</span> <span class="p">=</span> <span class="p">{</span><span class="nx">callbackService</span><span class="p">:</span> <span class="nx">ClientService</span><span class="p">});</span>
-    <span class="c1">// Pushes a text message to the server using [pushText](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketClient.html#pushText).</span>
+    <span class="c1">// Pushes a text message to the server using [pushText](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketClient#pushText).</span>
     <span class="k">var</span> <span class="nx">err</span> <span class="p">=</span> <span class="nx">wsClientEp</span><span class="o">-&gt;</span><span class="nx">pushText</span><span class="p">(</span><span class="s">&quot;Hello World!&quot;</span><span class="p">);</span>
     <span class="k">if</span> <span class="p">(</span><span class="nx">err</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
         <span class="c1">// Prints the error.</span>
@@ -48,7 +48,7 @@ redirect_from:
                             <h2>Client Endpoint</h2>
                             <p><p>The WebSocket client can be used to connect to and interact with a WebSocket server.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -162,7 +162,7 @@ import ballerina/io;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Creates a new <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketClient.html">WebSocket client</a> with the backend URL and assigns a callback service.</p>
+                                            <p>Creates a new <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketClient">WebSocket client</a> with the backend URL and assigns a callback service.</p>
 
                                         </div>
                                     </div>
@@ -182,7 +182,7 @@ import ballerina/io;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Pushes a text message to the server using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketClient.html#pushText">pushText</a>.</p>
+                                            <p>Pushes a text message to the server using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketClient#pushText">pushText</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/websocket-cookie.html
+++ b/swan-lake/learn/by-example/websocket-cookie.html
@@ -38,7 +38,7 @@ redirect_from:
                 <span class="c1">// Check the password value.</span>
                 <span class="k">if</span> <span class="p">(</span><span class="nx">password</span> <span class="o">==</span> <span class="s">&quot;p@ssw0rd&quot;</span><span class="p">)</span> <span class="p">{</span>
 
-                    <span class="c1">// [Create a new cookie](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Cookie.html) by setting the `name` as the `username`</span>
+                    <span class="c1">// [Create a new cookie](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Cookie) by setting the `name` as the `username`</span>
                     <span class="c1">// and `value` as the logged-in user&#39;s name.</span>
                     <span class="nx">http</span><span class="p">:</span><span class="nx">Cookie</span> <span class="nx">cookie</span> <span class="p">=</span> <span class="nx">new</span><span class="p">(</span><span class="s">&quot;username&quot;</span><span class="p">,</span> <span class="nx">name</span><span class="p">.</span><span class="nx">toString</span><span class="p">());</span>
 
@@ -46,7 +46,7 @@ redirect_from:
                     <span class="c1">// resources in the service.</span>
                     <span class="nx">cookie</span><span class="p">.</span><span class="nx">path</span> <span class="p">=</span> <span class="s">&quot;/&quot;</span><span class="p">;</span>
 
-                    <span class="c1">// [Add the created cookie to the response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#addCookie).</span>
+                    <span class="c1">// [Add the created cookie to the response](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#addCookie).</span>
                     <span class="nx">http</span><span class="p">:</span><span class="nx">Response</span> <span class="nx">response</span> <span class="p">=</span> <span class="nx">new</span><span class="p">;</span>
                     <span class="nx">response</span><span class="p">.</span><span class="nx">addCookie</span><span class="p">(</span><span class="nx">cookie</span><span class="p">);</span>
 
@@ -71,7 +71,7 @@ redirect_from:
     <span class="p">}</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">upgrader</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">Caller</span> <span class="nx">caller</span><span class="p">,</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Request</span> <span class="nx">req</span><span class="p">)</span> <span class="p">{</span>
 
-        <span class="c1">// [Retrieve cookies from the request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getCookies).</span>
+        <span class="c1">// [Retrieve cookies from the request](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getCookies).</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">Cookie</span><span class="p">[]</span> <span class="nx">cookies</span> <span class="p">=</span> <span class="nx">req</span><span class="p">.</span><span class="nx">getCookies</span><span class="p">();</span>
 
         <span class="c1">// Get the cookie value of the `username`.</span>
@@ -132,7 +132,7 @@ redirect_from:
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">io</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">log</span><span class="p">;</span>
 
-<span class="c1">// The HTTP client configurations associated with [enabling cookies](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CookieConfig.html).</span>
+<span class="c1">// The HTTP client configurations associated with [enabling cookies](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CookieConfig).</span>
 <span class="nx">http</span><span class="p">:</span><span class="nx">ClientConfiguration</span> <span class="nx">clientEPConfig</span> <span class="p">=</span> <span class="p">{</span>
     <span class="nx">cookieConfig</span><span class="p">:</span> <span class="p">{</span>
         <span class="nx">enabled</span><span class="p">:</span> <span class="kc">true</span>
@@ -165,7 +165,7 @@ redirect_from:
         <span class="k">if</span> <span class="p">(</span><span class="nx">loginMessage</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
             <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Login failed&quot;</span><span class="p">,</span> <span class="nx">loginMessage</span><span class="p">);</span>
         <span class="p">}</span> <span class="k">else</span> <span class="p">{</span>
-            <span class="c1">// [Gets cookies from the `http:Response`](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getCookies)</span>
+            <span class="c1">// [Gets cookies from the `http:Response`](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#getCookies)</span>
             <span class="nx">http</span><span class="p">:</span><span class="nx">Cookie</span><span class="p">[]</span> <span class="nx">cookies</span> <span class="p">=</span> <span class="nx">loginResp</span><span class="p">.</span><span class="nx">getCookies</span><span class="p">();</span>
             <span class="c1">// Initialize the WebSocket client with the cookies</span>
             <span class="nx">http</span><span class="p">:</span><span class="nx">WebSocketClient</span> <span class="nx">wsClientEp</span> <span class="p">=</span>
@@ -441,7 +441,7 @@ service cookieServer on new http:Listener(9095) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Cookie.html">Create a new cookie</a> by setting the <code>name</code> as the <code>username</code>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Cookie">Create a new cookie</a> by setting the <code>name</code> as the <code>username</code>
  and <code>value</code> as the logged-in user&rsquo;s name.</p>
 
                                         </div>
@@ -482,7 +482,7 @@ service cookieServer on new http:Listener(9095) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#addCookie">Add the created cookie to the response</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#addCookie">Add the created cookie to the response</a>.</p>
 
                                         </div>
                                     </div>
@@ -554,7 +554,7 @@ service cookieServer on new http:Listener(9095) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Request.html#getCookies">Retrieve cookies from the request</a>.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Request#getCookies">Retrieve cookies from the request</a>.</p>
 
                                         </div>
                                     </div>
@@ -889,7 +889,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The HTTP client configurations associated with <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/records/CookieConfig.html">enabling cookies</a>.</p>
+                                            <p>The HTTP client configurations associated with <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/records/CookieConfig">enabling cookies</a>.</p>
 
                                         </div>
                                     </div>
@@ -1047,7 +1047,7 @@ import ballerina/log;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/classes/Response.html#getCookies">Gets cookies from the <code>http:Response</code></a></p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/classes/Response#getCookies">Gets cookies from the <code>http:Response</code></a></p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/websocket-failover.html
+++ b/swan-lake/learn/by-example/websocket-failover.html
@@ -27,7 +27,7 @@ redirect_from:
     <span class="c1">// in the `onOpen` resource.</span>
     <span class="kd">resource</span> <span class="kd">function</span> <span class="nx">onOpen</span><span class="p">(</span><span class="nx">http</span><span class="p">:</span><span class="nx">WebSocketCaller</span> <span class="nx">caller</span><span class="p">)</span> <span class="p">{</span>
 
-        <span class="c1">// Defines the [webSocket failover client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketFailoverClient.html).</span>
+        <span class="c1">// Defines the [webSocket failover client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketFailoverClient).</span>
         <span class="nx">http</span><span class="p">:</span><span class="nx">WebSocketFailoverClient</span> <span class="nx">wsClientEp</span> <span class="p">=</span> <span class="nx">new</span> <span class="p">(</span>
         <span class="p">{</span>
             <span class="nx">callbackService</span><span class="p">:</span> <span class="nx">failoverClientService</span><span class="p">,</span>
@@ -46,7 +46,7 @@ redirect_from:
         <span class="nx">wsClientEp</span><span class="p">.</span><span class="nx">setAttribute</span><span class="p">(</span><span class="nx">ASSOCIATED_CONNECTION</span><span class="p">,</span> <span class="nx">caller</span><span class="p">);</span>
         <span class="nx">caller</span><span class="p">.</span><span class="nx">setAttribute</span><span class="p">(</span><span class="nx">ASSOCIATED_CONNECTION</span><span class="p">,</span> <span class="nx">wsClientEp</span><span class="p">);</span>
 
-        <span class="c1">// Once the client is ready to receive frames, the remote [ready](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketFailoverClient.html#ready) function</span>
+        <span class="c1">// Once the client is ready to receive frames, the remote [ready](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketFailoverClient#ready) function</span>
         <span class="c1">// of the client needs to be called separately.</span>
         <span class="k">var</span> <span class="nx">err</span> <span class="p">=</span> <span class="nx">wsClientEp</span><span class="o">-&gt;</span><span class="nx">ready</span><span class="p">();</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">err</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">WebSocketError</span><span class="p">)</span> <span class="p">{</span>
@@ -217,7 +217,7 @@ redirect_from:
  Ballerina automatically tries to connect with the remaining backends that are specified in the configuration.
  The trying happens only once for each of the backends.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -404,7 +404,7 @@ service failoverProxyService on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Defines the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketFailoverClient.html">webSocket failover client</a>.</p>
+                                            <p>Defines the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketFailoverClient">webSocket failover client</a>.</p>
 
                                         </div>
                                     </div>
@@ -508,7 +508,7 @@ service failoverProxyService on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Once the client is ready to receive frames, the remote <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketFailoverClient.html#ready">ready</a> function
+                                            <p>Once the client is ready to receive frames, the remote <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketFailoverClient#ready">ready</a> function
  of the client needs to be called separately.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/websocket-proxy-server.html
+++ b/swan-lake/learn/by-example/websocket-proxy-server.html
@@ -40,7 +40,7 @@ redirect_from:
         <span class="nx">wsClientEp</span><span class="p">.</span><span class="nx">setAttribute</span><span class="p">(</span><span class="nx">ASSOCIATED_CONNECTION</span><span class="p">,</span> <span class="nx">caller</span><span class="p">);</span>
         <span class="nx">caller</span><span class="p">.</span><span class="nx">setAttribute</span><span class="p">(</span><span class="nx">ASSOCIATED_CONNECTION</span><span class="p">,</span> <span class="nx">wsClientEp</span><span class="p">);</span>
 
-        <span class="c1">// Once the client is ready to receive frames, the remote function [ready](https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketClient.html#ready)</span>
+        <span class="c1">// Once the client is ready to receive frames, the remote function [ready](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketClient#ready)</span>
         <span class="c1">// of the client need to be called separately.</span>
         <span class="k">var</span> <span class="nx">err</span> <span class="p">=</span> <span class="nx">wsClientEp</span><span class="o">-&gt;</span><span class="nx">ready</span><span class="p">();</span>
         <span class="k">if</span> <span class="p">(</span><span class="nx">err</span> <span class="nx">is</span> <span class="nx">http</span><span class="p">:</span><span class="nx">WebSocketError</span><span class="p">)</span> <span class="p">{</span>
@@ -183,7 +183,7 @@ redirect_from:
                             <p><p>Ballerina can act as a proxy to another remote service. Ballerina forwards the
 requests sent by the clients that connect to it via a WebSocket to the respective remote service.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>
@@ -452,7 +452,7 @@ service SimpleProxyService on new http:Listener(9090) {
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Once the client is ready to receive frames, the remote function <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/clients/WebSocketClient.html#ready">ready</a>
+                                            <p>Once the client is ready to receive frames, the remote function <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/clients/WebSocketClient#ready">ready</a>
  of the client need to be called separately.</p>
 
                                         </div>

--- a/swan-lake/learn/by-example/websocket-retry.html
+++ b/swan-lake/learn/by-example/websocket-retry.html
@@ -202,7 +202,7 @@ redirect_from:
  Ballerina automatically reconnects to the same backend until the connection becomes successful or until
  the maximum reconnect attempts count is reached.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/http/index.html">HTTP module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/http/">HTTP module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/websub-hub-client-sample.html
+++ b/swan-lake/learn/by-example/websub-hub-client-sample.html
@@ -19,7 +19,7 @@ redirect_from:
 
 <span class="nx">public</span> <span class="kd">function</span> <span class="nx">main</span><span class="p">()</span> <span class="p">{</span>
 
-    <span class="c1">// Starts the internal Ballerina Hub using [startHub](https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/functions.html#startHub).</span>
+    <span class="c1">// Starts the internal Ballerina Hub using [startHub](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/functions#startHub).</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Starting up the Ballerina Hub Service&quot;</span><span class="p">);</span>
     <span class="nx">websub</span><span class="p">:</span><span class="nx">Hub</span> <span class="nx">webSubHub</span><span class="p">;</span>
     <span class="k">var</span> <span class="nx">result</span> <span class="p">=</span> <span class="nx">websub</span><span class="p">:</span><span class="nx">startHub</span><span class="p">(</span><span class="nx">new</span> <span class="nx">http</span><span class="p">:</span><span class="nx">Listener</span><span class="p">(</span><span class="mi">9191</span><span class="p">),</span> <span class="s">&quot;/websub&quot;</span><span class="p">,</span> <span class="s">&quot;/hub&quot;</span><span class="p">);</span>
@@ -31,7 +31,7 @@ redirect_from:
         <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Hub start error:&quot;</span> <span class="o">+</span> <span class="nx">result</span><span class="p">.</span><span class="kt">message</span><span class="p">());</span>
         <span class="k">return</span><span class="p">;</span>
     <span class="p">}</span>
-    <span class="c1">// Registers a topic at the hub using [registerTopic](https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/classes/Hub.html#registerTopic).</span>
+    <span class="c1">// Registers a topic at the hub using [registerTopic](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/classes/Hub#registerTopic).</span>
     <span class="k">var</span> <span class="nx">registrationResponse</span> <span class="p">=</span> <span class="nx">webSubHub</span><span class="p">.</span><span class="nx">registerTopic</span><span class="p">(</span>
                                             <span class="s">&quot;http://websubpubtopic.com&quot;</span><span class="p">);</span>
     <span class="k">if</span> <span class="p">(</span><span class="nx">registrationResponse</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
@@ -44,7 +44,7 @@ redirect_from:
     <span class="c1">// Makes the publisher wait until the subscriber subscribes at the hub.</span>
     <span class="nx">runtime</span><span class="p">:</span><span class="nx">sleep</span><span class="p">(</span><span class="mi">5000</span><span class="p">);</span>
 
-    <span class="c1">// Publishes directly to the internal Ballerina Hub using [publishUpdate][publishUpdate](https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/PublisherClient.html#publishUpdate)..</span>
+    <span class="c1">// Publishes directly to the internal Ballerina Hub using [publishUpdate][publishUpdate](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/PublisherClient#publishUpdate)..</span>
     <span class="k">var</span> <span class="nx">publishResponse</span> <span class="p">=</span> <span class="nx">webSubHub</span><span class="p">.</span><span class="nx">publishUpdate</span><span class="p">(</span><span class="s">&quot;http://websubpubtopic.com&quot;</span><span class="p">,</span>
                             <span class="p">{</span><span class="s">&quot;action&quot;</span><span class="p">:</span> <span class="s">&quot;publish&quot;</span><span class="p">,</span> <span class="s">&quot;mode&quot;</span><span class="p">:</span> <span class="s">&quot;internal-hub&quot;</span><span class="p">});</span>
     <span class="k">if</span> <span class="p">(</span><span class="nx">publishResponse</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
@@ -96,7 +96,7 @@ redirect_from:
         <span class="p">}</span>
     <span class="p">}</span>
 <span class="p">}</span>
-<span class="c1">// The Ballerina main program, which demonstrates the usage of the [Hub client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html) to subscribe/unsubscribe to notifications.</span>
+<span class="c1">// The Ballerina main program, which demonstrates the usage of the [Hub client](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/SubscriptionClient) to subscribe/unsubscribe to notifications.</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">io</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">runtime</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">websub</span><span class="p">;</span>
@@ -164,7 +164,7 @@ redirect_from:
 <p>The Hub Client Endpoint can be used by subscribers to subscribe/unsubscribe at a Hub, and by publishers to
  register topics and publish updates for topics at the Hub.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/index.html">WebSub module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/">WebSub module</a>.</p>
 </p>
 
                         </td>
@@ -299,7 +299,7 @@ import ballerina/websub;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Starts the internal Ballerina Hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/functions.html#startHub">startHub</a>.</p>
+                                            <p>Starts the internal Ballerina Hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/functions#startHub">startHub</a>.</p>
 
                                         </div>
                                     </div>
@@ -325,7 +325,7 @@ import ballerina/websub;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Registers a topic at the hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/classes/Hub.html#registerTopic">registerTopic</a>.</p>
+                                            <p>Registers a topic at the hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/classes/Hub#registerTopic">registerTopic</a>.</p>
 
                                         </div>
                                     </div>
@@ -369,7 +369,7 @@ import ballerina/websub;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Publishes directly to the internal Ballerina Hub using [publishUpdate]<a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/PublisherClient.html#publishUpdate">publishUpdate</a>..</p>
+                                            <p>Publishes directly to the internal Ballerina Hub using [publishUpdate]<a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/PublisherClient#publishUpdate">publishUpdate</a>..</p>
 
                                         </div>
                                     </div>
@@ -723,7 +723,7 @@ import ballerina/websub;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>The Ballerina main program, which demonstrates the usage of the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html">Hub client</a> to subscribe/unsubscribe to notifications.</p>
+                                            <p>The Ballerina main program, which demonstrates the usage of the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/SubscriptionClient">Hub client</a> to subscribe/unsubscribe to notifications.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/websub-internal-hub-sample.html
+++ b/swan-lake/learn/by-example/websub-internal-hub-sample.html
@@ -32,7 +32,7 @@ redirect_from:
         <span class="k">return</span><span class="p">;</span>
     <span class="p">}</span>
 
-    <span class="c1">// Registers a topic at the hub using [registerTopic](https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/classes/Hub.html#registerTopic).</span>
+    <span class="c1">// Registers a topic at the hub using [registerTopic](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/classes/Hub#registerTopic).</span>
     <span class="k">var</span> <span class="nx">registrationResponse</span> <span class="p">=</span> <span class="nx">webSubHub</span><span class="p">.</span><span class="nx">registerTopic</span><span class="p">(</span>
                                             <span class="s">&quot;http://websubpubtopic.com&quot;</span><span class="p">);</span>
     <span class="k">if</span> <span class="p">(</span><span class="nx">registrationResponse</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
@@ -45,7 +45,7 @@ redirect_from:
     <span class="c1">// Makes the publisher wait until the subscriber subscribes at the hub.</span>
     <span class="nx">runtime</span><span class="p">:</span><span class="nx">sleep</span><span class="p">(</span><span class="mi">5000</span><span class="p">);</span>
 
-    <span class="c1">// Publishes directly to the internal Ballerina hub using [publishUpdate](https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/classes/Hub.html#publishUpdate).</span>
+    <span class="c1">// Publishes directly to the internal Ballerina hub using [publishUpdate](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/classes/Hub#publishUpdate).</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Publishing update to internal Hub&quot;</span><span class="p">);</span>
     <span class="k">var</span> <span class="nx">publishResponse</span> <span class="p">=</span> <span class="nx">webSubHub</span><span class="p">.</span><span class="nx">publishUpdate</span><span class="p">(</span><span class="s">&quot;http://websubpubtopic.com&quot;</span><span class="p">,</span>
         <span class="p">{</span><span class="s">&quot;action&quot;</span><span class="p">:</span> <span class="s">&quot;publish&quot;</span><span class="p">,</span> <span class="s">&quot;mode&quot;</span><span class="p">:</span> <span class="s">&quot;internal-hub&quot;</span><span class="p">});</span>
@@ -132,7 +132,7 @@ redirect_from:
 <p>In this example, a WebSub Publisher brings up an internal hub and publishes updates to it, and a WebSub Subscriber
  subscribes at the publisher&rsquo;s hub to receive notifications of the updates sent to the topic.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/index.html">WebSub module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/">WebSub module</a>.</p>
 </p>
 
                         </td>
@@ -303,7 +303,7 @@ import ballerina/websub;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Registers a topic at the hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/classes/Hub.html#registerTopic">registerTopic</a>.</p>
+                                            <p>Registers a topic at the hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/classes/Hub#registerTopic">registerTopic</a>.</p>
 
                                         </div>
                                     </div>
@@ -343,7 +343,7 @@ import ballerina/websub;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Publishes directly to the internal Ballerina hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/classes/Hub.html#publishUpdate">publishUpdate</a>.</p>
+                                            <p>Publishes directly to the internal Ballerina hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/classes/Hub#publishUpdate">publishUpdate</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/websub-remote-hub-sample.html
+++ b/swan-lake/learn/by-example/websub-remote-hub-sample.html
@@ -49,13 +49,13 @@ redirect_from:
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">runtime</span><span class="p">;</span>
 <span class="kn">import</span> <span class="nx">ballerina</span><span class="o">/</span><span class="nx">websub</span><span class="p">;</span>
 
-<span class="c1">// This is the remote [WebSub Hub client]((https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/PublisherClient.html) to which registration and publish requests are sent.</span>
+<span class="c1">// This is the remote [WebSub Hub client]((https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/PublisherClient) to which registration and publish requests are sent.</span>
 <span class="nx">websub</span><span class="p">:</span><span class="nx">PublisherClient</span> <span class="nx">websubHubClientEP</span> <span class="p">=</span>
                     <span class="nx">new</span> <span class="p">(</span><span class="s">&quot;http://localhost:9191/websub/publish&quot;</span><span class="p">);</span>
 
 <span class="nx">public</span> <span class="kd">function</span> <span class="nx">main</span><span class="p">()</span> <span class="p">{</span>
 
-    <span class="c1">// Registers a topic at the hub using [registerTopic](https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/PublisherClient.html#registerTopic).</span>
+    <span class="c1">// Registers a topic at the hub using [registerTopic](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/PublisherClient#registerTopic).</span>
     <span class="k">var</span> <span class="nx">registrationResponse</span> <span class="p">=</span>
                 <span class="nx">websubHubClientEP</span><span class="o">-&gt;</span><span class="nx">registerTopic</span><span class="p">(</span><span class="s">&quot;http://websubpubtopic.com&quot;</span><span class="p">);</span>
     <span class="k">if</span> <span class="p">(</span><span class="nx">registrationResponse</span> <span class="nx">is</span> <span class="nx">error</span><span class="p">)</span> <span class="p">{</span>
@@ -68,7 +68,7 @@ redirect_from:
     <span class="c1">// Makes the publisher wait until the subscriber subscribes at the hub.</span>
     <span class="nx">runtime</span><span class="p">:</span><span class="nx">sleep</span><span class="p">(</span><span class="mi">5000</span><span class="p">);</span>
 
-    <span class="c1">// Publishes updates to the remote hub using [publishUpdate](https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/PublisherClient.html#publishUpdate).</span>
+    <span class="c1">// Publishes updates to the remote hub using [publishUpdate](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/PublisherClient#publishUpdate).</span>
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Publishing update to remote Hub&quot;</span><span class="p">);</span>
     <span class="k">var</span> <span class="nx">publishResponse</span> <span class="p">=</span>
         <span class="nx">websubHubClientEP</span><span class="o">-&gt;</span><span class="nx">publishUpdate</span><span class="p">(</span><span class="s">&quot;http://websubpubtopic.com&quot;</span><span class="p">,</span>
@@ -154,7 +154,7 @@ redirect_from:
  that is brought up remotely is used by a Ballerina WebSub publisher to publish updates to a topic. A Ballerina
  WebSub Subscriber subscribes at this remote hub to get the topic updates.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/index.html">WebSub module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/">WebSub module</a>.</p>
 </p>
 
                         </td>
@@ -472,7 +472,7 @@ import ballerina/websub;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>This is the remote [WebSub Hub client]((<a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/PublisherClient.html">https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/PublisherClient.html</a>) to which registration and publish requests are sent.</p>
+                                            <p>This is the remote [WebSub Hub client]((<a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/PublisherClient.html">https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/PublisherClient</a>) to which registration and publish requests are sent.</p>
 
                                         </div>
                                     </div>
@@ -510,7 +510,7 @@ import ballerina/websub;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Registers a topic at the hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/PublisherClient.html#registerTopic">registerTopic</a>.</p>
+                                            <p>Registers a topic at the hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/PublisherClient#registerTopic">registerTopic</a>.</p>
 
                                         </div>
                                     </div>
@@ -557,7 +557,7 @@ import ballerina/websub;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Publishes updates to the remote hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/clients/PublisherClient.html#publishUpdate">publishUpdate</a>.</p>
+                                            <p>Publishes updates to the remote hub using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/clients/PublisherClient#publishUpdate">publishUpdate</a>.</p>
 
                                         </div>
                                     </div>

--- a/swan-lake/learn/by-example/websub-service-integration-sample.html
+++ b/swan-lake/learn/by-example/websub-service-integration-sample.html
@@ -159,7 +159,7 @@ redirect_from:
 <p>Any of the Ballerina&rsquo;s WebSub components (Publisher, Hub, or Subscriber) could be used with non-Ballerina components, which
  are WebSub-compliant.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/websub/index.html">WebSub module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/websub/">WebSub module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/xml-functions.html
+++ b/swan-lake/learn/by-example/xml-functions.html
@@ -61,7 +61,7 @@ redirect_from:
                             <h2>XML Functions</h2>
                             <p><p>Ballerina supports various built-in functions to manipulate XML content.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/lang.xml/index.html">lang.xml module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/lang.xml/">lang.xml module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/xml-io.html
+++ b/swan-lake/learn/by-example/xml-io.html
@@ -88,7 +88,7 @@ redirect_from:
                             <p><p>This example demonstrates how XML content can be read from a file and written
  to a file using a character channel and the <code>readXml()</code> and <code>writeXml()</code> functions of the I/O API.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/io/index.html">IO module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/io/">IO module</a>.</p>
 </p>
 
                         </td>

--- a/swan-lake/learn/by-example/xslt-transformation.html
+++ b/swan-lake/learn/by-example/xslt-transformation.html
@@ -18,7 +18,7 @@ redirect_from:
     <span class="kt">xml</span> <span class="nx">sourceXml</span> <span class="p">=</span> <span class="nx">getXml</span><span class="p">();</span>
     <span class="c1">// Gets an `XSL` style sheet represented in an XML value.</span>
     <span class="kt">xml</span> <span class="nx">xsl</span> <span class="p">=</span> <span class="nx">getXsl</span><span class="p">();</span>
-    <span class="c1">// [Transforms](https://ballerina.io/swan-lake/learn/api-docs/ballerina/xslt/functions.html#transform) the `XML` content to another format.</span>
+    <span class="c1">// [Transforms](https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/xslt/functions#transform) the `XML` content to another format.</span>
     <span class="kt">xml</span> <span class="nx">target</span> <span class="p">=</span> <span class="nx">check</span> <span class="nx">xslt</span><span class="p">:</span><span class="nx">transform</span><span class="p">(</span><span class="nx">sourceXml</span><span class="p">,</span> <span class="nx">xsl</span><span class="p">);</span>
     
     <span class="nx">io</span><span class="p">:</span><span class="nb">println</span><span class="p">(</span><span class="s">&quot;Transformed XML: &quot;</span><span class="p">,</span> <span class="nx">target</span><span class="p">);</span>
@@ -83,7 +83,7 @@ redirect_from:
                             <h2>XSLT Transformation</h2>
                             <p><p>This example demonstrates how XML content can be transformed to HTML using a given XSL transformation.
  For more information on the underlying module,
- see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/xslt/index.html">XSLT module</a>.</p>
+ see the <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/xslt/">XSLT module</a>.</p>
 </p>
 
                         </td>
@@ -235,7 +235,7 @@ import ballerina/xslt;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/xslt/functions.html#transform">Transforms</a> the <code>XML</code> content to another format.</p>
+                                            <p><a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/xslt/functions#transform">Transforms</a> the <code>XML</code> content to another format.</p>
 
                                         </div>
                                     </div>


### PR DESCRIPTION
## Purpose
> Change links in BBEs to match to the api docs react app.

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
