### PR TITLE
Replaced the /learn redirections in 1.2 directory

### DIFF
--- a/1.2/learn.md
+++ b/1.2/learn.md
@@ -7,19 +7,19 @@ permalink: /1.2/learn/
 redirect_from:
   - /v1-2/learn/tools-ides
   - /v1-2/learn/tools-ides/
-  - /learn
+  - /1.2/learn
   - /v1-2/learn
   - /v1-2/learn/
-  - /learn/faqs
-  - /learn/faqs/
+  - /1.2/learn/faqs
+  - /1.2/learn/faqs/
   - /v1-2/learn/faqs
   - /v1-2/learn/faqs/
-  - /learn/faq
-  - /learn/faq/
+  - /1.2/learn/faq
+  - /1.2/learn/faq/
   - /v1-2/learn/faq
   - /v1-2/learn/faq/
-  - /learn/by-guide
-  - /learn/by-guide/
+  - /1.2/learn/by-guide
+  - /1.2/learn/by-guide/
   - /v1-2/learn/by-guide
   - /v1-2/learn/by-guide/
 ---

--- a/1.2/learn/by-example/testerina-before-and-after-each.html
+++ b/1.2/learn/by-example/testerina-before-and-after-each.html
@@ -6,8 +6,8 @@ permalink: /1.2/learn/by-example/testerina-before-and-after-each
 redirect_from:
   - /v1-2/learn/by-example/testerina-before-and-after-each
   - /v1-2/learn/by-example/testerina-before-and-after-each.html
-  - /learn/by-example/testerina-before-each-test
-  - /learn/by-example/testerina-before-each-test.html
+  - /1.2/learn/by-example/testerina-before-each-test
+  - /1.2/learn/by-example/testerina-before-each-test.html
 ---
 <div class="row cBallerina-io-Gray-row">
         <div class="container cBallerinaBySampleContainer">

--- a/1.2/learn/by-example/testerina-mocking-functions.html
+++ b/1.2/learn/by-example/testerina-mocking-functions.html
@@ -6,8 +6,8 @@ permalink: /1.2/learn/by-example/testerina-mocking-functions
 redirect_from:
   - /v1-2//learn/by-example/testerina-mocking-functions
   - /v1-2//learn/by-example/testerina-mocking-functions.html
-  - /learn/by-example/testerina-function-mocks.html
-  - /learn/by-example/testerina-function-mocks
+  - /1.2/learn/by-example/testerina-function-mocks.html
+  - /1.2/learn/by-example/testerina-function-mocks
 ---
 <div class="row cBallerina-io-Gray-row">
         <div class="container cBallerinaBySampleContainer">

--- a/1.2/learn/by-example/testerina-mocking-objects.html
+++ b/1.2/learn/by-example/testerina-mocking-objects.html
@@ -6,8 +6,8 @@ permalink: /1.2/learn/by-example/testerina-mocking-objects
 redirect_from:
   - /v1-2/learn/by-example/testerina-mocking-objects/
   - /v1-2/learn/by-example/testerina-mocking-objects.html
-  - /learn/by-example/testerina-object-mocks.html
-  - /learn/by-example/testerina-object-mocks
+  - /1.2/learn/by-example/testerina-object-mocks.html
+  - /1.2/learn/by-example/testerina-object-mocks
 ---
 <div class="row cBallerina-io-Gray-row">
         <div class="container cBallerinaBySampleContainer">

--- a/1.2/learn/calling-java-code-from-ballerina.md
+++ b/1.2/learn/calling-java-code-from-ballerina.md
@@ -7,13 +7,13 @@ permalink: /1.2/learn/calling-java-code-from-ballerina/
 active: calling-java-code-from-ballerina
 intro: Ballerina offers a straightforward way to call the existing Java code from Ballerina and also provides a Java API to call Ballerina code from Java.  Although Ballerina is not designed to be a JVM language, the current implementation, which targets the JVM, aka jBallerina, provides Java interoperability by adhering to the Ballerina language semantics.
 redirect_from:
-  - /learn/how-to-use-java-interoperability
-  - /learn/how-to-use-java-interoperability/
+  - /1.2/learn/how-to-use-java-interoperability
+  - /1.2/learn/how-to-use-java-interoperability/
   - /v1-2/learn/how-to-use-java-interoperability
   - /v1-2/learn/how-to-use-java-interoperability/
-  - /learn/how-to-call-java-code-from-ballerina/
-  - /learn/how-to-call-java-code-from-ballerina
-  - /learn/calling-java-code-from-ballerina
+  - /1.2/learn/how-to-call-java-code-from-ballerina/
+  - /1.2/learn/how-to-call-java-code-from-ballerina
+  - /1.2/learn/calling-java-code-from-ballerina
 ---
 
 ## Ballerina Bindings to Java code

--- a/1.2/learn/coding-conventions.md
+++ b/1.2/learn/coding-conventions.md
@@ -7,11 +7,11 @@ permalink: /1.2/learn/coding-conventions/
 active: coding-conventions
 intro: This Ballerina Style Guide aims at maintaining a standard coding style among the Ballerina community. Therefore, the Ballerina code formatting tools are based on this guide.
 redirect_from:
-  - /learn/style-guide
-  - /learn/style-guide/
+  - /1.2/learn/style-guide
+  - /1.2/learn/style-guide/
   - /v1-2/learn/style-guide
   - /v1-2/learn/style-guide/
-  - /learn/coding-conventions
+  - /1.2/learn/coding-conventions
 ---
 
 > You can follow your own coding style when writing Ballerina source code. Also, plugins and tools can be configured to match your coding style.

