### PR TITLE
Remove the Sequence Diagrams Why Ballerina Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,7 +261,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          </ul>
       </div>
    </div>
-   <a class="cBookmarkTop" id="Sequence-Diagrams-for-Programming"></a>
+   <!--<a class="cBookmarkTop" id="Sequence-Diagrams-for-Programming"></a>
    <div id="" class="container cFeatureSection">
       <div class="col-sm-12 col-md-7 cColCOntent">
          <h3>Sequence Diagrams for Programming</h3>
@@ -273,7 +273,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
       <div id="" class="col-sm-12 col-md-5 cColDiagram">
          <img src="/img/home-page/sequence-diagrams-for-programming.png"/>
       </div>
-   </div>
+   </div>-->
    <a class="cBookmarkTop" id="Structural-Open-by-Default-Typing"></a>
    <div id="" class="container cFeatureSection">
       <div class="col-sm-12 col-md-4 cColDiagram cSmallImage">


### PR DESCRIPTION
## Purpose
Remove the Sequence Diagrams Why Ballerina section from the Home page of Bio.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
