### PR TITLE
Fix the Breadcrumbs of the Learn Page

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-learn-landing-page
-title: Docs
+title: Learn
 description: Ballerina is a comprehensive language that is easy to grasp for anyone with prior programming experience. Start learning with the material below.
 keywords: ballerina, learn, documentation, docs, programming language
 permalink: /learn/


### PR DESCRIPTION
## Purpose
Fix the breadcrumbs of the learn page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
