### PR TITLE
Change the API Docs URL

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -39,7 +39,7 @@ redirect_from:
 </div>
 
 <div class="col-sm-12 col-md-4 cLearnPageContentCol">
-<a class="cBoxLink" href="https://docs.central.ballerina.io/" target="_blank">
+<a class="cBoxLink" href="https://lib.ballerina.io/" target="_blank">
 
 
 <img class="cLearnIcon" src="/img/API-Documentation-v1.png"/>


### PR DESCRIPTION
## Purpose
Change the API Docs URL.
> Fixes #2634 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
