### PR TITLE
Add VSCode Extension to the Swan Lake "Archived Versions" Page

### DIFF
--- a/_data/swanlake_release_notes_versions.json
+++ b/_data/swanlake_release_notes_versions.json
@@ -172,8 +172,9 @@
       "rpm-installer-size": "200mb",
       "other-artefacts": [
          "ballerina-swan-lake-alpha2.zip",
-         "ballerina-metrics-grafana-dashboard-prometheus.json",
          "ballerina-swan-lake-alpha2.vsix",
+         "ballerina-metrics-grafana-dashboard-prometheus.json"
+         
       ],
       "api-docs": "ballerina-api-docs-swan-lake-alpha2.zip",
       "release-notes": "ballerina-release-notes-swan-lake-alpha2.md"
@@ -193,8 +194,9 @@
       "rpm-installer-size": "206mb",
       "other-artefacts": [
          "ballerina-swan-lake-alpha3.zip",
-         "ballerina-metrics-grafana-dashboard-prometheus.json",
          "ballerina-swan-lake-alpha3.vsix",
+         "ballerina-metrics-grafana-dashboard-prometheus.json"
+         
       ],
       "api-docs": "ballerina-api-docs-swan-lake-alpha3.zip",
       "release-notes": "ballerina-release-notes-swan-lake-alpha3.md"

--- a/_data/swanlake_release_notes_versions.json
+++ b/_data/swanlake_release_notes_versions.json
@@ -172,7 +172,8 @@
       "rpm-installer-size": "200mb",
       "other-artefacts": [
          "ballerina-swan-lake-alpha2.zip",
-         "ballerina-metrics-grafana-dashboard-prometheus.json"
+         "ballerina-metrics-grafana-dashboard-prometheus.json",
+         "ballerina-swan-lake-alpha2.vsix",
       ],
       "api-docs": "ballerina-api-docs-swan-lake-alpha2.zip",
       "release-notes": "ballerina-release-notes-swan-lake-alpha2.md"
@@ -192,7 +193,8 @@
       "rpm-installer-size": "206mb",
       "other-artefacts": [
          "ballerina-swan-lake-alpha3.zip",
-         "ballerina-metrics-grafana-dashboard-prometheus.json"
+         "ballerina-metrics-grafana-dashboard-prometheus.json",
+         "ballerina-swan-lake-alpha3.vsix",
       ],
       "api-docs": "ballerina-api-docs-swan-lake-alpha3.zip",
       "release-notes": "ballerina-release-notes-swan-lake-alpha3.md"

--- a/download.html
+++ b/download.html
@@ -119,13 +119,13 @@ redirect_from:
    <div class=" ">
       <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 ">
          <h3 class="cVSCode">Visual Studio Code</h3>
-         <a id="packWindows" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix" class="cGTMDownload cDownload cDownloadNew" data-download="downloads">
+         <a id="packWindows" href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix" class="cGTMDownload cDownload cDownloadNew" data-download="downloads">
             <div class="cSize">Extension  vsix <span id="packWindowsName">2.7mb</span></div>
          </a>
          <ul class="cDiwnloadSubLinks">
-            <li><a id="packWindowsMd5" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix.md5">md5</a></li>
-            <li><a id="packWindowsSha1" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix.sha1">SHA-1</a></li>
-            <li><a id="packWindowsAsc" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix.asc">asc</a></li>
+            <li><a id="packWindowsMd5" href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.md5">md5</a></li>
+            <li><a id="packWindowsSha1" href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.sha1">SHA-1</a></li>
+            <li><a id="packWindowsAsc" href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.asc">asc</a></li>
          </ul>
       </div>
   

--- a/downloads/swan-lake-release-notes/swan-lake-alpha3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-alpha3/RELEASE_NOTE.md
@@ -842,7 +842,7 @@ repository = "local"
   - Introduced pushing to the local repository. Passing `--repository=local` will push the Ballerina archive (.bala) to the local repository. For information about local repository support, see the [Ballerina Packages Changelist](#ballerina-packages).
 - Run `bal help <command>` to get more information on the command changes.
 
-- CLI Auto Completion
+- CLI Auto-Completion
   - Installing On Linux Bash
     - Set up auto-completion in the current bash shell.
   

--- a/js/download/swan_lake_archived_download.js
+++ b/js/download/swan_lake_archived_download.js
@@ -87,7 +87,7 @@ function updateReleasearchiveTable(allData) {
             }
 
             // temporary adding idea plugin. This needs to be retrieve from release_notes_versions json
-            allArtifact.push("ballerina-intellij-idea-plugin");
+            //allArtifact.push("ballerina-intellij-idea-plugin");
 
             var halfWayThough = Math.ceil(allArtifact.length / 2);
             item["lefttable"] = allArtifact.slice(0, halfWayThough);

--- a/learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extesnion.md
+++ b/learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extesnion.md
@@ -44,13 +44,13 @@ Download the Visual Studio Code Ballerina Extension from below.
   <div class=" ">
       <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 ">
         <h3 class="cVSCode">Visual Studio Code</h3>
-        <a id="packWindows" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix" class="cGTMDownload cDownload cDownloadNew" data-download="downloads">
+        <a id="packWindows" href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix" class="cGTMDownload cDownload cDownloadNew" data-download="downloads">
               <div class="cSize">Extension  vsix <span id="packWindowsName">2.7mb</span></div>
         </a>
         <ul class="cDiwnloadSubLinks">
-            <li><a id="packWindowsMd5" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix.md5">md5</a></li>
-            <li><a id="packWindowsSha1" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix.sha1">SHA-1</a></li>
-            <li><a id="packWindowsAsc" href="https://github.com/ballerina-platform/plugin-vscode/releases/download/vswan-lake-alpha3/ballerina-swan-lake-alpha3.vsix.asc">asc</a></li>
+            <li><a id="packWindowsMd5" href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-swan-lake-alpha3.vsix.md5">md5</a></li>
+            <li><a id="packWindowsSha1" href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.sha1">SHA-1</a></li>
+            <li><a id="packWindowsAsc" href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix.asc">asc</a></li>
         </ul>
 </div></div></div></div>
 


### PR DESCRIPTION
## Purpose
Add the VSCode extension to the Swan Lake "Archived Versions" page.
> Fixes #2046 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
