### PR TITLE
Fix capitalization of titles in Ballerina Packages guides

### DIFF
--- a/1.2/learn/by-example/testerina-mocking-functions.html
+++ b/1.2/learn/by-example/testerina-mocking-functions.html
@@ -93,8 +93,8 @@ redirect_from:
  Mocking an imported function will apply the mocked function to every instance of the original function call.
  It is not limited to the test file in which it is being mocked. Mocking a function from the module under the test
  can be scoped to have different behaviors for different test cases.<br/><br/>
- For more information, see <a href="https://ballerina.io/learn/how-to-test-ballerina-code/">How to Test Ballerina Code</a>
- and the <a href="https://ballerina.io/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
+ For more information, see <a href="https://ballerina.io/1.2/learn/how-to-test-ballerina-code/">How to Test Ballerina Code</a>
+ and the <a href="https://ballerina.io/1.2/learn/api-docs/ballerina/test/index.html">Test Module</a>.</p>
 </p>
 
                         </td>

--- a/learn/tooling-guide/cli-tools/cli-commands.md
+++ b/learn/tooling-guide/cli-tools/cli-commands.md
@@ -133,12 +133,12 @@ These everyday commands are your best friends! They address the very basics of p
 <table class="cComandTable">
 <tr>
 <td class="cCommand">build</td>
-<td class="cDescription">Compile a standalone `.bal` file, or an entire package into an executable JAR file. For more information, see <a href="/learn/running-ballerina-code">Running Ballerina Code</a>.
+<td class="cDescription">Compile a standalone `.bal` file, or an entire package into an executable JAR file. For more information, see <a href="/learn/user-guide/getting-started/writing-your-first-ballerina-program">Writing Your First Ballerina Program</a>.
 </td>
 </tr>
 <tr>
 <td class="cCommand">run</td>
-<td class="cDescription">Build and run a standalone `.bal` file, an entire package, or a previously-built program. For more information, see <a href="/learn/running-ballerina-code">Running Ballerina Code</a>.
+<td class="cDescription">Build and run a standalone `.bal` file, an entire package, or a previously-built program. For more information, see <a href="/learn/user-guide/getting-started/writing-your-first-ballerina-program">Writing Your First Ballerina Program</a>.
 </td>
 </tr>
 <tr>
@@ -169,7 +169,7 @@ Ballerina packages are the way to organize real-world Ballerina development task
 <table class="cComandTable">
 <tr>
 <td class="cCommand">new</td>
-<td class="cDescription">Create a Ballerina package. For more information, see <a href="/learn/structuring-ballerina-code">Structuring Ballerina Code</a>.
+<td class="cDescription">Create a Ballerina package. For more information, see <a href="/learn/user-guide/ballerina-packages/creating-your-first-ballerina-package">Ballerina Packages</a>.
 </td>
 </tr>
 <tr>
@@ -189,7 +189,7 @@ Ballerina packages are the way to organize real-world Ballerina development task
 </tr>
 <tr>
 <td class="cCommand">push</td>
-<td class="cDescription">Upload a package to Ballerina Central. For more information, see <a href="/learn/publishing-packages-to-ballerina-central">Publishing Packages to Ballerina Central</a>.
+<td class="cDescription">Upload a package to Ballerina Central. For more information, see <a href="/learn/user-guide/ballerina-packages/sharing-a-library-package/#publishing-a-library-package-to-ballerina-central">Publishing a library package to Ballerina Central</a>.
 </td>
 </tr>
 <tr>

--- a/learn/user-guide/ballerina-packages/creating-your-first-ballerina-package.md
+++ b/learn/user-guide/ballerina-packages/creating-your-first-ballerina-package.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-left-nav-pages-swanlake
-title: Creating your first Ballerina Package
+title: Creating Your First Ballerina Package
 description: The below are the basic steps you need to know about writing a Ballerina package. It also introduces the package-related commands in the Ballerina command-line tool.
 keywords: ballerina, programming language, ballerina packages, getting started
 permalink: /learn/user-guide/ballerina-packages/creating-your-first-ballerina-package/

--- a/learn/user-guide/ballerina-packages/creating-your-first-ballerina-package.md
+++ b/learn/user-guide/ballerina-packages/creating-your-first-ballerina-package.md
@@ -8,7 +8,7 @@ active: creating-your-first-ballerina-package
 intro: The below are the basic steps you need to know about writing a Ballerina packages. It also introduces the package-related commands in the Ballerina command-line tool.
 redirect_from:
 - /learn/user-guide/ballerina-packages/creating-your-first-ballerina-package
-- /learn/user-guide/ballerina-packages
+- /learn/user-guide/ballerina-packages/
 ---
 
 ## Creating a new package

--- a/learn/user-guide/ballerina-packages/dependencies.md
+++ b/learn/user-guide/ballerina-packages/dependencies.md
@@ -10,7 +10,7 @@ redirect_from:
 - /learn/user-guide/ballerina-packages/dependencies
 ---
 
-### Importing Modules
+### Importing modules
 
 In Ballerina, we can access any public symbol from another module by importing the particular module using an import declaration. The import declaration syntax is as follows:
 
