### PR TITLE
Remove the Edit Option on the "Archived Versions" Page

### DIFF
--- a/downloads/swan-lake-archived.md
+++ b/downloads/swan-lake-archived.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-landing-page
+layout: ballerina-no-git-inner-page
 title: Swan Lake Archived Versions
 permalink: /downloads/swan-lake-archived/
 ---

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-inner-page
+layout: ballerina-no-git-inner-page
 title: Ballerina Platform Specifications
 intro: Read the Ballerina language spec and other specifications that cover the standard library, built-in language extensions, testing, documentation, and more.
 keywords: ballerina, language specification, spec 
@@ -47,7 +47,7 @@ For a current repo snapshot of the language specification including all changes,
 
 ## Proposals for improvements/enhancements
 
-Work in progress proposals for improving Ballerina can be found at the following URL: <a target="_blank" href="https://github.com/ballerina-platform/ballerina-spec/blob/master/lang/proposals/README.md">https://github.com/ballerina-platform/ballerina-spec/blob/master/lang/proposals/README.md</a>.
+For the proposals for improving Ballerina, see the <a target="_blank" href="https://github.com/ballerina-platform/ballerina-spec/blob/master/lang/proposals/README.md">work in progress proposals</a>.
 
 <style> 
 table {


### PR DESCRIPTION
## Purpose
Remove the edit option on the "Archived Versions" page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
