### PR TITLE
Fix command for retrieving short version

### DIFF
--- a/.github/workflows/sw_update_api_docs.yml
+++ b/.github/workflows/sw_update_api_docs.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Copy newly generated API Docs
       run: |
         VERSION="`jq -r '.version' _data/swanlake-latest/metadata.json`"
-        SHORT_VERSION="`jq -r '.short-version' _data/swanlake-latest/metadata.json`"
+        SHORT_VERSION="`jq -r '."short-version"' _data/swanlake-latest/metadata.json`"
 
         cp -r ballerina-${VERSION}/distributions/ballerina-${SHORT_VERSION}/docs learn/api-docs/ballerina
 

--- a/.github/workflows/sw_update_ballerina_by_example.yml
+++ b/.github/workflows/sw_update_ballerina_by_example.yml
@@ -39,7 +39,7 @@ jobs:
         cd ballerina-release
 
         BALLERINA_VERSION="`jq -r '.version' ../_data/swanlake-latest/metadata.json`"
-        SHORT_VERSION="`jq -r '.short-version' ../_data/swanlake-latest/metadata.json`"
+        SHORT_VERSION="`jq -r '."short-version"' ../_data/swanlake-latest/metadata.json`"
 
         curl http://dist-dev.ballerina.io/downloads/$BALLERINA_VERSION/ballerina-$BALLERINA_VERSION.zip --output ballerina.zip
 


### PR DESCRIPTION
## Purpose
> Fixes an issue in the Swan Lake API docs generating workflow.

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
