### PR TITLE
Fix a Link on the HTTP Services Page

### DIFF
--- a/learn/user-guide/network-communication/HTTP/http-services/http-services.md
+++ b/learn/user-guide/network-communication/HTTP/http-services/http-services.md
@@ -25,7 +25,7 @@ The elements of the service are as follows.
 
 - **Service name:** the service name represents the base path of the HTTP service. This is an optional value. If it’s kept empty, the base path defaults to the value “/”. 
 
-- **Listener object:** provides an instance of the [`http:Listener`]((/learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/listeners/Listener)) to bind to a specific host/port. 
+- **Listener object:** provides an instance of the [`http:Listener`](/learn/api-docs/ballerina/#/ballerina/http/1.0.6/http/listeners/Listener) to bind to a specific host/port. 
 
 - **Resource:** a resource represents a specific subpath that can be accessed in relation to the service base path.
 


### PR DESCRIPTION
## Purpose
Fix a link on the HTTP Services page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
