### PR TITLE
Remove the Bullet Points on the VSCode Installation Page

### DIFF
--- a/learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extesnion.md
+++ b/learn/tooling-guide/visual-studio-code-extension/installing-the-vs-code-extesnion.md
@@ -57,8 +57,6 @@ Download the Visual Studio Code Ballerina Extension from below.
 ## Installing the Extension
 
 Follow either of the below approaches to install the extension.
-  - [Using the VS Code editor](#using-the-vs-code-editor)
-  - [Using the Command Line](#using-the-command-line)
 
 ### Installing via the VS Code Editor
 


### PR DESCRIPTION
## Purpose
Remove the bullet points on the VSCode installation page.
> Fixes #2204 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
