### PR TITLE
Add the iFrame to the Home page for the Playground Widget

### DIFF
--- a/home.html
+++ b/home.html
@@ -43,6 +43,20 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
    </div>
 </div>
 
+<div class="row cWidget cWhyBallerinaLinks" style="padding-top:6rem;">
+   <div class="container">
+   <div class="col-sm-12 col-md-12">
+      <h2>
+         Try Ballerina
+      </h2>
+      <div class="embed-responsive embed-responsive-21by9">
+         <iframe class="embed-responsive-item" src="..."></iframe>
+       </div>
+      </div>
+   </div>
+</div>
+
+
 <div class="row cBallerinaFeatureSection">
    <div class="container">
       <div class="col-sm-12 col-md-12">


### PR DESCRIPTION
## Purpose
Add the iframe to the Home page for the Playground widget.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
