### PR TITLE
Remove the "What's Next" Section from the "Run & Debug" Learn Page

### DIFF
--- a/learn/tooling-guide/visual-studio-code-extension/run-and-debug.md
+++ b/learn/tooling-guide/visual-studio-code-extension/run-and-debug.md
@@ -44,7 +44,3 @@ For more information on debugging your code using VS Code, go to [VS Code Docume
     - workaround: manually put a breakpoint to the next line
 - There are some cases where stepping over gives unexpected behavior
     - E.g., when there are multiple workers and a wait expression waiting for them, even though it steps over to hit and pass the wait line in the source, the workers may not have finished the execution yet.
-
-## What's Next?
-
- - For information on the VS Code Ballerina extension, see [The Visual Studio Code Ballerina Extension](/learn/vscode-plugin).


### PR DESCRIPTION
## Purpose
Remove the "What's Next" section from the "Run & Debug" Learn page.
> Fixes #2063 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
