### PR TITLE
Enable the 1.2 BBEs Gen Workflow to Run Manually

### DIFF
--- a/.github/workflows/update_ballerina_by_example.yml
+++ b/.github/workflows/update_ballerina_by_example.yml
@@ -1,4 +1,4 @@
-name: Create PR for new 1.2. Ballerina by examples pages
+name: Create PR for new Ballerina by examples pages
 
 on:
   push:

--- a/.github/workflows/update_ballerina_by_example.yml
+++ b/.github/workflows/update_ballerina_by_example.yml
@@ -1,4 +1,4 @@
-name: Create PR for new Ballerina by examples pages
+name: Create PR for new 1.2. Ballerina by examples pages
 
 on:
   push:
@@ -6,6 +6,8 @@ on:
       - master
     paths:
       - '_data/stable-latest/**'
+  workflow_dispatch:
+
 
 jobs:
   bbe-gen:


### PR DESCRIPTION
## Purpose
Enable the 1.2 BBEs gen workflow to run manually.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
