### PR TITLE
Redirect the IntelliJ Learn Pages of Swan Lake

### DIFF
--- a/swan-lake/learn/tools-ides/setting-up-intellij-idea.md
+++ b/swan-lake/learn/tools-ides/setting-up-intellij-idea.md
@@ -12,6 +12,8 @@ redirect_from:
   - /swan-lake/learn/tools-ides/setting-up-intellij-idea
   - /swan-lake/learn/tools-ides/setting-up-intellij-idea/
   - /swan-lake/learn/setting-up-intellij-idea
+redirect_to:
+  - /swan-lake/page-not-available
 ---
 
 ## Setting Up the Prerequisites


### PR DESCRIPTION
## Purpose
Redirect the IntelliJ Learn pages of Swan Lake.
> Fixes #1606 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
