### PR TITLE
Fix the "Download" Top Menu Link

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -40,7 +40,7 @@
                     </div>
                     <div id="navbar" class="collapse navbar-collapse">
                         <ul class="nav navbar-nav cTopNav">
-                            <li class="toctree-l1" id="playli"><a class="cBioTopLink" href="https://ballerina.io/downloads/" target="_blank">Download</a>
+                            <li class="toctree-l1" id="playli"><a class="cBioTopLink" href="/downloads/" target="_blank">Download</a>
                             </li>
                             <li class="toctree-l1" id="playli"><a class="cBioTopLink" href="https://play.ballerina.io/" target="_blank">Playground</a>
                             </li>


### PR DESCRIPTION
## Purpose
Fix the "Download" top menu link.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
