### PR TITLE
Fix typos and few minor issues in learn pages

### DIFF
--- a/learn/calling-java-code-from-ballerina.md
+++ b/learn/calling-java-code-from-ballerina.md
@@ -259,7 +259,7 @@ Object mapObj = yaml.load(inputStream);
 The `org.yaml.snakeyaml.Yaml.load(InputStream is)` is a generic method. The bindgen tool does not support Java generics at the moment. That is why the corresponding Ballerina method returns an Object.  
 
 ####  Printing the Returned Map Instance
-You can print the content of the Map instance in the the standard out as follows. 
+You can print the content of the Map instance in the standard out as follows.
 ```ballerina
 io:println(mapObj);
 ```
@@ -680,7 +680,7 @@ Ballerina also allows you to define a function without a function body and marks
 function doSomething(int i) returns string = external;
 ```
 
-Now, let’s see how you can link this function with a foriegn function. 
+Now, let’s see how you can link this function with a foreign function.
 
 ```ballerina
 import ballerina/java;
@@ -1049,7 +1049,7 @@ function appendStringBuffer(handle sbObj, handle sb) returns handle = @java:Meth
 ```
 
 ### Java Exceptions as Ballerina Errors
-A function call in Ballerina may complete abruptly by returning an error or by raising a panic. Panics are rare in Ballerina. The best practise is to handle errors in your normal control flow. Raising a panic is similar to throwing a Java exception. The `trap` action will stop a panic and give you the control back in Ballerina and the `try-catch` statement does the same in Java. 
+A function call in Ballerina may complete abruptly by returning an error or by raising a panic. Panics are rare in Ballerina. The best practise is to handle errors in your normal control flow. Raising a panic is similar to throwing a Java exception. The `trap` action will stop a panic and give you the control back in Ballerina and the `try-catch` statement does the same in Java.
 
 Errors in Ballerina belong to the built-int type `error`. The error type can be considered as a distinct type from all other types: The `error` type does not belong to the `any` type, which is the supertype of all other Ballerina types. Therefore, errors are explicit in Ballerina programs and it is almost impossible to ignore them. For more details, see BBEs. 
 
@@ -1103,7 +1103,7 @@ public function main() {
 } 
 ```
 #### Java Checked Exceptions
-Let’s see how you can call a Java method that throws a checked exception. As illustrated in the following example, the corresponding Ballerina function should have the `error` type as part of it’s return type. 
+Let’s see how you can call a Java method that throws a checked exception. As illustrated in the following example, the corresponding Ballerina function should have the `error` type as part of it’s return type.
 
 The `java.util.zip.ZipFile` class is used to read entries in a ZIP file. There are many constructors in this class. Here, the constructor that takes the file name as an argument is used. 
 
@@ -1141,7 +1141,7 @@ The `detail`:
 ### Null Safety
 Ballerina provides strict null safety compared to Java with optional types.  The Java null reference can be assigned to any reference type. However, in Ballerina, you cannot assign the nil value to a variable unless the variable’s type is an optional type. 
 
-As explained above, Ballerina handle values cannot be created in Ballerina code. They are created and returned by foriegn functions and a variable of the handle type refers to a Java reference value. Since Java null is also a valid reference value, this variable can refer to a Java null value.
+As explained above, Ballerina handle values cannot be created in Ballerina code. They are created and returned by foreign functions and a variable of the handle type refers to a Java reference value. Since Java null is also a valid reference value, this variable can refer to a Java null value.
 
 Let’s look at an example, which deals with Java null. The following code uses the `peek` method in the `ArrayDeque` class. `Peek` retrieves but does not remove the head of the queue or returns null if the queue is empty. 
 

--- a/learn/documenting-ballerina-code.md
+++ b/learn/documenting-ballerina-code.md
@@ -161,7 +161,7 @@ public isolated function pow(float a, float b) returns float {
     return 0;
 }
 ```
-Add the follwoing class definition to the `world` module. Copy and paste the following code in to the `myproject/src/world/main.bal/` file.
+Add the following class definition to the `world` module. Copy and paste the following code in to the `myproject/src/world/main.bal/` file.
 
 ```ballerina
 # Represents a person object.

