### PR TITLE
Fix the VSCode Plugin Links on the Downloads Page

### DIFF
--- a/download.html
+++ b/download.html
@@ -127,18 +127,18 @@ redirect_from:
             <div class="">
                <table id="insPackages0">
                   <tr>
-                     <td style="width: 50%">Visual Studio Code plugin (vsix) <a href="https://marketplace.visualstudio.com/items?itemName=ballerina.ballerina" class="cDownloadLinkIcon" target="_blank"><img src="/img/download-bg-green-fill.svg"></a>
+                     <td style="width: 50%">Visual Studio Code plugin (vsix) <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swan-lake-latest.metadata.version }}.vsix" class="cDownloadLinkIcon" target="_blank"><img src="/img/download-bg-green-fill.svg"></a>
                   
                      <!--<td style="width: 25%; white-space: nowrap;">Install the Visual Studio Code Plugin (vsix) <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a>-->
 
                      <!--<td style="width: 1%"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a></td>-->
 
 
-                    <td><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.md5">md5</a> &nbsp;
+                    <td><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swan-lake-latest.metadata.version }}.vsix.md5">md5</a> &nbsp;
                     
-                    <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.sha1">SHA-1</a> &nbsp;
+                    <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swan-lake-latest.metadata.version }}.vsix.sha1">SHA-1</a> &nbsp;
                     
-                    <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.asc">asc</a>
+                    <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swan-lake-latest.metadata.version }}.vsix.asc">asc</a>
                     
                     </td> 
                     
@@ -252,10 +252,10 @@ redirect_from:
                </tr>
                <tr>
                   <td style="width: 50%">Visual Studio Code Plugin (vsix)</td>
-                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a></td>
-                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.md5">md5</a></td>
-                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.sha1">SHA-1</a></td>
-                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.asc">asc</a></td>
+                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/releases/downloads{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a></td>
+                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/releases/downloads{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.md5">md5</a></td>
+                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/releases/downloads{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.sha1">SHA-1</a></td>
+                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/releases/downloads{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.asc">asc</a></td>
                </tr>
             </table>
          </div>

--- a/download.html
+++ b/download.html
@@ -127,18 +127,18 @@ redirect_from:
             <div class="">
                <table id="insPackages0">
                   <tr>
-                     <td style="width: 50%">Visual Studio Code plugin (vsix) <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swan-lake-latest.metadata.version }}.vsix" class="cDownloadLinkIcon" target="_blank"><img src="/img/download-bg-green-fill.svg"></a>
+                     <td style="width: 50%">Visual Studio Code plugin (vsix) <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix" class="cDownloadLinkIcon" target="_blank"><img src="/img/download-bg-green-fill.svg"></a>
                   
                      <!--<td style="width: 25%; white-space: nowrap;">Install the Visual Studio Code Plugin (vsix) <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a>-->
 
                      <!--<td style="width: 1%"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a></td>-->
 
 
-                    <td><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swan-lake-latest.metadata.version }}.vsix.md5">md5</a> &nbsp;
+                    <td><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.md5">md5</a> &nbsp;
                     
-                    <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swan-lake-latest.metadata.version }}.vsix.sha1">SHA-1</a> &nbsp;
+                    <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.sha1">SHA-1</a> &nbsp;
                     
-                    <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swan-lake-latest.metadata.version }}.vsix.asc">asc</a>
+                    <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swan-lake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.asc">asc</a>
                     
                     </td> 
                     

--- a/download.html
+++ b/download.html
@@ -252,10 +252,10 @@ redirect_from:
                </tr>
                <tr>
                   <td style="width: 50%">Visual Studio Code Plugin (vsix)</td>
-                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/releases/downloads{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a></td>
-                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/releases/downloads{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.md5">md5</a></td>
-                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/releases/downloads{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.sha1">SHA-1</a></td>
-                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/releases/downloads{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.asc">asc</a></td>
+                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a></td>
+                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.md5">md5</a></td>
+                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.sha1">SHA-1</a></td>
+                  <td style="width: 1%; white-space: nowrap;"><a href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.asc">asc</a></td>
                </tr>
             </table>
          </div>


### PR DESCRIPTION
## Purpose
Fix the VSCode plugin links on the Downloads page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
