### PR TITLE
Increase the Height of the Playground Widget

### DIFF
--- a/css/home-page-2020.css
+++ b/css/home-page-2020.css
@@ -4,7 +4,7 @@ padding: 80px 0 130px 0;
 }
 
 .embed-responsive.playground {
-    height: 400px;
+    height: 650px;
 }
 
 #iMainNavigation {


### PR DESCRIPTION
## Purpose
Increase the height of the playground widget on the Home page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
