### PR TITLE
Fix Broken Links for the Swan Lake Alpha Release

### DIFF
--- a/_data/learnnavswanlake.yml
+++ b/_data/learnnavswanlake.yml
@@ -82,7 +82,7 @@
   url: '#' 
   sublinks:
     - title: Writing Secure Ballerina Code
-      url: /swan-lake/learn/writing-secure-ballerina-code
+      url: /swan-lake/learn/security/writing-secure-ballerina-code
       active: writing-secure-ballerina-code
     - title: Authentication and Authorization
       url: /swan-lake/learn/authentication-and-authorization

--- a/learn/coding-conventions/top-level-definitions.md
+++ b/learn/coding-conventions/top-level-definitions.md
@@ -126,7 +126,7 @@ service hello on new http:Listener(9090) {
 ```
 
 * When formatting resource functions and function definitions, block indent each element and
-  follow the [function formatting guidelines](/learn/style-guide/top-level-definitions#function-definition).
+  follow the [function formatting guidelines](/learn/coding-conventions/top-level-definitions/#function-definition).
   
 **Example,**
 
@@ -150,7 +150,7 @@ service hello on ep1, ep2 {
 
 * Block indent each field definition and each function definition on their own line.
 * Init function should be placed before all the other functions. 
-* For function definitions in the object definition, follow the [function formatting guidelines](/learn/style-guide/top-level-definitions#function-definition).
+* For function definitions in the object definition, follow the [function formatting guidelines](/learn/coding-conventions/top-level-definitions/#function-definition).
 
 **Example,**
 

--- a/swan-lake/learn/deployment/azure-functions.md
+++ b/swan-lake/learn/deployment/azure-functions.md
@@ -17,12 +17,12 @@ This is done by importing the `ballerinax/azure.functions` module and simply ann
 An Azure Function consists of a trigger and optional bindings. A trigger defines how a function is invoked. A binding is an approach in which you can declaratively connect other resources to the function. There are *input* and *output* bindings. An input binding is a source of data into the function. An output binding allows to output data from the function out to an external resource. For more information, go to [Azure Functions triggers and bindings concepts](https://docs.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings).
 
 The following Azure Functions triggers and bindings are currently supported in Ballerina:
-- HTTP [trigger](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#HTTPTrigger) and [output](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#HTTPOutput) binding
-- Queue [trigger](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#QueueTrigger) and [output](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#QueueOutput) binding
-- Blob [trigger](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#BlobTrigger), [input](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#BlobInput) binding, and [output](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#BlobOutput) binding
-- Twilio SMS [output](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#TwilioSmsOutput) binding
-- CosmosDB [trigger](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#CosmosDBTrigger), [input](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#CosmosDBInput) binding, and [output](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#CosmosDBOutput) binding
-- Timer [trigger](/swan-lake/learn/api-docs/ballerina/#/azure_functions/annotations#TimerTrigger)
+- HTTP [trigger](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#HTTPTrigger) and [output](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#HTTPOutput) binding
+- Queue [trigger](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#QueueTrigger) and [output](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#QueueOutput) binding
+- Blob [trigger](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#BlobTrigger), [input](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#BlobInput) binding, and [output](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#BlobOutput) binding
+- Twilio SMS [output](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#TwilioSmsOutput) binding
+- CosmosDB [trigger](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#CosmosDBTrigger), [input](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#CosmosDBInput) binding, and [output](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#CosmosDBOutput) binding
+- Timer [trigger](/swan-lake/learn/api-docs/ballerina/#/ballerinax/azure_functions/annotations#TimerTrigger)
 
 ## Writing a Function
 

--- a/swan-lake/learn/security/authentication-and-authorization.md
+++ b/swan-lake/learn/security/authentication-and-authorization.md
@@ -3,11 +3,13 @@ layout: ballerina-left-nav-pages-swanlake
 title: Authentication and Authorization
 description: Ballerina HTTP services/clients can be configured to enforce authentication and authorization.
 keywords: ballerina, programming language, security, secure ballerina code, authorization, authentication
-permalink: /swan-lake/learn/authentication-and-authorization/
+permalink: /swan-lake/learn/security/authentication-and-authorization/
 active: authentication-and-authorization
 intro: Ballerina HTTP services/clients can be configured to enforce authentication and authorization.
 redirect_from:
 - /swan-lake/learn/authentication-and-authorization
+- /swan-lake/learn/authentication-and-authorization/
+- /swan-lake/learn/security/authentication-and-authorization
 ---
 
 ### HTTP Listener Authentication and Authorization

--- a/swan-lake/learn/security/writing-secure-ballerina-code.md
+++ b/swan-lake/learn/security/writing-secure-ballerina-code.md
@@ -3,13 +3,15 @@ layout: ballerina-left-nav-pages-swanlake
 title: Writing Secure Ballerina Code
 description: Check out the different security features and controls available within the Ballerina programming language and follow the guidelines on writing secure Ballerina programs.
 keywords: ballerina, programming language, security, secure ballerina code
-permalink: /swan-lake/learn/writing-secure-ballerina-code/
+permalink: /swan-lake/learn/security/writing-secure-ballerina-code/
 active: writing-secure-ballerina-code
 intro: The sections below include information on the different security features and controls available within Ballerina. Also, they provide guidelines on writing secure Ballerina programs.
 redirect_from:
   - /swan-lake/learn/how-to-write-secure-ballerina-code
   - /swan-lake/learn/how-to-write-secure-ballerina-code/
+  - /swan-lake/learn/writing-secure-ballerina-code/
   - /swan-lake/learn/writing-secure-ballerina-code
+  - /swan-lake/learn/security/writing-secure-ballerina-code
 ---
 
 ## Securing by Design

--- a/swan-lake/learn/testing-ballerina-code/writing-tests.md
+++ b/swan-lake/learn/testing-ballerina-code/writing-tests.md
@@ -643,7 +643,7 @@ Configurations for testing can be provided using configurable variables. The val
 variables can be provided in a file named `Config.toml` located in the tests directory.
 
 For information on using configurable variables, see
- [Configurable Variables](swan-lake/learn/by-example/configurable.html).
+ [Configurable Variables](/swan-lake/learn/by-example/configurable.html).
 
 
 ## What's Next?


### PR DESCRIPTION
## Purpose
Fix broken links for the Swan Lake Alpha release.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
