### PR TITLE
Fix the Version Label in 1.2 API Docs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,7 +41,7 @@ latest_version: 1.2
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
-exclude: ["downloads/RELEASE_NOTE.md","vendor","0.991/","v1-2","v1-1","v1-0","v0-991","v-0.990","0.990"]
+exclude: ["downloads/RELEASE_NOTE.md","vendor","0.991/","v1-2","v1-1","v1-0","v0-991","v-0.990","0.990","1.1","1.0","swan-lake","learn/by-example"]
 #   - Gemfile.lock
 #   - node_modules
 #   - vendor/bundle/

--- a/learn/api-docs/ballerina/auth/constants.html
+++ b/learn/api-docs/ballerina/auth/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/auth/errors.html
+++ b/learn/api-docs/ballerina/auth/errors.html
@@ -76,7 +76,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/auth/functions.html
+++ b/learn/api-docs/ballerina/auth/functions.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/auth/index.html
+++ b/learn/api-docs/ballerina/auth/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
+++ b/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
+++ b/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
+++ b/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
+++ b/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
+++ b/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/auth/records/Credential.html
+++ b/learn/api-docs/ballerina/auth/records/Credential.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/auth/records/Detail.html
+++ b/learn/api-docs/ballerina/auth/records/Detail.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/awslambda/index.html
+++ b/learn/api-docs/ballerina/awslambda/index.html
@@ -61,7 +61,7 @@
             
 
     
-        <div class="version">v0.0.0</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/azure.functions/index.html
+++ b/learn/api-docs/ballerina/azure.functions/index.html
@@ -61,7 +61,7 @@
             
 
     
-        <div class="version">v0.0.0</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/constants.html
+++ b/learn/api-docs/ballerina/cache/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/errors.html
+++ b/learn/api-docs/ballerina/cache/errors.html
@@ -76,7 +76,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/functions.html
+++ b/learn/api-docs/ballerina/cache/functions.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/index.html
+++ b/learn/api-docs/ballerina/cache/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/objects/AbstractCache.html
+++ b/learn/api-docs/ballerina/cache/objects/AbstractCache.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/objects/AbstractEvictionPolicy.html
+++ b/learn/api-docs/ballerina/cache/objects/AbstractEvictionPolicy.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/objects/Cache.html
+++ b/learn/api-docs/ballerina/cache/objects/Cache.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/objects/LruEvictionPolicy.html
+++ b/learn/api-docs/ballerina/cache/objects/LruEvictionPolicy.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/records/CacheConfig.html
+++ b/learn/api-docs/ballerina/cache/records/CacheConfig.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/records/Detail.html
+++ b/learn/api-docs/ballerina/cache/records/Detail.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/records/LinkedList.html
+++ b/learn/api-docs/ballerina/cache/records/LinkedList.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/cache/records/Node.html
+++ b/learn/api-docs/ballerina/cache/records/Node.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/config/functions.html
+++ b/learn/api-docs/ballerina/config/functions.html
@@ -105,7 +105,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/config/index.html
+++ b/learn/api-docs/ballerina/config/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/constants.html
+++ b/learn/api-docs/ballerina/crypto/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/errors.html
+++ b/learn/api-docs/ballerina/crypto/errors.html
@@ -76,7 +76,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/functions.html
+++ b/learn/api-docs/ballerina/crypto/functions.html
@@ -201,7 +201,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/index.html
+++ b/learn/api-docs/ballerina/crypto/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/records/Certificate.html
+++ b/learn/api-docs/ballerina/crypto/records/Certificate.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/records/Detail.html
+++ b/learn/api-docs/ballerina/crypto/records/Detail.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/records/KeyStore.html
+++ b/learn/api-docs/ballerina/crypto/records/KeyStore.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/records/PrivateKey.html
+++ b/learn/api-docs/ballerina/crypto/records/PrivateKey.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/records/PublicKey.html
+++ b/learn/api-docs/ballerina/crypto/records/PublicKey.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/records/TrustStore.html
+++ b/learn/api-docs/ballerina/crypto/records/TrustStore.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/crypto/types.html
+++ b/learn/api-docs/ballerina/crypto/types.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/docker/index.html
+++ b/learn/api-docs/ballerina/docker/index.html
@@ -59,7 +59,7 @@
 </a>
 
             
