### PR TITLE
Change "BALO" to "BALA" in Swan Lake Learn Pages

### DIFF
--- a/swan-lake/learn/by-example/c2c-deployment.html
+++ b/swan-lake/learn/by-example/c2c-deployment.html
@@ -332,7 +332,7 @@ $ bal build
 
                                 <td class="code leading cOutput">
                                     <div class="highlight"><pre><code class=shell-session>Creating balos
-        target/balo/hello-2020r2-any-0.1.0.balo
+        target/BALA/hello-2020r2-any-0.1.0.BALA
 </code></pre></div>
 
                                 </td>

--- a/swan-lake/learn/calling-java-code-from-ballerina.md
+++ b/swan-lake/learn/calling-java-code-from-ballerina.md
@@ -131,7 +131,7 @@ Compiling source
 ...
 
 Creating balos
-	target/balo/sameera-yaml_package-any-0.1.0.balo
+	target/BALA/sameera-yaml_package-any-0.1.0.BALA
 
 Generating executables
 	target/bin/yaml_package.jar
@@ -279,7 +279,7 @@ Compiling source
 ...
 
 Creating balos
-	target/balo/sameera-yaml_package-java11-0.1.0.balo
+	target/BALA/sameera-yaml_package-java11-0.1.0.BALA
 
 Generating executables
 	target/bin/yaml_package.jar
@@ -548,7 +548,7 @@ function read() returns int|IOException {
 
 >**Note:** This section assumes that you have already read [Structuring Ballerina Code](/learn/structuring-ballerina-code/).
  
-When you compile a Ballerina program with `bal build`, the compiler creates an executable JAR file and when you compile a Ballerina module with `bal build -c`, the compiler creates a BALO file. In both cases, the Ballerina compiler produces self-contained archives. There are situations in which you need to package JAR files with these archives. The most common example would be packing the corresponding JDBC driver.
+When you compile a Ballerina program with `bal build`, the compiler creates an executable JAR file and when you compile a Ballerina module with `bal build -c`, the compiler creates a BALA file. In both cases, the Ballerina compiler produces self-contained archives. There are situations in which you need to package JAR files with these archives. The most common example would be packing the corresponding JDBC driver.
 
 There are two kinds of Ballerina packages:
 1. Produces executable programs 

--- a/swan-lake/learn/deployment/code-to-cloud/code-to-cloud-samples.md
+++ b/swan-lake/learn/deployment/code-to-cloud/code-to-cloud-samples.md
@@ -67,7 +67,7 @@ Compiling source
         wso2/hello:0.1.0
 
 Creating balos
-        target/balo/hello-2020r2-any-0.1.0.balo
+        target/BALA/hello-2020r2-any-0.1.0.BALA
 
 Running Tests
 
@@ -335,7 +335,7 @@ Compiling source
         wso2/scaling:0.1.0
 
 Creating balos
-        target/balo/scaling-2020r2-any-0.1.0.balo
+        target/BALA/scaling-2020r2-any-0.1.0.BALA
 
 Running Tests
 

--- a/swan-lake/learn/deployment/code-to-cloud/code-to-cloud.md
+++ b/swan-lake/learn/deployment/code-to-cloud/code-to-cloud.md
@@ -38,8 +38,8 @@ Ballerina encourages to have one microservice per package. In order to adhere to
 │   └── module
 │       └── entry.bal                             
 └── target
-    ├── balo
-    │   └── module-0.0.1.balo
+    ├── BALA
+    │   └── module-0.0.1.BALA
     ├── bin
     │   └── module.jar
     ├── caches

--- a/swan-lake/learn/network-communication/grpc/implementing-grpc-services-and-clients.md
+++ b/swan-lake/learn/network-communication/grpc/implementing-grpc-services-and-clients.md
@@ -156,8 +156,8 @@ After completing the full code for both the client and the service, you can exec
    Compiling source
       laf/service:0.1.0
 
-   Creating balo
-      target/balo/laf-service-any-0.1.0.balo
+   Creating BALA
+      target/BALA/laf-service-any-0.1.0.BALA
 
    Running executable
 
@@ -172,8 +172,8 @@ After completing the full code for both the client and the service, you can exec
    Compiling source
       laf/client:0.1.0
 
-   Creating balo
-      target/balo/laf-client-any-0.1.0.balo
+   Creating BALA
+      target/BALA/laf-client-any-0.1.0.BALA
 
    Running executable
 

--- a/swan-lake/learn/network-communication/grpc/performing-grpc-streaming.md
+++ b/swan-lake/learn/network-communication/grpc/performing-grpc-streaming.md
@@ -149,8 +149,8 @@ Follow the steps below to perform a sample run of the above implementation.
 Compiling source
     laf/service:0.1.0
 
-Creating balo
-    target/balo/laf-service-any-0.1.0.balo
+Creating BALA
+    target/BALA/laf-service-any-0.1.0.BALA
 
 Running executable
 

--- a/swan-lake/learn/structuring-ballerina-code/structuring-ballerina-code.md
+++ b/swan-lake/learn/structuring-ballerina-code/structuring-ballerina-code.md
@@ -94,8 +94,8 @@ Follow the steps below to write a simple program in a Ballerina package, which p
         helloworld
         No tests found
     
-    Creating balo
-        target/balo/examples-helloworld-any-0.1.0.balo
+    Creating BALA
+        target/BALA/examples-helloworld-any-0.1.0.BALA
     
     Generating executable
         target/bin/helloworld.jar


### PR DESCRIPTION
## Purpose
Change "BALO" to "BALA" in Swan Lake Learn pages.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
