### PR TITLE
Remove ToC from Package Layout page and fix formatting issues

### DIFF
--- a/learn/user-guide/ballerina-packages/creating-your-first-ballerina-package.md
+++ b/learn/user-guide/ballerina-packages/creating-your-first-ballerina-package.md
@@ -59,9 +59,6 @@ Let’s build the package and generate an executable jar file:
 
 ```bash
 $ bal build
-````
-
-```bal
 Compiling source
  	examples/helloworld:0.1.0 
 

--- a/learn/user-guide/ballerina-packages/package-layout.md
+++ b/learn/user-guide/ballerina-packages/package-layout.md
@@ -127,3 +127,8 @@ These are directories related to the default modules. The [Modules](/learn/user-
 **modules/ directory**
 
 This directory contains the other modules. The layout of this directory is explained in the [Module Layout](/learn/user-guide/ballerina-packages/modules#module-layout) section.
+
+<style> 
+#tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} 
+.cGitButtonContainer {padding-left: 40px;} 
+</style>

--- a/learn/user-guide/ballerina-packages/sharing-a-library-package.md
+++ b/learn/user-guide/ballerina-packages/sharing-a-library-package.md
@@ -10,6 +10,8 @@ redirect_from:
 - /learn/user-guide/ballerina-packages/sharing-a-library-package
 ---
 
+### Creating a Library Package
+
 To create a new library package, we use `bal new -t lib`:
 
 ```bash
@@ -97,8 +99,6 @@ That’s how you publish your first package!
 
 Now you can create your second package and use the package you just published in it.
 
-#### Using Packages in Ballerina Central
+### Using Packages in Ballerina Central
 
-Any package published in Ballerina Central is public and they can be used in packages as explained in the [Dependencies](/learn/user-guide/ballerina-packages/dependencies#dependencies) section. 
-
-
+Any package published in Ballerina Central is public and they can be used in packages as explained in the [Dependencies](/learn/user-guide/ballerina-packages/dependencies#dependencies) section.


### PR DESCRIPTION
## Purpose
> Remove ToC from Package Layout page and fix formatting issues

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
