### PR TITLE
Fix Broken Links After User Guide Changes

### DIFF
--- a/learn/tooling-guide/cli-tools/cli-commands.md
+++ b/learn/tooling-guide/cli-tools/cli-commands.md
@@ -14,6 +14,8 @@ redirect_from:
   - /swan-lake/learn/using-the-cli-tools/
   - /swan-lake/learn/using-the-cli-tools
   - /learn/tooling-guide/cli-tools/cli-commands
+  - /learn/tooling-guide/cli-tools/
+  - /learn/tooling-guide/cli-tools
 ---
 
 ## Using the Ballerina Tool

--- a/learn/tooling-guide/cli-tools/update-tool.md
+++ b/learn/tooling-guide/cli-tools/update-tool.md
@@ -9,6 +9,7 @@ intro: This guide explains how to maintain your Ballerina installation up to dat
 redirect_from:
   - /learn/how-to-keep-ballerina-up-to-date
   - /learn/how-to-keep-ballerina-up-to-date/
+  - /learn/keeping-ballerina-up-to-date/
   - /learn/keeping-ballerina-up-to-date
   - /swan-lake/learn/keeping-ballerina-up-to-date/
   - /swan-lake/learn/keeping-ballerina-up-to-date

--- a/learn/tooling-guide/vs-code-extension/installing-the-vs-code-extesnion.md
+++ b/learn/tooling-guide/vs-code-extension/installing-the-vs-code-extesnion.md
@@ -18,6 +18,8 @@ redirect_from:
   - /learn/setting-up-visual-studio-code
   - /learn/tooling-guide/
   - /learn/tooling-guide
+  - /learn/tooling-guide/vs-code-extension/
+  - /learn/tooling-guide/vs-code-extension
   - /learn/tooling-guide/vs-code-extension/installing-the-vs-code-extension
 ---
 

--- a/learn/user-guide/data-and-events-processing/using-language-integrated-queries.md
+++ b/learn/user-guide/data-and-events-processing/using-language-integrated-queries.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/data-and-events-processing/using-language-integrated-queries/
   - /learn/data-and-events-processing/using-language-integrated-queries
   - /learn/user-guide/data-and-events-processing/using-language-integrated-queries
+  - /learn/user-guide/data-and-events-processing/
+  - /learn/user-guide/data-and-events-processing
 ---
 
 ## Using Language-Integrated Queries

--- a/learn/user-guide/deployment/code-to-cloud/code-to-cloud.md
+++ b/learn/user-guide/deployment/code-to-cloud/code-to-cloud.md
@@ -13,6 +13,8 @@ redirect_from:
   - /learn/deployment/code-to-cloud/
   - /learn/deployment/code-to-cloud
   - /learn/user-guide/deployment/code-to-cloud
+  - /learn/user-guide/deployment/
+  - /learn/user-guide/deployment
 ---
 
 This greatly simplifies the experience of developing and deploying Ballerina code in the cloud. It also enables using cloud native technologies easily without in-depth knowledge.

--- a/learn/user-guide/getting-started/Installation-options.md
+++ b/learn/user-guide/getting-started/Installation-options.md
@@ -75,7 +75,7 @@ If you already have a jBallerina version above 1.1.0 installed, you can use the 
 `bal dist update`|Update to the latest patch version of the active distribution
 `bal dist pull <JBALLERINA-VERSION>`|Fetch a specific distribution and set it as the active version
 
-For more information, see [Keeping Ballerina Up to Date](/learn/keeping-ballerina-up-to-date/).
+For more information, see [Keeping Ballerina Up to Date](/learn/tooling-guide/cli-tools/update-tool/).
   
 ## Building from Source
 

--- a/learn/user-guide/network-communication/HTTP/http-clients/communication-resiliency.md
+++ b/learn/user-guide/network-communication/HTTP/http-clients/communication-resiliency.md
@@ -13,6 +13,8 @@ redirect_from:
   - /learn/network-communication/http/http-clients/communication-resiliency/
   - /learn/network-communication/http/http-clients/communication-resiliency
   - /learn/user-guide/network-communication/http/http-clients/communication-resiliency
+  - /learn/network-communication/http/communication-resiliency/
+  - /learn/network-communication/http/communication-resiliency
 ---
 
 These features allow you to handle and recover from unexpected communication scenarios gracefully. 