--- a/1.2/learn/coding-conventions/annotations_documentation_and_comments.md
+++ b/1.2/learn/coding-conventions/annotations_documentation_and_comments.md
@@ -7,9 +7,9 @@ intro: The sections below include the coding conventions with respect to annotat
 redirect_from:
   - /v1-2/learn/style-guide/annotations_documentation_and_comments/
   - /v1-2/learn/style-guide/annotations_documentation_and_comments
-  - /learn/style-guide/annotations_documentation_and_comments/
-  - /learn/style-guide/annotations_documentation_and_comments
-  - /learn/coding-conventions/annotations_documentation_and_comments
+  - /1.2/learn/style-guide/annotations_documentation_and_comments/
+  - /1.2/learn/style-guide/annotations_documentation_and_comments
+  - /1.2/learn/coding-conventions/annotations_documentation_and_comments
 ---
 
 ## Annotations

--- a/1.2/learn/coding-conventions/expressions.md
+++ b/1.2/learn/coding-conventions/expressions.md
@@ -7,9 +7,9 @@ intro: The sections below include the coding conventions with respect to express
 redirect_from:
   - /v1-2/learn/style-guide/expressions/
   - /v1-2/learn/style-guide/expressions
-  - /learn/style-guide/expressions
-  - /learn/style-guide/expressions/
-  - /learn/coding-conventions/expressions
+  - /1.2/learn/style-guide/expressions
+  - /1.2/learn/style-guide/expressions/
+  - /1.2/learn/coding-conventions/expressions
 ---
 
 ## Function Invocation

--- a/1.2/learn/coding-conventions/operators_keywords_and_types.md
+++ b/1.2/learn/coding-conventions/operators_keywords_and_types.md
@@ -7,9 +7,9 @@ intro: The sections below include the coding conventions with respect to operato
 redirect_from:
   - /v1-2/learn/style-guide/operators_keywords_and_types/
   - /v1-2/learn/style-guide/operators_keywords_and_types
-  - /learn/style-guide/operators_keywords_and_types
-  - /learn/style-guide/operators_keywords_and_types/
-  - /learn/coding-conventions/operators_keywords_and_types
+  - /1.2/learn/style-guide/operators_keywords_and_types
+  - /1.2/learn/style-guide/operators_keywords_and_types/
+  - /1.2/learn/coding-conventions/operators_keywords_and_types
 ---
 
 ## Keywords and Types

--- a/1.2/learn/coding-conventions/statements.md
+++ b/1.2/learn/coding-conventions/statements.md
@@ -7,9 +7,9 @@ intro: The sections below include the coding conventions with respect to stateme
 redirect_from:
   - /v1-2/learn/style-guide/statements/
   - /v1-2/learn/style-guide/statements
-  - /learn/style-guide/statements
-  - /learn/style-guide/statements/
-  - /learn/coding-conventions/statements
+  - /1.2/learn/style-guide/statements
+  - /1.2/learn/style-guide/statements/
+  - /1.2/learn/coding-conventions/statements
 ---
 
 ## If Statement

--- a/1.2/learn/coding-conventions/top-level-definitions.md
+++ b/1.2/learn/coding-conventions/top-level-definitions.md
@@ -7,10 +7,10 @@ intro: The sections below include the coding conventions with respect to top-lev
 redirect_from:
   - /v1-2/learn/style-guide/definitions/
   - /v1-2/learn/style-guide/definitions
-  - /learn/style-guide/definitions
-  - /learn/style-guide/definitions/
-  - /learn/coding-conventions/definitions
-  - /learn/coding-conventions/top-level-definitions
+  - /1.2/learn/style-guide/definitions
+  - /1.2/learn/style-guide/definitions/
+  - /1.2/learn/coding-conventions/definitions
+  - /1.2/learn/coding-conventions/top-level-definitions
 ---
 
 ## General Practices

--- a/1.2/learn/deployment/aws-lambda.md
+++ b/1.2/learn/deployment/aws-lambda.md
@@ -7,7 +7,7 @@ permalink: /1.2/learn/deployment/aws-lambda/
 intro: The AWS Lambda extension provides the functionality to expose a Ballerina function as an AWS Lambda function.
 active: aws-lambda
 redirect_from:
-  - /learn/deployment/aws-lambda
+  - /1.2/learn/deployment/aws-lambda
 ---
 
 Exposing a Ballerina function as an AWS Lambda function is done by importing the `ballerinax/awslambda` module and simply annotating the Ballerina function with the `awslambda:Function` annotation. Also, the Ballerina function must have the following signature: `function (awslambda:Context, json|EventType) returns json|error`. 

--- a/1.2/learn/deployment/azure-functions.md
+++ b/1.2/learn/deployment/azure-functions.md
@@ -7,7 +7,7 @@ permalink: /1.2/learn/deployment/azure-functions/
 active: azure-functions
 intro: The Azure Functions extension provides the functionality to expose a Ballerina function as a serverless function in the Azure Functions platform.
 redirect_from:
-  - /learn/deployment/azure-functions
+  - /1.2/learn/deployment/azure-functions
 ---
 
 This is done by importing the `ballerinax/azure.functions` module and simply annotating the Ballerina function with the `functions:Function` annotation. 

--- a/1.2/learn/deployment/docker.md
+++ b/1.2/learn/deployment/docker.md
@@ -7,10 +7,10 @@ permalink: /1.2/learn/deployment/docker/
 active: docker
 intro: Docker helps to package applications and their dependencies in a binary image, which can run in various locations whether on-premise, in a public cloud, or in a private cloud. 
 redirect_from:
-  - /learn/deployment/docker
-  - /learn/deploying-ballerina-programs-in-the-cloud
-  - /learn/deploying-ballerina-programs-in-the-cloud/
-  - /learn/deployment/
+  - /1.2/learn/deployment/docker
+  - /1.2/learn/deploying-ballerina-programs-in-the-cloud
+  - /1.2/learn/deploying-ballerina-programs-in-the-cloud/
+  - /1.2/learn/deployment/
 ---
 
 To create a Docker image, you have to create a Dockerfile by choosing a suitable base image, bundling all dependencies, copying the application binary, and setting the execution command with proper permissions. To create optimized images, youhave to follow a set of [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/). Otherwise, the image that is built will be large in size, less secure, and have many other shortcomings. 

--- a/1.2/learn/deployment/kubernetes.md
+++ b/1.2/learn/deployment/kubernetes.md
@@ -7,7 +7,7 @@ permalink: /1.2/learn/deployment/kubernetes/
 active: kubernetes
 intro: The Kubernetes builder extension offers native support for running Ballerina programs on Kubernetes with the use of annotations that you can include as part of your service code.
 redirect_from:
-  - /learn/deployment/kubernetes
+  - /1.2/learn/deployment/kubernetes
 ---
 
 The Kubernetes builder extension takes care of the creation of the Docker images, so you don't need to explicitly create Docker images prior to deployment on Kubernetes.

--- a/1.2/learn/documenting-ballerina-code.md
+++ b/1.2/learn/documenting-ballerina-code.md
@@ -7,11 +7,11 @@ permalink: /1.2/learn/documenting-ballerina-code/
 active: documenting-ballerina-code
 intro: Ballerina has a built-in Ballerina Flavored Markdown (BFM) documentation framework named Docerina. The documentation framework allows you to write unstructured documents with a bit of structure to enable generating HTML content as API documentation.
 redirect_from:
-  - /learn/how-to-document-ballerina-code
-  - /learn/how-to-document-ballerina-code/
+  - /1.2/learn/how-to-document-ballerina-code
+  - /1.2/learn/how-to-document-ballerina-code/
   - /v1-2/learn/how-to-document-ballerina-code
   - /v1-2/learn/how-to-document-ballerina-code/
-  - /learn/documenting-ballerina-code
+  - /1.2/learn/documenting-ballerina-code
 ---
 
 ## Generating Documentation for Modules

--- a/1.2/learn/extending-with-compiler-extensions.md
+++ b/1.2/learn/extending-with-compiler-extensions.md
@@ -7,11 +7,11 @@ permalink: /1.2/learn/extending-with-compiler-extensions/
 active: extending-with-compiler-extensions
 intro: The sections below include information about extending with compiler extensions.
 redirect_from:
-  - /learn/how-to-extend-ballerina
-  - /learn/how-to-extend-ballerina/
+  - /1.2/learn/how-to-extend-ballerina
+  - /1.2/learn/how-to-extend-ballerina/
   - /v1-2/learn/how-to-extend-ballerina
   - /v1-2/learn/how-to-extend-ballerina/
-  - /learn/extending-with-compiler-extensions
+  - /1.2/learn/extending-with-compiler-extensions
 ---
 
 ## Annotations

--- a/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
+++ b/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions.md
@@ -7,11 +7,11 @@ permalink: /1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions/
 active: generating-ballerina-code-for-protocol-buffer-definitions
 intro: The 'Protocol Buffers to Ballerina' tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions. 
 redirect_from:
-  - /learn/how-to-generate-code-for-protocol-buffers
-  - /learn/how-to-generate-code-for-protocol-buffers/
+  - /1.2/learn/how-to-generate-code-for-protocol-buffers
+  - /1.2/learn/how-to-generate-code-for-protocol-buffers/
   - /v1-2/learn/how-to-generate-code-for-protocol-buffers
   - /v1-2/learn/how-to-generate-code-for-protocol-buffers/
-  - /learn/generating-ballerina-code-for-protocol-buffer-definitions
+  - /1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions
 ---
 
 ## Usage of the Tool

--- a/1.2/learn/installing-ballerina.md
+++ b/1.2/learn/installing-ballerina.md
@@ -8,14 +8,14 @@ active: installing-ballerina
 intro: The sections below include information about installing Ballerina.
 redirect_from:
   - /v1-2/learn/getting-started
-  - /learn/getting-started
-  - /learn/getting-started/
-  - /learn/installing-ballerina
-  - /learn/installing-ballerina/#installing-from-source
+  - /1.2/learn/getting-started
+  - /1.2/learn/getting-started/
+  - /1.2/learn/installing-ballerina
+  - /1.2/learn/installing-ballerina/#installing-from-source
   - /v1-2/learn/installing-ballerina
   - /v1-2/learn/installing-ballerina/
-  - /learn/getting-started/installing-ballerina/
-  - /learn/getting-started/installing-ballerina
+  - /1.2/learn/getting-started/installing-ballerina/
+  - /1.2/learn/getting-started/installing-ballerina
 ---
 
 ## Installing Ballerina via Installers

--- a/1.2/learn/keeping-ballerina-up-to-date.md
+++ b/1.2/learn/keeping-ballerina-up-to-date.md
@@ -9,9 +9,9 @@ intro: This guide explains how to maintain your Ballerina installation up to dat
 redirect_from:
   - /v1-2/learn/how-to-keep-ballerina-up-to-date
   - /v1-2/learn/how-to-keep-ballerina-up-to-date/
-  - /learn/how-to-keep-ballerina-up-to-date/
-  - /learn/how-to-keep-ballerina-up-to-date
-  - /learn/keeping-ballerina-up-to-date
+  - /1.2/learn/how-to-keep-ballerina-up-to-date/
+  - /1.2/learn/how-to-keep-ballerina-up-to-date
+  - /1.2/learn/keeping-ballerina-up-to-date
 ---
 
 If you haven’t installed Ballerina yet, see the [Installing Ballerina](/learn/installing-ballerina/).