-
+<div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/clients/ImapClient.html
+++ b/learn/api-docs/ballerina/email/clients/ImapClient.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/clients/PopClient.html
+++ b/learn/api-docs/ballerina/email/clients/PopClient.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/clients/SmtpClient.html
+++ b/learn/api-docs/ballerina/email/clients/SmtpClient.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/constants.html
+++ b/learn/api-docs/ballerina/email/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/errors.html
+++ b/learn/api-docs/ballerina/email/errors.html
@@ -84,7 +84,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/index.html
+++ b/learn/api-docs/ballerina/email/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/records/Detail.html
+++ b/learn/api-docs/ballerina/email/records/Detail.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/records/Email.html
+++ b/learn/api-docs/ballerina/email/records/Email.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/records/ImapConfig.html
+++ b/learn/api-docs/ballerina/email/records/ImapConfig.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/records/PopConfig.html
+++ b/learn/api-docs/ballerina/email/records/PopConfig.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/records/SmtpConfig.html
+++ b/learn/api-docs/ballerina/email/records/SmtpConfig.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/email/types.html
+++ b/learn/api-docs/ballerina/email/types.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/encoding/constants.html
+++ b/learn/api-docs/ballerina/encoding/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/encoding/errors.html
+++ b/learn/api-docs/ballerina/encoding/errors.html
@@ -76,7 +76,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/encoding/functions.html
+++ b/learn/api-docs/ballerina/encoding/functions.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/encoding/index.html
+++ b/learn/api-docs/ballerina/encoding/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/encoding/records/Detail.html
+++ b/learn/api-docs/ballerina/encoding/records/Detail.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/file/constants.html
+++ b/learn/api-docs/ballerina/file/constants.html
@@ -68,7 +68,7 @@ file/directory, and retrieve metadata of the file.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/file/errors.html
+++ b/learn/api-docs/ballerina/file/errors.html
@@ -89,7 +89,7 @@ file/directory, and retrieve metadata of the file.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/file/functions.html
+++ b/learn/api-docs/ballerina/file/functions.html
@@ -114,7 +114,7 @@ file/directory, and retrieve metadata of the file.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/file/index.html
+++ b/learn/api-docs/ballerina/file/index.html
@@ -67,7 +67,7 @@ file/directory, and retrieve metadata of the file.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/file/listeners/Listener.html
+++ b/learn/api-docs/ballerina/file/listeners/Listener.html
@@ -78,7 +78,7 @@ file/directory, and retrieve metadata of the file.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/file/objects/FileInfo.html
+++ b/learn/api-docs/ballerina/file/objects/FileInfo.html
@@ -78,7 +78,7 @@ file/directory, and retrieve metadata of the file.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/file/records/Detail.html
+++ b/learn/api-docs/ballerina/file/records/Detail.html
@@ -86,7 +86,7 @@ file/directory, and retrieve metadata of the file.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/file/records/FileEvent.html
+++ b/learn/api-docs/ballerina/file/records/FileEvent.html
@@ -86,7 +86,7 @@ file/directory, and retrieve metadata of the file.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/file/records/ListenerConfig.html
+++ b/learn/api-docs/ballerina/file/records/ListenerConfig.html
@@ -86,7 +86,7 @@ file/directory, and retrieve metadata of the file.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/file/types.html
+++ b/learn/api-docs/ballerina/file/types.html
@@ -78,7 +78,7 @@ file/directory, and retrieve metadata of the file.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/filepath/constants.html
+++ b/learn/api-docs/ballerina/filepath/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/filepath/errors.html
+++ b/learn/api-docs/ballerina/filepath/errors.html
@@ -108,7 +108,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/filepath/functions.html
+++ b/learn/api-docs/ballerina/filepath/functions.html
@@ -129,7 +129,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/filepath/index.html
+++ b/learn/api-docs/ballerina/filepath/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/filepath/records/Detail.html
+++ b/learn/api-docs/ballerina/filepath/records/Detail.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/filepath/types.html
+++ b/learn/api-docs/ballerina/filepath/types.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/annotations.html
+++ b/learn/api-docs/ballerina/grpc/annotations.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/clients/Caller.html
+++ b/learn/api-docs/ballerina/grpc/clients/Caller.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/clients/Client.html
+++ b/learn/api-docs/ballerina/grpc/clients/Client.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
+++ b/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/constants.html
+++ b/learn/api-docs/ballerina/grpc/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/errors.html
+++ b/learn/api-docs/ballerina/grpc/errors.html
@@ -140,7 +140,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/functions.html
+++ b/learn/api-docs/ballerina/grpc/functions.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/index.html
+++ b/learn/api-docs/ballerina/grpc/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/listeners/Listener.html
+++ b/learn/api-docs/ballerina/grpc/listeners/Listener.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
+++ b/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/objects/Headers.html
+++ b/learn/api-docs/ballerina/grpc/objects/Headers.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
+++ b/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/Detail.html
+++ b/learn/api-docs/ballerina/grpc/records/Detail.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
+++ b/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
+++ b/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
+++ b/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
+++ b/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
+++ b/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/Local.html
+++ b/learn/api-docs/ballerina/grpc/records/Local.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
+++ b/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/Protocols.html
+++ b/learn/api-docs/ballerina/grpc/records/Protocols.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/Remote.html
+++ b/learn/api-docs/ballerina/grpc/records/Remote.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/RetryConfiguration.html
+++ b/learn/api-docs/ballerina/grpc/records/RetryConfiguration.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/SecureSocket.html
+++ b/learn/api-docs/ballerina/grpc/records/SecureSocket.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
+++ b/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/records/ValidateCert.html
+++ b/learn/api-docs/ballerina/grpc/records/ValidateCert.html
@@ -133,7 +133,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/grpc/types.html
+++ b/learn/api-docs/ballerina/grpc/types.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/annotations.html
+++ b/learn/api-docs/ballerina/http/annotations.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/Caller.html
+++ b/learn/api-docs/ballerina/http/clients/Caller.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
+++ b/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/Client.html
+++ b/learn/api-docs/ballerina/http/clients/Client.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/FailoverClient.html
+++ b/learn/api-docs/ballerina/http/clients/FailoverClient.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
+++ b/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/HttpClient.html
+++ b/learn/api-docs/ballerina/http/clients/HttpClient.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
+++ b/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
+++ b/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/RedirectClient.html
+++ b/learn/api-docs/ballerina/http/clients/RedirectClient.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/RetryClient.html
+++ b/learn/api-docs/ballerina/http/clients/RetryClient.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
+++ b/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/WebSocketClient.html
+++ b/learn/api-docs/ballerina/http/clients/WebSocketClient.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/clients/WebSocketFailoverClient.html
+++ b/learn/api-docs/ballerina/http/clients/WebSocketFailoverClient.html
@@ -125,7 +125,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/constants.html
+++ b/learn/api-docs/ballerina/http/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/errors.html
+++ b/learn/api-docs/ballerina/http/errors.html
@@ -224,7 +224,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/functions.html
+++ b/learn/api-docs/ballerina/http/functions.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/index.html
+++ b/learn/api-docs/ballerina/http/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/listeners/Listener.html
+++ b/learn/api-docs/ballerina/http/listeners/Listener.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/listeners/MockListener.html
+++ b/learn/api-docs/ballerina/http/listeners/MockListener.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/AuthnFilter.html
+++ b/learn/api-docs/ballerina/http/objects/AuthnFilter.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/AuthzFilter.html
+++ b/learn/api-docs/ballerina/http/objects/AuthzFilter.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/AuthzHandler.html
+++ b/learn/api-docs/ballerina/http/objects/AuthzHandler.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
+++ b/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
+++ b/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/Cookie.html
+++ b/learn/api-docs/ballerina/http/objects/Cookie.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/CookieClient.html
+++ b/learn/api-docs/ballerina/http/objects/CookieClient.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/CookieStore.html
+++ b/learn/api-docs/ballerina/http/objects/CookieStore.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/CsvPersistentCookieHandler.html
+++ b/learn/api-docs/ballerina/http/objects/CsvPersistentCookieHandler.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/FilterContext.html
+++ b/learn/api-docs/ballerina/http/objects/FilterContext.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/HttpCache.html
+++ b/learn/api-docs/ballerina/http/objects/HttpCache.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/HttpFuture.html
+++ b/learn/api-docs/ballerina/http/objects/HttpFuture.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
+++ b/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
+++ b/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
+++ b/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
+++ b/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/PersistentCookieHandler.html
+++ b/learn/api-docs/ballerina/http/objects/PersistentCookieHandler.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/PushPromise.html
+++ b/learn/api-docs/ballerina/http/objects/PushPromise.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/Request.html
+++ b/learn/api-docs/ballerina/http/objects/Request.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
+++ b/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/RequestFilter.html
+++ b/learn/api-docs/ballerina/http/objects/RequestFilter.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/Response.html
+++ b/learn/api-docs/ballerina/http/objects/Response.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
+++ b/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/objects/ResponseFilter.html
+++ b/learn/api-docs/ballerina/http/objects/ResponseFilter.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/Bucket.html
+++ b/learn/api-docs/ballerina/http/records/Bucket.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/CacheConfig.html
+++ b/learn/api-docs/ballerina/http/records/CacheConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
+++ b/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
+++ b/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/CircuitHealth.html
+++ b/learn/api-docs/ballerina/http/records/CircuitHealth.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ClientConfiguration.html
+++ b/learn/api-docs/ballerina/http/records/ClientConfiguration.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
+++ b/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
+++ b/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
+++ b/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/CommonClientConfiguration.html
+++ b/learn/api-docs/ballerina/http/records/CommonClientConfiguration.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/CompressionConfig.html
+++ b/learn/api-docs/ballerina/http/records/CompressionConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/CookieConfig.html
+++ b/learn/api-docs/ballerina/http/records/CookieConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/CorsConfig.html
+++ b/learn/api-docs/ballerina/http/records/CorsConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/Detail.html
+++ b/learn/api-docs/ballerina/http/records/Detail.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
+++ b/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/FailoverConfig.html
+++ b/learn/api-docs/ballerina/http/records/FailoverConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
+++ b/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/FollowRedirects.html
+++ b/learn/api-docs/ballerina/http/records/FollowRedirects.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
+++ b/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
+++ b/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
+++ b/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ListenerAuth.html
+++ b/learn/api-docs/ballerina/http/records/ListenerAuth.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
+++ b/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
+++ b/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
+++ b/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
+++ b/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
+++ b/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
+++ b/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/Local.html
+++ b/learn/api-docs/ballerina/http/records/Local.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
+++ b/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
+++ b/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/PoolConfiguration.html
+++ b/learn/api-docs/ballerina/http/records/PoolConfiguration.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/Protocols.html
+++ b/learn/api-docs/ballerina/http/records/Protocols.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ProxyConfig.html
+++ b/learn/api-docs/ballerina/http/records/ProxyConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/Remote.html
+++ b/learn/api-docs/ballerina/http/records/Remote.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ResourceAuth.html
+++ b/learn/api-docs/ballerina/http/records/ResourceAuth.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/RetryConfig.html
+++ b/learn/api-docs/ballerina/http/records/RetryConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
+++ b/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/RollingWindow.html
+++ b/learn/api-docs/ballerina/http/records/RollingWindow.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ServiceAuth.html
+++ b/learn/api-docs/ballerina/http/records/ServiceAuth.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/TargetService.html
+++ b/learn/api-docs/ballerina/http/records/TargetService.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/ValidateCert.html
+++ b/learn/api-docs/ballerina/http/records/ValidateCert.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/Versioning.html
+++ b/learn/api-docs/ballerina/http/records/Versioning.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/WSServiceConfig.html
+++ b/learn/api-docs/ballerina/http/records/WSServiceConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
+++ b/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/WebSocketFailoverClientConfiguration.html
+++ b/learn/api-docs/ballerina/http/records/WebSocketFailoverClientConfiguration.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/WebSocketRetryConfig.html
+++ b/learn/api-docs/ballerina/http/records/WebSocketRetryConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
+++ b/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
@@ -265,7 +265,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/http/types.html
+++ b/learn/api-docs/ballerina/http/types.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/constants.html
+++ b/learn/api-docs/ballerina/io/constants.html
@@ -68,7 +68,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/errors.html
+++ b/learn/api-docs/ballerina/io/errors.html
@@ -93,7 +93,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/functions.html
+++ b/learn/api-docs/ballerina/io/functions.html
@@ -110,7 +110,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/index.html
+++ b/learn/api-docs/ballerina/io/index.html
@@ -67,7 +67,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
+++ b/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
+++ b/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
+++ b/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
+++ b/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
+++ b/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/StringReader.html
+++ b/learn/api-docs/ballerina/io/objects/StringReader.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
+++ b/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
+++ b/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
+++ b/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
+++ b/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
+++ b/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
@@ -118,7 +118,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/records/Detail.html
+++ b/learn/api-docs/ballerina/io/records/Detail.html
@@ -78,7 +78,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/io/types.html
+++ b/learn/api-docs/ballerina/io/types.html
@@ -86,7 +86,7 @@ or non-blocking manner.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/istio/index.html
+++ b/learn/api-docs/ballerina/istio/index.html
@@ -60,7 +60,7 @@
 
             
 
