### PR TITLE
Fix a typo in Overriding Dependencies

### DIFF
--- a/learn/guides/managing-dependencies.md
+++ b/learn/guides/managing-dependencies.md
@@ -108,7 +108,7 @@ error: compilation failed: Two incompatible versions exist in the dependency gra
 
 ## Overriding Dependencies
 
-The needto override a dependency can arise through a number of scenarios. The most common scenario out of them is the need to test a package 
+The need to override a dependency can arise through a number of scenarios. The most common scenario out of them is the need to test a package 
 before [publishing to the Ballerina Central](/learn/publishing-packages-to-ballerina-central/#publishing-a-library-package-to-ballerina-central). This can be achieved with the local repository.
 
 ### The Local Repository


### PR DESCRIPTION
## Purpose
> $Title

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
