### PR TITLE
Update 1.2.x BBE Gen Workflow to Use the 1.2.x Branch

### DIFF
--- a/.github/workflows/update_ballerina_by_example.yml
+++ b/.github/workflows/update_ballerina_by_example.yml
@@ -8,7 +8,6 @@ on:
       - '_data/stable-latest/**'
   workflow_dispatch:
 
-
 jobs:
   bbe-gen:
     runs-on: ubuntu-latest
@@ -35,9 +34,12 @@ jobs:
     - name: Clone ballerina-release
       run: git clone https://ballerina-bot:$GITHUB_TOKEN@github.com/ballerina-platform/ballerina-release.git
 
+
     - name: Generate BBEs
       run: |
         cd ballerina-release
+
+        git checkout ballerina-1.2.x
 
         BALLERINA_VERSION="`jq -r '.version' ../_data/stable-latest/metadata.json`"
         array=($(echo $BALLERINA_VERSION | tr "." "\n"))


### PR DESCRIPTION
## Purpose
Update 1.2.x BBE gen workflow to use the 1.2.x branch of the `ballerina-release` repo.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
