### PR TITLE
Improve the Learn Page Descriptions

### DIFF
--- a/_layouts/ballerina-learn-landing-page.html
+++ b/_layouts/ballerina-learn-landing-page.html
@@ -51,7 +51,7 @@
                         <div class="rst-content">
                            <div role="main">
                               <div class="section">
-                                 <h1 id="the-network-in-the-language">Ballerina Documentation</h1>
+                                 <h1 id="the-network-in-the-language">Learn Ballerina</h1>
                                  <p>
                                     Ballerina is a comprehensive language that is easy to grasp for anyone with prior
                                     programming experience. Start learning with the material below.

--- a/learn.md
+++ b/learn.md
@@ -85,7 +85,6 @@ redirect_from:
 		</div>
 	</div>
 </div>
-
 <style>
 	:not(pre) > code[class*="language-"], pre[class*="language-"]{
 		    background: #e0dede !important;

--- a/learn.md
+++ b/learn.md
@@ -4,7 +4,7 @@ title: Learn
 description: Ballerina is a comprehensive language that is easy to grasp for anyone with prior programming experience. Start learning with the material below.
 keywords: ballerina, learn, documentation, docs, programming language
 permalink: /learn/
-intro: Ballerina is a comprehensive language that is easy to grasp for anyone with prior programming experience. Start learning with the material below.
+intro: Ballerina is a comprehensive language that is easy to grasp for anyone with prior programming experience. Let's start learning Ballerina.
 redirect_from:
  - /learn-beta2-column
  - /learn-beta2-column/
@@ -15,12 +15,12 @@ redirect_from:
 	<div class="column-gray-box-grid">
 		<div class="column-gray-box"> 
 			<h2 id="getting-started">Getting Started</h2>
-			<h3 id="installing-ballerina"><a href="/learn/installing-ballerina/setting-up-ballerina/">Installing Ballerina</a></h3>
-			<p>Download and install Ballerina via the installers.</p>
+			<h3 id="installing-ballerina"><a href="/learn/installing-ballerina/setting-up-ballerina/">Setting Up Ballerina</a></h3>
+			<p>Setting up the Ballerina development environment.</p>
 			<h3 id="hello-world"><a href="/learn/getting-started/hello-world/writing-your-first-ballerina-program/">Hello World</a></h3>
-			<p>Write your first Ballerina program and create your first Ballerina package.</p>
+			<p>Writing your first Ballerina program and creating your first Ballerina package.</p>
 			<h3 id="learn-by-example"><a href="/learn/by-example/introduction/">Learn by Examples</a></h3>
-			<p>A guided path to learn the language through a series of examples.</p>
+			<p>A series of guided examples to learn the language.</p>
 			<!--<h3 id="language-introduction-video"><a href="https://www.youtube.com/watch?v=My_uqtHvXV8&amp;t=10s">Language Introduction Video</a></h3>
 			<p>A video introduction to the Ballerina Programming Language and what’s new in Swan Lake.</p>
 			<h3 id="language-tasters"><a href="https://www.youtube.com/watch?v=My_uqtHvXV8&amp;t=10s">Language Tasters</a></h3>
@@ -28,9 +28,9 @@ redirect_from:
 			<h3 id="language-walkthrough-slides"><a href="http://localhost:4000/learn/language-concepts/Ballerina_Language_Presentation-2021-03-08.pdf">Language Walkthrough Slides</a></h3>
 			<p>A comprehensive reference slide deck explaining the language.</p>-->
 			<h3 id="language-walkthrough-video"><a href="/learn/language-walkthrough/">Language Walkthrough</a></h3>
-			<p>A comprehensive video explaining the language and its reference slide deck.</p>
+			<p>A video series, which explains the language and its reference slide deck.</p>
 			<h3 id="installing-ballerina"><a href="/learn/visual-studio-code-extension/quick-start/">Visual Studio Code Extension</a></h3>
-			<p>Details of all the high-level and important features of the Ballerina Visual Studio Code extension.</p>
+			<p>Details of all the features of the Ballerina Visual Studio Code extension.</p>
 		</div>
 	</div>
 	<div class="column-gray-box-grid">
@@ -41,9 +41,9 @@ redirect_from:
 		<!--<h3 id="writing-idiomatic-ballerina-code"><a href="/learn/user-guide/">Writing Idiomatic Ballerina Code</a></h3>
 		<p>Guide developers to start thinking in Ballerina.</p>-->
 		<h3 id="organizing-ballerina-code"><a href="/learn/organizing-ballerina-code/package-layout/">Organizing Ballerina Code</a></h3>
-		<p>Basics of projects/packages/modules.</p>
+		<p>Basics of projects, packages, and modules.</p>
 		<h3 id="testing-ballerina-code"><a href="/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a></h3>
-		<p>Write automated tests using the built-in test framework.</p>
+		<p>Writing automated tests using the built-in test framework.</p>
 		<h3 id="generatinging-code-documentation"><a href="/learn/generating-code-documentation/">Generating Code Documentation
 </a></h3>
 		<p>The usage of the <code class="highlighter-rouge language-plaintext">bal doc</code> CLI command.</p>
@@ -51,14 +51,14 @@ redirect_from:
 		<p>The language support for configurability.</p>
 		<h3 id="observing-ballerina-programs"><a href="/learn/observing-ballerina-programs/observing-your-application-with-prometheus-grafana-and-jaeger/">Observing Ballerina Programs
 </a></h3>
-		<p>The basics of the observing functionalities that are provided for Ballerina programs.</p>
+		<p>Basics of the observability functionalities that are provided for Ballerina programs.</p>
 		<h3 id="running-ballerina-programs-in-the-cloud"><a href="/learn/running-ballerina-programs-in-the-cloud/code-to-cloud/">Running Ballerina Programs in the Cloud
 </a></h3>
 		<p>The cloud offerings for running Ballerina programs.</p>
 		<h3 id="managing-dependencies"><a href="/learn/managing-dependencies/">Managing Dependencies </a></h3>
-		<p>Declare and manage dependencies and how to use the local repository.</p>
+		<p>Declaring and managing dependencies and using the local repository.</p>
 		<h3 id="publishing-packages-to-ballerina-central"><a href="/learn/publishing-packages-to-ballerina-central/">Publishing Packages to Ballerina Central</a></h3>
-		<p>Instructions on how to publish your package to Ballerina Central.</p>
+		<p>Details on publishing your library package to Ballerina Central.</p>
 		<h3 id="calling-java-code-from-ballerina-and-vice-versa"><a href="/learn/calling-java-code-from-ballerina-and-vice-versa/">Calling Java Code from Ballerina and Vice Versa</a></h3>
 		<p>Instructions on the supported interoperability features.</p>
 		</div>
@@ -66,20 +66,20 @@ redirect_from:
 	<div class="column-gray-box-grid">
 		<div class="column-gray-box">  
 		<h2 id="references">References</h2>
-		<h3 id="language-introduction-slides"><a href="/learn/language-introduction/">Language Introduction</a></h3>
-		<p>Presentation slides on the Ballerina language that anyone can use to talk about the language.</p>
 		<!--<h3 id="language-guide"><a href="/learn/language-concepts/">Language Guide</a></h3>
 		<p>An elaborate textual guide to the Ballerina language.</p>-->
 		<h3 id="reference-guide-by-examples"><a href="/learn/by-example/">Reference by Examples</a></h3>
-		<p>A series of examples that serve as a reference guide for each language construct and concept.</p>
+		<p>A series of examples that serve as a reference guide for language constructs, concepts, and standard library modules.</p>
 		<h3 id="library-documentation"><a href="https://lib.ballerina.io/">Library Documentation</a></h3>
-		<p>All library API docs.</p>
+		<p>Standard library API documentation.</p>
 		<h3 id="the-bal-tool"><a href="/learn/cli-documentation/cli-commands/">CLI Documentation</a></h3>
 		<p>Details of all the CLI commands of the <code class="highlighter-rouge language-plaintext">bal</code> tool.</p>
 		<h3 id="specifications"><a href="/learn/platform-specifications/">Platform Specifications</a></h3>
-		<p>Specifications for the platform.</p>
+		<p>Details of the Ballerina language specifications and proposals.</p>
         <h3 id="style-guide"><a href="/learn/style-guide/coding-conventions/">Style Guide</a></h3>
-		<p>The coding conventions and the coding best practices of the Ballerina language.</p>
+		<p>Best practices to follow when formatting Ballerina code.</p>
+		<h3 id="language-introduction-slides"><a href="/learn/language-introduction/">Language Introduction</a></h3>
+		<p>Presentation slides on the Ballerina language that you can use to talk about the language.</p>
         <!--<h3 id="blogs-and-articles"><a href="https://blog.ballerina.io/">Blogs/Articles</a></h3>
 		<p>Provides details of all the CLI commands of the `bal` tool.</p>-->
 		</div>

--- a/learn.md
+++ b/learn.md
@@ -85,6 +85,7 @@ redirect_from:
 		</div>
 	</div>
 </div>
+
 <style>
 	:not(pre) > code[class*="language-"], pre[class*="language-"]{
 		    background: #e0dede !important;

--- a/learn.md
+++ b/learn.md
@@ -43,7 +43,7 @@ redirect_from:
 		<h3 id="organizing-ballerina-code"><a href="/learn/organizing-ballerina-code/package-layout/">Organizing Ballerina Code</a></h3>
 		<p>Basics of projects, packages, and modules.</p>
 		<h3 id="testing-ballerina-code"><a href="/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a></h3>
-		<p>Writing automated tests using the built-in test framework.</p>
+		<p>Details on writing automated tests using the built-in test framework.</p>
 		<h3 id="generatinging-code-documentation"><a href="/learn/generating-code-documentation/">Generating Code Documentation
 </a></h3>
 		<p>The usage of the <code class="highlighter-rouge language-plaintext">bal doc</code> CLI command.</p>
@@ -56,7 +56,7 @@ redirect_from:
 </a></h3>
 		<p>The cloud offerings for running Ballerina programs.</p>
 		<h3 id="managing-dependencies"><a href="/learn/managing-dependencies/">Managing Dependencies </a></h3>
-		<p>Declaring and managing dependencies and using the local repository.</p>
+		<p>Details on declaring and managing dependencies and using the local repository.</p>
 		<h3 id="publishing-packages-to-ballerina-central"><a href="/learn/publishing-packages-to-ballerina-central/">Publishing Packages to Ballerina Central</a></h3>
 		<p>Details on publishing your library package to Ballerina Central.</p>
 		<h3 id="calling-java-code-from-ballerina-and-vice-versa"><a href="/learn/calling-java-code-from-ballerina-and-vice-versa/">Calling Java Code from Ballerina and Vice Versa</a></h3>
@@ -71,7 +71,7 @@ redirect_from:
 		<h3 id="reference-guide-by-examples"><a href="/learn/by-example/">Reference by Examples</a></h3>
 		<p>A series of examples that serve as a reference guide for language constructs, concepts, and standard library modules.</p>
 		<h3 id="library-documentation"><a href="https://lib.ballerina.io/">Library Documentation</a></h3>
-		<p>Standard library API documentation.</p>
+		<p>Ballerina library API documentation.</p>
 		<h3 id="the-bal-tool"><a href="/learn/cli-documentation/cli-commands/">CLI Documentation</a></h3>
 		<p>Details of all the CLI commands of the <code class="highlighter-rouge language-plaintext">bal</code> tool.</p>
 		<h3 id="specifications"><a href="/learn/platform-specifications/">Platform Specifications</a></h3>

--- a/learn.md
+++ b/learn.md
@@ -43,7 +43,7 @@ redirect_from:
 		<h3 id="organizing-ballerina-code"><a href="/learn/organizing-ballerina-code/package-layout/">Organizing Ballerina Code</a></h3>
 		<p>Basics of projects, packages, and modules.</p>
 		<h3 id="testing-ballerina-code"><a href="/learn/testing-ballerina-code/testing-quick-start/">Testing Ballerina Code</a></h3>
-		<p>Details on writing automated tests using the built-in test framework.</p>
+		<p>Details of writing automated tests using the built-in test framework.</p>
 		<h3 id="generatinging-code-documentation"><a href="/learn/generating-code-documentation/">Generating Code Documentation
 </a></h3>
 		<p>The usage of the <code class="highlighter-rouge language-plaintext">bal doc</code> CLI command.</p>
@@ -56,7 +56,7 @@ redirect_from:
 </a></h3>
 		<p>The cloud offerings for running Ballerina programs.</p>
 		<h3 id="managing-dependencies"><a href="/learn/managing-dependencies/">Managing Dependencies </a></h3>
-		<p>Details on declaring and managing dependencies and using the local repository.</p>
+		<p>Details of declaring and managing dependencies and using the local repository.</p>
 		<h3 id="publishing-packages-to-ballerina-central"><a href="/learn/publishing-packages-to-ballerina-central/">Publishing Packages to Ballerina Central</a></h3>
 		<p>Details on publishing your library package to Ballerina Central.</p>
 		<h3 id="calling-java-code-from-ballerina-and-vice-versa"><a href="/learn/calling-java-code-from-ballerina-and-vice-versa/">Calling Java Code from Ballerina and Vice Versa</a></h3>

--- a/learn.md
+++ b/learn.md
@@ -58,7 +58,7 @@ redirect_from:
 		<h3 id="managing-dependencies"><a href="/learn/managing-dependencies/">Managing Dependencies </a></h3>
 		<p>Details of declaring and managing dependencies and using the local repository.</p>
 		<h3 id="publishing-packages-to-ballerina-central"><a href="/learn/publishing-packages-to-ballerina-central/">Publishing Packages to Ballerina Central</a></h3>
-		<p>Details on publishing your library package to Ballerina Central.</p>
+		<p>Details of publishing your library package to Ballerina Central.</p>
 		<h3 id="calling-java-code-from-ballerina-and-vice-versa"><a href="/learn/calling-java-code-from-ballerina-and-vice-versa/">Calling Java Code from Ballerina and Vice Versa</a></h3>
 		<p>Instructions on the supported interoperability features.</p>
 		</div>

--- a/learn/guides/organizing-ballerina-code/package-layout.md
+++ b/learn/guides/organizing-ballerina-code/package-layout.md
@@ -12,6 +12,8 @@ redirect_from:
   - /learn/organizing-ballerina-code/package-layout
   - /learn/organizing-ballerina-code/
   - /learn/organizing-ballerina-code
+  - /learn/user-guide/structuring-ballerina-code/
+  - /learn/user-guide/structuring-ballerina-code
 ---
 
 ```bash


### PR DESCRIPTION
## Purpose
Improve the Learn page descriptions.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
