### PR TITLE
Fix usage of stringutils in test guide

### DIFF
--- a/learn/user-guide/testing-ballerina-code/mocking.md
+++ b/learn/user-guide/testing-ballerina-code/mocking.md
@@ -82,7 +82,7 @@ The example in the [Quick Start](/learn/testing-ballerina-code/testing-quick-sta
 ```ballerina
 import ballerina/io;
 import ballerina/http;
-import ballerina/stringutils;
+import ballerina/regex;
 
 http:Client clientEndpoint = check new("https://api.chucknorris.io/jokes/");
 
@@ -118,7 +118,7 @@ function getRandomJoke(string name, string category = "food") returns @tainted s
 
             if (payload is json) {
                 json joke = check payload.value;
-                replacedText = stringutils:replace(joke.toJsonString(), "Chuck Norris", name);
+                replacedText = regex:replaceAll(joke.toJsonString(), "Chuck Norris", name);
                 return replacedText;
             }
             

--- a/learn/user-guide/testing-ballerina-code/testing-quick-start.md
+++ b/learn/user-guide/testing-ballerina-code/testing-quick-start.md
@@ -45,7 +45,7 @@ For more information on the command, see [Structuring Ballerina Code](/learn/str
     // main.bal
     import ballerina/io;
     import ballerina/http;
-    import ballerina/stringutils;
+    import ballerina/regex;
 
     http:Client clientEndpoint = check new ("https://api.chucknorris.io/jokes/");
 
@@ -60,7 +60,7 @@ For more information on the command, see [Structuring Ballerina Code](/learn/str
 
                 if (payload is json) {
                     json joke = check payload.value;
-                    string replacedText = stringutils:replace(joke.toJsonString(), "Chuck Norris", name);
+                    string replacedText = regex:replaceAll(joke.toJsonString(), "Chuck Norris", name);
                     return replacedText;
                 }
             } else {


### PR DESCRIPTION
## Purpose
> Fix usage of `stringutils` package in code samples of testing guide.
> Fixes #2056

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
