### PR TITLE
Remove unnecessary equal operator from gRPC doc

### DIFF
--- a/1.2/learn/api-docs/ballerina/grpc/index.html
+++ b/1.2/learn/api-docs/ballerina/grpc/index.html
@@ -578,7 +578,7 @@ service Chat on new grpc:Listener(9090) {
     ChatClient chatClient = new(&quot;http://localhost:9090&quot;);
 
     // Execute the service streaming call by registering a message listener.
-    grpc:StreamingClient|grpc:Error ep = = chatClient-&gt;chat(ChatMessageListener);
+    grpc:StreamingClient|grpc:Error ep = chatClient-&gt;chat(ChatMessageListener);
 
 // Send multiple messages to the server.
 string[] greets = [&quot;Hi&quot;, &quot;Hey&quot;, &quot;GM&quot;];


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/664

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
