### PR TITLE
Fix Concurrency Page Intro and Broken Links

### DIFF
--- a/1.2/learn/by-example/kubernetes-deployment.html
+++ b/1.2/learn/by-example/kubernetes-deployment.html
@@ -103,7 +103,7 @@ Before running the sample, create a directory named <code>security</code> inside
 from where the ballerina build command will be issued.
 Then, copy the <a href="https://github.com/ballerina-platform/ballerina-lang/tree/ballerina-1.2.x/examples/resources/">ballerinaKeystore.p12 and ballerinaTruststore.p12 files</a>
 to the security folder.<br/><br/>
-For more information, see the <a href="https://ballerina.io/learn/deployment/kubernetes/">Kubernetes Deployment Guide</a>.</p>
+For more information, see the <a href="/1.2/learn/deployment/kubernetes/">Kubernetes Deployment Guide</a>.</p>
 </p>
 
                         </td>

--- a/1.2/learn/deployment/aws-lambda.md
+++ b/1.2/learn/deployment/aws-lambda.md
@@ -51,7 +51,7 @@ public function apigwRequest(awslambda:Context ctx, awslambda:APIGatewayProxyReq
 }
 ```
 
-The first parameter with the [awslambda:Context](/1.2/learn/api-docs/ballerina/awslambda/objects/Context.html) object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time. 
+The first parameter with the [awslambda:Context](https://docs.central.ballerina.io/ballerinax/awslambda/1.0.0/classes/Context) object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time. 
 
 The second parameter contains the input request data. This input value will vary depending on the source, which invoked the function (e.g., an AWS S3 bucket update event). 
 
@@ -130,3 +130,5 @@ $ cat response.txt
 ## What's Next?
 
 For more information on how to connect external event sources such as Amazon DynamoDB and Amazon S3 to Lambda Functions, go to [AWS Lambda event source mapping documentation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html).
+
+<style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/community.md
+++ b/community.md
@@ -435,7 +435,7 @@ body {font-family: Arial;}
          <h5>Ballerina – An Open-Source, Cloud-Native Programming Language for Microservices</h5>
          <b>Anjana Fernando,</b> Director of Developer Relations, WSO2
       </td>
-      <td class="cEventURL"><a class="cEventRegistration" href="https://www.slideshare.net/lafernando/ballerina-opensource-cloudnative-programming-language-for-microservices" target="_blank">View Slides</a></td>
+      <td class="cEventURL"><a class="cEventRegistration" href="https://www.slideshare.net/lafernando/ballerina-an-opensource-cloudnative-programming-language-for-microservices" target="_blank">View Slides</a></td>
    </tr>
    <tr class="event-expiry" style="display:none" data-expiry="">
       <td class="cEventDateContainer">

--- a/learn/user-guide/code-organization/coding-conventions.md
+++ b/learn/user-guide/code-organization/coding-conventions.md
@@ -19,6 +19,8 @@ redirect_from:
   - /learn/user-guide/code-organization/coding-conventions
   - /learn/user-guide/code-organization/coding-conventions/
   - /learn/user-guide/style-guide/coding-conventions
+  - /learn/user-guide/style-guide/
+  - /learn/user-guide/style-guide
 ---
 
 > You can follow your own coding style when writing Ballerina source code. Also, plugins and tools can be configured to match your coding style.

--- a/learn/user-guide/network-communication/gRPC/implementing-grpc-services-and-clients/implementing-grpc-clients.md
+++ b/learn/user-guide/network-communication/gRPC/implementing-grpc-services-and-clients/implementing-grpc-clients.md
@@ -3,7 +3,7 @@ layout: ballerina-left-nav-pages-swanlake
 title: Implementing gRPC Clients
 description: The topics below explain how to implement a gRPC service and write a client to invoke it.
 keywords: ballerina, cli, command line interface, programming language
-permalink: /learn/user-guide/network-communication/grpc/implementing-grpc-clients/
+permalink: /learn/user-guide/network-communication/grpc/implementing-grpc-services-and-clients/implementing-grpc-clients/
 active: implementing-grpc-clients
 intro: The topics below explain how to implement a gRPC service and write a client to invoke it. 
 redirect_from:

--- a/learn/user-guide/why-ballerina/cloud-native.md
+++ b/learn/user-guide/why-ballerina/cloud-native.md
@@ -16,6 +16,8 @@ redirect_from:
   - /learn/user-guide/why-ballerina/cloud-native
   - /learn/user-guide/why-ballerina/cloud-native/
   - /learn/why-ballerina/cloud-native
+  - /learn/why-ballerina/
+  - /learn/why-ballerina
 ---
 
 In a microservice architecture, smaller services are developed, deployed, and scaled individually. These disaggregated services communicate with each other over the network forcing developers to deal with the [Fallacies of Distributed Computing](https://en.wikipedia.org/wiki/Fallacies_of_distributed_computing) in their application logic. For decades, programming languages have treated networks simply as I/O sources. The sections below demonstrate a few of Ballerina's inherent capabilities to develop distributed services effectively and the cloud native deployment process that is provided as part of the programming experience. 

--- a/learn/user-guide/why-ballerina/concurrent.md
+++ b/learn/user-guide/why-ballerina/concurrent.md
@@ -5,7 +5,7 @@ description: Concurrency in Ballerina is enabled by strands, which are lightweig
 keywords: ballerina, ballerina platform, api documentation, testing, ide, ballerina central
 permalink: /learn/why-ballerina/concurrent/
 active: concurrent
-intro: Ballerina's concurrency model supports both threads and coroutines.
+intro: Concurrency in Ballerina is enabled by strands, which are lightweight threads.
 redirct_from:
   - /learn/user-guide/why-ballerina/concurrent
   - /learn/user-guide/why-ballerina/concurrent/


### PR DESCRIPTION
## Purpose
Fix concurrency page intro and broken links.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
