### PR TITLE
Fix the Breadcrumbs of the FaaS Learn page

### DIFF
--- a/learn/guides/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda.md
+++ b/learn/guides/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/user-guide/deployment/aws-lambda
   - /learn/user-guide/deployment/aws-lambda/
   - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda
+  - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/
+  - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina
 ---
 
 Exposing a Ballerina function as an AWS Lambda function is done by importing the `ballerinax/awslambda` module and simply annotating the Ballerina function with the `awslambda:Function` annotation. Also, the Ballerina function must have the following signature: `function (awslambda:Context, json) returns json|error`. 


### PR DESCRIPTION
## Purpose
Fix the breadcrumbs of the FaaS Learn page.

> Fixes #2855 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
