### PR TITLE
Remove the Expand/Collapse All Option from the TOCs

### DIFF
--- a/learn/user-guide/calling-java-code-from-ballerina.md
+++ b/learn/user-guide/calling-java-code-from-ballerina.md
@@ -4,7 +4,7 @@ title: Calling Java Code from Ballerina
 description: See how Ballerina offers a straightforward way to call existing Java code from Ballerina and a Java API to call Ballerina code from Java.
 keywords: ballerina, programming language, java api, interoperability
 permalink: /learn/user-guide/calling-java-code-from-ballerina/
-active: calling-java-code-from-ballerina/
+active: calling-java-code-from-ballerina
 intro: Ballerina offers a straightforward way to call the existing Java code from Ballerina and also provides a Java API to call Ballerina code from Java.  Although Ballerina is not designed to be a JVM language, the current implementation, which targets the JVM, aka jBallerina, provides Java interoperability by adhering to the Ballerina language semantics.
 redirect_from:
   - /learn/how-to-use-java-interoperability

--- a/learn/user-guide/coding-conventions.md
+++ b/learn/user-guide/coding-conventions.md
@@ -313,3 +313,5 @@ For style guidelines on function invocation, literals, tuple, type casting, etc.
 ## Annotations, Documentation, and Comments
 
 For style guidelines on annotations, documentation, and comments, see [Annotations, Documentation, and Comments](/learn/style-guide/annotations_documentation_and_comments).
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/learn/user-guide/deployment/aws-lambda.md
+++ b/learn/user-guide/deployment/aws-lambda.md
@@ -138,3 +138,5 @@ You view the output below.
 ## What's Next?
 
 In a more practical scenario, the AWS Lambda functions will be used by associating them to an external event source such as Amazon DynamoDB or Amazon SQS. For more information on this, go to [AWS Lambda event source mapping documentation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html).
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/learn/user-guide/deployment/azure-functions.md
+++ b/learn/user-guide/deployment/azure-functions.md
@@ -133,3 +133,5 @@ Value - `AccountEndpoint=https://db-cosmos.documents.azure.com:443/;AccountKey=1
 ## What's Next?
 
 For a full sample with all the supported Azure Functions triggers and bindings in Ballerina, see [Azure Functions Deployment Example](/learn/by-example/azure-functions-deployment.html).
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/learn/user-guide/publishing-packages-to-ballerina-central.md
+++ b/learn/user-guide/publishing-packages-to-ballerina-central.md
@@ -53,3 +53,5 @@ To successfully push your package, your package should contain `Package.md` file
 ## Organizations
 
 When you push a package to Ballerina Central, the runtime validates organizations for the user against the `org` defined in your package’s `Ballerina.toml` file. Therefore, when you have more than one organization in Ballerina Central, be sure to pick the organization name that you intend to push the package into and set that as the `org` in the `Ballerina.toml` file inside the package directory.
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/learn/user-guide/testing-ballerina-code/executing-tests.md
+++ b/learn/user-guide/testing-ballerina-code/executing-tests.md
@@ -153,3 +153,5 @@ You can pass the `--coverage-format=xml`  flag along with the `--code-coverage` 
  generate the JaCoCo XML report at the end of the test execution.
  This file can be uploaded to CI/CD tools (e.g., CodeCov) to display the coverage information for both Ballerina and
   the native Java sources used within a Ballerina package.
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/learn/user-guide/testing-ballerina-code/testing-quick-start.md
+++ b/learn/user-guide/testing-ballerina-code/testing-quick-start.md
@@ -137,3 +137,5 @@ For more information on the command, see [Structuring Ballerina Code](/learn/str
 
 Now, that you have an understanding of how a test case can be written and executed, you can dive deep into the available
  features in the [Writing Tests](/learn/testing-ballerina-code/writing-tests) section.
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/learn/user-guide/why-ballerina/graphical.md
+++ b/learn/user-guide/why-ballerina/graphical.md
@@ -99,3 +99,5 @@ The result of the above diagram represents the response retrieved back from the 
    display:none !important;
 }
 </style>
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>
+


### PR DESCRIPTION
## Purpose
Remove the Expand/Collapse All Option from the TOCs in pages that do not have sub-sections.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