-    
+<div class="version">v1.2.11</div>
 
 
 <div class="primary-list module">

--- a/learn/api-docs/ballerina/java.arrays/functions.html
+++ b/learn/api-docs/ballerina/java.arrays/functions.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.arrays/index.html
+++ b/learn/api-docs/ballerina/java.arrays/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/clients/Client.html
+++ b/learn/api-docs/ballerina/java.jdbc/clients/Client.html
@@ -78,7 +78,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/constants.html
+++ b/learn/api-docs/ballerina/java.jdbc/constants.html
@@ -68,7 +68,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/errors.html
+++ b/learn/api-docs/ballerina/java.jdbc/errors.html
@@ -81,7 +81,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/index.html
+++ b/learn/api-docs/ballerina/java.jdbc/index.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
+++ b/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
@@ -102,7 +102,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
+++ b/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
@@ -102,7 +102,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
+++ b/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
@@ -102,7 +102,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
+++ b/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
@@ -102,7 +102,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
+++ b/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
@@ -102,7 +102,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
+++ b/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
@@ -102,7 +102,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
+++ b/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
@@ -102,7 +102,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java.jdbc/types.html
+++ b/learn/api-docs/ballerina/java.jdbc/types.html
@@ -90,7 +90,7 @@ that is accessible via Java Database Connectivity (JDBC).
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java/annotations.html
+++ b/learn/api-docs/ballerina/java/annotations.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java/functions.html
+++ b/learn/api-docs/ballerina/java/functions.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java/index.html
+++ b/learn/api-docs/ballerina/java/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java/objects/JObject.html
+++ b/learn/api-docs/ballerina/java/objects/JObject.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java/records/ArrayType.html
+++ b/learn/api-docs/ballerina/java/records/ArrayType.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java/records/ConstructorData.html
+++ b/learn/api-docs/ballerina/java/records/ConstructorData.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java/records/FieldData.html
+++ b/learn/api-docs/ballerina/java/records/FieldData.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java/records/MethodData.html
+++ b/learn/api-docs/ballerina/java/records/MethodData.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/java/records/ObjectData.html
+++ b/learn/api-docs/ballerina/java/records/ObjectData.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jsonutils/functions.html
+++ b/learn/api-docs/ballerina/jsonutils/functions.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jsonutils/index.html
+++ b/learn/api-docs/ballerina/jsonutils/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
+++ b/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/constants.html
+++ b/learn/api-docs/ballerina/jwt/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/errors.html
+++ b/learn/api-docs/ballerina/jwt/errors.html
@@ -76,7 +76,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/functions.html
+++ b/learn/api-docs/ballerina/jwt/functions.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/index.html
+++ b/learn/api-docs/ballerina/jwt/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
+++ b/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
+++ b/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/records/Detail.html
+++ b/learn/api-docs/ballerina/jwt/records/Detail.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/records/InboundJwtCacheEntry.html
+++ b/learn/api-docs/ballerina/jwt/records/InboundJwtCacheEntry.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/records/JwksConfig.html
+++ b/learn/api-docs/ballerina/jwt/records/JwksConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/records/JwtHeader.html
+++ b/learn/api-docs/ballerina/jwt/records/JwtHeader.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
+++ b/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
+++ b/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/records/JwtPayload.html
+++ b/learn/api-docs/ballerina/jwt/records/JwtPayload.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
+++ b/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
+++ b/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/jwt/types.html
+++ b/learn/api-docs/ballerina/jwt/types.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/clients/Consumer.html
+++ b/learn/api-docs/ballerina/kafka/clients/Consumer.html
@@ -82,7 +82,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/clients/Producer.html
+++ b/learn/api-docs/ballerina/kafka/clients/Producer.html
@@ -82,7 +82,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/constants.html
+++ b/learn/api-docs/ballerina/kafka/constants.html
@@ -68,7 +68,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/errors.html
+++ b/learn/api-docs/ballerina/kafka/errors.html
@@ -85,7 +85,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/index.html
+++ b/learn/api-docs/ballerina/kafka/index.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/objects/Deserializer.html
+++ b/learn/api-docs/ballerina/kafka/objects/Deserializer.html
@@ -82,7 +82,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/objects/Serializer.html
+++ b/learn/api-docs/ballerina/kafka/objects/Serializer.html
@@ -82,7 +82,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/AuthenticationConfiguration.html
+++ b/learn/api-docs/ballerina/kafka/records/AuthenticationConfiguration.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/AvroRecord.html
+++ b/learn/api-docs/ballerina/kafka/records/AvroRecord.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/ConsumerConfiguration.html
+++ b/learn/api-docs/ballerina/kafka/records/ConsumerConfiguration.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
+++ b/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/Detail.html
+++ b/learn/api-docs/ballerina/kafka/records/Detail.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/KeyStore.html
+++ b/learn/api-docs/ballerina/kafka/records/KeyStore.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
+++ b/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/ProducerConfiguration.html
+++ b/learn/api-docs/ballerina/kafka/records/ProducerConfiguration.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/Protocols.html
+++ b/learn/api-docs/ballerina/kafka/records/Protocols.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/SecureSocket.html
+++ b/learn/api-docs/ballerina/kafka/records/SecureSocket.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/TopicPartition.html
+++ b/learn/api-docs/ballerina/kafka/records/TopicPartition.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/records/TrustStore.html
+++ b/learn/api-docs/ballerina/kafka/records/TrustStore.html
@@ -122,7 +122,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kafka/types.html
+++ b/learn/api-docs/ballerina/kafka/types.html
@@ -102,7 +102,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/knative/index.html
+++ b/learn/api-docs/ballerina/knative/index.html
@@ -59,7 +59,7 @@
 </a>
 
             
