### PR TITLE
Remove the "Back To Top" button from the Swan Lake BBE Landing Page

### DIFF
--- a/swan-lake/learn/by-example/index.html
+++ b/swan-lake/learn/by-example/index.html
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-inner-page
+layout: ballerina-no-git-inner-page
 title: Ballerina by Example
 description: Ballerina by Example enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
 ---


### PR DESCRIPTION
## Purpose
Remove the "Back To Top" button from the Swan Lake BBE landing page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
