### PR TITLE
Fix the VSCode Download Icon for Swan Lake

### DIFF
--- a/download.html
+++ b/download.html
@@ -126,23 +126,19 @@ redirect_from:
             <h3 style="margin-bottom: 24px; margin-top: 40px;"></h3>
             <div class="">
                <table id="insPackages0">
+
                   <tr>
-                     <td style="width: 50%">Visual Studio Code plugin (vsix) <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix" class="cDownloadLinkIcon" target="_blank"><img src="/img/download-bg-green-fill.svg"></a>
-                  
-                     <!--<td style="width: 25%; white-space: nowrap;">Install the Visual Studio Code Plugin (vsix) <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a>-->
-
-                     <!--<td style="width: 1%"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/download-bg-green-fill.svg"></a></td>-->
-
-
-                    <td><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.md5">md5</a> &nbsp;
-                    
-                    <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.sha1">SHA-1</a> &nbsp;
-                    
-                    <a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.asc">asc</a>
-                    
-                    </td> 
-                    
+                     <td style="width: 50%">Visual Studio Code Plugin (vsix)</td>
+                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix" class="cDownloadLinkIcon" target="_blank"><img src="/img/download-bg-green-fill.svg"></a></td>
+                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.md5">md5</a></td>
+                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.sha1">SHA-1</a></td>
+                     <td style="width: 1%; white-space: nowrap;"><a href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.asc">asc</a></td>
                   </tr>
+
+
+
+
+
 
                </table>
             </div>


### PR DESCRIPTION
## Purpose
Fix the VSCode Download icon for Swan Lake.
> Fixes #1861 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
