### PR TITLE
Fix the macOS pkg Installer Pack Size

### DIFF
--- a/download.html
+++ b/download.html
@@ -89,7 +89,7 @@ redirect_from:
          <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 ">
             <h3 class="cMac">macOS</h3>
             <a id="packMac" href="{{ site.dist_server }}/downloads/{{ site.data.swanlake-latest.metadata.version }}/{{ site.data.swanlake-latest.metadata.macos-installer }}" class="cGTMDownload cDownload cDownloadNew" data-download="downloads" data-pack="{{ site.data.swanlake-latest.metadata.macos-installer }}">
-               <div class="cSize">Installer pkg <span id="packWindowsName">{{ site.data.swanlake-latest.metadata.windows-installer-size }}</span></div>
+               <div class="cSize">Installer pkg <span id="packWindowsName">{{ site.data.swanlake-latest.metadata.macos-installer-size }}</span></div>
             </a>
             <ul class="cDiwnloadSubLinks">
                <li><a id="packMacMd5" href="{{ site.dist_server }}/downloads/{{ site.data.swanlake-latest.metadata.version }}/{{ site.data.swanlake-latest.metadata.macos-installer }}.md5">md5</a></li>


### PR DESCRIPTION
## Purpose
Fix the macOS pkg installer pack size.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
