### PR TITLE
Fix the Report Issues Links on the Community Page in the Master Branch

### DIFF
--- a/community-old.md
+++ b/community-old.md
@@ -94,8 +94,8 @@ We are happy to help! Come engage with us on any channel that works for you.
 Report issues in the GitHub repositories of the areas and components listed below.
 
 - <a href="https://github.com/ballerina-platform/ballerina-lang/issues/new/choose" target="_blank">Compiler, runtime, or tooling</a>
-- <a href="https://github.com/ballerina-platform/ballerina-standard-library/issues" target="_blank">Standard Library</a>
-- <a href="https://github.com/ballerina-platform/ballerina-standard-library/issues/new/choose" target="_blank">Language specification</a>
+- <a href="https://github.com/ballerina-platform/ballerina-standard-library/issues/new/choose" target="_blank">Standard Library</a>
+- <a href="https://github.com/ballerina-platform/ballerina-spec/issues/new" target="_blank">Language specification</a>
 - <a href="https://github.com/ballerina-platform/ballerina-dev-website/issues/new/choose" target="_blank">Website</a>
 - <a href="mailto:security@ballerina.io" target="_blank">Security</a> (For details, see the <a href="/security" target="_blank">security policy</a>.)
 


### PR DESCRIPTION
## Purpose
Fix the report issues links on the Community page in the `master` branch.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