--- a/1.2/learn/observing-ballerina-code.md
+++ b/1.2/learn/observing-ballerina-code.md
@@ -7,13 +7,13 @@ permalink: /1.2/learn/observing-ballerina-code/
 active: observing-ballerina-code
 intro: Observability is a measure of how well internal states of a system can be inferred from knowledge of its external outputs. 
 redirect_from:
-  - /learn/how-to-observe-ballerina-code
-  - /learn/how-to-observe-ballerina-code/
+  - /1.2/learn/how-to-observe-ballerina-code
+  - /1.2/learn/how-to-observe-ballerina-code/
   - /v1-2/learn/how-to-observe-ballerina-code
   - /v1-2/learn/how-to-observe-ballerina-code/
-  - /learn/how-to-observe-ballerina-services/
-  - /learn/how-to-observe-ballerina-services
-  - /learn/observing-ballerina-code
+  - /1.2/learn/how-to-observe-ballerina-services/
+  - /1.2/learn/how-to-observe-ballerina-services
+  - /1.2/learn/observing-ballerina-code
 ---
 
 ## Providing Observability in Ballerina

--- a/1.2/learn/publishing-modules-to-ballerina-central.md
+++ b/1.2/learn/publishing-modules-to-ballerina-central.md
@@ -7,11 +7,11 @@ permalink: /1.2/learn/publishing-modules-to-ballerina-central/
 active: publishing-modules-to-ballerina-central
 intro: The sections below include information about publishing modules to Ballerina Central.
 redirect_from:
-  - /learn/how-to-publish-modules
-  - /learn/how-to-publish-modules/
+  - /1.2/learn/how-to-publish-modules
+  - /1.2/learn/how-to-publish-modules/
   - /v1-2/learn/how-to-publish-modules
   - /v1-2/learn/how-to-publish-modules/
-  - /learn/publishing-modules-to-ballerina-central
+  - /1.2/learn/publishing-modules-to-ballerina-central
 ---
 
 ## The CLI Command

--- a/1.2/learn/quick-tour.md
+++ b/1.2/learn/quick-tour.md
@@ -7,11 +7,11 @@ permalink: /1.2/learn/quick-tour/
 active: quick-tour
 intro: Now, that you know a little bit of Ballerina, let's take it for a spin!
 redirect_from:
-  - /learn/quick-tour
+  - /1.2/learn/quick-tour
   - /v1-2/learn/quick-tour
   - /v1-2/learn/quick-tour/
-  - /learn/getting-started/quick-tour/
-  - /learn/getting-started/quick-tour
+  - /1.2/learn/getting-started/quick-tour/
+  - /1.2/learn/getting-started/quick-tour
 ---
 
 ## Installing Ballerina

--- a/1.2/learn/running-ballerina-code.md
+++ b/1.2/learn/running-ballerina-code.md
@@ -7,12 +7,12 @@ permalink: /1.2/learn/running-ballerina-code/
 active: running-ballerina-code
 intro: The sections below include information on running Ballerina programs.
 redirect_from:
-  - /learn/how-to-deploy-and-run-ballerina-programs
-  - /learn/how-to-deploy-and-run-ballerina-programs/
-  - /learn/how-to-run-ballerina-programs/
+  - /1.2/learn/how-to-deploy-and-run-ballerina-programs
+  - /1.2/learn/how-to-deploy-and-run-ballerina-programs/
+  - /1.2/learn/how-to-run-ballerina-programs/
   - /v1-2/learn/how-to-deploy-and-run-ballerina-programs
   - /v1-2/learn/how-to-deploy-and-run-ballerina-programs/
-  - /learn/running-ballerina-code
+  - /1.2/learn/running-ballerina-code
 ---
 
 ## Understanding the Structure

--- a/1.2/learn/set-up-ballerina-sdk.md
+++ b/1.2/learn/set-up-ballerina-sdk.md
@@ -5,7 +5,7 @@ permalink: /1.2/learn/set-up-ballerina-sdk/
 active: set-up-ballerina-sdk
 intro: After installing the IntelliJ Ballerina plugin, you need to set up Ballerina SDK for your Ballerina projects to activate all the capabilities of the plugin. Click on the below links for instructions on how to set up Ballerina SDK.
 redirect_from:
-  - /learn/set-up-ballerina-sdk
+  - /1.2/learn/set-up-ballerina-sdk
   - /v1-2/learn/set-up-ballerina-sdk
   - /v1-2/learn/set-up-ballerina-sdk/
 ---

--- a/1.2/learn/structuring-ballerina-code.md
+++ b/1.2/learn/structuring-ballerina-code.md
@@ -7,11 +7,11 @@ permalink: /1.2/learn/structuring-ballerina-code/
 active: structuring-ballerina-code
 intro: This document demonstrates the development of a Ballerina project and shows how to use the `Ballerina Tool` to fetch, build, and install Ballerina modules. 
 redirect_from:
-  - /learn/how-to-structure-ballerina-code
-  - /learn/how-to-structure-ballerina-code/
+  - /1.2/learn/how-to-structure-ballerina-code
+  - /1.2/learn/how-to-structure-ballerina-code/
   - /v1-2/learn/how-to-structure-ballerina-code
   - /v1-2/learn/how-to-structure-ballerina-code/
-  - /learn/structuring-ballerina-code
+  - /1.2/learn/structuring-ballerina-code
 ---
 
 ## Organizing Your Code

