### PR TITLE
Fix the Security Page Email Link and Change VSCode to Visual Studio Code

### DIFF
--- a/_data/toolingguidenavswanlake.yml
+++ b/_data/toolingguidenavswanlake.yml
@@ -1,5 +1,5 @@
 
-- title: VS Code Extension
+- title: Visual Studio Code Extension
   url: '#'
   sublinks:
     - title: Installing the VS Code Extension

--- a/learn/tooling-guide/visual-studio-code-extension/configurations.md
+++ b/learn/tooling-guide/visual-studio-code-extension/configurations.md
@@ -1,9 +1,11 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
-title: Low Code
-permalink: /learn/tooling-guide/vs-code-extension/low-code/
-active: low-code
+title: Configurations
+permalink: /learn/tooling-guide/visual-studio-code-extension/configurations/
+active: configurations
 intro: The VS Code Ballerina extension gives you the same debugging experience as the conventional VS Code Debugger. Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
 redirect_from:
-  - learn/tooling-guide/vs-code-extension/low-code
+  - /learn/tooling-guide/vs-code-extension/configurations
+  - /learn/tooling-guide/vs-code-extension/configurations
+  - /learn/tooling-guide/visual-studio-code-extension/configurations
 ---

--- a/learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extesnion.md
+++ b/learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extesnion.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
 title: Installing the VS Code Extension
-permalink: /learn/tooling-guide/vs-code-extension/installing-the-vs-code-extension/
+permalink: /learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extension/
 active: installing-the-vs-code-extension
 intro: The VS Code Ballerina extension provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code extension.
 redirect_from:
@@ -21,6 +21,8 @@ redirect_from:
   - /learn/tooling-guide/vs-code-extension/
   - /learn/tooling-guide/vs-code-extension
   - /learn/tooling-guide/vs-code-extension/installing-the-vs-code-extension
+  - /learn/tooling-guide/vs-code-extension/installing-the-vs-code-extension/
+  - /learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extension
 ---
 
 ## Downloading VS Code 

--- a/learn/tooling-guide/visual-studio-code-extension/language-support/documentation-viewer.md
+++ b/learn/tooling-guide/visual-studio-code-extension/language-support/documentation-viewer.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
 title: Documentation Viewer
-permalink: /learn/tooling-guide/vs-code-extension/language-support/documentation-viewer/
+permalink: /learn/tooling-guide/visual-studio-code-extension/language-support/documentation-viewer/
 active: documentation-viewer
 intro: The VS Code Ballerina extension is shipped with a Documentation Viewer. You can add documentation for the functions and other public entities in your module for the reference of other users of it. 
 redirect_from:
@@ -18,6 +18,8 @@ redirect_from:
   - /swan-lake/learn/getting-started/setting-up-visual-studio-code/documentation-viewer/
   - /swan-lake/learn/getting-started/setting-up-visual-studio-code/documentation-viewer
   - /learn/tooling-guide/vs-code-extension/language-support/documentation-viewer
+  - /learn/tooling-guide/vs-code-extension/language-support/documentation-viewer/
+  - /learn/tooling-guide/visual-studio-code-extension/language-support/documentation-viewer
 redirect_to:
  - /page-not-available
 ---

--- a/learn/tooling-guide/visual-studio-code-extension/language-support/graphical-editor.md
+++ b/learn/tooling-guide/visual-studio-code-extension/language-support/graphical-editor.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
 title: Graphical View
-permalink: /learn/tooling-guide/vs-code-extension/language-support/graphical-editor/
+permalink: /learn/tooling-guide/visual-studio-code-extension/language-support/graphical-editor/
 active: graphical-editor
 intro: A rich set of visualization tools will immensely enhance your development experience especially in the integration space. The Graphical Editor of the VS Code Ballerina extension allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. The sections below discuss how to use the Graphical Editor and explore its capabilities.
 redirect_from:
