### PR TITLE
Fix the ZIP and Source Download Links

### DIFF
--- a/download.html
+++ b/download.html
@@ -149,12 +149,12 @@ redirect_from:
                               <tr> </tr>
                               <tr>
                                  <td style="width: 50%">Install via the ZIP archive
-                                    <a href="/learn/user-guide/getting-started/setting-up-ballerina/installation-options/#installing-via-the-ballerina-language-zip-file" class="cDownloadLinkIcon"><img src="/img/right-bg-green-fill.svg"></a>
+                                    <a href="/learn/user-guide/getting-started/installation-options/#installing-via-the-ballerina-language-zip-file" class="cDownloadLinkIcon"><img src="/img/right-bg-green-fill.svg"></a>
                                  </td>
                               </tr>
                               <tr>
                                  <td style="width: 50%">Install from source
-                                    <a href="/learn/user-guide/getting-started/setting-up-ballerina/installation-options/#building-from-source" class="cDownloadLinkIcon"><img src="/img/right-bg-green-fill.svg"></a>
+                                    <a href="/learn/user-guide/getting-started/installation-options/#building-from-source" class="cDownloadLinkIcon"><img src="/img/right-bg-green-fill.svg"></a>
                                  </td>
                               </tr>
                            </table>


### PR DESCRIPTION
## Purpose
Fix the ZIP and source download links.
> Fixes #2563 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
