### PR TITLE
Update the Getting Started Link on the Home Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
    Download Ballerina
    <p>Distributions available for <br>Linux, OS X, and Windows</p>
    </a>
-   <a class="cBallerina-io-Home-main-download-button cPlayButton" target="_blank" href="">
+   <a class="cBallerina-io-Home-main-download-button cPlayButton" target="_blank" href="/learn/user-guide/getting-started/">
       Get Started
       <p>Install Ballerina, set it all up <br>and take it for a spin.</p>
    </a>


### PR DESCRIPTION
## Purpose
Update the getting started link on the Home page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
