### PR TITLE
Add cosmos db steps to Azure learn page

### DIFF
--- a/learn/user-guide/deployment/azure-functions.md
+++ b/learn/user-guide/deployment/azure-functions.md
@@ -118,6 +118,19 @@ $ curl -d "Hello!" https://functions1777.azurewebsites.net/api/fromHttpToQueue
 Request: url=https://functions1777.azurewebsites.net/api/fromHttpToQueue method=POST query= headers=Accept=*/* Connection=Keep-Alive Content-Length=6 Content-Type=application/x-www-form-urlencoded Host=functions1777.azurewebsites.net Max-Forwards=9 User-Agent=curl/7.64.0 X-WAWS-Unencoded-URL=/api/fromHttpToQueue CLIENT-IP=10.0.128.31:47794 X-ARR-LOG-ID=c905b483-af19-4cf2-9ce0-0741e5998a98 X-SITE-DEPLOYMENT-ID=functions1777 WAS-DEFAULT-HOSTNAME=functions1777.azurewebsites.net X-Original-URL=/api/fromHttpToQueue X-Forwarded-For=45.30.94.9:47450 X-ARR-SSL=2048|256|C=US, S=Washington, L=Redmond, O=Microsoft Corporation, OU=Microsoft IT, CN=Microsoft IT TLS CA 5|CN=*.azurewebsites.net X-Forwarded-Proto=https X-AppService-Proto=https X-Forwarded-TlsVersion=1.2 DISGUISED-HOST=functions1777.azurewebsites.net params= identities=[{"AuthenticationType":null,"IsAuthenticated":false,"Actor":null,"BootstrapContext":null,"Claims":[],"Label":null,"Name":null,"NameClaimType":"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name","RoleClaimType":"http://schemas.microsoft.com/ws/2008/06/identity/claims/role"}] body=Hello!
 ```
 
+Additionally, Please note that when you are using CosmosDB you have `connectionStringSetting` field. You need to 
+manually the connection string of the database. You can do that by doing the following steps.
+1. Go to the keys tab of Cosmos page.
+2. Copy value of the `PRIMARY CONNECTION STRING`
+3. Go to Configuration tab of the Function App page.
+4. Select `New Application Setting` and paste the above copied data as the value. For the key use the value of the `connectionStringSetting` key.
+   
+Example Application Setting
+```
+Name - `CosmosDBConnection`
+Value - `AccountEndpoint=https://db-cosmos.documents.azure.com:443/;AccountKey=12345asda;`
+```
+
 ## What's Next?
 
 For a full sample with all the supported Azure Functions triggers and bindings in Ballerina, see [Azure Functions Deployment Example](/learn/by-example/azure-functions-deployment.html).

--- a/learn/user-guide/deployment/azure-functions.md
+++ b/learn/user-guide/deployment/azure-functions.md
@@ -118,14 +118,13 @@ $ curl -d "Hello!" https://functions1777.azurewebsites.net/api/fromHttpToQueue
 Request: url=https://functions1777.azurewebsites.net/api/fromHttpToQueue method=POST query= headers=Accept=*/* Connection=Keep-Alive Content-Length=6 Content-Type=application/x-www-form-urlencoded Host=functions1777.azurewebsites.net Max-Forwards=9 User-Agent=curl/7.64.0 X-WAWS-Unencoded-URL=/api/fromHttpToQueue CLIENT-IP=10.0.128.31:47794 X-ARR-LOG-ID=c905b483-af19-4cf2-9ce0-0741e5998a98 X-SITE-DEPLOYMENT-ID=functions1777 WAS-DEFAULT-HOSTNAME=functions1777.azurewebsites.net X-Original-URL=/api/fromHttpToQueue X-Forwarded-For=45.30.94.9:47450 X-ARR-SSL=2048|256|C=US, S=Washington, L=Redmond, O=Microsoft Corporation, OU=Microsoft IT, CN=Microsoft IT TLS CA 5|CN=*.azurewebsites.net X-Forwarded-Proto=https X-AppService-Proto=https X-Forwarded-TlsVersion=1.2 DISGUISED-HOST=functions1777.azurewebsites.net params= identities=[{"AuthenticationType":null,"IsAuthenticated":false,"Actor":null,"BootstrapContext":null,"Claims":[],"Label":null,"Name":null,"NameClaimType":"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name","RoleClaimType":"http://schemas.microsoft.com/ws/2008/06/identity/claims/role"}] body=Hello!
 ```
 
-Additionally, Please note that when you are using CosmosDB you have `connectionStringSetting` field. You need to 
-manually the connection string of the database. You can do that by doing the following steps.
-1. Go to the keys tab of Cosmos page.
-2. Copy value of the `PRIMARY CONNECTION STRING`
-3. Go to Configuration tab of the Function App page.
-4. Select `New Application Setting` and paste the above copied data as the value. For the key use the value of the `connectionStringSetting` key.
-   
-Example Application Setting
+>**Note:** Additionally, when you are using CosmosDB, follow the steps below to configure the connection string of the database manually via the `connectionStringSetting` field.
+1. Click the **Keys** tab of the Cosmos DB page.
+2. Copy the value of the `PRIMARY CONNECTION STRING`.
+3. Click the **Configuration** tab of the Function App page.
+4. Select **New Application Setting** and paste the data you copied above as the value. For the key, use the value of the `connectionStringSetting` key.   
+
+Example application setting is as follows.
 ```
 Name - `CosmosDBConnection`
 Value - `AccountEndpoint=https://db-cosmos.documents.azure.com:443/;AccountKey=12345asda;`


### PR DESCRIPTION
## Purpose
Adds cosmos database connection related steps to learn page to make the development process easier for users.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