-
+<div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/kubernetes/index.html
+++ b/learn/api-docs/ballerina/kubernetes/index.html
@@ -60,7 +60,7 @@
 
             
 
-    
+<div class="version">v1.2.11</div>
 
 
 <div class="primary-list module">

--- a/learn/api-docs/ballerina/lang.array/functions.html
+++ b/learn/api-docs/ballerina/lang.array/functions.html
@@ -169,7 +169,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.array/index.html
+++ b/learn/api-docs/ballerina/lang.array/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.array/objects/T1.html
+++ b/learn/api-docs/ballerina/lang.array/objects/T1.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.array/records/T0.html
+++ b/learn/api-docs/ballerina/lang.array/records/T0.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.array/records/T2.html
+++ b/learn/api-docs/ballerina/lang.array/records/T2.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.boolean/functions.html
+++ b/learn/api-docs/ballerina/lang.boolean/functions.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.boolean/index.html
+++ b/learn/api-docs/ballerina/lang.boolean/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.decimal/functions.html
+++ b/learn/api-docs/ballerina/lang.decimal/functions.html
@@ -105,7 +105,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.decimal/index.html
+++ b/learn/api-docs/ballerina/lang.decimal/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.error/errors.html
+++ b/learn/api-docs/ballerina/lang.error/errors.html
@@ -80,7 +80,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.error/functions.html
+++ b/learn/api-docs/ballerina/lang.error/functions.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.error/index.html
+++ b/learn/api-docs/ballerina/lang.error/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.error/objects/CallStack.html
+++ b/learn/api-docs/ballerina/lang.error/objects/CallStack.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
+++ b/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.error/records/Detail.html
+++ b/learn/api-docs/ballerina/lang.error/records/Detail.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.float/constants.html
+++ b/learn/api-docs/ballerina/lang.float/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.float/functions.html
+++ b/learn/api-docs/ballerina/lang.float/functions.html
@@ -197,7 +197,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.float/index.html
+++ b/learn/api-docs/ballerina/lang.float/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.future/functions.html
+++ b/learn/api-docs/ballerina/lang.future/functions.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.future/index.html
+++ b/learn/api-docs/ballerina/lang.future/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.int/constants.html
+++ b/learn/api-docs/ballerina/lang.int/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.int/functions.html
+++ b/learn/api-docs/ballerina/lang.int/functions.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.int/index.html
+++ b/learn/api-docs/ballerina/lang.int/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.map/functions.html
+++ b/learn/api-docs/ballerina/lang.map/functions.html
@@ -129,7 +129,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.map/index.html
+++ b/learn/api-docs/ballerina/lang.map/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.map/objects/T2.html
+++ b/learn/api-docs/ballerina/lang.map/objects/T2.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.map/records/T0.html
+++ b/learn/api-docs/ballerina/lang.map/records/T0.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.map/records/T1.html
+++ b/learn/api-docs/ballerina/lang.map/records/T1.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.object/index.html
+++ b/learn/api-docs/ballerina/lang.object/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.object/objects/Listener.html
+++ b/learn/api-docs/ballerina/lang.object/objects/Listener.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/functions.html
+++ b/learn/api-docs/ballerina/lang.stream/functions.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/index.html
+++ b/learn/api-docs/ballerina/lang.stream/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/objects/T0.html
+++ b/learn/api-docs/ballerina/lang.stream/objects/T0.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/objects/T2.html
+++ b/learn/api-docs/ballerina/lang.stream/objects/T2.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/objects/T3.html
+++ b/learn/api-docs/ballerina/lang.stream/objects/T3.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/objects/T4.html
+++ b/learn/api-docs/ballerina/lang.stream/objects/T4.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/objects/T6.html
+++ b/learn/api-docs/ballerina/lang.stream/objects/T6.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/objects/T7.html
+++ b/learn/api-docs/ballerina/lang.stream/objects/T7.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/records/T1.html
+++ b/learn/api-docs/ballerina/lang.stream/records/T1.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/records/T10.html
+++ b/learn/api-docs/ballerina/lang.stream/records/T10.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/records/T11.html
+++ b/learn/api-docs/ballerina/lang.stream/records/T11.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/records/T12.html
+++ b/learn/api-docs/ballerina/lang.stream/records/T12.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/records/T5.html
+++ b/learn/api-docs/ballerina/lang.stream/records/T5.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/records/T8.html
+++ b/learn/api-docs/ballerina/lang.stream/records/T8.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.stream/records/T9.html
+++ b/learn/api-docs/ballerina/lang.stream/records/T9.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.string/functions.html
+++ b/learn/api-docs/ballerina/lang.string/functions.html
@@ -157,7 +157,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.string/index.html
+++ b/learn/api-docs/ballerina/lang.string/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.string/objects/T2.html
+++ b/learn/api-docs/ballerina/lang.string/objects/T2.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.string/records/T0.html
+++ b/learn/api-docs/ballerina/lang.string/records/T0.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.string/records/T1.html
+++ b/learn/api-docs/ballerina/lang.string/records/T1.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.table/functions.html
+++ b/learn/api-docs/ballerina/lang.table/functions.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.table/index.html
+++ b/learn/api-docs/ballerina/lang.table/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.table/objects/T2.html
+++ b/learn/api-docs/ballerina/lang.table/objects/T2.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.table/records/T0.html
+++ b/learn/api-docs/ballerina/lang.table/records/T0.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.table/records/T1.html
+++ b/learn/api-docs/ballerina/lang.table/records/T1.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.typedesc/functions.html
+++ b/learn/api-docs/ballerina/lang.typedesc/functions.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.typedesc/index.html
+++ b/learn/api-docs/ballerina/lang.typedesc/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.value/functions.html
+++ b/learn/api-docs/ballerina/lang.value/functions.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.value/index.html
+++ b/learn/api-docs/ballerina/lang.value/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.xml/constants.html
+++ b/learn/api-docs/ballerina/lang.xml/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.xml/functions.html
+++ b/learn/api-docs/ballerina/lang.xml/functions.html
@@ -157,7 +157,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.xml/index.html
+++ b/learn/api-docs/ballerina/lang.xml/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.xml/objects/T7.html
+++ b/learn/api-docs/ballerina/lang.xml/objects/T7.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.xml/records/T0.html
+++ b/learn/api-docs/ballerina/lang.xml/records/T0.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/lang.xml/records/T6.html
+++ b/learn/api-docs/ballerina/lang.xml/records/T6.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/ldap/constants.html
+++ b/learn/api-docs/ballerina/ldap/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/ldap/errors.html
+++ b/learn/api-docs/ballerina/ldap/errors.html
@@ -76,7 +76,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/ldap/functions.html
+++ b/learn/api-docs/ballerina/ldap/functions.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/ldap/index.html
+++ b/learn/api-docs/ballerina/ldap/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/ldap/objects/InboundLdapAuthProvider.html
+++ b/learn/api-docs/ballerina/ldap/objects/InboundLdapAuthProvider.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/ldap/records/LdapConnection.html
+++ b/learn/api-docs/ballerina/ldap/records/LdapConnection.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/ldap/records/LdapConnectionConfig.html
+++ b/learn/api-docs/ballerina/ldap/records/LdapConnectionConfig.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/ldap/records/SecureSocket.html
+++ b/learn/api-docs/ballerina/ldap/records/SecureSocket.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/log/functions.html
+++ b/learn/api-docs/ballerina/log/functions.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/log/index.html
+++ b/learn/api-docs/ballerina/log/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/math/constants.html
+++ b/learn/api-docs/ballerina/math/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/math/errors.html
+++ b/learn/api-docs/ballerina/math/errors.html
@@ -76,7 +76,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/math/functions.html
+++ b/learn/api-docs/ballerina/math/functions.html
@@ -237,7 +237,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/math/index.html
+++ b/learn/api-docs/ballerina/math/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/math/records/Detail.html
+++ b/learn/api-docs/ballerina/math/records/Detail.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/mime/constants.html
+++ b/learn/api-docs/ballerina/mime/constants.html
@@ -69,7 +69,7 @@ the RFC 2045 standard.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/mime/errors.html
+++ b/learn/api-docs/ballerina/mime/errors.html
@@ -114,7 +114,7 @@ the RFC 2045 standard.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/mime/functions.html
+++ b/learn/api-docs/ballerina/mime/functions.html
@@ -107,7 +107,7 @@ the RFC 2045 standard.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/mime/index.html
+++ b/learn/api-docs/ballerina/mime/index.html
@@ -68,7 +68,7 @@ the RFC 2045 standard.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
+++ b/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
@@ -87,7 +87,7 @@ the RFC 2045 standard.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/mime/objects/Entity.html
+++ b/learn/api-docs/ballerina/mime/objects/Entity.html
@@ -87,7 +87,7 @@ the RFC 2045 standard.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/mime/objects/MediaType.html
+++ b/learn/api-docs/ballerina/mime/objects/MediaType.html
@@ -87,7 +87,7 @@ the RFC 2045 standard.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/mime/records/Detail.html
+++ b/learn/api-docs/ballerina/mime/records/Detail.html
@@ -79,7 +79,7 @@ the RFC 2045 standard.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/mime/types.html
+++ b/learn/api-docs/ballerina/mime/types.html
@@ -83,7 +83,7 @@ the RFC 2045 standard.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/annotations.html
+++ b/learn/api-docs/ballerina/nats/annotations.html
@@ -82,7 +82,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/clients/Producer.html
+++ b/learn/api-docs/ballerina/nats/clients/Producer.html
@@ -86,7 +86,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
+++ b/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
@@ -86,7 +86,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
+++ b/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
@@ -86,7 +86,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/constants.html
+++ b/learn/api-docs/ballerina/nats/constants.html
@@ -68,7 +68,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/errors.html
+++ b/learn/api-docs/ballerina/nats/errors.html
@@ -77,7 +77,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/index.html
+++ b/learn/api-docs/ballerina/nats/index.html
@@ -67,7 +67,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/listeners/Listener.html
+++ b/learn/api-docs/ballerina/nats/listeners/Listener.html
@@ -82,7 +82,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
+++ b/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
@@ -82,7 +82,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/objects/Connection.html
+++ b/learn/api-docs/ballerina/nats/objects/Connection.html
@@ -82,7 +82,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/objects/Message.html
+++ b/learn/api-docs/ballerina/nats/objects/Message.html
@@ -82,7 +82,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
+++ b/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
@@ -102,7 +102,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/records/Detail.html
+++ b/learn/api-docs/ballerina/nats/records/Detail.html
@@ -102,7 +102,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/records/PendingLimits.html
+++ b/learn/api-docs/ballerina/nats/records/PendingLimits.html
@@ -102,7 +102,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/records/SecureSocket.html
+++ b/learn/api-docs/ballerina/nats/records/SecureSocket.html
@@ -102,7 +102,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/records/StreamingConfig.html
+++ b/learn/api-docs/ballerina/nats/records/StreamingConfig.html
@@ -102,7 +102,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
+++ b/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
@@ -102,7 +102,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
+++ b/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
@@ -102,7 +102,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/nats/types.html
+++ b/learn/api-docs/ballerina/nats/types.html
@@ -90,7 +90,7 @@ below functionalities.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/constants.html
+++ b/learn/api-docs/ballerina/oauth2/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/errors.html
+++ b/learn/api-docs/ballerina/oauth2/errors.html
@@ -76,7 +76,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/functions.html
+++ b/learn/api-docs/ballerina/oauth2/functions.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/index.html
+++ b/learn/api-docs/ballerina/oauth2/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
+++ b/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
+++ b/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
+++ b/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/records/Detail.html
+++ b/learn/api-docs/ballerina/oauth2/records/Detail.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
+++ b/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
+++ b/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/records/InboundOAuth2CacheEntry.html
+++ b/learn/api-docs/ballerina/oauth2/records/InboundOAuth2CacheEntry.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
+++ b/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/records/OutboundOAuth2CacheEntry.html
+++ b/learn/api-docs/ballerina/oauth2/records/OutboundOAuth2CacheEntry.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
+++ b/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
+++ b/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
@@ -109,7 +109,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/observe/functions.html
+++ b/learn/api-docs/ballerina/observe/functions.html
@@ -98,7 +98,7 @@ Ballerina supports Observability out of the box. This module provides user api's
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/observe/index.html
+++ b/learn/api-docs/ballerina/observe/index.html
@@ -67,7 +67,7 @@ Ballerina supports Observability out of the box. This module provides user api's
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/observe/objects/Counter.html
+++ b/learn/api-docs/ballerina/observe/objects/Counter.html
@@ -82,7 +82,7 @@ Ballerina supports Observability out of the box. This module provides user api's
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/observe/objects/Gauge.html
+++ b/learn/api-docs/ballerina/observe/objects/Gauge.html
@@ -82,7 +82,7 @@ Ballerina supports Observability out of the box. This module provides user api's
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/observe/records/Metric.html
+++ b/learn/api-docs/ballerina/observe/records/Metric.html
@@ -90,7 +90,7 @@ Ballerina supports Observability out of the box. This module provides user api's
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/observe/records/PercentileValue.html
+++ b/learn/api-docs/ballerina/observe/records/PercentileValue.html
@@ -90,7 +90,7 @@ Ballerina supports Observability out of the box. This module provides user api's
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/observe/records/Snapshot.html
+++ b/learn/api-docs/ballerina/observe/records/Snapshot.html
@@ -90,7 +90,7 @@ Ballerina supports Observability out of the box. This module provides user api's
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/observe/records/StatisticConfig.html
+++ b/learn/api-docs/ballerina/observe/records/StatisticConfig.html
@@ -90,7 +90,7 @@ Ballerina supports Observability out of the box. This module provides user api's
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/openapi/annotations.html
+++ b/learn/api-docs/ballerina/openapi/annotations.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/openapi/index.html
+++ b/learn/api-docs/ballerina/openapi/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/openapi/records/ClientInformation.html
+++ b/learn/api-docs/ballerina/openapi/records/ClientInformation.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
+++ b/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/openshift/index.html
+++ b/learn/api-docs/ballerina/openshift/index.html
@@ -60,7 +60,7 @@
 
             
 
