### PR TITLE
Fix the "Network in the Language" "Why Ballerina" Section on the Home Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,16 +251,21 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
       </div>
       </div> -->
    <a class="cBookmarkTop" id="The-Network-in-the-Language"></a>
-   <div class="container cFeatureSection">
+   <!--<div class="container cFeatureSection">
       <div class="col-sm-12 col-md-4 cColDiagram  cSmallImage ">
          <img src="/img/home-page/network-in-the-language.png"/>
       </div>
-      <div class="col-sm-12 col-md-8 cColCOntent">
+      <div class="col-sm-12 col-md-4 cColCOntent">-->
+         <div id="" class="container cFeatureSection">
+            <div class="col-sm-12 col-md-8 cColCOntent">
          <h3>The Network in the Language</h3>
          <p>For decades, programming languages have treated networks simply as I/O sources. Ballerina introduces fundamental, new abstractions of client objects, services, resource functions, and listeners to bring networking into the language so that programmers can directly address the <a target="_blank" href="https://en.wikipedia.org/wiki/Fallacies_of_distributed_computing" target="_blank">Fallacies of Distributed Computing</a> as part of their application logic. This facilitates resilient, secure, performant network applications to be within every programmer’s reach.</p>
         <ul class="cInlinelinklist">
             <li><a class="cGreenLinkArrow" href="/why-ballerina/the-network-in-the-language">More Info</a></li>
          </ul>
+      </div>
+      <div class="col-sm-12 col-md-4 cColDiagram cSmallImage">
+         <img src="/img/home-page/network-in-the-language.png"/>
       </div>
    </div>
    <!--<a class="cBookmarkTop" id="Sequence-Diagrams-for-Programming"></a>


### PR DESCRIPTION
## Purpose
Fix the "Network in the Language" "Why Ballerina" section on the Home Page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
