### PR TITLE
Upgrade the Playground Widget from Playground Staging to Prod

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,7 +221,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          Try Ballerina
       </h2>
       <div class="embed-responsive embed-responsive-21by9 playground">
-         <iframe  class="embed-responsive-item" src="https://stg-play.ballerina.io/index-embedded.html"></iframe>
+         <iframe  class="embed-responsive-item" src="https://play.ballerina.io/index-embedded.html"></iframe>
        </div>
       </div>
    </div>


### PR DESCRIPTION
## Purpose
Upgrade the playground widget from playground staging to prod.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
