### PR TITLE
Add unary op in const expr

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-beta2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-beta2/RELEASE_NOTE.md
@@ -84,6 +84,13 @@ public function extra(XY xy) returns NotXY {
 }
 ```
 
+- Supported unary operators in constant expressions.
+
+```ballerina
+const int MIN_VALUE = (-(10+5));
+const int CUI3 = ~2;
+```
+
 ### Bug Fixes
 
 To view bug fixes, see the [GitHub milestone for Swan Lake Beta2](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22Ballerina+Swan+Lake+-+Beta2%22+label%3AType%2FBug+label%3ATeam%2FCompilerFE).


### PR DESCRIPTION
## Purpose
Include a bit about allowing unary operator in constant expressions.

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
