### PR TITLE
Fix the ZIP Link in the Downloads Page

### DIFF
--- a/download.html
+++ b/download.html
@@ -165,7 +165,7 @@ redirect_from:
                   </tr>
                  
                   <tr>
-                     <td style="width: 50%">Install via the ZIP archive <a href="/learn/getting-started/installing-ballerina/#installing-via-the-ballerina-language-zip-file" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td>
+                     <td style="width: 50%">Install via the ZIP archive <a href="/learn/user-guide/getting-started/setting-up-ballerina/installation-options/#installing-via-the-ballerina-language-zip-file" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td>
                   </tr>
                   <tr>
                      <td style="width: 50%">Install from source <a href="/learn/getting-started/installing-ballerina/#building-from-source" class="cDownloadLinkIcon" target="_blank"><img src="/img/right-bg-green-fill.svg"></a></td>


### PR DESCRIPTION
## Purpose
Fix the ZIP link in the Downloads page.
> Fixes #1602 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
