### PR TITLE
Fix tuple syntax in sample

### DIFF
--- a/learn/user-guide/coding-conventions/expressions.md
+++ b/learn/user-guide/coding-conventions/expressions.md
@@ -124,8 +124,8 @@ map<string> mapOfString2 = {
 **Example,**
 
 ```ballerina
-(string, int) tuple = 
-(nameOfEmployee, ageOfTheEmployee);
+[string, int] tuple = 
+    [nameOfEmployee, ageOfTheEmployee];
 ```
 
 ## Array Literal


### PR DESCRIPTION
$title and add missing indentation to second line.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
