### PR TITLE
Change messaging package links to central 

### DIFF
--- a/learn/by-example/kafka-authentication-sasl-plain-consumer.html
+++ b/learn/by-example/kafka-authentication-sasl-plain-consumer.html
@@ -62,7 +62,7 @@ redirect_from:
  and it should be configured to use the SASL/PLAIN authentication mechanism.
  <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/kafka/latest/kafka/">Kafka module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/kafka/*">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/kafka-authentication-sasl-plain-producer.html
+++ b/learn/by-example/kafka-authentication-sasl-plain-producer.html
@@ -58,7 +58,7 @@ redirect_from:
  and it should be configured to use the SASL/PLAIN authentication mechanism.
  <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/kafka/latest/kafka/">Kafka module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/kafka/*">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/kafka-consumer-client.html
+++ b/learn/by-example/kafka-consumer-client.html
@@ -63,7 +63,7 @@ redirect_from:
  this example to work properly, an active Kafka broker should be present.
  <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/kafka/latest/kafka/">Kafka module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/kafka/*">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/kafka-consumer-group-service.html
+++ b/learn/by-example/kafka-consumer-group-service.html
@@ -71,7 +71,7 @@ redirect_from:
  values. For this example to work properly, an active Kafka broker should be
  present.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/kafka/latest/kafka/">Kafka module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/kafka/*">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/kafka-consumer-service.html
+++ b/learn/by-example/kafka-consumer-service.html
@@ -75,7 +75,7 @@ redirect_from:
  builtin <code>string</code> deserializer for the values. For this example to work
  properly, an active Kafka broker should be present.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/kafka/latest/kafka/">Kafka module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/kafka/*">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/kafka-producer-transactional.html
+++ b/learn/by-example/kafka-producer-transactional.html
@@ -74,7 +74,7 @@ redirect_from:
  this example to work properly, an active Kafka broker should be present.
  <br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/kafka/latest/kafka/">Kafka module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/kafka/*">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/kafka-producer.html
+++ b/learn/by-example/kafka-producer.html
@@ -47,7 +47,7 @@ redirect_from:
  values and <code>int</code> keys. For this example to work properly, an active Kafka
  broker should be present.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/kafka/latest/kafka/">Kafka module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/kafka/*">Kafka module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/nats-basic-client.html
+++ b/learn/by-example/nats-basic-client.html
@@ -59,7 +59,7 @@ redirect_from:
  For instructions on installing the NATS server,
  go to <a href="https://docs.nats.io/nats-server/installation">NATS Server Installation</a>.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/nats/latest/nats/">NATS module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/nats/*">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/nats-streaming-client.html
+++ b/learn/by-example/nats-streaming-client.html
@@ -63,7 +63,7 @@ redirect_from:
  In order to run this sample, a NATS Streaming server should be
  running on the corresponding port used in the sample.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/nats/latest/nats/">NATS module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/nats/*">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/nats-streaming-durable-subscriptions.html
+++ b/learn/by-example/nats-streaming-durable-subscriptions.html
@@ -75,7 +75,7 @@ redirect_from:
  disconnects, the position is lost. Durable subscriptions
  remember their position even if the client is disconnected.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/nats/latest/nats/">NATS module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/nats/*">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/nats-streaming-queue-group.html
+++ b/learn/by-example/nats-streaming-queue-group.html
@@ -114,7 +114,7 @@ redirect_from:
  to receive the message. Although queue groups have multiple subscribers,
  each message is consumed by only one.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/nats/latest/nats/">NATS module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/nats/*">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/nats-streaming-start-position.html
+++ b/learn/by-example/nats-streaming-start-position.html
@@ -82,7 +82,7 @@ redirect_from:
     (e.g., the last 30 seconds).
  4. A specific message sequence number<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/nats/latest/nats/">NATS module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/nats/*">NATS module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html
+++ b/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html
@@ -52,7 +52,7 @@ redirect_from:
  By default, the ackMode is rabbitmq:AUTO_ACK, which will automatically acknowledge
  all messages once consumed.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/rabbitmq/latest/rabbitmq/">RabbitMQ module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/rabbitmq/*">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/rabbitmq-consumer.html
+++ b/learn/by-example/rabbitmq-consumer.html
@@ -49,7 +49,7 @@ redirect_from:
  Multiple services consuming messages from the same queue or from
  different queues can be attached to the same Listener.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/rabbitmq/latest/rabbitmq/">RabbitMQ module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/rabbitmq/*">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/rabbitmq-producer.html
+++ b/learn/by-example/rabbitmq-producer.html
@@ -37,7 +37,7 @@ redirect_from:
                             <p><p>In this example, messages are sent to two different queues,
  to one queue using the same channel and to the other using two different channels.<br/><br/>
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/rabbitmq/latest/rabbitmq/">RabbitMQ module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/rabbitmq/*">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/rabbitmq-transaction-consumer.html
+++ b/learn/by-example/rabbitmq-transaction-consumer.html
@@ -63,7 +63,7 @@ redirect_from:
  Messages will not be re-queued in the case of a rollback
  automatically unless negatively acknowledged by the user.
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/rabbitmq/latest/rabbitmq/">RabbitMQ module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/rabbitmq/*">RabbitMQ module</a>.</p>
 </p>
 
                         </td>

--- a/learn/by-example/rabbitmq-transaction-producer.html
+++ b/learn/by-example/rabbitmq-transaction-producer.html
@@ -40,7 +40,7 @@ redirect_from:
  Upon successful execution of the transaction block,
  the channel will commit and rollback in the case of any error.
  For more information on the underlying module,
- see the <a href="https://ballerina.io/learn/api-docs/ballerina/#/ballerinax/rabbitmq/latest/rabbitmq/">RabbitMQ module</a>.</p>
+ see the <a href="https://docs.central.ballerina.io/ballerinax/rabbitmq/*">RabbitMQ module</a>.</p>
 </p>
 
                         </td>


### PR DESCRIPTION
## Purpose
Changes (kafka, rabbitmq, nats) api docs links to central.


## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