--- a/1.2/learn/testing-ballerina-code.md
+++ b/1.2/learn/testing-ballerina-code.md
@@ -7,11 +7,11 @@ permalink: /1.2/learn/testing-ballerina-code/
 active: testing-ballerina-code
 intro: Ballerina has a built-in test framework named Testerina. Testerina enables developers to write testable code. The test framework provides a set of building blocks to help write tests and a set of tools to help test. 
 redirect_from:
-  - /learn/how-to-test-ballerina-code
-  - /learn/how-to-test-ballerina-code/
+  - /1.2/learn/how-to-test-ballerina-code
+  - /1.2/learn/how-to-test-ballerina-code/
   - /v1-2/learn/how-to-test-ballerina-code
   - /v1-2/learn/how-to-test-ballerina-code/
-  - /learn/testing-ballerina-code
+  - /1.2/learn/testing-ballerina-code
 ---
 
 ## Writing and Running Tests 

--- a/1.2/learn/testing-ballerina-code/executing-tests.md
+++ b/1.2/learn/testing-ballerina-code/executing-tests.md
@@ -8,7 +8,7 @@ active: executing-tests
 intro: The sections below include information about executing tests in Ballerina.
 redirect_from:
   - /v1-2/learn/testing-ballerina-code/executing-tests
-  - /learn/testing-ballerina-code/executing-tests
+  - /1.2/learn/testing-ballerina-code/executing-tests
 ---
 
 ## Executing Tests Using CLI Commands

--- a/1.2/learn/testing-ballerina-code/mocking.md
+++ b/1.2/learn/testing-ballerina-code/mocking.md
@@ -9,7 +9,7 @@ active: mocking
 intro: Mocking is useful to control the behavior of functions and objects to control the communication with other modules and external endpoints. A mock can be created by defining return values or replacing the entire object or function with a user-defined equivalent. This feature will help you to test the Ballerina code independently from other modules and external endpoints.
 redirect_from:
   - /v1-2/learn/testing-ballerina-code/mocking
-  - /learn/testing-ballerina-code/mocking
+  - /1.2/learn/testing-ballerina-code/mocking
 ---
 
 ## Mocking Objects

--- a/1.2/learn/testing-ballerina-code/testing-quick-start.md
+++ b/1.2/learn/testing-ballerina-code/testing-quick-start.md
@@ -9,11 +9,11 @@ intro: The Ballerina Language has a built-in robust test framework, which allows
 redirect_from:
   - /v1-2/learn/how-to-test-ballerina-code/
   - /v1-2/learn/how-to-test-ballerina-code
-  - /learn/how-to-test-ballerina-code/
-  - /learn/how-to-test-ballerina-code
-  - /learn/testing-ballerina-code/testing-quick-start
-  - /learn/testing-ballerina-code/
-  - /learn/testing-ballerina-code
+  - /1.2/learn/how-to-test-ballerina-code/
+  - /1.2/learn/how-to-test-ballerina-code
+  - /1.2/learn/testing-ballerina-code/testing-quick-start
+  - /1.2/learn/testing-ballerina-code/
+  - /1.2/learn/testing-ballerina-code
 ---
 
 ## Writing a simple function

--- a/1.2/learn/testing-ballerina-code/writing-tests.md
+++ b/1.2/learn/testing-ballerina-code/writing-tests.md
@@ -8,7 +8,7 @@ active: writing-tests
 intro: The sections below include information about writing tests in Ballerina.
 redirect_from:
   - /v1-2/learn/testing-ballerina-code/writing-tests
-  - /learn/testing-ballerina-code/writing-tests
+  - /1.2/learn/testing-ballerina-code/writing-tests
 ---
 
 ## Project Structure

--- a/1.2/learn/tools-ides/setting-up-intellij-idea.md
+++ b/1.2/learn/tools-ides/setting-up-intellij-idea.md
@@ -7,15 +7,15 @@ intro: The IntelliJ Ballerina plugin provides the Ballerina development capabili
 redirect_from:
   - /v1-2/learn/tools-ides/intellij-plugin
   - /v1-2/learn/tools-ides/intellij-plugin/
-  - /learn/tools-ides/intellij-plugin/
-  - /learn/tools-ides/intellij-plugin
-  - /learn/intellij-plugin
-  - /learn/intellij-plugin/
+  - /1.2/learn/tools-ides/intellij-plugin/
+  - /1.2/learn/tools-ides/intellij-plugin
+  - /1.2/learn/intellij-plugin
+  - /1.2/learn/intellij-plugin/
   - /v1-2/learn/intellij-plugin
   - /v1-2/learn/intellij-plugin/
-  - /learn/tools-ides/setting-up-intellij-idea
-  - /learn/tools-ides/setting-up-intellij-idea/
-  - /learn/setting-up-intellij-idea
+  - /1.2/learn/tools-ides/setting-up-intellij-idea
+  - /1.2/learn/tools-ides/setting-up-intellij-idea/
+  - /1.2/learn/setting-up-intellij-idea
 ---
 
 ## Setting Up the Prerequisites

--- a/1.2/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
+++ b/1.2/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md
@@ -7,17 +7,17 @@ intro: The sections below include information on the various capabilities that a
 redirect_from:
   - /v1-2/learn/tools-ides/intellij-plugin/using-intellij-plugin-features
   - /v1-2/learn/tools-ides/intellij-plugin/using-intellij-plugin-features/
-  - /learn/tools-ides/intellij-plugin/using-intellij-plugin-features
-  - /learn/tools-ides/intellij-plugin/using-intellij-plugin-features/
+  - /1.2/learn/tools-ides/intellij-plugin/using-intellij-plugin-features
+  - /1.2/learn/tools-ides/intellij-plugin/using-intellij-plugin-features/
   - /v1-2/learn/intellij-plugin/using-intellij-plugin-features/
   - /v1-2/learn/intellij-plugin/using-intellij-plugin-features
