### PR TITLE
Remove the "Graphical View" Link in the "What's Next?" Section

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -17,7 +17,7 @@ redirect_from:
 ---
 
 <div class="col-sm-12 col-md-4 cLearnPageContentCol">
-<a class="cBoxLink" href="/learn/getting-started/quick-tour/" target="_blank">
+<a class="cBoxLink" href="/learn/getting-started/quick-tour/">
 
 <h2>Get Started</h2>
 
@@ -56,7 +56,7 @@ redirect_from:
 
 <div class="col-sm-12 col-md-4 cLearnPageContentCol">
 
-  <a class="cBoxLink" href="/learn/using-the-cli-tools/" target="_blank">
+  <a class="cBoxLink" href="/learn/using-the-cli-tools/">
   <h2>User Guide</h2>
   <p>Learn about all the features of the language and its platform capabilities.</p>
   </a>

--- a/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
+++ b/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
@@ -41,5 +41,4 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
 
 ## What's Next?
 
- - For information on the next capability of the VS Code Ballerina extension, see [Graphical View](/learn/vscode-plugin/graphical-editor).
  - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin).


### PR DESCRIPTION
## Purpose
Remove the "Graphical View" link in the "What's Next?" section.
> Fixes #1814 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
