### PR TITLE
Fix links to bbes from API Docs v1.2

### DIFF
--- a/1.2/learn/api-docs/ballerina/auth/index.html
+++ b/1.2/learn/api-docs/ballerina/auth/index.html
@@ -351,7 +351,7 @@ redirect_from:
                 </h1>
                     <h2>Module Overview</h2>
 <p>This module provides the default authentication provider configurations, which can be extended to create new authentication providers.</p>
-<p>For information on the operations, which you can perform with this module, see the below <strong>Objects</strong>. For examples on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/secured-service-with-basic-auth.html">Secured Service with Basic Auth Example</a> and <a href="https://ballerina.io/learn/by-example/secured-client-with-basic-auth.html">Secured Client with Basic Auth Example</a>.</p>
+<p>For information on the operations, which you can perform with this module, see the below <strong>Objects</strong>. For examples on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/secured-service-with-basic-auth.html">Secured Service with Basic Auth Example</a> and <a href="https://ballerina.io/1.2/learn/by-example/secured-client-with-basic-auth.html">Secured Client with Basic Auth Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/cache/index.html
+++ b/1.2/learn/api-docs/ballerina/cache/index.html
@@ -413,7 +413,7 @@ This is an optional parameter.</li>
 <p>A linked list is used for the eviction of the cache. According to the user-configured eviction policy, when inserting / updating / retrieving cache entries, the linked list will be updated. Therefore, when an eviction happens, cache entries can be removed efficiently without iterating the complete map data structure.</p>
 <p><strong>Example:</strong> If the eviction policy is LRU, the MRU item will always be the head of the linked list. When an eviction happens, nodes from the tail will be deleted without iterating the map.</p>
 <p>Furthermore, you can implement custom caching implementations based on different cache storage mechanisms (file, database. etc.) and different eviction policies (MRU, FIFO, etc.). Ballerina provides a &quot;map-based cache&quot; as the default cache implementation.</p>
-<p>For information on the operations, which you can perform with the cache module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see <a href="https://ballerina.io/learn/by-example/cache.html">Cache Example</a></p>
+<p>For information on the operations, which you can perform with the cache module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see <a href="https://ballerina.io/1.2/learn/by-example/cache.html">Cache Example</a></p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/crypto/index.html
+++ b/1.2/learn/api-docs/ballerina/crypto/index.html
@@ -351,7 +351,7 @@ redirect_from:
                 </h1>
                     <h2>Module Overview</h2>
 <p>This module provides the necessary utilities that are required to hash content using different hashing mechanisms and algorithms.</p>
