### PR TITLE
Remove SLP6 from the "Archived Versions" Page for SLAlpha1

### DIFF
--- a/downloads/swan-lake-archived.md
+++ b/downloads/swan-lake-archived.md
@@ -19,12 +19,12 @@ permalink: /downloads/swan-lake-archived/
         <div class="col-xs-12 col-sm-16 col-md-12 col-lg-12">
             <div class="cStandaloneInstallers" id="archived-versions">
                 <h2>Swan Lake Archived Versions</h2>
-                <div class="cInstallers" style="height:150px"> 
-                <h3 class="release-version">swan-lake-preview6</h3>
+                <!--<div class="cInstallers" style="height:150px">--> 
+                <!--<h3 class="release-version">swan-lake-preview6</h3>
 <div class="releases-row">
-    <div class="col-xs-12 col-sm-16 col-md-6 col-lg-6 cLeftTable">
+    <div class="col-xs-12 col-sm-16 col-md-6 col-lg-6 cLeftTable">-->
 
-This is an internal-only release.
+<!--This is an internal-only release.
 
 </div>
 
@@ -36,5 +36,5 @@ This is an internal-only release.
 </div>
 <style>
 li.cVersionItem  {display: none !important;  }
-</style>
+</style>-->
 


### PR DESCRIPTION
## Purpose
Remove SLP6 from the "Archived Versions" page for SLAlpha1.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
