### PR TITLE
Fix the Package Layout Link in the Interop Page

### DIFF
--- a/learn/guides/calling-java-code-from-ballerina-and-vice-versa.md
+++ b/learn/guides/calling-java-code-from-ballerina-and-vice-versa.md
@@ -553,7 +553,7 @@ function read() returns int|IOException {
 
 ## Packaging Java Libraries with Ballerina Programs
 
->**Note:** This section assumes that you have already read [Structuring Ballerina Code](/learn/user-guide/ballerina-packages/).
+>**Note:** This section assumes that you have already read [Structuring Ballerina Code](/learn/organizing-ballerina-code/package-layout/).
  
 When you compile a Ballerina program with `bal build`, the compiler creates an executable JAR file and when you compile a Ballerina module with `bal build -c`, the compiler creates a BALA file. In both cases, the Ballerina compiler produces self-contained archives. There are situations in which you need to package JAR files with these archives. The most common example would be packing the corresponding JDBC driver.
 

--- a/learn/guides/organizing-ballerina-code/package-layout.md
+++ b/learn/guides/organizing-ballerina-code/package-layout.md
@@ -14,6 +14,8 @@ redirect_from:
   - /learn/organizing-ballerina-code
   - /learn/user-guide/structuring-ballerina-code/
   - /learn/user-guide/structuring-ballerina-code
+  - /learn/user-guide/ballerina-packages/
+  - /learn/user-guide/ballerina-packages
 ---
 
 ```bash


### PR DESCRIPTION
## Purpose
Fix the package layout link in the Interop page.
> Fixes #2870 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