-    
+<div class="version">v1.2.11</div>
 
 
 <div class="primary-list module">

--- a/learn/api-docs/ballerina/rabbitmq/annotations.html
+++ b/learn/api-docs/ballerina/rabbitmq/annotations.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
+++ b/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/clients/Message.html
+++ b/learn/api-docs/ballerina/rabbitmq/clients/Message.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/constants.html
+++ b/learn/api-docs/ballerina/rabbitmq/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/errors.html
+++ b/learn/api-docs/ballerina/rabbitmq/errors.html
@@ -76,7 +76,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/index.html
+++ b/learn/api-docs/ballerina/rabbitmq/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
+++ b/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
+++ b/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
+++ b/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
+++ b/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/records/Detail.html
+++ b/learn/api-docs/ballerina/rabbitmq/records/Detail.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
+++ b/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
+++ b/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
+++ b/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
+++ b/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
@@ -101,7 +101,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/rabbitmq/types.html
+++ b/learn/api-docs/ballerina/rabbitmq/types.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/reflect/functions.html
+++ b/learn/api-docs/ballerina/reflect/functions.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/reflect/index.html
+++ b/learn/api-docs/ballerina/reflect/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/runtime/functions.html
+++ b/learn/api-docs/ballerina/runtime/functions.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/runtime/index.html
+++ b/learn/api-docs/ballerina/runtime/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
+++ b/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/runtime/records/CallStackElement.html
+++ b/learn/api-docs/ballerina/runtime/records/CallStackElement.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/runtime/records/InvocationContext.html
+++ b/learn/api-docs/ballerina/runtime/records/InvocationContext.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/runtime/records/Principal.html
+++ b/learn/api-docs/ballerina/runtime/records/Principal.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/clients/Client.html
+++ b/learn/api-docs/ballerina/socket/clients/Client.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/clients/UdpClient.html
+++ b/learn/api-docs/ballerina/socket/clients/UdpClient.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/constants.html
+++ b/learn/api-docs/ballerina/socket/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/errors.html
+++ b/learn/api-docs/ballerina/socket/errors.html
@@ -80,7 +80,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/index.html
+++ b/learn/api-docs/ballerina/socket/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/listeners/Listener.html
+++ b/learn/api-docs/ballerina/socket/listeners/Listener.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/records/Address.html
+++ b/learn/api-docs/ballerina/socket/records/Address.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/records/ClientConfig.html
+++ b/learn/api-docs/ballerina/socket/records/ClientConfig.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/records/Detail.html
+++ b/learn/api-docs/ballerina/socket/records/Detail.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/records/ListenerConfig.html
+++ b/learn/api-docs/ballerina/socket/records/ListenerConfig.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
+++ b/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/socket/types.html
+++ b/learn/api-docs/ballerina/socket/types.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/stringutils/functions.html
+++ b/learn/api-docs/ballerina/stringutils/functions.html
@@ -113,7 +113,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/stringutils/index.html
+++ b/learn/api-docs/ballerina/stringutils/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/system/constants.html
+++ b/learn/api-docs/ballerina/system/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/system/errors.html
+++ b/learn/api-docs/ballerina/system/errors.html
@@ -88,7 +88,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/system/functions.html
+++ b/learn/api-docs/ballerina/system/functions.html
@@ -93,7 +93,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/system/index.html
+++ b/learn/api-docs/ballerina/system/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/system/objects/Process.html
+++ b/learn/api-docs/ballerina/system/objects/Process.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/system/records/Detail.html
+++ b/learn/api-docs/ballerina/system/records/Detail.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/system/types.html
+++ b/learn/api-docs/ballerina/system/types.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/task/constants.html
+++ b/learn/api-docs/ballerina/task/constants.html
@@ -68,7 +68,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/task/errors.html
+++ b/learn/api-docs/ballerina/task/errors.html
@@ -81,7 +81,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/task/index.html
+++ b/learn/api-docs/ballerina/task/index.html
@@ -67,7 +67,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/task/listeners/Listener.html
+++ b/learn/api-docs/ballerina/task/listeners/Listener.html
@@ -78,7 +78,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/task/objects/Scheduler.html
+++ b/learn/api-docs/ballerina/task/objects/Scheduler.html
@@ -78,7 +78,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
+++ b/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
@@ -90,7 +90,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/task/records/AppointmentData.html
+++ b/learn/api-docs/ballerina/task/records/AppointmentData.html
@@ -90,7 +90,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/task/records/Detail.html
+++ b/learn/api-docs/ballerina/task/records/Detail.html
@@ -90,7 +90,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/task/records/TimerConfiguration.html
+++ b/learn/api-docs/ballerina/task/records/TimerConfiguration.html
@@ -90,7 +90,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/task/types.html
+++ b/learn/api-docs/ballerina/task/types.html
@@ -78,7 +78,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/annotations.html
+++ b/learn/api-docs/ballerina/test/annotations.html
@@ -97,7 +97,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/constants.html
+++ b/learn/api-docs/ballerina/test/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/errors.html
+++ b/learn/api-docs/ballerina/test/errors.html
@@ -92,7 +92,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/functions.html
+++ b/learn/api-docs/ballerina/test/functions.html
@@ -113,7 +113,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/index.html
+++ b/learn/api-docs/ballerina/test/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/FunctionStub.html
+++ b/learn/api-docs/ballerina/test/objects/FunctionStub.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/MemberFunctionStub.html
+++ b/learn/api-docs/ballerina/test/objects/MemberFunctionStub.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/MemberVariableStub.html
+++ b/learn/api-docs/ballerina/test/objects/MemberVariableStub.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/MockFunction.html
+++ b/learn/api-docs/ballerina/test/objects/MockFunction.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/MockObject.html
+++ b/learn/api-docs/ballerina/test/objects/MockObject.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T10.html
+++ b/learn/api-docs/ballerina/test/objects/T10.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T11.html
+++ b/learn/api-docs/ballerina/test/objects/T11.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T12.html
+++ b/learn/api-docs/ballerina/test/objects/T12.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T13.html
+++ b/learn/api-docs/ballerina/test/objects/T13.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T14.html
+++ b/learn/api-docs/ballerina/test/objects/T14.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T15.html
+++ b/learn/api-docs/ballerina/test/objects/T15.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T16.html
+++ b/learn/api-docs/ballerina/test/objects/T16.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T17.html
+++ b/learn/api-docs/ballerina/test/objects/T17.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T18.html
+++ b/learn/api-docs/ballerina/test/objects/T18.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T19.html
+++ b/learn/api-docs/ballerina/test/objects/T19.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T20.html
+++ b/learn/api-docs/ballerina/test/objects/T20.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T21.html
+++ b/learn/api-docs/ballerina/test/objects/T21.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T22.html
+++ b/learn/api-docs/ballerina/test/objects/T22.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T23.html
+++ b/learn/api-docs/ballerina/test/objects/T23.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T24.html
+++ b/learn/api-docs/ballerina/test/objects/T24.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T25.html
+++ b/learn/api-docs/ballerina/test/objects/T25.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T26.html
+++ b/learn/api-docs/ballerina/test/objects/T26.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/objects/T9.html
+++ b/learn/api-docs/ballerina/test/objects/T9.html
@@ -165,7 +165,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/records/Detail.html
+++ b/learn/api-docs/ballerina/test/records/Detail.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/records/MockConfig.html
+++ b/learn/api-docs/ballerina/test/records/MockConfig.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/records/TestConfig.html
+++ b/learn/api-docs/ballerina/test/records/TestConfig.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/test/types.html
+++ b/learn/api-docs/ballerina/test/types.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/time/constants.html
+++ b/learn/api-docs/ballerina/time/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/time/errors.html
+++ b/learn/api-docs/ballerina/time/errors.html
@@ -76,7 +76,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/time/functions.html
+++ b/learn/api-docs/ballerina/time/functions.html
@@ -149,7 +149,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/time/index.html
+++ b/learn/api-docs/ballerina/time/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/time/records/Detail.html
+++ b/learn/api-docs/ballerina/time/records/Detail.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/time/records/Time.html
+++ b/learn/api-docs/ballerina/time/records/Time.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/time/records/TimeZone.html
+++ b/learn/api-docs/ballerina/time/records/TimeZone.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/time/types.html
+++ b/learn/api-docs/ballerina/time/types.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/transactions/annotations.html
+++ b/learn/api-docs/ballerina/transactions/annotations.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/transactions/functions.html
+++ b/learn/api-docs/ballerina/transactions/functions.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/transactions/index.html
+++ b/learn/api-docs/ballerina/transactions/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/transactions/records/T0.html
+++ b/learn/api-docs/ballerina/transactions/records/T0.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/transactions/records/T1.html
+++ b/learn/api-docs/ballerina/transactions/records/T1.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/transactions/records/TransactionParticipantConfig.html
+++ b/learn/api-docs/ballerina/transactions/records/TransactionParticipantConfig.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/annotations.html
+++ b/learn/api-docs/ballerina/websub/annotations.html
@@ -81,7 +81,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/clients/Caller.html
+++ b/learn/api-docs/ballerina/websub/clients/Caller.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/clients/PublisherClient.html
+++ b/learn/api-docs/ballerina/websub/clients/PublisherClient.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
+++ b/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/constants.html
+++ b/learn/api-docs/ballerina/websub/constants.html
@@ -67,7 +67,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/errors.html
+++ b/learn/api-docs/ballerina/websub/errors.html
@@ -80,7 +80,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/functions.html
+++ b/learn/api-docs/ballerina/websub/functions.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/index.html
+++ b/learn/api-docs/ballerina/websub/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/listeners/Listener.html
+++ b/learn/api-docs/ballerina/websub/listeners/Listener.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/objects/Hub.html
+++ b/learn/api-docs/ballerina/websub/objects/Hub.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
+++ b/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
+++ b/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/objects/Notification.html
+++ b/learn/api-docs/ballerina/websub/objects/Notification.html
@@ -89,7 +89,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/Detail.html
+++ b/learn/api-docs/ballerina/websub/records/Detail.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
+++ b/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/HubConfiguration.html
+++ b/learn/api-docs/ballerina/websub/records/HubConfiguration.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
+++ b/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
+++ b/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
+++ b/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
+++ b/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.111</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
+++ b/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.111</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
+++ b/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
+++ b/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
+++ b/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
@@ -117,7 +117,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/websub/types.html
+++ b/learn/api-docs/ballerina/websub/types.html
@@ -85,7 +85,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/xmlutils/functions.html
+++ b/learn/api-docs/ballerina/xmlutils/functions.html
@@ -82,7 +82,7 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/xmlutils/index.html
+++ b/learn/api-docs/ballerina/xmlutils/index.html
@@ -67,7 +67,7 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
+++ b/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
@@ -78,7 +78,7 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.1111</div>
     
 
 

--- a/learn/api-docs/ballerina/xslt/functions.html
+++ b/learn/api-docs/ballerina/xslt/functions.html
@@ -77,7 +77,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 

--- a/learn/api-docs/ballerina/xslt/index.html
+++ b/learn/api-docs/ballerina/xslt/index.html
@@ -66,7 +66,7 @@ redirect_from:
             
 
     
-        <div class="version">v1.2.8</div>
+        <div class="version">v1.2.11</div>
     
 
 


### PR DESCRIPTION
## Purpose
Fix the version label in 1.2 API Docs.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
