### PR TITLE
Redirect "/download" to the Bio "Download" Page

### DIFF
--- a/download.html
+++ b/download.html
@@ -1,16 +1,16 @@
 ---
 layout: ballerina-home-page
-title: Ballerina Download
+title: Ballerina Downloads
 description: Download the Ballerina programming language for Windows, Linux and MacOS. You can find the release notes, plugin downloads and archived versions here too.
 keywords: ballerina, ballerina downloads, release notes, getting started, programming language
-permalink: /download/
-active: download
+permalink: /downloads/
+active: downloads
 redirect_from:
   - /learn/downloads
   - /v1-2/learn/downloads
   - /v1-2/learn/downloads/
-  - /downloads/
-  - /downloads
+  - /download/
+  - /download
 ---
 <link rel="stylesheet" href="/css/download-page.css">
 <script src="/js/download-page.js"></script>
@@ -18,7 +18,7 @@ redirect_from:
 <div class="container">
    <div class="row">
       <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
-         <h1>Download</h1>
+         <h1>Downloads</h1>
       </div>
    </div>
    <div class="row">

--- a/download.html
+++ b/download.html
@@ -1,14 +1,16 @@
 ---
 layout: ballerina-home-page
-title: Ballerina Downloads
+title: Ballerina Download
 description: Download the Ballerina programming language for Windows, Linux and MacOS. You can find the release notes, plugin downloads and archived versions here too.
 keywords: ballerina, ballerina downloads, release notes, getting started, programming language
-permalink: /downloads/
-active: downloads
+permalink: /download/
+active: download
 redirect_from:
   - /learn/downloads
   - /v1-2/learn/downloads
   - /v1-2/learn/downloads/
+  - /downloads/
+  - /downloads
 ---
 <link rel="stylesheet" href="/css/download-page.css">
 <script src="/js/download-page.js"></script>
@@ -16,7 +18,7 @@ redirect_from:
 <div class="container">
    <div class="row">
       <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12 cDownloadsHeader">
-         <h1>Downloads</h1>
+         <h1>Download</h1>
       </div>
    </div>
    <div class="row">


### PR DESCRIPTION
## Purpose
Redirect "/download" to the Bio "Download" page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
