### PR TITLE
Add Links to API Docs in Ballerina Central

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
    </p>
    <ul>
    <!--<li><a class="cIconLink" href="">Quick Tour</a></li>-->
-   <li><a class="cIconLink" href="/learn/by-example/">Ballerina by Example</a></li>
-   <li><a class="cIconLink" href="/learn/api-docs/">API Documentation</a></li>
+   <li><a class="cIconLink" href="/learn/by-example/" target="_blank">Ballerina by Example</a></li>
+   <li><a class="cIconLink" href="https://docs.central.ballerina.io" target="_blank">API Documentation</a></li>
    </ul>
    </div>
    <div class="col-sm-12 col-md-5 cMainCTAContainer">

--- a/learn.md
+++ b/learn.md
@@ -39,7 +39,7 @@ redirect_from:
 </div>
 
 <div class="col-sm-12 col-md-4 cLearnPageContentCol">
-<a class="cBoxLink" href="/learn/api-docs/ballerina" target="_blank">
+<a class="cBoxLink" href="https://docs.central.ballerina.io" target="_blank">
 
 
 <img class="cLearnIcon" src="/img/API-Documentation-v1.png"/>


### PR DESCRIPTION
## Purpose
Add links to API Docs in Ballerina Central.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