-  - /learn/intellij-plugin/using-intellij-plugin-features/
-  - /learn/intellij-plugin/using-intellij-plugin-features/
-  - /learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features
-  - /learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features/
-  - /learn/setting-up-intellij-idea/using-intellij-plugin-features
-  - /learn/using-intellij-plugin-features
-  - /learn/using-intellij-plugin-features/
+  - /1.2/learn/intellij-plugin/using-intellij-plugin-features/
+  - /1.2/learn/intellij-plugin/using-intellij-plugin-features/
+  - /1.2/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features
+  - /1.2/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features/
+  - /1.2/learn/setting-up-intellij-idea/using-intellij-plugin-features
+  - /1.2/learn/using-intellij-plugin-features
+  - /1.2/learn/using-intellij-plugin-features/
 ---
 
 ## Running Ballerina Programs

--- a/1.2/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
+++ b/1.2/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md
@@ -9,17 +9,17 @@ redirect_from:
   - /v1-2/learn/tools-ides/intellij-plugin/using-the-intellij-plugin/
   - /v1-2/learn/intellij-plugin/using-the-intellij-plugin
   - /v1-2/learn/intellij-plugin/using-the-intellij-plugin/
-  - /learn/set-up-ballerina-sdk/
-  - /learn/set-up-ballerina-sdk
-  - /learn/intellij-plugin/using-the-intellij-plugin/
-  - /learn/intellij-plugin/using-the-intellij-plugin
-  - /learn/tools-ides/intellij-plugin/using-the-intellij-plugin/
-  - /learn/tools-ides/intellij-plugin/using-the-intellij-plugin
-  - /learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin
-  - /learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin/
-  - /learn/setting-up-intellij-idea/using-the-intellij-plugin
-  - /learn/using-the-intellij-plugin
-  - /learn/using-the-intellij-plugin/
+  - /1.2/learn/set-up-ballerina-sdk/
+  - /1.2/learn/set-up-ballerina-sdk
+  - /1.2/learn/intellij-plugin/using-the-intellij-plugin/
+  - /1.2/learn/intellij-plugin/using-the-intellij-plugin
+  - /1.2/learn/tools-ides/intellij-plugin/using-the-intellij-plugin/
+  - /1.2/learn/tools-ides/intellij-plugin/using-the-intellij-plugin
+  - /1.2/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin
+  - /1.2/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin/
+  - /1.2/learn/setting-up-intellij-idea/using-the-intellij-plugin
+  - /1.2/learn/using-the-intellij-plugin
+  - /1.2/learn/using-the-intellij-plugin/
 ---
 
 ## Creating a New Ballerina Project

--- a/1.2/learn/tools-ides/setting-up-visual-studio-code.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code.md
@@ -7,17 +7,17 @@ intro: The VS Code Ballerina extension provides the Ballerina development capabi
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin
   - /v1-2/learn/tools-ides/vscode-plugin/
-  - /learn/tools-ides/vscode-plugin
-  - /learn/tools-ides/vscode-plugin/
+  - /1.2/learn/tools-ides/vscode-plugin
+  - /1.2/learn/tools-ides/vscode-plugin/
   - /v1-2/learn/vscode-plugin
   - /v1-2/learn/vscode-plugin/
-  - /learn/vscode-plugin/
-  - /learn/vscode-plugin
-  - /learn/tools-ides/setting-up-visual-studio-code
-  - /learn/tools-ides/setting-up-visual-studio-code/
-  - /learn/setting-up-visual-studio-code
-  - /learn/getting-started/setting-up-visual-studio-code
-  - /learn/getting-started/setting-up-visual-studio-code/
+  - /1.2/learn/vscode-plugin/
+  - /1.2/learn/vscode-plugin
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/
+  - /1.2/learn/setting-up-visual-studio-code
+  - /1.2/learn/getting-started/setting-up-visual-studio-code
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/
 ---
 
 ## Downloading VS Code 

--- a/1.2/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
@@ -9,17 +9,17 @@ redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/documentation-viewer/
   - /v1-2/learn/vscode-plugin/documentation-viewer/
   - /v1-2/learn/vscode-plugin/documentation-viewer
-  - /learn/tools-ides/vscode-plugin/documentation-viewer/
-  - /learn/tools-ides/vscode-plugin/documentation-viewer
-  - /learn/vscode-plugin/documentation-viewer/
-  - /learn/vscode-plugin/documentation-viewer
-  - /learn/tools-ides/setting-up-visual-studio-code/documentation-viewer
-  - /learn/tools-ides/setting-up-visual-studio-code/documentation-viewer/
-  - /learn/setting-up-visual-studio-code/documentation-viewer
-  - /learn/documentation-viewer
-  - /learn/documentation-viewer/
-  - /learn/getting-started/documentation-viewer
-  - /learn/getting-started/documentation-viewer/
+  - /1.2/learn/tools-ides/vscode-plugin/documentation-viewer/
+  - /1.2/learn/tools-ides/vscode-plugin/documentation-viewer
+  - /1.2/learn/vscode-plugin/documentation-viewer/
+  - /1.2/learn/vscode-plugin/documentation-viewer
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer/
+  - /1.2/learn/setting-up-visual-studio-code/documentation-viewer
+  - /1.2/learn/documentation-viewer
+  - /1.2/learn/documentation-viewer/
+  - /1.2/learn/getting-started/documentation-viewer
+  - /1.2/learn/getting-started/documentation-viewer/
 ---
 
 ## Launching the Documentation Viewer

