### PR TITLE
Fix the OpenAPI Text in Learn Left Nav

### DIFF
--- a/_data/clidocumentationnavswanlake.yml
+++ b/_data/clidocumentationnavswanlake.yml
@@ -7,7 +7,7 @@
     - title: Update Tool
       url: /learn/cli-documentation/update-tool/
       active: update-tool
-    - title: Open API
+    - title: OpenAPI
       url: /learn/cli-documentation/openapi/
       active: openapi
     - title: GRPC


### PR DESCRIPTION
## Purpose
Fix the OpenAPI text in left nav.
> Fixes #2873 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
