### PR TITLE
Fix the "More Info" Links in the "Why Ballerina" Section

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          <h3>Cloud Native</h3> 
          <p>Network primitives in the language make it simpler to write services and run them in the cloud.
             <ul class="cInlinelinklist">
-            <li><a class="cGreenLinkArrow" href="/why-ballerina/the-network-in-the-language">More Info</a></li>
+            <li><a class="cGreenLinkArrow" href="/learn/user-guide/why-ballerina/the-network-in-the-language/">More Info</a></li>
          </ul>
       </div>
 </div>
@@ -125,7 +125,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          <h3>Flexible Typing</h3> 
          <p>Structural types with support for openness are used both for static typing within a program and for describing service interfaces.</p>
          <ul class="cInlinelinklist">
-            <li><a class="cGreenLinkArrow" href="/why-ballerina/sequence-diagrams-for-programming">More Info</a></li>
+            <li><a class="cGreenLinkArrow" href="/learn/user-guide/why-ballerina/network-aware-type-system/">More Info</a></li>
          </ul>
       </div>
      
@@ -145,7 +145,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          <h3>Data Transformation</h3> 
          <p>Type-safe, declarative processing of JSON, XML and tabular data with language-integrated query.</p>
       <ul class="cInlinelinklist">
-            <li><a class="cGreenLinkArrow" href="/why-ballerina/network-aware-type-system">More Info</a></li>
+            <li><a class="cGreenLinkArrow" href="/learn/user-guide/why-ballerina/from-code-to-cloud/">More Info</a></li>
          </ul>
       </div>
       </div>
@@ -166,7 +166,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          <p>Programs have both a textual syntax and an editable graphical form based on sequence diagrams.
          </p>
          <ul class="cInlinelinklist">
-            <li><a class="cGreenLinkArrow" href="/why-ballerina/from-code-to-cloud">More Info</a></li>
+            <li><a class="cGreenLinkArrow" href="/learn/user-guide/why-ballerina/batteries-included/">More Info</a></li>
          </ul>
       </div>
     
@@ -184,7 +184,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          <p>Easy and efficient  concurrency with sequence diagrams and language-managed threads, without the complexity of asynchronous functions.
          </p>
          <ul class="cInlinelinklist">
-            <li><a class="cGreenLinkArrow" href="/why-ballerina/batteries-included">More Info</a></li>
+            <li><a class="cGreenLinkArrow" href="/learn/user-guide/why-ballerina/sequence-diagrams-for-programming/">More Info</a></li>
          </ul>
       </div>
       </div>


### PR DESCRIPTION
## Purpose
Fix the "More Info" links in the "Why Ballerina" section
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
