### PR TITLE
Fix oauth2 service example

### DIFF
--- a/learn/by-example/secured-service-with-oauth2.html
+++ b/learn/by-example/secured-service-with-oauth2.html
@@ -25,7 +25,7 @@ redirect_from:
     <span class="nx">secureSocket</span><span class="p">:</span> <span class="p">{</span>
         <span class="nx">keyStore</span><span class="p">:</span> <span class="p">{</span>
             <span class="nx">path</span><span class="p">:</span> <span class="nx">config</span><span class="p">:</span><span class="nx">getAsString</span><span class="p">(</span><span class="s">&quot;b7a.home&quot;</span><span class="p">)</span> <span class="o">+</span>
-                  <span class="s">&quot;/bre/security/ballerinaTruststore.p12&quot;</span><span class="p">,</span>
+                  <span class="s">&quot;/bre/security/ballerinaKeystore.p12&quot;</span><span class="p">,</span>
             <span class="nx">password</span><span class="p">:</span> <span class="s">&quot;ballerina&quot;</span>
         <span class="p">}</span>
     <span class="p">}</span>
@@ -219,7 +219,7 @@ import ballerina/oauth2;
                                     <div class="highlight"><pre><code class=language-ballerina>    secureSocket: {
         keyStore: {
             path: config:getAsString(&quot;b7a.home&quot;) +
-                  &quot;/bre/security/ballerinaTruststore.p12&quot;,
+                  &quot;/bre/security/ballerinaKeystore.p12&quot;,
             password: &quot;ballerina&quot;
         }
     }


### PR DESCRIPTION
The example https://ballerina.io/learn/by-example/secured-service-with-oauth2.html is not working. 

When trying to connect to server with command: 
curl -k -H "Authorization: Bearer YWRtaW46MTIz" https://localhost:9090/hello/sayHello

The request fails with ssl error.

After checking at example https://ballerina.io/learn/by-example/https-listener.html that explains how to configure https it appears that the wrong p12 is used in the example. 

By making this change the example is working and it's possible to connect to server