--- a/learn/user-guide/network-communication/HTTP/http-clients/data-binding.md
+++ b/learn/user-guide/network-communication/HTTP/http-clients/data-binding.md
@@ -13,6 +13,8 @@ redirect_from:
   - /learn/network-communication/http/http-clients/data-binding/
   - /learn/network-communication/http/http-clients/data-binding
   - /learn/user-guide/network-communication/http/http-clients/data-binding
+  - /learn/network-communication/http/data-binding/
+  - /learn/network-communication/http/data-binding
 ---
 
 In the [HTTP GET scenarios](/learn/network-communication/http/#get), the default value of the target type parameter is used in the [`get`](/learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/clients/Client#get) remote method of the [`http:Client`](/learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/clients/HttpClient), which is the [`http:Response`](/learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/classes/Response). You can also pass in the types `string`, `json`, `xml`, `map<json>`, `byte[]`, custom record, and record array types to perform automatic data binding with the returned payload. 

--- a/learn/user-guide/network-communication/HTTP/http-clients/data-streaming.md
+++ b/learn/user-guide/network-communication/HTTP/http-clients/data-streaming.md
@@ -13,6 +13,8 @@ redirect_from:
   - /learn/network-communication/http/http-clients/data-streaming/
   - /learn/network-communication/http/http-clients/data-streaming
   - /learn/user-guide/network-communication/http/http-clients/data-streaming
+  - /learn/network-communication/http/data-streaming/
+  - /learn/network-communication/http/data-streaming
 ---
 
 ## Data Streaming Modes

--- a/learn/user-guide/network-communication/HTTP/http-clients/multipart-message-handling.md
+++ b/learn/user-guide/network-communication/HTTP/http-clients/multipart-message-handling.md
@@ -13,6 +13,8 @@ redirect_from:
   - /learn/network-communication/http/http-clients/multipart-message-handling/
   - /learn/network-communication/http/http-clients/multipart-message-handling
   - /learn/user-guide/network-communication/http/http-clients/multipart-message-handling
+  - /learn/network-communication/http/multipart-message-handling/
+  - /learn/network-communication/http/multipart-message-handling
 ---
 
 You can provide MIME entity values to create single or multi-part HTTP messages using the [`http:Request`](/learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/classes/Request) object.

--- a/learn/user-guide/network-communication/HTTP/http-clients/secure-communication.md
+++ b/learn/user-guide/network-communication/HTTP/http-clients/secure-communication.md
@@ -13,6 +13,8 @@ redirect_from:
   - /learn/network-communication/http/http-clients/secure-communication/
   - /learn/network-communication/http/http-clients/secure-communication
   - /learn/user-guide/network-communication/http/http-clients/secure-communication
+  - /learn/network-communication/http/secure-communication/
+  - /learn/network-communication/http/secure-communication
 ---
 
 ## TLS

--- a/learn/user-guide/network-communication/HTTP/http-services/http-services.md
+++ b/learn/user-guide/network-communication/HTTP/http-services/http-services.md
@@ -25,7 +25,7 @@ The elements of the service are as follows.
 
 - **Service name:** the service name represents the base path of the HTTP service. This is an optional value. If it’s kept empty, the base path defaults to the value “/”. 
 
-- **Listener object:** provides an instance of the [`http:Listener`]((learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/listeners/Listener)) to bind to a specific host/port. 
+- **Listener object:** provides an instance of the [`http:Listener`]((/learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/listeners/Listener)) to bind to a specific host/port. 
 
 - **Resource:** a resource represents a specific subpath that can be accessed in relation to the service base path.
 

--- a/learn/user-guide/network-communication/HTTP/http-services/secure-communication.md
+++ b/learn/user-guide/network-communication/HTTP/http-services/secure-communication.md
@@ -17,7 +17,7 @@ redirect_from:
 
 ## Configuring Secure Communication
 
-This is done by providing an optional [`ListenerConfiguration`](/learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/records/ListenerConfiguration) instance when creating the [`http:Listener`](learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/listeners/Listener) client and providing the secure socket configurations. 
+This is done by providing an optional [`ListenerConfiguration`](/learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/records/ListenerConfiguration) instance when creating the [`http:Listener`](/learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/listeners/Listener) client and providing the secure socket configurations. 
 
 ## Example
 

--- a/learn/user-guide/network-communication/HTTP/http.md
+++ b/learn/user-guide/network-communication/HTTP/http.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/network-communication/http/
   - /learn/network-communication/http
   - /learn/user-guide/network-communication/http
+  - /learn/user-guide/network-communication/
+  - /learn/user-guide/network-communication
 ---
 
 ## Working with HTTP Clients

--- a/learn/user-guide/network-communication/WebSocket/websocket.md
+++ b/learn/user-guide/network-communication/WebSocket/websocket.md
@@ -53,7 +53,7 @@ The connection creation state is achieved when the WebSocket client establishes 
 remote function onOpen(websocket:Caller caller);
 ```
 
-This remote function provides an instance of a [`websocket:Caller`](learn/api-docs/ballerina/#/ballerina/websocket/1.1.2/websocket/clients/Caller) object, which can be used to communicate back with the WebSocket client. This saves the caller object when the connection is created so whenever the application wants to send messages to the connected clients, it can use the stored caller objects to do so.
+This remote function provides an instance of a [`websocket:Caller`](/learn/api-docs/ballerina/#/ballerina/websocket/1.1.2/websocket/clients/Caller) object, which can be used to communicate back with the WebSocket client. This saves the caller object when the connection is created so whenever the application wants to send messages to the connected clients, it can use the stored caller objects to do so.
 
 #### Connection Creation Example
 

--- a/learn/user-guide/security/authentication-and-authorization.md
+++ b/learn/user-guide/security/authentication-and-authorization.md
@@ -15,6 +15,8 @@ redirect_from:
 - /learn/security/authentication-and-authorization/
 - /learn/security/authentication-and-authorization
 - /learn/user-guide/security/authentication-and-authorization
+- /learn/user-guide/authentication-and-authorization/
+- /learn/user-guide/authentication-and-authorization
 ---
 
 ### HTTP Listener Authentication and Authorization

--- a/learn/user-guide/security/writing-secure-ballerina-code.md
+++ b/learn/user-guide/security/writing-secure-ballerina-code.md
@@ -19,6 +19,8 @@ redirect_from:
   - /learn/security/writing-secure-ballerina-code/
   - /learn/security/writing-secure-ballerina-code
   - /learn/user-guide/security/writing-secure-ballerina-code
+  - /learn/user-guide/security/
+  - /learn/user-guide/security
 ---
 
 ## Securing by Design

--- a/learn/user-guide/testing-ballerina-code/testing-quick-start.md
+++ b/learn/user-guide/testing-ballerina-code/testing-quick-start.md
@@ -17,6 +17,8 @@ redirect_from:
   - /learn/testing-ballerina-code/testing-quick-start/
   - /learn/testing-ballerina-code/testing-quick-start
   - /learn/user-guide/testing-ballerina-code/testing-quick-start
+  - /learn/user-guide/testing-ballerina-code/
+  - /learn/user-guide/testing-ballerina-code
 ---
 
 ## Writing a Simple Function

--- a/why-ballerina/sequence-diagrams-for-programming.md
+++ b/why-ballerina/sequence-diagrams-for-programming.md
@@ -26,7 +26,7 @@ redirect_from:
                               <p><img src="/img/why-pages/sequence-diagrams-for-programming-1.png" alt="Sequence Diagrams for Programming"></p>
                               <p>In Ballerina services, the entry point is the service resource function. The actor who invokes the service resource is shown as the “caller”. The “Default” participant is the resource function itself, showing the operations in its lifeline. From the resource function, further function calls are shown in its lifeline and their internal operations are expanded and merged to the same sequence diagram to show their operations as well.</p>
                               <h3 id="get-started">Get Started</h3>
-                              <p>The Ballerina IDE plugin (for example, the <a href="/learn/getting-started/setting-up-visual-studio-code/">VSCode plugin</a>) can generate a sequence diagram dynamically from the source code. To start generating a sequence diagram from your Ballerina code, <a href="/learn/getting-started/setting-up-visual-studio-code/graphical-editor">download the VSCode plugin and launch the graphical editor</a>.</p>
+                              <p>The Ballerina IDE plugin (for example, the <a href="/learn/tooling-guide/vs-code-extension/installing-the-vs-code-extension/">VSCode plugin</a>) can generate a sequence diagram dynamically from the source code. To start generating a sequence diagram from your Ballerina code, <a href="/learn/tooling-guide/vs-code-extension/installing-the-vs-code-extension/">download the VSCode plugin and launch the graphical editor</a>.</p>
                            </div>
                         </div>
                      </div>


### PR DESCRIPTION
## Purpose
Fix broken links after user guide changes.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
