### PR TITLE
Remove the Homebrew Option from the "Downloads" Page

### DIFF
--- a/download.html
+++ b/download.html
@@ -169,9 +169,9 @@ redirect_from:
                     </td>--> 
                     
                   </tr>
-                  <tr>
+                  <!--<tr>
                      <td style="width: 50%">Install on macOS using Homebrew <a href="/learn/getting-started/installing-ballerina/#installing-on-macos" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td>
-                  </tr>
+                  </tr>-->
                   <tr>
                      <td style="width: 50%">Install via the ZIP archive <a href="/learn/getting-started/installing-ballerina/#installing-via-the-ballerina-language-zip-file" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td>
                   </tr>

--- a/page-not-available.html
+++ b/page-not-available.html
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-inner-page
+layout: ballerina-no-git-inner-page
 redirect_from:
   - /learn/page-not-available/
   - /swan-lake/page-not-available/


### PR DESCRIPTION
## Purpose
Remove the Homebrew option from the "Downloads" page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
