### PR TITLE
Remove the "Expand/Collapse All" Option in Learn Page TOCs

### DIFF
--- a/learn/coding-conventions/annotations_documentation_and_comments.md
+++ b/learn/coding-conventions/annotations_documentation_and_comments.md
@@ -186,3 +186,8 @@ service greet on new http:Listener(8080) {
     resource function sayHello(http:Caller caller, http:Request request) {...}
 }
 ```
+
+<div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
+
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/learn/coding-conventions/expressions.md
+++ b/learn/coding-conventions/expressions.md
@@ -218,4 +218,9 @@ table<Employee> employee4 = table {
     ]
 }
 ```
+
+<div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
+
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>
   

--- a/learn/coding-conventions/operators_keywords_and_types.md
+++ b/learn/coding-conventions/operators_keywords_and_types.md
@@ -105,3 +105,7 @@ io:println("john");
 http:Response res = new();
 ```
   
+<div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
+
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/learn/coding-conventions/top-level-definitions.md
+++ b/learn/coding-conventions/top-level-definitions.md
@@ -244,3 +244,8 @@ type Employee object {
     }
 };
 ```
+
+<div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
+
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/swan-lake/learn/coding-conventions/annotations_documentation_and_comments.md
+++ b/swan-lake/learn/coding-conventions/annotations_documentation_and_comments.md
@@ -184,3 +184,8 @@ service greet on new http:Listener(8080) {
     resource function sayHello(http:Caller caller, http:Request request) {...}
 }
 ```
+
+<div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
+
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/swan-lake/learn/coding-conventions/expressions.md
+++ b/swan-lake/learn/coding-conventions/expressions.md
@@ -217,3 +217,7 @@ table<Employee> employee4 = table {
 }
 ```
   
+<div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
+
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/swan-lake/learn/coding-conventions/operators_keywords_and_types.md
+++ b/swan-lake/learn/coding-conventions/operators_keywords_and_types.md
@@ -102,4 +102,8 @@ name += lastName;
 io:println("john");
 http:Response res = new();
 ```
-  
+
+<div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
+
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/swan-lake/learn/coding-conventions/top-level-definitions.md
+++ b/swan-lake/learn/coding-conventions/top-level-definitions.md
@@ -249,3 +249,8 @@ type Employee object {
     }
 };
 ```
+
+<div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
+
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>


### PR DESCRIPTION
## Purpose
Remove the "Expand/Collapse All" option in Learn page TOCs that do not have any sub headings.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
