### PR TITLE
Improve the Learn Page Descriptions

### DIFF
--- a/_layouts/ballerina-learn-landing-page.html
+++ b/_layouts/ballerina-learn-landing-page.html
@@ -51,7 +51,7 @@
                                  <div class="section">
                                     <h1 id="the-network-in-the-language">Let’s Learn Ballerina!</h1>
                                  <p>
-                                    Ballerina is a comprehensive language that is easy to grasp for anyone with prior programming experience. Start learning with the resources below.
+                                    Ballerina is a comprehensive language that is easy to grasp for anyone with prior programming experience. Start learning with the material below.
                                     </p>
                                  </div>
                               </div>

--- a/_layouts/ballerina-learn-landing-page.html
+++ b/_layouts/ballerina-learn-landing-page.html
@@ -49,9 +49,9 @@
                            <div class="rst-content">
                               <div role="main">
                                  <div class="section">
-                                    <h1 id="the-network-in-the-language">Let’s learn Ballerina!</h1>
+                                    <h1 id="the-network-in-the-language">Let’s Learn Ballerina!</h1>
                                  <p>
-                                    Ballerina is meant to be a quick start for anyone with prior programming experience. The below resources will help you to get going with Ballerina.
+                                    Ballerina is a comprehensive language that is easy to grasp for anyone with prior programming experience. Start learning with the resources below.
                                     </p>
                                  </div>
                               </div>

--- a/learn-old.md
+++ b/learn-old.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-learn-landing-page
-title: Let’s learn Ballerina!
+title: Let’s Learn Ballerina!
 description: Learn and master the Ballerina programming language through setting up, Ballerina by examples, the standard library or API documentation, and how to guides.
 keywords: ballerina, learn, documentation, docs, programming language
 permalink: /learn-old/

--- a/learn.md
+++ b/learn.md
@@ -59,7 +59,7 @@ redirect_from:
 
 <h2>Tooling Guide</h2>
 
-<p>Learn about using the VSCode plugin and other CLI tools.</p>
+<p>Learn to use the VSCode plugin and other CLI tools.</p>
 
 </a>
 

--- a/learn.md
+++ b/learn.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-learn-landing-page
-title: Let’s learn Ballerina!
+title: Let’s Learn Ballerina!
 description: Learn and master the Ballerina programming language through setting up, Ballerina by examples, the standard library or API documentation, and how to guides.
 keywords: ballerina, learn, documentation, docs, programming language
 permalink: /learn/
@@ -44,7 +44,7 @@ redirect_from:
 
 <img class="cLearnIcon" src="/img/API-Documentation-v1.png"/>
 <h2>API Documentation</h2>
-<p>Learn the Ballerina standard library APIs comprehensively.</p>
+<p>Check out the Ballerina standard library APIs comprehensively.</p>
 
 
 
@@ -59,7 +59,7 @@ redirect_from:
 
 <h2>Tooling Guide</h2>
 
-<p>Learn about the VSCode plugin and other cli tools of the platform.</p>
+<p>Learn about using the VSCode plugin and other CLI tools of the platform.</p>
 
 </a>
 
@@ -71,7 +71,7 @@ redirect_from:
 
 <img class="cLearnIcon" src="/img/Language-Guide-v1.png"/>
 <h2>Language Concepts</h2>
-<p>Learn about all the details of the Ballerina language.</p>
+<p>Get an in-depth understanding of the language principles.</p>
 </a>
 
 </div>
@@ -122,14 +122,13 @@ redirect_from:
 <a class="cBoxLink" href="/spec/" target="_blank">
 
 <img class="cLearnIcon" src="/img/Language-Specification-v1.png"/>
-<h2>Language Specification</h2>
-<p>Master Ballerina by knowing how the platform is specified.</p>
+<h2>Language Specifications</h2>
+<p>Master Ballerina by reading its formal specifications.</p>
 </a>
 
 </div>
 
 <div class="clearfix"></div>
-
 
 
 

--- a/learn.md
+++ b/learn.md
@@ -59,7 +59,7 @@ redirect_from:
 
 <h2>Tooling Guide</h2>
 
-<p>Learn about using the VSCode plugin and other CLI tools of the platform.</p>
+<p>Learn about the VSCode plugin and other CLI tools of the platform.</p>
 
 </a>
 
@@ -122,8 +122,8 @@ redirect_from:
 <a class="cBoxLink" href="/spec/" target="_blank">
 
 <img class="cLearnIcon" src="/img/Language-Specification-v1.png"/>
-<h2>Language Specifications</h2>
-<p>Master Ballerina by reading its formal specifications.</p>
+<h2>Language Specification</h2>
+<p>Master Ballerina by reading its formal specification.</p>
 </a>
 
 </div>

--- a/learn.md
+++ b/learn.md
@@ -21,7 +21,7 @@ redirect_from:
 
   <img class="cLearnIcon" src="/img/User-Guide-v1.png"/>
   <h2>User Guide</h2>
-  <p>Learn about all the features of the language and its capabilities.</p>
+  <p>Start programming with Ballerina.</p>
   </a>
 
 </div>
@@ -33,7 +33,7 @@ redirect_from:
 <img class="cLearnIcon" src="/img/Ballerina-By-Example-v1.png"/>
 <h2>Ballerina by Example</h2>
 
-<p>Obtain a hands-on experience of the language and its key features.</p>
+<p>Try out an extensive list of Ballerina code examples.</p>
 
 </a>
 </div>
@@ -44,7 +44,7 @@ redirect_from:
 
 <img class="cLearnIcon" src="/img/API-Documentation-v1.png"/>
 <h2>API Documentation</h2>
-<p>Check out the Ballerina standard library APIs comprehensively.</p>
+<p>Check out the Ballerina standard library APIs.</p>
 
 
 
@@ -59,7 +59,7 @@ redirect_from:
 
 <h2>Tooling Guide</h2>
 
-<p>Learn about the VSCode plugin and other CLI tools of the platform.</p>
+<p>Learn about using the VSCode plugin and other CLI tools.</p>
 
 </a>
 
@@ -122,8 +122,8 @@ redirect_from:
 <a class="cBoxLink" href="/spec/" target="_blank">
 
 <img class="cLearnIcon" src="/img/Language-Specification-v1.png"/>
-<h2>Language Specification</h2>
-<p>Master Ballerina by reading its formal specification.</p>
+<h2>Language Specifications</h2>
+<p>Read the formal specifications of the Ballerina language.</p>
 </a>
 
 </div>


### PR DESCRIPTION
## Purpose
Improve the Learn page descriptions.
> Fixes #2238 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
