### PR TITLE
Remove the duplicated TOC in the "Top-level Definitions" page

### DIFF
--- a/learn/references/style-guide/coding-conventions/top-level-definitions.md
+++ b/learn/references/style-guide/coding-conventions/top-level-definitions.md
@@ -54,13 +54,6 @@ service / on ep1 {
     }
 ```
 
-- [Imports](#imports)
-- [Function Definition](#function-definition)
-- [Service Definition](#service-definition)
-- [Class Definition](#class-definition)
-- [Record Definition](#record-definition)
-- [Referencing Record or Abstract Object](#referencing-record-or-abstract-object)
-
 ## Imports
 
 * Do not keep spaces between the organization name, divider `/`, and module name.


### PR DESCRIPTION
## Purpose
Remove the duplicated TOC in the "Top-level Definitions" page.
> Fixes #2871 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