--- a/1.2/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
@@ -7,19 +7,19 @@ intro: A rich set of visualization tools will immensely enhance your development
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/graphical-editor
   - /v1-2/learn/tools-ides/vscode-plugin/graphical-editor/
-  - /learn/vscode-plugin/graphical-editor
-  - /learn/vscode-plugin/graphical-editor/
+  - /1.2/learn/vscode-plugin/graphical-editor
+  - /1.2/learn/vscode-plugin/graphical-editor/
   - /v1-2/learn/vscode-plugin/graphical-editor/
   - /v1-2/learn/vscode-plugin/graphical-editor
-  - /learn/tools-ides/vscode-plugin/graphical-editor/
-  - /learn/tools-ides/vscode-plugin/graphical-editor
-  - /learn/tools-ides/setting-up-visual-studio-code/graphical-editor
-  - /learn/tools-ides/setting-up-visual-studio-code/graphical-editor/
-  - /learn/setting-up-visual-studio-code/graphical-editor
-  - /learn/graphical-editor
-  - /learn/graphical-editor/
-  - /learn/getting-started/graphical-editor/
-  - /learn/getting-started/graphical-editor
+  - /1.2/learn/tools-ides/vscode-plugin/graphical-editor/
+  - /1.2/learn/tools-ides/vscode-plugin/graphical-editor
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/graphical-editor
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/graphical-editor/
+  - /1.2/learn/setting-up-visual-studio-code/graphical-editor
+  - /1.2/learn/graphical-editor
+  - /1.2/learn/graphical-editor/
+  - /1.2/learn/getting-started/graphical-editor/
+  - /1.2/learn/getting-started/graphical-editor
 ---
 
 ## Launching the Graphical View

--- a/1.2/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
@@ -7,19 +7,19 @@ intro: The VS Code Ballerina extension brings in language intelligence to enhanc
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/language-intelligence
   - /v1-2/learn/tools-ides/vscode-plugin/language-intelligence/
-  - /learn/tools-ides/vscode-plugin/language-intelligence
-  - /learn/tools-ides/vscode-plugin/language-intelligence/
+  - /1.2/learn/tools-ides/vscode-plugin/language-intelligence
+  - /1.2/learn/tools-ides/vscode-plugin/language-intelligence/
   - /v1-2/learn/vscode-plugin/language-intelligence/
   - /v1-2/learn/vscode-plugin/language-intelligence
-  - /learn/vscode-plugin/language-intelligence/
-  - /learn/vscode-plugin/language-intelligence/
-  - /learn/tools-ides/setting-up-visual-studio-code/language-intelligence
-  - /learn/tools-ides/setting-up-visual-studio-code/language-intelligence/
-  - /learn/setting-up-visual-studio-code/language-intelligence
-  - /learn/language-intelligence
-  - /learn/language-intelligence/
-  - /learn/getting-started/language-intelligence
-  - /learn/getting-started/language-intelligence/
+  - /1.2/learn/vscode-plugin/language-intelligence/
+  - /1.2/learn/vscode-plugin/language-intelligence/
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/language-intelligence
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/language-intelligence/
+  - /1.2/learn/setting-up-visual-studio-code/language-intelligence
+  - /1.2/learn/language-intelligence
+  - /1.2/learn/language-intelligence/
+  - /1.2/learn/getting-started/language-intelligence
+  - /1.2/learn/getting-started/language-intelligence/
 ---
 
 ## Semantic and Syntactic Diagnostics

--- a/1.2/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
@@ -7,19 +7,19 @@ intro: This option allows you to run all the tests that belong to multiple modul
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/run-all-tests
   - /v1-2/learn/tools-ides/vscode-plugin/run-all-tests/
-  - /learn/tools-ides/vscode-plugin/run-all-tests
-  - /learn/tools-ides/vscode-plugin/run-all-tests/
+  - /1.2/learn/tools-ides/vscode-plugin/run-all-tests
+  - /1.2/learn/tools-ides/vscode-plugin/run-all-tests/
   - /v1-2/learn/vscode-plugin/run-all-tests/
   - /v1-2/learn/vscode-plugin/run-all-tests
-  - /learn/vscode-plugin/run-all-tests/
-  - /learn/vscode-plugin/run-all-tests
-  - /learn/tools-ides/setting-up-visual-studio-code/run-all-tests
-  - /learn/tools-ides/setting-up-visual-studio-code/run-all-tests/
-  - /learn/setting-up-visual-studio-code/run-all-tests
-  - /learn/run-all-tests
-  - /learn/run-all-tests/
-  - /learn/getting-started/run-all-tests
-  - /learn/getting-started/run-all-tests/
+  - /1.2/learn/vscode-plugin/run-all-tests/
+  - /1.2/learn/vscode-plugin/run-all-tests
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/run-all-tests
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/run-all-tests/
+  - /1.2/learn/setting-up-visual-studio-code/run-all-tests
+  - /1.2/learn/run-all-tests
+  - /1.2/learn/run-all-tests/
+  - /1.2/learn/getting-started/run-all-tests
+  - /1.2/learn/getting-started/run-all-tests/
 ---
 
 ## Running All Tests 

--- a/1.2/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
@@ -7,19 +7,19 @@ intro: The VS Code Ballerina extension gives you the same debugging experience a
 redirect_from:
   - /v1-2/learn/tools-ides/vscode-plugin/run-and-debug
   - /v1-2/learn/tools-ides/vscode-plugin/run-and-debug/
