### PR TITLE
Add Keywords to the BBE Index Page for the Algolia Search

### DIFF
--- a/learn/by-example/index.html
+++ b/learn/by-example/index.html
@@ -2,6 +2,7 @@
 layout: ballerina-no-git-inner-page
 title: Reference by Examples
 description: Reference by Examples enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
+keywords: hello world, basics, network interaction, working with data, concurrency, transactions
 ---
 
 <div class="row cBallerina-io-Gray-row">


### PR DESCRIPTION
## Purpose
Add keywords to the BBE index page for the Algolia search.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
