### PR TITLE
Fix Broken Links After SLP8

### DIFF
--- a/1.0/page-not-available.html
+++ b/1.0/page-not-available.html
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-inner-page
+layout: ballerina-no-git-inner-page
 ---
 
 <!--<script src="/js/redirections.js" type="application/javascript"></script>-->

--- a/1.1/page-not-available.html
+++ b/1.1/page-not-available.html
@@ -201,9 +201,9 @@
                      </div>
                      <div class="col-md-12 col-lg-2 cBallerina-io-breadcrumbs">
                         <ul class="wy-breadcrumbs">
-                           <li class="wy-breadcrumbs-aside">
+                           <!--<li class="wy-breadcrumbs-aside">
                               <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-platform.github.io/blob/master/1.1/page-not-available.md">Edit on GitHub</a>
-                           </li>
+                           </li>-->
                         </ul>
                      </div>
                   </div>

--- a/page-not-available.html
+++ b/page-not-available.html
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-inner-page
+layout: ballerina-no-git-inner-page
 ---
 
 <!--<script src="/js/redirections.js" type="application/javascript"></script>-->

--- a/swan-lake/learn/installing-ballerina.md
+++ b/swan-lake/learn/installing-ballerina.md
@@ -68,7 +68,7 @@ If you already have a jBallerina version above 1.1.0 installed, you can use the 
 `ballerina dist update`|Update to the latest patch version of the active distribution
 `ballerina dist pull <JBALLERINA-VERSION>`|Fetch a specific distribution and set it as the active version
 
-For more information, see [Keeping Ballerina Up to Date](/learn/keeping-ballerina-up-to-date/).
+For more information, see [Keeping Ballerina Up to Date](/swan-lake//learn/keeping-ballerina-up-to-date/).
   
 ## Building from Source
 

--- a/swan-lake/learn/structuring-ballerina-code/structuring-ballerina-code.md
+++ b/swan-lake/learn/structuring-ballerina-code/structuring-ballerina-code.md
@@ -39,7 +39,7 @@ A Ballerina package is stored in a directory. It contains a collection of source
 
 Follow the steps below to write a simple program in a Ballerina package, which prints `Hello World!` in the console. 
 
-1. Get Ballerina [installed](/swan-lake/learn-installing-ballerina).
+1. Get Ballerina [installed](/swan-lake/learn/installing-ballerina).
 
 2. In the CLI, execute the `ballerina new helloworld` command to create a new Ballerina package.
 

--- a/swan-lake/page-not-available.html
+++ b/swan-lake/page-not-available.html
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-inner-page
+layout: ballerina-no-git-inner-page
 ---
 
 <!--<script src="/js/redirections.js" type="application/javascript"></script>-->


### PR DESCRIPTION
## Purpose
Fix broken links after slp8.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
