### PR TITLE
Add a Section on the "Community Call" on the "Community" Page

### DIFF
--- a/community.md
+++ b/community.md
@@ -86,7 +86,7 @@ Through these calls, we aim to open up our channels and give you direct access t
 
 - Be notified about [details of the upcoming community calls](https://docs.google.com/forms/d/e/1FAIpQLSfJkkaXmOf-ULhZ1Oi7bXAG_UmieRQ3wF8mKDohWux-8Ltfsw/viewform).
 
-- Get involved in our next call by either submitting a topic of discussion or by [requesting to do a quick demo of your own](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform).
+- Get involved in our next call by [submitting a topic of discussion or requesting to do a quick demo of your own](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform).
 
 ## Report issues
 

--- a/community.md
+++ b/community.md
@@ -78,9 +78,7 @@ We are happy to help! Come engage with us on any channel that works for you.
 
 ## Join the Community Call
 
-The Ballerina team is now hosting monthly recorded Community Calls! These are interactive meetings that will explore Ballerina use cases.
-
-Through these calls, we aim to open up our channels and give you direct access to our Engineers. As a participant, you will get the chance to ask our team and other community members any questions you have about Ballerina or your projects. 
+The Ballerina team is now hosting monthly recorded Community Calls! These are interactive meetings that will explore Ballerina use cases. These calls give you direct access to our Engineers and other community members to question or discuss about Ballerina and your projects.
 
 - Get information on the [past and upcoming calls](https://docs.google.com/document/d/1TPi0ktNvk-gQhVh46ckP5_LyhvwLJSQ3NJeSfv8459A/edit).
 

--- a/community.md
+++ b/community.md
@@ -47,7 +47,15 @@ Interested? Subscribe to it below:
    </div>
 </div>
 
+## Join the Community Call
 
+The Ballerina team is now hosting monthly recorded Community Calls! These are interactive meetings that will explore Ballerina use cases. These calls give you direct access to our Engineers and other community members to question or discuss about Ballerina and your projects.
+
+- Get information on the [past and upcoming calls](https://docs.google.com/document/d/1TPi0ktNvk-gQhVh46ckP5_LyhvwLJSQ3NJeSfv8459A/edit).
+
+- Be notified about [details of the upcoming community calls](https://docs.google.com/forms/d/e/1FAIpQLSfJkkaXmOf-ULhZ1Oi7bXAG_UmieRQ3wF8mKDohWux-8Ltfsw/viewform).
+
+- Get involved in our next Community Call by [submitting a discussion topic or requesting to do your own quick demo](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform).
 
 ## Seek help
 
@@ -75,16 +83,6 @@ We are happy to help! Come engage with us on any channel that works for you.
       </div>
    </div>
 </div>
-
-## Join the Community Call
-
-The Ballerina team is now hosting monthly recorded Community Calls! These are interactive meetings that will explore Ballerina use cases. These calls give you direct access to our Engineers and other community members to question or discuss about Ballerina and your projects.
-
-- Get information on the [past and upcoming calls](https://docs.google.com/document/d/1TPi0ktNvk-gQhVh46ckP5_LyhvwLJSQ3NJeSfv8459A/edit).
-
-- Be notified about [details of the upcoming community calls](https://docs.google.com/forms/d/e/1FAIpQLSfJkkaXmOf-ULhZ1Oi7bXAG_UmieRQ3wF8mKDohWux-8Ltfsw/viewform).
-
-- Get involved in our next Community Call by [submitting a discussion topic or requesting to do your own quick demo](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform).
 
 ## Report issues
 

--- a/community.md
+++ b/community.md
@@ -76,6 +76,18 @@ We are happy to help! Come engage with us on any channel that works for you.
    </div>
 </div>
 
+## Community Call
+
+The Ballerina team is now hosting monthly recorded community calls! These are interactive meetings that will explore Ballerina use cases.
+
+Through these calls, we aim to open up our channels and give you direct access to our engineers. As a participant, you will get the chance to ask our team and other community members any questions you have about Ballerina or your projects. 
+
+- Get information on the [past and upcoming calls](https://docs.google.com/document/d/1TPi0ktNvk-gQhVh46ckP5_LyhvwLJSQ3NJeSfv8459A/edit).
+
+- Be notified about [details of the upcoming community calls](https://docs.google.com/forms/d/e/1FAIpQLSfJkkaXmOf-ULhZ1Oi7bXAG_UmieRQ3wF8mKDohWux-8Ltfsw/viewform).
+
+- Get involved in our next call by either submitting a topic of discussion or by [requesting to do a quick demo of your own](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform).
+
 ## Report issues
 
 Hit a bump on the road? Report an issue in the relevant repo out of the GitHub repos listed below. We want to fix all bugs!

--- a/community.md
+++ b/community.md
@@ -78,9 +78,9 @@ We are happy to help! Come engage with us on any channel that works for you.
 
 ## Join the Community Call
 
-The Ballerina team is now hosting monthly recorded community calls! These are interactive meetings that will explore Ballerina use cases.
+The Ballerina team is now hosting monthly recorded Community Calls! These are interactive meetings that will explore Ballerina use cases.
 
-Through these calls, we aim to open up our channels and give you direct access to our engineers. As a participant, you will get the chance to ask our team and other community members any questions you have about Ballerina or your projects. 
+Through these calls, we aim to open up our channels and give you direct access to our Engineers. As a participant, you will get the chance to ask our team and other community members any questions you have about Ballerina or your projects. 
 
 - Get information on the [past and upcoming calls](https://docs.google.com/document/d/1TPi0ktNvk-gQhVh46ckP5_LyhvwLJSQ3NJeSfv8459A/edit).
 

--- a/community.md
+++ b/community.md
@@ -86,7 +86,7 @@ Through these calls, we aim to open up our channels and give you direct access t
 
 - Be notified about [details of the upcoming community calls](https://docs.google.com/forms/d/e/1FAIpQLSfJkkaXmOf-ULhZ1Oi7bXAG_UmieRQ3wF8mKDohWux-8Ltfsw/viewform).
 
-- Get involved in our next call by [submitting a topic of discussion or requesting to do a quick demo of your own](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform).
+- [Submit a discussion topic or request to do your own quick demo](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform) in our next call.
 
 ## Report issues
 

--- a/community.md
+++ b/community.md
@@ -76,7 +76,7 @@ We are happy to help! Come engage with us on any channel that works for you.
    </div>
 </div>
 
-## Community Call
+## Join the Community Call
 
 The Ballerina team is now hosting monthly recorded community calls! These are interactive meetings that will explore Ballerina use cases.
 
@@ -86,7 +86,7 @@ Through these calls, we aim to open up our channels and give you direct access t
 
 - Be notified about [details of the upcoming community calls](https://docs.google.com/forms/d/e/1FAIpQLSfJkkaXmOf-ULhZ1Oi7bXAG_UmieRQ3wF8mKDohWux-8Ltfsw/viewform).
 
-- [Submit a discussion topic or request to do your own quick demo](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform) in our next call.
+- Get involved in our next cimmunity call by [submitting a discussion topic or requesting to do your own quick demo](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform).
 
 ## Report issues
 

--- a/community.md
+++ b/community.md
@@ -86,7 +86,7 @@ Through these calls, we aim to open up our channels and give you direct access t
 
 - Be notified about [details of the upcoming community calls](https://docs.google.com/forms/d/e/1FAIpQLSfJkkaXmOf-ULhZ1Oi7bXAG_UmieRQ3wF8mKDohWux-8Ltfsw/viewform).
 
-- Get involved in our next cimmunity call by [submitting a discussion topic or requesting to do your own quick demo](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform).
+- Get involved in our next Community Call by [submitting a discussion topic or requesting to do your own quick demo](https://docs.google.com/forms/d/e/1FAIpQLSewd7XGlQeuCI2P9XlQ-A8rtFGn9ghbdYpghIi9K03VlxHcRg/viewform).
 
 ## Report issues
 


### PR DESCRIPTION
## Purpose
Add a section on the "Community Call" on the "Community" page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