@@ -55,7 +55,7 @@ String formattedMsg = util:properCaseMessage(“hello world!”);
 
 Since the import-prefix is not given here, we use `util` to refer to the symbols in the hello_world.util module. Here, `util:properCaseMessage` is called a qualified identifier.
 
-### Managing Dependencies
+### Managing dependencies
 
 When we build a package that has dependencies to other packages, the compiler automatically figures out the latest compatible versions of the required packages. 
 For identifying the latest versions of these dependencies, by default, Ballerina searches for the packages of dependencies in 2 repositories: The Distribution repository and the Ballerina Central repository.

--- a/learn/user-guide/ballerina-packages/modules.md
+++ b/learn/user-guide/ballerina-packages/modules.md
@@ -18,7 +18,7 @@ Module names can only contain alphanumerics, underscores, and periods and the ma
 <package-name>[.<module-directory-name>]
 ```
 
-### Module Layout
+### Module layout
 
 ```bash
 .

--- a/learn/user-guide/ballerina-packages/package-layout.md
+++ b/learn/user-guide/ballerina-packages/package-layout.md
@@ -64,7 +64,7 @@ The name can only contain alphanumerics, underscore, period and the maximum leng
 
 If the package name is not provided in the Ballerina.toml, then the current directory name is set as the package name. If there are any characters in the directory name mismatching the allowed regex, these will be replaced with the `_` character.
 
-##### Hierarchical Package names
+##### Hierarchical package names
 
 When there are various functionalities to be provided, it would make more sense to split them into multiple packages instead of adding it all into a single package.  For scenarios like this, we can give a hierarchical name to the package.
 
@@ -91,7 +91,7 @@ Ballerina follows the convention of [Semantic Versioning](https://semver.org/). 
 *   Once the package is production-ready, you can use a stable version (E.g. 1.0.0). Any subsequent minor or patch releases of the same major version should be backward compatible and should not break existing builds.
 
 
-#### Build Options
+#### Build options
 
 The `[build-options]` table specifies options that should be applied when building the package. We can use build options in the Ballerina.toml instead of passing options to the `bal build` command.
 

--- a/learn/user-guide/ballerina-packages/sharing-a-library-package.md
+++ b/learn/user-guide/ballerina-packages/sharing-a-library-package.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-left-nav-pages-swanlake
-title: Sharing a Library package
+title: Sharing a Library Package
 description: The below is all about working with a library package. It explains how a library package is created and published to Ballerina Central.
 keywords: ballerina, programming language, ballerina packages, libraries, publishing packages
 permalink: /learn/user-guide/ballerina-packages/sharing-a-library-package/
@@ -10,7 +10,7 @@ redirect_from:
 - /learn/user-guide/ballerina-packages/sharing-a-library-package
 ---
 
-### Creating a Library Package
+### Creating a library package
 
 To create a new library package, we use `bal new -t lib`:
 
@@ -56,7 +56,7 @@ Creating bala
 	target/bala/user-hello-any-0.1.0.bala
 ```
 
-### Publishing a Library Package to Ballerina Central
+### Publishing a library package to Ballerina Central
 
 Now that you have a package to share with others, it can be published to the [Ballerina Central](https://central.ballerina.io/). 
 Ensure the package works as intended, because a publish is **permanent**. Once published to Ballerina Central, the version can never be overwritten, 
@@ -100,6 +100,6 @@ That’s how you publish your first package!
 
 Now you can create your second package and use the package you just published in it.
 
-### Using Packages in Ballerina Central
+### Using packages in Ballerina Central
 
 Any package published in Ballerina Central is public and they can be used in packages as explained in the [Dependencies](/learn/user-guide/ballerina-packages/dependencies) section.

--- a/learn/user-guide/getting-started/writing-your-first-ballerina-program.md
+++ b/learn/user-guide/getting-started/writing-your-first-ballerina-program.md
@@ -19,7 +19,7 @@ Both of these are considered as entry points for program execution.
 
 Let's create a simple Ballerina HTTP service and an HTTP client with a main function to invoke it.
 
-## Writing a Simple Service
+## Writing a simple service
 
 Let's write a simple HTTP service as shown below in a file with the `.bal` extension:
 
@@ -82,7 +82,7 @@ Hello Ballerina!
 
 Next, let's create a Ballerina HTTP client and use that to invoke the service.
 
-## Creating an HTTP Client to Invoke the Service
+## Creating an HTTP client to invoke the service
 
 A Ballerina client is a component, which interacts with a network-accessible service. It aggregates one or more actions that can be executed on the network-accessible service and accepts configuration parameters related to the network-accessible service.
 
@@ -120,7 +120,7 @@ bal run hello_client.bal
 Hello Ballerina!
 ```
 
-## What's Next?
+## What's next?
 
 Now, that you have written your first Ballerina program, you can explore more about writing [Ballerina Packages](/learn/user-guide/ballerina-packages/creating-your-first-ballerina-package/).
 


### PR DESCRIPTION
## Purpose
> Fix capitalization of titles in Ballerina Packages guides
> Fixes part of #2288

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
