### PR TITLE
Remove gRPC from Swan Lake Learn

### DIFF
--- a/_data/learnnavswanlake.yml
+++ b/_data/learnnavswanlake.yml
@@ -53,9 +53,9 @@
     - title: HTTP
       url: /swan-lake/learn/network-communication/http/
       active: http
-    - title: gRPC
-      url: /swan-lake/learn/network-communication/grpc/
-      active: grpc
+    #- title: gRPC
+      #url: /swan-lake/learn/network-communication/grpc/
+      #active: grpc
 
 - title: Deployment
   url: '#' 


### PR DESCRIPTION
## Purpose
Remove gRPC from Swan Lake Learn.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