--- a/swan-lake/learn/calling-java-code-from-ballerina.md
+++ b/swan-lake/learn/calling-java-code-from-ballerina.md
@@ -254,7 +254,7 @@ Object mapObj = yaml.load(fileInputStream);
 The `org.yaml.snakeyaml.Yaml.load(InputStream is)` is a generic method. The bindgen tool does not support Java generics at the moment. That is why the corresponding Ballerina method returns an Object.  
 
 ####  Printing the Returned Map Instance
-You can print the content of the Map instance in the the standard out as follows. 
+You can print the content of the Map instance in the standard out as follows. 
 ```ballerina
 io:println(mapObj);
 ```
@@ -394,7 +394,7 @@ class ArrayDeque {
 ```
 If there are multiple classes with the same simple name, they need to be generated using a single execution. The tool will then apply a numerical identifier at the end of duplicated object names. This could be manually changed into something meaningful if required.
 
-The format for specifying inner classes using the command is `<package-name>.ClassName$InnerClassName`. The dollar sign might have to be escaped using the blackslash key.
+The format for specifying inner classes using the command is `<package-name>.ClassName$InnerClassName`. The dollar sign might have to be escaped using the backslash key.
 
 E.g. The command to generate bindings for `java.lang.Character.Subset` class will be as follows.
 ```sh
@@ -654,7 +654,7 @@ Ballerina also allows you to define a function without a function body and marks
 function doSomething(int i) returns string = external;
 ```
 
-Now, let’s see how you can link this function with a foriegn function. 
+Now, let’s see how you can link this function with a foreign function. 
 
 ```ballerina
 import ballerina/java;
@@ -1023,7 +1023,7 @@ function appendStringBuffer(handle sbObj, handle sb) returns handle = @java:Meth
 ```
 
 ### Java Exceptions as Ballerina Errors
-A function call in Ballerina may complete abruptly by returning an error or by raising a panic. Panics are rare in Ballerina. The best practise is to handle errors in your normal control flow. Raising a panic is similar to throwing a Java exception. The `trap` action will stop a panic and give you the control back in Ballerina and the `try-catch` statement does the same in Java. 
+A function call in Ballerina may complete abruptly by returning an error or by raising a panic. Panics are rare in Ballerina. The best practice is to handle errors in your normal control flow. Raising a panic is similar to throwing a Java exception. The `trap` action will stop a panic and give you the control back in Ballerina and the `try-catch` statement does the same in Java. 
 
 Errors in Ballerina belong to the built-int type `error`. The error type can be considered as a distinct type from all other types: The `error` type does not belong to the `any` type, which is the supertype of all other Ballerina types. Therefore, errors are explicit in Ballerina programs and it is almost impossible to ignore them. For more details, see BBEs. 
 
@@ -1077,7 +1077,7 @@ public function main() {
 } 
 ```
 #### Java Checked Exceptions
-Let’s see how you can call a Java method that throws a checked exception. As illustrated in the following example, the corresponding Ballerina function should have the `error` type as part of it’s return type. 
+Let’s see how you can call a Java method that throws a checked exception. As illustrated in the following example, the corresponding Ballerina function should have the `error` type as part of its return type. 
 
 The `java.util.zip.ZipFile` class is used to read entries in a ZIP file. There are many constructors in this class. Here, the constructor that takes the file name as an argument is used. 
 
@@ -1115,7 +1115,7 @@ The `detail`:
 ### Null Safety
 Ballerina provides strict null safety compared to Java with optional types.  The Java null reference can be assigned to any reference type. However, in Ballerina, you cannot assign the nil value to a variable unless the variable’s type is an optional type. 
 
-As explained above, Ballerina handle values cannot be created in Ballerina code. They are created and returned by foriegn functions and a variable of the handle type refers to a Java reference value. Since Java null is also a valid reference value, this variable can refer to a Java null value.
+As explained above, Ballerina handle values cannot be created in Ballerina code. They are created and returned by foreign functions and a variable of the handle type refers to a Java reference value. Since Java null is also a valid reference value, this variable can refer to a Java null value.
 
 Let’s look at an example, which deals with Java null. The following code uses the `peek` method in the `ArrayDeque` class. `Peek` retrieves but does not remove the head of the queue or returns null if the queue is empty. 
 

--- a/swan-lake/learn/coding-conventions.md
+++ b/swan-lake/learn/coding-conventions.md
@@ -289,11 +289,11 @@ For style guidelines on operators, keywords, and types, see [Operators, Keywords
 
 ## Statements
 
-For style guidelines on statements such as if, match, transaction etc., see [Statements](/swan-lake/learn/style-guide/statements).
+For style guidelines on statements such as if, match, transaction, etc., see [Statements](/swan-lake/learn/style-guide/statements).
 
 ## Expressions
 
-For style guidelines on function invocation, literals, tuple, type casting etc. see [Expressions](/swan-lake/learn/style-guide/expressions).
+For style guidelines on function invocation, literals, tuple, type casting, etc. see [Expressions](/swan-lake/learn/style-guide/expressions).
 
 ## Annotations, Documentation, and Comments
 

--- a/swan-lake/learn/coding-conventions/annotations_documentation_and_comments.md
+++ b/swan-lake/learn/coding-conventions/annotations_documentation_and_comments.md
@@ -32,7 +32,7 @@ service greetingService on new http:Listener(8080) {
 }
 ```
 
-* Each annotation attribute (i.e., key-value pairs) should block indent on its own line..
+* Each annotation attribute (i.e., key-value pairs) should block indent on its own line.
   
 **Example,**
   

--- a/swan-lake/learn/deployment/aws-lambda.md
+++ b/swan-lake/learn/deployment/aws-lambda.md
@@ -53,7 +53,7 @@ Generating executables
 
 ## Deploying the Function
 
-Ballerina's AWS Lambda functionality is implemented as a custom AWS Lambda layer. As shown in the above instructions output, this information is provided when the function is created. The compiler generates the `aws-ballerina-lambda-functions.zip` file, which encapsulates all the AWS Lambda functions that are generated. This ZIP file can be used with the AWS web console, or the [AWS CLI](https://docs.aws.amazon.com/codedeploy/latest/userguide/getting-started-configure-cli.html) to deploy the functions. An [AWS Lambda Role ](https://console.aws.amazon.com/iam/home?#/roles) for the user must be created with the `AWSLambdaBasicExecutionRole` permission in order to deploy the AWS Lambda functions. The created AWS Lambda Role ARN is required when deploying the functions through the CLI. 
+Ballerina's AWS Lambda functionality is implemented as a custom AWS Lambda layer. As shown in the above instructions output, this information is provided when the function is created. The compiler generates the `aws-ballerina-lambda-functions.zip` file, which encapsulates all the AWS Lambda functions that are generated. This ZIP file can be used with the AWS web console, or the [AWS CLI](https://docs.aws.amazon.com/codedeploy/latest/userguide/getting-started-configure-cli.html) to deploy the functions. An [AWS Lambda Role](https://console.aws.amazon.com/iam/home?#/roles) for the user must be created with the `AWSLambdaBasicExecutionRole` permission in order to deploy the AWS Lambda functions. The created AWS Lambda Role ARN is required when deploying the functions through the CLI.
 
 A sample execution to deploy the hash function as an AWS Lambda is shown below. 
 

--- a/swan-lake/learn/deployment/code-to-cloud/code-to-cloud.md
+++ b/swan-lake/learn/deployment/code-to-cloud/code-to-cloud.md
@@ -171,7 +171,7 @@ Probe to indicate whether the container is running. No liveness probe will be ge
 
 ### [[cloud.deployment.storage.volumes]]
 
-Contains the volume definitions of the application. No default volumes will be generated if this propoert is not specified.
+Contains the volume definitions of the application. No default volumes will be generated if this property is not specified.
 
 | Identifier 	| Description                	| Example Value 	|
 |------------	|----------------------------	|---------------	|

--- a/swan-lake/learn/deployment/docker.md
+++ b/swan-lake/learn/deployment/docker.md
@@ -13,7 +13,7 @@ redirect_from:
   - /swan-lake/learn/deployment/
 ---
 
-To create a Docker image, you have to create a Dockerfile by choosing a suitable base image, bundling all dependencies, copying the application binary, and setting the execution command with proper permissions. To create optimized images, youhave to follow a set of [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/). Otherwise, the image that is built will be large in size, less secure, and have many other shortcomings. 
+To create a Docker image, you have to create a Dockerfile by choosing a suitable base image, bundling all dependencies, copying the application binary, and setting the execution command with proper permissions. To create optimized images, you have to follow a set of [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/). Otherwise, the image that is built will be large in size, less secure, and have many other shortcomings.
 
 The Ballerina compiler is capable of creating optimized Docker images out of the application source code. This guide includes step-by-step instructions on different use cases and executing the corresponding sample source code. 
 
@@ -466,7 +466,7 @@ This sample sends a greeting to the caller by getting the name from a text file.
 }
 ```
 
->**Note:** In addition to the above, if you want to copy driver files such as JDBC, you can create a Ballerina project, add following entires to its `Ballerina.toml` file, and change the path to the JDBC driver appropriately.
+>**Note:** In addition to the above, if you want to copy driver files such as JDBC, you can create a Ballerina project, add following entries to its `Ballerina.toml` file, and change the path to the JDBC driver appropriately.
 
 `Ballerina.toml`
 

--- a/swan-lake/learn/documenting-ballerina-code.md
+++ b/swan-lake/learn/documenting-ballerina-code.md
@@ -171,7 +171,7 @@ public isolated function pow(float a, float b) returns float {
     return 0;
 }
 ```
-Add the follwoing class definition to the `world` module. Copy and paste the following code in to the `math/modules/world/world.bal` file.
+Add the following class definition to the `world` module. Copy and paste the following code in to the `math/modules/world/world.bal` file.
 
 ```ballerina
 # Represents a person object.

--- a/swan-lake/learn/structuring-ballerina-code/structuring-ballerina-code.md
+++ b/swan-lake/learn/structuring-ballerina-code/structuring-ballerina-code.md
@@ -85,7 +85,7 @@ Follow the steps below to write a simple program in a Ballerina package, which p
 
     This function prints “Hello World!” in the console. 
 
-3. Execute the `ballerina build` command to build an execuatble of this file. You view the output below.
+3. Execute the `ballerina build` command to build an executable of this file. You view the output below.
 
     ```bash
     Compiling source

--- a/swan-lake/learn/testing-ballerina-code/mocking.md
+++ b/swan-lake/learn/testing-ballerina-code/mocking.md
@@ -343,7 +343,7 @@ import ballerina/test;
 test:MockFunction intAddMockFn = new();
 ```
 
-After the initialization, the following options can be used to stub the behaviour of a function written in the
+After the initialization, the following options can be used to stub the behavior of a function written in the
  module being tested.
  
 ### Stubbing to Return a Specific Value
@@ -396,7 +396,7 @@ public function mockIntAdd(int a, int b) returns int {
 }
 ```
 
-This test stubs the behaviour of an imported function to substitute it with a user-defined mock function.
+This test stubs the behavior of an imported function to substitute it with a user-defined mock function.
 
 ```ballerina
 import ballerina/test;

--- a/swan-lake/learn/testing-ballerina-code/writing-tests.md
+++ b/swan-lake/learn/testing-ballerina-code/writing-tests.md
@@ -131,7 +131,7 @@ On the other hand, symbols defined in the test files will not be visible inside 
 
 ## Using Assertions
 
-The Ballerina test framework supports the following assertions, which help to verify the expected behaviour of a piece of code. These assertions can be used to decide if the test is passing or failing based on the condition.
+The Ballerina test framework supports the following assertions, which help to verify the expected behavior of a piece of code. These assertions can be used to decide if the test is passing or failing based on the condition.
 
 
 ### assertTrue(boolean expression, string message)

--- a/swan-lake/learn/writing-secure-ballerina-code.md
+++ b/swan-lake/learn/writing-secure-ballerina-code.md
@@ -396,7 +396,7 @@ service helloWorld on secureHelloWorldEp {
 
 The authn/authz filters are engaged as the top-most filters of the filter array, which are configured in the HTTP listener configuration. You can configure the index of the authn/authz filters if it is needed to engage a custom filter before the authn/authz filters.
 
-The `position` attribute represents the authn/authz-filter position of the filter array. The position values starts from 0 and it is set to 0 implicitly.
+The `position` attribute represents the authn/authz-filter position of the filter array. The position values start from 0 and it is set to 0 implicitly.
 
 The following example engages the authn/authz filters in between the `customFilter1` and `customFilter2`. Then, the internally-updated filter chain would be `[customFilter1, authnFilter, authzFilter, customFilter2]`.
 


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