@@ -18,6 +18,8 @@ redirect_from:
   - /swan-lake/learn/getting-started/setting-up-visual-studio-code/graphical-editor/
   - /swan-lake/learn/getting-started/setting-up-visual-studio-code/graphical-editor
   - /learn/tooling-guide/vs-code-extension/language-support/graphical-editor
+  - /learn/tooling-guide/vs-code-extension/language-support/graphical-editor/
+  - /learn/tooling-guide/visual-studio-code-extension/language-support/graphical-editor
 redirect_to:
  - /page-not-available
 ---

--- a/learn/tooling-guide/visual-studio-code-extension/language-support/language-intelligence.md
+++ b/learn/tooling-guide/visual-studio-code-extension/language-support/language-intelligence.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
 title: Language Intelligence
-permalink: /learn/tooling-guide/vs-code-extension/language-support/language-intelligence/
+permalink: /learn/tooling-guide/visual-studio-code-extension/language-support/language-intelligence/
 active: language-intelligence
 intro: The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency. Language intelligence is built in to the extension via a Language Server implementation, which consists of the below language intelligence options.
 redirect_from:
@@ -18,6 +18,8 @@ redirect_from:
   - /swan-lake/learn/getting-started/setting-up-visual-studio-code/language-intelligence/
   - /swan-lake/learn/getting-started/setting-up-visual-studio-code/language-intelligence
   - /learn/tooling-guide/vs-code-extension/language-support/language-intelligence
+  - /learn/tooling-guide/vs-code-extension/language-support/language-intelligence/
+  - /learn/tooling-guide/visual-studio-code-extension/language-support/language-intelligence
 ---
 
 ## Semantic and Syntactic Diagnostics

--- a/learn/tooling-guide/visual-studio-code-extension/language-support/language-support.md
+++ b/learn/tooling-guide/visual-studio-code-extension/language-support/language-support.md
@@ -1,11 +1,13 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
 title: Language Support
-permalink: /learn/tooling-guide/vs-code-extension/language-support/
+permalink: /learn/tooling-guide/visual-studio-code-extension/language-support/
 active: language-support
 intro: The sections below describes the language support features of the Ballerina VS Code extension.  
 redirect_from:
   - /learn/tooling-guide/vs-code-extension/language-support
+  - /learn/tooling-guide/vs-code-extension/language-support/
+  - /learn/tooling-guide/visual-studio-code-extension/language-support
 ---
 
 ## Language Intelligence

--- a/learn/tooling-guide/visual-studio-code-extension/language-support/run-all-tests.md
+++ b/learn/tooling-guide/visual-studio-code-extension/language-support/run-all-tests.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
 title: Run all Tests
-permalink: /learn/tooling-guide/vs-code-extension/language-support/run-all-tests/
+permalink: /learn/tooling-guide/visual-studio-code-extension/language-support/run-all-tests/
 active: run-all-tests
 intro: This option allows you to run all the tests that belong to multiple modules of your project. 
 redirect_from:
@@ -18,6 +18,8 @@ redirect_from:
   - /swan-lake/learn/getting-started/setting-up-visual-studio-code/run-all-tests/
   - /swan-lake/learn/getting-started/setting-up-visual-studio-code/run-all-tests
   - /learn/tooling-guide/vs-code-extension/language-support/run-all-tests
+  - /learn/tooling-guide/vs-code-extension/language-support/run-all-tests/
+  - /learn/tooling-guide/visual-studio-code-extension/language-support/run-all-tests
 redirect_to:
  - /page-not-available
 ---

--- a/learn/tooling-guide/visual-studio-code-extension/low-code.md
+++ b/learn/tooling-guide/visual-studio-code-extension/low-code.md
@@ -1,9 +1,11 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
-title: Configurations
-permalink: /learn/tooling-guide/vs-code-extension/configurations/
-active: configurations
+title: Low Code
+permalink: /learn/tooling-guide/visual-studio-code-extension/low-code/
+active: low-code
 intro: The VS Code Ballerina extension gives you the same debugging experience as the conventional VS Code Debugger. Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
 redirect_from:
