### PR TITLE
Fix alpha3 vscode links

### DIFF
--- a/learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extesnion.md
+++ b/learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extesnion.md
@@ -42,13 +42,13 @@ Download the Visual Studio Code Ballerina Extension from below.
   <div class=" ">
       <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 ">
         <h3 class="cVSCode">Visual Studio Code</h3>
-        <a id="packWindows" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha2/ballerina-swan-lake-alpha2.vsix" class="cGTMDownload cDownload cDownloadNew" data-download="downloads">
+        <a id="packWindows" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix" class="cGTMDownload cDownload cDownloadNew" data-download="downloads">
               <div class="cSize">Extension  vsix <span id="packWindowsName">2.7mb</span></div>
         </a>
         <ul class="cDiwnloadSubLinks">
-            <li><a id="packWindowsMd5" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha2/ballerina-swan-lake-alpha2.vsix.md5">md5</a></li>
-            <li><a id="packWindowsSha1" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha2/ballerina-swan-lake-alpha2.vsix.sha1">SHA-1</a></li>
-            <li><a id="packWindowsAsc" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha2/ballerina-swan-lake-alpha2.vsix.asc">asc</a></li>
+            <li><a id="packWindowsMd5" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix.md5">md5</a></li>
+            <li><a id="packWindowsSha1" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix.sha1">SHA-1</a></li>
+            <li><a id="packWindowsAsc" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix.asc">asc</a></li>
         </ul>
 </div></div></div></div>
 


### PR DESCRIPTION


## Purpose
Fix vscode extension download links for alpha3 release.

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
