### PR TITLE
Fix the Link of the Logos in the "Community" Page

### DIFF
--- a/community.md
+++ b/community.md
@@ -103,7 +103,7 @@ Getting a language established is like getting a new religion going. If you like
 - Share the wealth by publishing your Ballerina module on <a href="https://central.ballerina.io">Ballerina Central</a> so that the whole community can benefit from your work. 
 - Write your own blog and submit it to be published in our <a href="https://medium.com/ballerina-techblog">community-driven Tech Blog</a>. 
 - Buzz us on <a href="mailto:contact@ballerina.io">contact@ballerina.io</a> if you want to organize a local meetup or hackathon. WSO2 will get right on it and help with presentation/training content, logistics, swag, and some funds for munchies.
-- Download any file of the [Ballerina logo](/ballerina-logos) to use for content or swag.
+- Download any file of the [Ballerina logo](https://github.com/ballerina-platform/ballerina-dev-website/tree/master/ballerina-logos) to use for content or swag.
 
 
 <!-- ## Want to be kept up-to-date?


### PR DESCRIPTION
## Purpose
Fix the link of the logos in the "Community" page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
