### PR TITLE
Fix the 1.2.11 Release Note and VSCode Marketplace Link

### DIFF
--- a/download.html
+++ b/download.html
@@ -119,7 +119,7 @@ redirect_from:
    <div class=" ">
       <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4 ">
          <h3 class="cVSCode">Visual Studio Code</h3>
-         <a id="packWindows" href="{{ site.plugin_vscode_repo }}/releases/download/v{{ site.data.swanlake-latest.metadata.version }}/ballerina-{{ site.data.swanlake-latest.metadata.version }}.vsix" class="cGTMDownload cDownload cDownloadNew" data-download="downloads">
+         <a id="packWindows" href="https://marketplace.visualstudio.com/items?itemName=ballerina.ballerina" class="cGTMDownload cDownload cDownloadNew" data-download="downloads">
             <div class="cSize">Installer Ballerina Extension<span id="packWindowsName"></span></div>
          </a>
          <!--<ul class="cDiwnloadSubLinks">

--- a/downloads/1.2.x-release-notes/1.2.10.md
+++ b/downloads/1.2.x-release-notes/1.2.10.md
@@ -26,3 +26,5 @@ However, you need to use the following commands instead of the above if you have
 **For new users:**
 
 If you have not installed jBallerina, then download the [installers](/downloads/) to install.
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/downloads/1.2.x-release-notes/1.2.11.md
+++ b/downloads/1.2.x-release-notes/1.2.11.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-left-nav-release-notes
 title: 1.2.11 
-permalink: /downloads/1.2.x-release-notes/1.2.11-release-note/
+permalink: /downloads/1.2.x-release-notes/1.2.11/
 active: 1.2.11
 redirect_from: 
 ---

--- a/downloads/1.2.x-release-notes/1.2.6.md
+++ b/downloads/1.2.x-release-notes/1.2.6.md
@@ -25,3 +25,5 @@ However, you need to use the following commands instead of the above if you have
 **For new users:**
 
 If you have not installed jBallerina, then download the [installers](https://ballerina.io/downloads/) to install.
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/downloads/swan-lake-release-notes/swan-lake-preview6/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview6/RELEASE_NOTE.md
@@ -10,4 +10,7 @@ redirect_from:
 
 This is an internal-only release.
 
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>
+
+
  


### PR DESCRIPTION
## Purpose
Fix the 1.2.11 release note and VSCode Marketplace Link.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
