### PR TITLE
Change c2c module name

### DIFF
--- a/swan-lake/learn/deployment/code-to-cloud/code-to-cloud-samples.md
+++ b/swan-lake/learn/deployment/code-to-cloud/code-to-cloud-samples.md
@@ -25,7 +25,7 @@ redirect_from:
     ```ballerina
     import ballerina/http;
     import ballerina/log;
-    import ballerina/c2c as _;
+    import ballerina/cloud as _;
 
     listener http:Listener helloEP = new(9090);
 
@@ -285,7 +285,7 @@ Auto scaling policies allow the container to scale seamlessly without overloadin
     ```ballerina
     import ballerina/http;
     import ballerina/log;
-    import ballerina/c2c as _;
+    import ballerina/cloud as _;
 
     listener http:Listener helloEP = new(9090);
 


### PR DESCRIPTION
## Purpose
- Change module name from c2c -> cloud
> Fixes https://github.com/ballerina-platform/module-ballerina-c2c/issues/50

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