-<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For an example on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/crypto.html">Cryptographic Operations Example</a>.</p>
+<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For an example on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/crypto.html">Cryptographic Operations Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/email/index.html
+++ b/1.2/learn/api-docs/ballerina/email/index.html
@@ -444,7 +444,7 @@ email:ImapClient|email:Error imapClient = new (&quot;imap.email.com&quot;,
 Samples for this operation can be found below.</p>
 <pre><code class="language-ballerina">email:Email|email:Error emailResponse = imapClient-&gt;read();
 </code></pre>
-<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operation, see the <a href="https://ballerina.io/learn/by-example/send-and-receive-emails.html">Send and Receive Emails Example</a>.</p>
+<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operation, see the <a href="https://ballerina.io/1.2/learn/by-example/send-and-receive-emails.html">Send and Receive Emails Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/file/index.html
+++ b/1.2/learn/api-docs/ballerina/file/index.html
@@ -361,10 +361,10 @@ file/directory, and retrieve metadata of the file.
                     <h2>Module Overview</h2>
 <p>This module contains functions to perform file system based operations such as create, delete, rename the
 file/directory, and retrieve metadata of the file.</p>
-<p>For an example on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/file.html">File Example</a>.</p>
+<p>For an example on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/file.html">File Example</a>.</p>
 <h2>Directory Listener</h2>
 <p>The <code>Directory Listener</code> is used to listen to a directory in the local file system. It notifies when new files are created in the directory or when the existing files are deleted or modified.</p>
-<p>For an example on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/directory-listener.html">Directory Listener Example</a>.</p>
+<p>For an example on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/directory-listener.html">Directory Listener Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/filepath/index.html
+++ b/1.2/learn/api-docs/ballerina/filepath/index.html
@@ -353,7 +353,7 @@ redirect_from:
 <p>This module provides a platform-independent API for working with file paths.</p>
 <p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>.</p>
 <ul>
-<li>For an example on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/filepath.html">File Path Example</a>.</li>
+<li>For an example on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/filepath.html">File Path Example</a>.</li>
 </ul>
 
 

--- a/1.2/learn/api-docs/ballerina/grpc/index.html
+++ b/1.2/learn/api-docs/ballerina/grpc/index.html
@@ -386,7 +386,7 @@ message HelloResponse {
 </code></pre>
 <p>gRPC allows client applications to directly call the server-side methods using the auto-generated stubs. Protocol Buffer compiler is used to generate the stubs for the specified language. In Ballerina, the stubs are generated using the built-in proto compiler.</p>
 <p>For the guide on how to generate Ballerina code for Protocol Buffers definition, see <a href="https://ballerina.io/learn/how-to-generate-code-for-protocol-buffers/">how to guide</a>.
-For examples on the usage of the operation, see the <a href="https://ballerina.io/learn/by-example/proto-to-ballerina.html">Proto to Ballerina Example</a>.</p>
+For examples on the usage of the operation, see the <a href="https://ballerina.io/1.2/learn/by-example/proto-to-ballerina.html">Proto to Ballerina Example</a>.</p>
 <h3>gRPC Communication Patterns</h3>
 <p>The common communication pattern between client and server is simple request-response style communication. However, with gRPC, you can leverage different inter-process communication patterns other than the simple request-response pattern.
 This module supports four fundamental communication patterns used in gRPC-based applications: simple RPC(unary RPC), server-side streaming, client-side streaming, and bidirectional streaming.</p>
@@ -422,7 +422,7 @@ headers.setEntry(&quot;id&quot;, &quot;newrequest1&quot;);
 // Call the method in the service using a client stub.
 [string, grpc:Headers]|grpc:Error responseFromServer = blockingClient-&gt;hello(&quot;Ballerina&quot;, headers);
 </code></pre>
-<p>For examples on the usage of the operation, see <a href="https://ballerina.io/learn/by-example/grpc-unary-blocking.html">Unary Ballerina Example</a> and <a href="https://ballerina.io/learn/by-example/grpc-unary-non-blocking.html">Unary Non-Ballerina Example</a></p>
+<p>For examples on the usage of the operation, see <a href="https://ballerina.io/1.2/learn/by-example/grpc-unary-blocking.html">Unary Ballerina Example</a> and <a href="https://ballerina.io/1.2/learn/by-example/grpc-unary-non-blocking.html">Unary Non-Ballerina Example</a></p>
 <h4>Server streaming RPC</h4>
 <p>In server-side streaming RPC, the sends back a sequence of responses after getting the client's request message. After sending all the server responses, the server marks the end of the stream by sending the server status details.
 Users can invoke in a non-blocking manner.</p>
@@ -472,7 +472,7 @@ service HelloWorldMessageListener = service {
    }
 }
 </code></pre>
-<p>For examples on the usage of the operation, see the <a href="https://ballerina.io/learn/by-example/grpc-server-streaming.html">Server Streaming Example</a>.</p>
+<p>For examples on the usage of the operation, see the <a href="https://ballerina.io/1.2/learn/by-example/grpc-server-streaming.html">Server Streaming Example</a>.</p>
 <h4>Client streaming RPC</h4>
 <p>In client streaming RPC, the client sends multiple messages to the server instead of a single request. The server sends back a single response to the client.</p>
 <pre><code class="language-proto">rpc lotsOfGreetings (stream google.protobuf.StringValue)
@@ -538,7 +538,7 @@ service HelloWorldMessageListener = service {
    }
 }
 </code></pre>
-<p>For examples on the usage of the operation, see the <a href="https://ballerina.io/learn/by-example/grpc-client-streaming.html">Client Streaming Example</a>.</p>
+<p>For examples on the usage of the operation, see the <a href="https://ballerina.io/1.2/learn/by-example/grpc-client-streaming.html">Client Streaming Example</a>.</p>
 <h4>Bidirectional Streaming RPC</h4>
 <p>In bidirectional streaming RPC, the client is sending a request to the server as a stream of messages. The server also responds with a stream of messages.</p>
 <pre><code class="language-proto">rpc chat (stream ChatMessage)
@@ -607,7 +607,7 @@ service ChatMessageListener = service {
    }
 }
 </code></pre>
-<p>For examples on the usage of the operation, see the <a href="https://ballerina.io/learn/by-example/grpc-bidirectional-streaming.html">Bidirectional Streaming Example</a>.</p>
+<p>For examples on the usage of the operation, see the <a href="https://ballerina.io/1.2/learn/by-example/grpc-bidirectional-streaming.html">Bidirectional Streaming Example</a>.</p>
 <h3>Advanced Use cases</h3>
 <h4>Using the TLS protocol</h4>
 <p>The Ballerina gRPC module allows the use TLS in communication. This setting expects a secure socket to be
@@ -639,7 +639,7 @@ service HelloWorld on ep {
             }
     });
 </code></pre>
