### PR TITLE
Remove the Docker Learn Page from Swan Lake User Guide

### DIFF
--- a/_data/learnnavswanlake.yml
+++ b/_data/learnnavswanlake.yml
@@ -58,9 +58,6 @@
     - title: Code to Cloud
       url: /learn/user-guide/deployment/code-to-cloud/
       active: code-to-cloud
-    - title: Docker
-      url: /learn/user-guide/deployment/docker/
-      active: docker
     - title: AWS Lambda
       url: /learn/user-guide/deployment/aws-lambda/
       active: aws-lambda

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
    <li><a class="cIconLink" href="/learn/by-example/" target="_blank">Ballerina by Example</a></li>
    </br></br>
    <li><a class="cIconLink" href="https://docs.central.ballerina.io" target="_blank">API Documentation</a></li></br></br>
-   <li><a class="cIconLink" href="/spec/" target="_blank">Language Specification</a></li>
+   <li><a class="cIconLink" href="/learn/language-guide/" target="_blank">Language Guide</a></li>
    </ul>
    </div>
    <div class="col-sm-12 col-md-5 cMainCTAContainer">

--- a/learn/user-guide/deployment/code-to-cloud/code-to-cloud.md
+++ b/learn/user-guide/deployment/code-to-cloud/code-to-cloud.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/user-guide/deployment/code-to-cloud
   - /learn/user-guide/deployment/
   - /learn/user-guide/deployment
+  - /learn/user-guide/deployment/docker/
+  - /learn/user-guide/deployment/docker
 ---
 
 This greatly simplifies the experience of developing and deploying Ballerina code in the cloud. It also enables using cloud native technologies easily without in-depth knowledge.


### PR DESCRIPTION
## Purpose
Remove the Docker Learn page from Swan Lake User Guide.

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
