### PR TITLE
Fix the Incorrect Link in the AWS Lambda Learn Page

### DIFF
--- a/learn/guides/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda.md
+++ b/learn/guides/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda.md
@@ -35,7 +35,7 @@ public function hash(awslambda:Context ctx, json input) returns json|error {
 }
 ```
 
-The first parameter with the [awslambda:Context](/learn/api-docs/ballerina/#/awslambda/classes/Context) object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time. 
+The first parameter with the [awslambda:Context](https://lib.ballerina.io/ballerinax/awslambda/latest/classes/Context) object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time. 
 
 The second parameter with the `json` value contains the input request data. This input value format will vary depending on the source, which invoked the function (e.g., an AWS S3 bucket update event). The return type of the function is `json|error`, which means in a successful scenario, the function can return a `json` value with the response, or else in an error situation, the function will return an `error` value, which provides information on the error to the system.
 


### PR DESCRIPTION
## Purpose
Fix the incorrect link in the AWS Lambda Learn page.
> Fixes #2864 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