-<p>For examples on the usage of the operation, see the <a href="https://ballerina.io/learn/by-example/grpc-secured-unary.html">Secured Unary Example</a>.</p>
+<p>For examples on the usage of the operation, see the <a href="https://ballerina.io/1.2/learn/by-example/grpc-secured-unary.html">Secured Unary Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/grpc/index.html
+++ b/1.2/learn/api-docs/ballerina/grpc/index.html
@@ -385,7 +385,7 @@ message HelloResponse {
 }
 </code></pre>
 <p>gRPC allows client applications to directly call the server-side methods using the auto-generated stubs. Protocol Buffer compiler is used to generate the stubs for the specified language. In Ballerina, the stubs are generated using the built-in proto compiler.</p>
-<p>For the guide on how to generate Ballerina code for Protocol Buffers definition, see <a href="https://ballerina.io/learn/how-to-generate-code-for-protocol-buffers/">how to guide</a>.
+<p>For the guide on how to generate Ballerina code for Protocol Buffers definition, see <a href="https://ballerina.io/1.2/learn/how-to-generate-code-for-protocol-buffers/">how to guide</a>.
 For examples on the usage of the operation, see the <a href="https://ballerina.io/1.2/learn/by-example/proto-to-ballerina.html">Proto to Ballerina Example</a>.</p>
 <h3>gRPC Communication Patterns</h3>
 <p>The common communication pattern between client and server is simple request-response style communication. However, with gRPC, you can leverage different inter-process communication patterns other than the simple request-response pattern.

--- a/1.2/learn/api-docs/ballerina/http/index.html
+++ b/1.2/learn/api-docs/ballerina/http/index.html
@@ -383,10 +383,10 @@ var response = clientEndpoint-&gt;get(&quot;/get?id=123&quot;);
 </code></pre>
 <p>For more information, see the following.</p>
 <ul>
-<li><a href="https://ballerina.io/learn/by-example/http-client-endpoint.html">Client Endpoint Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/http-circuit-breaker.html">Circuit Breaker Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/http-redirects.html">HTTP Redirects Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/http-cookies.html">HTTP Cookies</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/http-client-endpoint.html">Client Endpoint Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/http-circuit-breaker.html">Circuit Breaker Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/http-redirects.html">HTTP Redirects Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/http-cookies.html">HTTP Cookies</a></li>
 </ul>
 <h3>Listener</h3>
 <p>A <code>Service</code> represents a collection of network-accessible entry points and can be exposed via a <code>Listener</code> endpoint. A resource represents one such entry point and can have its own path, HTTP methods, body format, 'consumes' and 'produces' content types, CORS headers, etc. In resources, <code>http:caller</code> and <code>http:Request</code> are mandatory parameters while <code>path</code> and <code>body</code> are optional.</p>