-  - /learn/tooling-guide/vs-code-extension/configurations
+  - learn/tooling-guide/vs-code-extension/low-code
+  - /learn/tooling-guide/vs-code-extension/low-code/
+  - /learn/tooling-guide/visual-studio-code-extension/low-code
 ---

--- a/learn/tooling-guide/visual-studio-code-extension/run-and-debug.md
+++ b/learn/tooling-guide/visual-studio-code-extension/run-and-debug.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
 title: Run and Debug
-permalink: /learn/tooling-guide/vs-code-extension/run-and-debug/
+permalink: /learn/tooling-guide/visual-studio-code-extension/run-and-debug/
 active: run-and-debug
 intro: The VS Code Ballerina extension gives you the same debugging experience as the conventional VS Code Debugger. Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
 redirect_from:
@@ -18,6 +18,8 @@ redirect_from:
   - /swan-lake/learn/getting-started/setting-up-visual-studio-code/run-and-debug/
   - /swan-lake/learn/getting-started/setting-up-visual-studio-code/run-and-debug
   - /learn/tooling-guide/vs-code-extension/run-and-debug
+  - /learn/tooling-guide/vs-code-extension/run-and-debug/
+  - /learn/tooling-guide/visual-studio-code-extension/run-and-debug
 ---
 
 ## Starting a Debug Session

--- a/learn/tooling-guide/visual-studio-code-extension/vs-code-commands.md
+++ b/learn/tooling-guide/visual-studio-code-extension/vs-code-commands.md
@@ -1,9 +1,11 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
 title: VS Code Commands
-permalink: /learn/tooling-guide/vs-code-extension/vs-code-commands/
+permalink: /learn/tooling-guide/visual-studio-code-extension/vs-code-commands/
 active: vs-code-commands
 intro: The VS Code Ballerina extension gives you the same debugging experience as the conventional VS Code Debugger. Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger. 
 redirect_from:
   - /learn/tooling-guide/vs-code-extension/vs-code-commands
+  - /learn/tooling-guide/vs-code-extension/vs-code-commands/
+  - /learn/tooling-guide/visual-studio-code-extension/vs-code-commands
 ---

--- a/security.md
+++ b/security.md
@@ -13,7 +13,7 @@ Based on the ethics of responsible disclosure, you must **only use the [security
 
 > **WARNING:** To protect the end-user security, **please do not use any other medium to report security vulnerabilities**. Also, kindly refrain from disclosing the vulnerability details you come across with other individuals, in any forums, sites, or other groups - public or private before it’s mitigation actions and disclosure process are completed.
 
-Use the following key to send secure messages to security@ballerina.io:
+Use the following key to send secure messages to [security@ballerina.io](mailto:security@ballerina.io):
 
 > security@ballerina.io: 0168 DA26 2989 0DB9 4ACD 8367 E683 061E 2F85 C381 [pgp.mit.edu](https://pgp.surfnet.nl/pks/lookup?op=vindex&fingerprint=on&search=0xE683061E2F85C381)
 
@@ -31,7 +31,7 @@ We will keep you informed of the progress towards a fix and disclosure of the vu
 
 The below is an overview of the vulnerability handling process.
 
-1. The vulnerability will be reported privately to security@ballerina.io. (The initial response time will be less than 24 hours).
+1. The vulnerability will be reported privately to [security@ballerina.io](mailto:security@ballerina.io). (The initial response time will be less than 24 hours).
 2. The reported vulnerability gets fixed and the solution gets verified by the relevant teams at WSO2.
 3. The fix gets applied to the main branch and a new version of the distribution gets released if required.
 4. The reported user is kept updated on the progress of the process. 


### PR DESCRIPTION
## Purpose
Fix the Security page email link and change VSCode to Visual Studio Code in the left navigation and breadcrumbs.
> Fixes #1960 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
