### PR TITLE
Rename "Language Intelligence" to "IntelliSense" in VSCode Docs

### DIFF
--- a/_data/toolingguidenavswanlake.yml
+++ b/_data/toolingguidenavswanlake.yml
@@ -5,9 +5,9 @@
     - title: Installing the VS Code Extension
       url: /learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extension/ 
       active: installing-vs-code
-    - title: Language Intelligence
-      url: /learn/tooling-guide/visual-studio-code-extension/language-intelligence/ 
-      active: language-intelligence
+    - title: IntelliSense
+      url: /learn/tooling-guide/visual-studio-code-extension/intellisense/ 
+      active: intellisense
     #- title: VS Code Commands
       #url: /learn/tooling-guide/vs-code-extension/vs-code-commands/ 
       #active: vs-code-commands

--- a/learn/tooling-guide/visual-studio-code-extension/language-support/intellisense.md
+++ b/learn/tooling-guide/visual-studio-code-extension/language-support/intellisense.md
@@ -1,8 +1,8 @@
 ---
 layout: ballerina-tooling-guide-left-nav-pages-swanlake
-title: Language Intelligence
-permalink: /learn/tooling-guide/visual-studio-code-extension/language-support/language-intelligence/
-active: language-intelligence
+title: IntelliSense
+permalink: /learn/tooling-guide/visual-studio-code-extension/language-support/intellisense/
+active: intellisense
 intro: The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency. Language intelligence is built in to the extension via a Language Server implementation, which consists of the below language intelligence options.
 redirect_from:
   - /learn/tools-ides/vscode-plugin/language-intelligence
@@ -20,6 +20,8 @@ redirect_from:
   - /learn/tooling-guide/vs-code-extension/language-support/language-intelligence
   - /learn/tooling-guide/vs-code-extension/language-support/language-intelligence/
   - /learn/tooling-guide/visual-studio-code-extension/language-support/language-intelligence
+  - /learn/tooling-guide/visual-studio-code-extension/language-support/language-intelligence/
+  - /learn/tooling-guide/visual-studio-code-extension/language-support/intellisense
 ---
 
 ## Semantic and Syntactic Diagnostics


### PR DESCRIPTION
## Purpose
Rename "language intelligence" to "IntelliSense" in VSCode Docs.

> Fixes #2194 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