@@ -421,14 +421,14 @@ service helloWorld on helloWorldEP {
 </code></pre>
 <p>See the following.</p>
 <ul>
-<li><a href="https://ballerina.io/learn/by-example/http-data-binding.html">Listener Endpoint Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/http-cors.html">HTTP CORS Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/http-failover.html">HTTP Failover Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/http-load-balancer.html">HTTP Load Balancer Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/http-data-binding.html">Listener Endpoint Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/http-cors.html">HTTP CORS Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/http-failover.html">HTTP Failover Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/http-load-balancer.html">HTTP Load Balancer Example</a></li>
 </ul>
 <p><code>Listener</code> endpoints can be exposed via SSL. They support Mutual SSL, Hostname Verification, and Application Layer Protocol Negotiation (ALPN) for HTTP2. <code>Listener</code> endpoints also support Certificate Revocation List (CRL), Online Certificate Status Protocol (OCSP), OCSP Stapling, HTTP2, keep-alive, chunking, HTTP caching, data compression/decompression, and authentication/authorization.</p>
-<p>For more information, see <a href="https://ballerina.io/learn/by-example/mutual-ssl.html">Mutual SSL Example</a>.</p>
-<p>For more information, see <a href="https://ballerina.io/learn/by-example/cache.html">Caching Example</a>, <a href="https://ballerina.io/learn/by-example/http-disable-chunking.html">HTTP Disable Chunking Example</a>.</p>
+<p>For more information, see <a href="https://ballerina.io/1.2/learn/by-example/mutual-ssl.html">Mutual SSL Example</a>.</p>
+<p>For more information, see <a href="https://ballerina.io/1.2/learn/by-example/cache.html">Caching Example</a>, <a href="https://ballerina.io/1.2/learn/by-example/http-disable-chunking.html">HTTP Disable Chunking Example</a>.</p>
 <h3>WebSocket</h3>
 <p>This module also provides support for WebSockets. There are two types of WebSocket endpoints: <code>WebSocketClient</code> and <code>WebSocketListener</code>. Both endpoints support all WebSocket frames. The <code>WebSocketClient</code> has a callback service.</p>
 <p>There are two types of services for WebSockets. The service of the server has the <code>WebSockerCaller</code> as the resource parameter and the callback service of the client has <code>WebSocketClient</code> as the resource parameter. The WebSocket services have a fixed set of resources that do not have a resource config. The incoming messages are passed to these resources.</p>
@@ -452,13 +452,13 @@ resource function upgrader(http:Caller caller, http:Request req, string name) {
 <p><strong>onError</strong>: This resource is dispatched when an error occurs in the WebSocket connection. This will always be preceded by a connection closure with an appropriate close frame.</p>
 <p>For more information, see the following.</p>
 <ul>
-<li><a href="https://ballerina.io/learn/by-example/websocket-basic-sample.html">WebSocket Basic Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/http-to-websocket-upgrade.html">HTTP to WebSocket Upgrade Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/websocket-chat-application.html">WebSocket Chat Application</a></li>
-<li><a href="https://ballerina.io/learn/by-example/websocket-proxy-server.html">WebSocket Proxy Server</a></li>
-<li><a href="https://ballerina.io/learn/by-example/websocket-client.html">Client Endpoint</a></li>
-<li><a href="https://ballerina.io/learn/by-example/websocket-retry.html">Retry</a></li>
-<li><a href="https://ballerina.io/learn/by-example/websocket-failover.html">Failover</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/websocket-basic-sample.html">WebSocket Basic Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/http-to-websocket-upgrade.html">HTTP to WebSocket Upgrade Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/websocket-chat-application.html">WebSocket Chat Application</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/websocket-proxy-server.html">WebSocket Proxy Server</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/websocket-client.html">Client Endpoint</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/websocket-retry.html">Retry</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/websocket-failover.html">Failover</a></li>
 </ul>
 <h3>Logging</h3>
 <p>This module supports two types of logs:</p>
@@ -479,7 +479,7 @@ resource function upgrader(http:Caller caller, http:Request req, string name) {
 </li>
 </ul>
 <p>To publish logs to a socket, both the host and port configurations must be provided.</p>
-<p>See <a href="https://ballerina.io/learn/by-example/http-access-logs.html">HTTP Access Logs Example</a>, <a href="https://ballerina.io/learn/by-example/http-trace-logs.html">HTTP Trace Logs Example</a></p>
+<p>See <a href="https://ballerina.io/1.2/learn/by-example/http-access-logs.html">HTTP Access Logs Example</a>, <a href="https://ballerina.io/1.2/learn/by-example/http-trace-logs.html">HTTP Trace Logs Example</a></p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/io/index.html
+++ b/1.2/learn/api-docs/ballerina/io/index.html
@@ -362,17 +362,17 @@ or non-blocking manner.</p>
 <p>A channel represents an I/O source or sink of some bytes, characters, or records that are opened for reading or
 writing respectively.</p>
 <h3>Byte channels</h3>
-<p>The most primitive channel is the <code>ByteChannel</code> which reads and writes 8-bit bytes. For an example on the <code>ByteChannel</code>, see the <a href="https://ballerina.io/learn/by-example/byte-io.html">Byte I/O Example</a>.</p>
+<p>The most primitive channel is the <code>ByteChannel</code> which reads and writes 8-bit bytes. For an example on the <code>ByteChannel</code>, see the <a href="https://ballerina.io/1.2/learn/by-example/byte-io.html">Byte I/O Example</a>.</p>
 <h3>Character channels</h3>
-<p>The <code>CharacterChannel</code> is used to read and write characters. The charset encoding is specified when creating the <code>CharacterChannel</code>. For an example on the <code>CharacterChannel</code>, see the <a href="https://ballerina.io/learn/by-example/character-io.html">Read/Write Files Example</a>.</p>
+<p>The <code>CharacterChannel</code> is used to read and write characters. The charset encoding is specified when creating the <code>CharacterChannel</code>. For an example on the <code>CharacterChannel</code>, see the <a href="https://ballerina.io/1.2/learn/by-example/character-io.html">Read/Write Files Example</a>.</p>
 <p>If a <code>ReadableCharacterChannel</code> points to a JSON or XML source, it can be read and then written directly into a variable of
-the respective type. For examples on reading/writing JSON or XML sources, see the <a href="https://ballerina.io/learn/by-example/json-io.html">JSON I/O Example</a> and <a href="https://ballerina.io/learn/by-example/xml-io.html">XML I/O Example</a>.</p>
+the respective type. For examples on reading/writing JSON or XML sources, see the <a href="https://ballerina.io/1.2/learn/by-example/json-io.html">JSON I/O Example</a> and <a href="https://ballerina.io/1.2/learn/by-example/xml-io.html">XML I/O Example</a>.</p>
 <h3>Record channels</h3>
-<p>Also, Ballerina supports I/O for delimited records. For an example on reading the records in a text file, see the <a href="https://ballerina.io/learn/by-example/record-io.html">Record I/O Example</a>.</p>
-<p>A <code>.CSV</code> file can be read and written directly into a <code>CSVChannel</code> as shown in this <a href="https://ballerina.io/learn/by-example/csv-io.html">CSV I/O Example</a>.</p>
+<p>Also, Ballerina supports I/O for delimited records. For an example on reading the records in a text file, see the <a href="https://ballerina.io/1.2/learn/by-example/record-io.html">Record I/O Example</a>.</p>
+<p>A <code>.CSV</code> file can be read and written directly into a <code>CSVChannel</code> as shown in this <a href="https://ballerina.io/1.2/learn/by-example/csv-io.html">CSV I/O Example</a>.</p>
 <h3>Data Channels</h3>
 <p>Ballerina supports performing data i/o operations.</p>
-<p>A Person object could be serialized into a file or a network socket as seen in the <a href="https://ballerina.io/learn/by-example/data-io.html">Data I/O Example</a>.</p>
+<p>A Person object could be serialized into a file or a network socket as seen in the <a href="https://ballerina.io/1.2/learn/by-example/data-io.html">Data I/O Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/java.arrays/index.html
+++ b/1.2/learn/api-docs/ballerina/java.arrays/index.html
@@ -335,7 +335,7 @@ redirect_from:
                 </h1>
                     <h2>Module Overview</h2>
 <p>This module provides APIs to create new Java array instances, get elements from arrays, set elements, etc.</p>
-<p>For information on the operations, which you can perform with the java.arrays module, see the below <strong>Functions</strong>. For an example on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/java-arrays.html">Java Arrays Example</a>.</p>
+<p>For information on the operations, which you can perform with the java.arrays module, see the below <strong>Functions</strong>. For an example on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/java-arrays.html">Java Arrays Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/java/index.html
+++ b/1.2/learn/api-docs/ballerina/java/index.html
@@ -349,12 +349,12 @@ redirect_from:
 <p>This module provides the API for Java interoperability in Ballerina. It includes a set of Ballerina annotations with which Java constructors, methods, and fields can provide implementations of Ballerina functions with external function bodies.</p>
 <p>For information on the operations, which you can perform with the Java module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the following.</p>
 <ul>
-<li><a href="https://ballerina.io/learn/by-example/create-java-objects.html">Create Java Objects Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/invoke-java-methods.html">Invoke Java Methods Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/access-mutate-java-fields.html">Access/Mutate Java Fields Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/java-varargs.html">Java Varargs Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/overloaded-methods-constructors.html">Overloaded Methods/Constructors Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/java-exceptions.html">Java Exceptions Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/create-java-objects.html">Create Java Objects Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/invoke-java-methods.html">Invoke Java Methods Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/access-mutate-java-fields.html">Access/Mutate Java Fields Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/java-varargs.html">Java Varargs Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/overloaded-methods-constructors.html">Overloaded Methods/Constructors Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/java-exceptions.html">Java Exceptions Example</a></li>
 </ul>
 
 

--- a/1.2/learn/api-docs/ballerina/jwt/index.html
+++ b/1.2/learn/api-docs/ballerina/jwt/index.html
@@ -357,9 +357,9 @@ redirect_from:
 <p>This module provides an inbound and outbound JWT authentication provider, which can be used to authenticate using a JWT and the functionality related to issuing and validating JWT.</p>
 <p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the following.</p>
 <ul>
-<li><a href="https://ballerina.io/learn/by-example/jwt-issue-validate.html">JWT Issue/Validate Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/secured-client-with-jwt-auth.html">Secured Client with JWT Auth Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/secured-service-with-jwt-auth.html">Secured Service with JWT Auth Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/jwt-issue-validate.html">JWT Issue/Validate Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/secured-client-with-jwt-auth.html">Secured Client with JWT Auth Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/secured-service-with-jwt-auth.html">Secured Service with JWT Auth Example</a></li>
 </ul>
 
 

--- a/1.2/learn/api-docs/ballerina/kafka/index.html
+++ b/1.2/learn/api-docs/ballerina/kafka/index.html
@@ -360,12 +360,12 @@ This module supports Kafka 1.x.x and 2.0.0 versions.</p>
 <p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>.
 For examples on the usage of the operations, see the following.</p>
 <ul>
-<li><a href="https://ballerina.io/learn/by-example/kafka-producer.html">Producer Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/kafka-consumer-service.html">Consumer Service Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/kafka-consumer-client.html">Consumer Client Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/kafka-producer-transactional.html">Transactional Producer Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/kafka-authentication-sasl-plain-consumer.html">SASL Consumer Authentication Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/kafka-authentication-sasl-plain-producer.html">SASL Producer Authentication Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/kafka-producer.html">Producer Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/kafka-consumer-service.html">Consumer Service Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/kafka-consumer-client.html">Consumer Client Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/kafka-producer-transactional.html">Transactional Producer Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/kafka-authentication-sasl-plain-consumer.html">SASL Consumer Authentication Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/kafka-authentication-sasl-plain-producer.html">SASL Producer Authentication Example</a></li>
 </ul>
 <h4>Basic Usages</h4>
 <h5>Publishing Messages</h5>

--- a/1.2/learn/api-docs/ballerina/ldap/index.html
+++ b/1.2/learn/api-docs/ballerina/ldap/index.html
@@ -351,7 +351,7 @@ redirect_from:
                 </h1>
                     <h2>Module Overview</h2>
 <p>This module provides an inbound LDAP authentication provider, which is used to authenticate using LDAP credentials.</p>
-<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For an example on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/secured-service-with-ldap.html">Secured Service with LDAP Example</a>.</p>
+<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For an example on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/secured-service-with-ldap.html">Secured Service with LDAP Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/log/index.html
+++ b/1.2/learn/api-docs/ballerina/log/index.html
@@ -363,7 +363,7 @@ loglevel=&quot;DEBUG&quot;
 <p>The log level of <code>foo</code> can also be configured through the CLI as follows:</p>
 <pre><code class="language-bash">$ ballerina run foo --\&quot;&lt;org-name&gt;/foo.loglevel\&quot;=DEBUG
 </code></pre>
-<p>For information on the operation, which you can perform with this module, see the below Function. For examples on the usage of the operation, see <a href="https://ballerina.io/learn/by-example/log-api.html">Log Api</a>.</p>
+<p>For information on the operation, which you can perform with this module, see the below Function. For examples on the usage of the operation, see <a href="https://ballerina.io/1.2/learn/by-example/log-api.html">Log Api</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/math/index.html
+++ b/1.2/learn/api-docs/ballerina/math/index.html
@@ -347,7 +347,7 @@ redirect_from:
                 </h1>
                     <h2>Module Overview</h2>
 <p>This module provides functions to perform fixed-precision integer arithmetic and fixed-precision decimal arithmetic. It includes functions to get the absolute, cosine, sine, root, tangent, and more for a given value.</p>
-<p>For information on the operation, which you can perform with this module, see the below Function. For examples on the usage of the operation, see <a href="https://ballerina.io/learn/by-example/math-functions.html">Math Api</a>.</p>
+<p>For information on the operation, which you can perform with this module, see the below Function. For examples on the usage of the operation, see <a href="https://ballerina.io/1.2/learn/by-example/math-functions.html">Math Api</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/mime/index.html
+++ b/1.2/learn/api-docs/ballerina/mime/index.html
@@ -364,7 +364,7 @@ the <a href="https://www.ietf.org/rfc/rfc2045.txt">RFC 2045 standard</a>.</p>
 </blockquote>
 <h3>Modify and retrieve the data in an entity</h3>
 <p>This module provides functions to set and get an entity body from different kinds of message types such as XML, text, JSON, byte[], and body parts. Headers can be modified through functions such as <code>addHeader()</code>, <code>setHeader()</code>, <code>removeHeader()</code>, etc.</p>
-<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/request-with-multiparts.html">Request with multiparts Example</a> and <a href="https://ballerina.io/learn/by-example/response-with-multiparts.html">Response with multiparts Example</a>.</p>
+<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/request-with-multiparts.html">Request with multiparts Example</a> and <a href="https://ballerina.io/1.2/learn/by-example/response-with-multiparts.html">Response with multiparts Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/nats/index.html
+++ b/1.2/learn/api-docs/ballerina/nats/index.html
@@ -496,12 +496,12 @@ nats:Connection connection = new(&quot;tls://localhost:4222&quot;, config = conf
 <p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>.</p>
 <p>For examples on the usage of the connector, see the following.</p>
 <ul>
-<li><a href="https://ballerina.io/learn/by-example/nats-basic-client.html">Basic Publisher and Subscriber Example</a>.</li>
-<li><a href="https://ballerina.io/learn/by-example/nats-streaming-client.html">Basic Streaming Publisher and Subscriber Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/nats-streaming-consumer-with-data-binding.html">Streaming Publisher and Subscriber With Data Binding Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/nats-streaming-durable-subscriptions.html">Durable Subscriptions Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/nats-streaming-queue-group.html">Queue Groups Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/nats-streaming-start-position.html">Historical Message Replay Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/nats-basic-client.html">Basic Publisher and Subscriber Example</a>.</li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/nats-streaming-client.html">Basic Streaming Publisher and Subscriber Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/nats-streaming-consumer-with-data-binding.html">Streaming Publisher and Subscriber With Data Binding Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/nats-streaming-durable-subscriptions.html">Durable Subscriptions Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/nats-streaming-queue-group.html">Queue Groups Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/nats-streaming-start-position.html">Historical Message Replay Example</a></li>
 </ul>
 
 

--- a/1.2/learn/api-docs/ballerina/oauth2/index.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/index.html
@@ -351,7 +351,7 @@ redirect_from:
                 </h1>
                     <h2>Module Overview</h2>
 <p>This module provides an inbound OAuth2 authentication provider, which can be used to authenticate the provided credentials against an introspection endpoint and an outbound OAuth2 authentication provider, which can be used to authenticate an external endpoint.</p>
-<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/secured-service-with-oauth2.html">Secured Service with OAuth2 Example</a> and <a href="https://ballerina.io/learn/by-example/secured-client-with-oauth2.html">Secured Client with OAuth2 Example</a>.</p>
+<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/secured-service-with-oauth2.html">Secured Service with OAuth2 Example</a> and <a href="https://ballerina.io/1.2/learn/by-example/secured-client-with-oauth2.html">Secured Client with OAuth2 Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/rabbitmq/index.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/index.html
@@ -498,10 +498,10 @@ The default acknowledgement mode is auto-ack (messages are acknowledged immediat
 <p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>.</p>
 <p>For examples on the usage of the connector, see the following.</p>
 <ul>
-<li><a href="https://ballerina.io/learn/by-example/rabbitmq-producer.html">Producer Example</a>.</li>
-<li><a href="https://ballerina.io/learn/by-example/rabbitmq-consumer.html">Consumer Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html">Client Acknowledgements Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/rabbitmq-consumer-with-qos-settings.html">QoS Settings Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/rabbitmq-producer.html">Producer Example</a>.</li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/rabbitmq-consumer.html">Consumer Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html">Client Acknowledgements Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/rabbitmq-consumer-with-qos-settings.html">QoS Settings Example</a></li>
 </ul>
 
 

--- a/1.2/learn/api-docs/ballerina/socket/index.html
+++ b/1.2/learn/api-docs/ballerina/socket/index.html
@@ -395,8 +395,8 @@ service echoServer on server {
 </code></pre>
 <p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the following.</p>
 <ul>
-<li><a href="https://ballerina.io/learn/by-example/tcp-socket-listener-client.html">Basic TCP Socket Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/udp-socket-client.html">Basic UDP Client Socket Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/tcp-socket-listener-client.html">Basic TCP Socket Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/udp-socket-client.html">Basic UDP Client Socket Example</a></li>
 </ul>
 
 

--- a/1.2/learn/api-docs/ballerina/task/index.html
+++ b/1.2/learn/api-docs/ballerina/task/index.html
@@ -383,7 +383,7 @@ service timerService on timer {
     }
 }
 </code></pre>
-<p>For an example on the usage of the <code>task:Listener</code> as a timer, see the <a href="https://ballerina.io/learn/by-example/task-service-timer.html">Task Service Timer Example</a>.</p>
+<p>For an example on the usage of the <code>task:Listener</code> as a timer, see the <a href="https://ballerina.io/1.2/learn/by-example/task-service-timer.html">Task Service Timer Example</a>.</p>
 <h5>Task Listener as an Appointment</h5>
 <p>The <code>AppointmentConfiguration</code> can be used to schedule an appointment.</p>
 <p>The following code snippet shows how to create a task appointment, which registers a service using a CRON expression to execute the task every second for 10 times.</p>
@@ -403,7 +403,7 @@ service appointmentService on appointment {
     }
 }
 </code></pre>
-<p>For an example on the usage of the <code>task:Listener</code> as an appointment, see the <a href="https://ballerina.io/learn/by-example/task-service-appointment.html">Task Service Appointment Example</a>.</p>
+<p>For an example on the usage of the <code>task:Listener</code> as an appointment, see the <a href="https://ballerina.io/1.2/learn/by-example/task-service-appointment.html">Task Service Appointment Example</a>.</p>
 <h4>Task Schedulers</h4>
 <p>A Task <code>Scheduler</code> can be used to create timers/appointments dynamically. Service(s) can be attached to the <code>Scheduler</code> so that they can be invoked when the Scheduler is triggered.</p>
 <p>Similar to Task Listeners, below are the two types of configurations that can be used to configure a Task Scheduler either as a timer or as an appointment.</p>
@@ -421,7 +421,7 @@ service appointmentService on appointment {
 };
 task:Scheduler timer = new(timerConfiguration);
 </code></pre>
-<p>For an example on the usage of the <code>task:Scheduler</code> as a timer, see the <a href="https://ballerina.io/learn/by-example/task-scheduler-timer.html">Task Scheduler Timer Example</a>.</p>
+<p>For an example on the usage of the <code>task:Scheduler</code> as a timer, see the <a href="https://ballerina.io/1.2/learn/by-example/task-scheduler-timer.html">Task Scheduler Timer Example</a>.</p>
 <h4>Task Scheduler as an Appointment</h4>
 <p>A <code>Scheduler</code> can also be used to create appointments via its <code>AppointmentConfiguration</code>.</p>
 <p>The following code snippet shows how to create a Task Scheduler as an appointment.</p>
@@ -431,7 +431,7 @@ task:Scheduler timer = new(timerConfiguration);
 };
 task:Scheduler appointment = new(appointmentConfiguration);
 </code></pre>
-<p>For an example on the usage of the <code>task:Scheduler</code> as an appointment, see the <a href="https://ballerina.io/learn/by-example/task-scheduler-appointment.html">Task Scheduler Appointment Example</a>.</p>
+<p>For an example on the usage of the <code>task:Scheduler</code> as an appointment, see the <a href="https://ballerina.io/1.2/learn/by-example/task-scheduler-appointment.html">Task Scheduler Appointment Example</a>.</p>
 
 
             

--- a/1.2/learn/api-docs/ballerina/time/index.html
+++ b/1.2/learn/api-docs/ballerina/time/index.html
@@ -358,7 +358,7 @@ redirect_from:
 <li>If <code>id</code> starts with '+' or '-', the ID is parsed as an offset. The offset can be specified in one of the following ways: +h, +hh, +hh:mm, -hh:mm, +hhmm, -hhmm, +hh:mm:ss, -hh:mm:ss, +hhmmss, -hhmmss</li>
 <li>Also, <code>id</code> can be a region-based zone ID. The format is '{area}/{city}' e.g., &quot;America/Panama&quot;. The zones are based on IANA Time Zone Database (TZDB) supplied data.</li>
 </ul>
-<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For an example on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/time.html">Time Example</a>.</p>
+<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For an example on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/time.html">Time Example</a>.</p>
 <h3>Patterns for formatting and parsing</h3>
 <p>The below patterns can be used to generate the formatter string when using the <code>format()</code> and <code>parse()</code> functions.</p>
 <table>

--- a/1.2/learn/api-docs/ballerina/websub/index.html
+++ b/1.2/learn/api-docs/ballerina/websub/index.html
@@ -706,10 +706,10 @@ service specificSubscriber on new WebhookListener(8080) {
 <p>For a step-by-step guide on introducing custom subscriber services, see the <a href="https://ballerina.io/learn/how-to-extend-ballerina/#create-webhook-callback-services">&quot;Create Webhook Callback Services&quot;</a> section of &quot;How to Extend Ballerina&quot;.</p>
 <p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the following.</p>
 <ul>
-<li><a href="https://ballerina.io/learn/by-example/websub-internal-hub-sample.html">Internal Hub Sample Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/websub-remote-hub-sample.html">Remote Hub Sample Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/websub-hub-client-sample.html">Hub Client Sample Example</a></li>
-<li><a href="https://ballerina.io/learn/by-example/websub-service-integration-sample.html">Service Integration Sample Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/websub-internal-hub-sample.html">Internal Hub Sample Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/websub-remote-hub-sample.html">Remote Hub Sample Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/websub-hub-client-sample.html">Hub Client Sample Example</a></li>
+<li><a href="https://ballerina.io/1.2/learn/by-example/websub-service-integration-sample.html">Service Integration Sample Example</a></li>
 </ul>
 
 

--- a/1.2/learn/api-docs/ballerina/websub/index.html
+++ b/1.2/learn/api-docs/ballerina/websub/index.html
@@ -703,7 +703,7 @@ service specificSubscriber on new WebhookListener(8080) {
     }
 }
 </code></pre>
-<p>For a step-by-step guide on introducing custom subscriber services, see the <a href="https://ballerina.io/learn/how-to-extend-ballerina/#create-webhook-callback-services">&quot;Create Webhook Callback Services&quot;</a> section of &quot;How to Extend Ballerina&quot;.</p>
+<p>For a step-by-step guide on introducing custom subscriber services, see the <a href="https://ballerina.io/1.2/learn/how-to-extend-ballerina/#create-webhook-callback-services">&quot;Create Webhook Callback Services&quot;</a> section of &quot;How to Extend Ballerina&quot;.</p>
 <p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the following.</p>
 <ul>
 <li><a href="https://ballerina.io/1.2/learn/by-example/websub-internal-hub-sample.html">Internal Hub Sample Example</a></li>

--- a/1.2/learn/api-docs/ballerina/xslt/index.html
+++ b/1.2/learn/api-docs/ballerina/xslt/index.html
@@ -335,7 +335,7 @@ redirect_from:
                 </h1>
                     <h2>Module Overview</h2>
 <p>This module provides a function to transform the XML content to another XML/HTML/plain text using XSL transformations.</p>
-<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the <a href="https://ballerina.io/learn/by-example/xslt-transformation.html">XSLT Transformation Example</a>.</p>
+<p>For information on the operations, which you can perform with this module, see the below <strong>Functions</strong>. For examples on the usage of the operations, see the <a href="https://ballerina.io/1.2/learn/by-example/xslt-transformation.html">XSLT Transformation Example</a>.</p>
 
 
             


### PR DESCRIPTION
## Purpose
> Fixes links from api docs v1.2 to BBEs.

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