-  - /learn/tools-ides/vscode-plugin/run-and-debug/
-  - /learn/tools-ides/vscode-plugin/run-and-debug
+  - /1.2/learn/tools-ides/vscode-plugin/run-and-debug/
+  - /1.2/learn/tools-ides/vscode-plugin/run-and-debug
   - /v1-2/learn/vscode-plugin/run-and-debug/
   - /v1-2/learn/vscode-plugin/run-and-debug
-  - /learn/vscode-plugin/run-and-debug/
-  - /learn/vscode-plugin/run-and-debug
-  - /learn/tools-ides/setting-up-visual-studio-code/run-and-debug
-  - /learn/tools-ides/setting-up-visual-studio-code/run-and-debug/
-  - /learn/setting-up-visual-studio-code/run-and-debug
-  - /learn/run-and-debug
-  - /learn/run-and-debug/
-  - /learn/getting-started/run-and-debug/
-  - /learn/getting-started/run-and-debug
+  - /1.2/learn/vscode-plugin/run-and-debug/
+  - /1.2/learn/vscode-plugin/run-and-debug
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/run-and-debug
+  - /1.2/learn/tools-ides/setting-up-visual-studio-code/run-and-debug/
+  - /1.2/learn/setting-up-visual-studio-code/run-and-debug
+  - /1.2/learn/run-and-debug
+  - /1.2/learn/run-and-debug/
+  - /1.2/learn/getting-started/run-and-debug/
+  - /1.2/learn/getting-started/run-and-debug
 ---
 
 ## Starting a Debug Session

--- a/1.2/learn/using-the-cli-tools.md
+++ b/1.2/learn/using-the-cli-tools.md
@@ -9,9 +9,9 @@ intro: The Ballerina Tool is your one-stop-shop for all the things you do in Bal
 redirect_from:
   - /v1-2/learn/cli-commands
   - /v1-2/learn/cli-commands/
-  - /learn/cli-commands/
-  - /learn/cli-commands
-  - /learn/using-the-cli-tools
+  - /1.2/learn/cli-commands/
+  - /1.2/learn/cli-commands
+  - /1.2/learn/using-the-cli-tools
 ---
 
 ## Using the Ballerina Tool

--- a/1.2/learn/using-the-openapi-tools.md
+++ b/1.2/learn/using-the-openapi-tools.md
@@ -9,9 +9,9 @@ intro: OpenAPI Specification is a specification that creates a RESTFUL contract 
 redirect_from:
   - /v1-2/learn/how-to-use-openapi-tools
   - /v1-2/learn/how-to-use-openapi-tools/
-  - /learn/how-to-use-openapi-tools
-  - /learn/how-to-use-openapi-tools/
-  - /learn/using-the-openapi-tools
+  - /1.2/learn/how-to-use-openapi-tools
+  - /1.2/learn/how-to-use-openapi-tools/
+  - /1.2/learn/using-the-openapi-tools
 ---
 
 ## Using the Capabilities of the OpenAPI Tools

--- a/1.2/learn/writing-secure-ballerina-code.md
+++ b/1.2/learn/writing-secure-ballerina-code.md
@@ -7,11 +7,11 @@ permalink: /1.2/learn/writing-secure-ballerina-code/
 active: writing-secure-ballerina-code
 intro: The sections below include information on the different security features and controls available within Ballerina. Also, they provide guidelines on writing secure Ballerina programs.
 redirect_from:
-  - /learn/how-to-write-secure-ballerina-code
-  - /learn/how-to-write-secure-ballerina-code/
+  - /1.2/learn/how-to-write-secure-ballerina-code
+  - /1.2/learn/how-to-write-secure-ballerina-code/
   - /v1-2/learn/how-to-write-secure-ballerina-code
   - /v1-2/learn/how-to-write-secure-ballerina-code/
-  - /learn/writing-secure-ballerina-code
+  - /1.2/learn/writing-secure-ballerina-code
 ---
 
 ## Secure by Design

--- a/learn.md
+++ b/learn.md
@@ -17,7 +17,7 @@ redirect_from:
 ---
 
 <div class="col-sm-12 col-md-4 cLearnPageContentCol">
-<a class="cBoxLink" href="/swan-lake/learn/quick-tour" target="_blank">
+<a class="cBoxLink" href="/learn/quick-tour" target="_blank">
 
 <h2>Get Started</h2>
 
@@ -30,7 +30,7 @@ redirect_from:
 
 
 <div class="col-sm-12 col-md-4 cLearnPageContentCol">
-<a class="cBoxLink" href="/swan-lake/learn/by-example/" target="_blank">
+<a class="cBoxLink" href="/learn/by-example/" target="_blank">
 
 <h2>Ballerina by Example</h2>
 
@@ -42,7 +42,7 @@ redirect_from:
 </div>
 
 <div class="col-sm-12 col-md-4 cLearnPageContentCol">
-<a class="cBoxLink" href="/swan-lake/learn/api-docs/ballerina" target="_blank">
+<a class="cBoxLink" href="/learn/api-docs/ballerina" target="_blank">
 <h2>API Documentation</h2>
 <p>Learn the Ballerina standard library APIs and its components comprehensively.</p>
 
@@ -56,7 +56,7 @@ redirect_from:
 
 <div class="col-sm-12 col-md-4 cLearnPageContentCol">
 
-  <a class="cBoxLink" href="/swan-lake/learn/using-the-cli-tools/" target="_blank">
+  <a class="cBoxLink" href="/learn/using-the-cli-tools/" target="_blank">
   <h2>User Guide</h2>
   <p>Learn about all the features of the language and its platform capabilities.</p>
   </a>


### PR DESCRIPTION
## Purpose
> Replaced the /learn redirections in 1.2 directory
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
