### PR TITLE
Fix the "Next/Previous" Links in the "Anydata" BBE

### DIFF
--- a/swan-lake/learn/by-example/anydata-type.html
+++ b/swan-lake/learn/by-example/anydata-type.html
@@ -40,11 +40,11 @@ redirect_from:
                     <tr>
                         <td class="cLeftTD">
                             <h2>Anydata Type</h2>
-                            <p><p>The <code>anydata</code> type consists of plain data (a simple value, sequence value, or structured value that does not contain behavioral members at any depth).
+                            <p>The <code>anydata</code> type consists of plain data (a simple value, sequence value, or structured value that does not contain behavioral members at any depth).
  Thus, the <code>anydata</code> type is equivalent to the below. <pre><code>()|boolean|int|float|decimal|string|xml|anydata[]|map&lt;anydata&gt;|table&lt;map&lt;anydata&gt;&gt;</code></pre></p>
  <p>Although <code>json</code> and <code>byte</code> are not explicitly mentioned, they are subsets of the aforementioned union.
  The same is true for a record of which the type of each individual field is a subtype of <code>anydata</code> (including the rest field in open records).</p>
-</p>
+
 
                         </td>
                         <td class="cRightTD">

--- a/swan-lake/learn/by-example/anydata-type.html
+++ b/swan-lake/learn/by-example/anydata-type.html
@@ -41,9 +41,9 @@ redirect_from:
                         <td class="cLeftTD">
                             <h2>Anydata Type</h2>
                             <p><p>The <code>anydata</code> type consists of plain data (a simple value, sequence value, or structured value that does not contain behavioral members at any depth).
- Thus, the <code>anydata</code> type is equivalent to <code>()|boolean|int|float|decimal|string|xml|anydata[]|map&lt;anydata&gt;|table&lt;map&lt;anydata&gt;&gt;</code>.
- Although <code>json</code> and <code>byte</code> are not explicitly mentioned, they are subsets of the aforementioned union.
- The same is true for a record of which the type of each individual field is a subtype of <code>anydata</code>(including the rest field in open records).</p>
+ Thus, the <code>anydata</code> type is equivalent to the below. <pre><code>()|boolean|int|float|decimal|string|xml|anydata[]|map&lt;anydata&gt;|table&lt;map&lt;anydata&gt;&gt;</code></pre></p>
+ <p>Although <code>json</code> and <code>byte</code> are not explicitly mentioned, they are subsets of the aforementioned union.
+ The same is true for a record of which the type of each individual field is a subtype of <code>anydata</code> (including the rest field in open records).</p>
 </p>
 
                         </td>


### PR DESCRIPTION
## Purpose
Fix the "next/previous" links in the "Anydata" BBE in Swan Lake.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
