### PR TITLE
Fix Redirections in VSCode Sub Pages

### DIFF
--- a/1.2/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md
@@ -18,8 +18,8 @@ redirect_from:
   - /1.2/learn/setting-up-visual-studio-code/documentation-viewer
   - /1.2/learn/documentation-viewer
   - /1.2/learn/documentation-viewer/
-  - /1.2/learn/getting-started/documentation-viewer
-  - /1.2/learn/getting-started/documentation-viewer/
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/documentation-viewer
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/documentation-viewer/
 ---
 
 ## Launching the Documentation Viewer

--- a/1.2/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md
@@ -18,8 +18,8 @@ redirect_from:
   - /1.2/learn/setting-up-visual-studio-code/graphical-editor
   - /1.2/learn/graphical-editor
   - /1.2/learn/graphical-editor/
-  - /1.2/learn/getting-started/graphical-editor/
-  - /1.2/learn/getting-started/graphical-editor
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/graphical-editor/
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/graphical-editor
 ---
 
 ## Launching the Graphical View

--- a/1.2/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md
@@ -18,8 +18,8 @@ redirect_from:
   - /1.2/learn/setting-up-visual-studio-code/language-intelligence
   - /1.2/learn/language-intelligence
   - /1.2/learn/language-intelligence/
-  - /1.2/learn/getting-started/language-intelligence
-  - /1.2/learn/getting-started/language-intelligence/
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/language-intelligence
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/language-intelligence/
 ---
 
 ## Semantic and Syntactic Diagnostics

--- a/1.2/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md
@@ -18,8 +18,8 @@ redirect_from:
   - /1.2/learn/setting-up-visual-studio-code/run-all-tests
   - /1.2/learn/run-all-tests
   - /1.2/learn/run-all-tests/
-  - /1.2/learn/getting-started/run-all-tests
-  - /1.2/learn/getting-started/run-all-tests/
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/run-all-tests
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/run-all-tests/
 ---
 
 ## Running All Tests 

--- a/1.2/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
+++ b/1.2/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md
@@ -18,8 +18,8 @@ redirect_from:
   - /1.2/learn/setting-up-visual-studio-code/run-and-debug
   - /1.2/learn/run-and-debug
   - /1.2/learn/run-and-debug/
-  - /1.2/learn/getting-started/run-and-debug/
-  - /1.2/learn/getting-started/run-and-debug
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/run-and-debug/
+  - /1.2/learn/getting-started/setting-up-visual-studio-code/run-and-debug
 ---
 
 ## Starting a Debug Session


### PR DESCRIPTION
## Purpose
Fix redirections in VSCode sub pages.
> Fixes #1854 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
