### PR TITLE
Remove the "Expand/Collapse All" Option from Page TOCs

### DIFF
--- a/_layouts/ballerina-cli-documentation-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-cli-documentation-left-nav-pages-swanlake.html
@@ -32,7 +32,6 @@
                                  <h1>{{ page.title }}</h1>
                                  <p>{{ page.intro }}</p>
                                  <div class="cBallerinaTocContainer" id="table-of-content">
-                                    <p class="cTOCcontol" ><strong>Table of contents</strong>  &nbsp;  <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                     {% include toc.html html=content sanitize=true id="tree" %}
                                  </div>
                                  {{ content }}

--- a/_layouts/ballerina-guides-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-guides-left-nav-pages-swanlake.html
@@ -32,7 +32,6 @@
                                  <h1>{{ page.title }}</h1>
                                  <p>{{ page.intro }}</p>
                                  <div class="cBallerinaTocContainer" id="table-of-content">
-                                    <p class="cTOCcontol" ><strong>Table of contents</strong>  &nbsp;  <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                     {% include toc.html html=content sanitize=true id="tree" %}
                                  </div>
                                  {{ content }}

--- a/_layouts/ballerina-hello-world-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-hello-world-left-nav-pages-swanlake.html
@@ -38,7 +38,6 @@
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>{{ page.intro }}</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">
-                                       <p class="cTOCcontol" ><strong>Table of contents</strong> &nbsp; <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                        {% include toc.html html=content sanitize=true id="tree" %}
                                     </div>
                                     {{ content }}

--- a/_layouts/ballerina-inner-page.html
+++ b/_layouts/ballerina-inner-page.html
@@ -49,7 +49,6 @@
                                  <div class="col-xs-12 col-sm-12 cNoPadding">
                                     <p>{{ page.intro }}</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">
-                                       <p class="cTOCcontol" ><strong>Table of contents</strong> <span class="cTocElements">  &nbsp;  </span> <a href="#" id="tree-expand-all">Expand all</a> <span class="cTocElements"> &nbsp; </span> <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                        {% include toc.html html=content sanitize=true id="tree" %}
                                     </div>
                                     {{ content }}

--- a/_layouts/ballerina-installing-ballerina-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-installing-ballerina-left-nav-pages-swanlake.html
@@ -38,7 +38,6 @@
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>{{ page.intro }}</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">
-                                       <p class="cTOCcontol" ><strong>Table of contents</strong> &nbsp; <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                        {% include toc.html html=content sanitize=true id="tree" %}
                                     </div>
                                     {{ content }}

--- a/_layouts/ballerina-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-left-nav-pages-swanlake.html
@@ -38,7 +38,6 @@
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>{{ page.intro }}</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">
-                                       <p class="cTOCcontol" ><strong>Table of contents</strong> &nbsp; <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                        {% include toc.html html=content sanitize=true id="tree" %}
                                     </div>
                                     {{ content }}

--- a/_layouts/ballerina-left-nav-pages.html
+++ b/_layouts/ballerina-left-nav-pages.html
@@ -46,7 +46,6 @@
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>{{ page.intro }}</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">
-                                       <p class="cTOCcontol" ><strong>Table of contents</strong>  &nbsp;  <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                        {% include toc.html html=content sanitize=true id="tree" %}
                                     </div>
                                     {{ content }}

--- a/_layouts/ballerina-left-nav-release-notes.html
+++ b/_layouts/ballerina-left-nav-release-notes.html
@@ -38,7 +38,6 @@
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>{{ page.intro }}</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">
-                                       <p class="cTOCcontol" ><strong>Table of contents</strong> &nbsp; <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                        {% include toc.html html=content sanitize=true id="tree" %}
                                     </div>
                                     {{ content }}

--- a/_layouts/ballerina-style-guide-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-style-guide-left-nav-pages-swanlake.html
@@ -38,7 +38,6 @@
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>{{ page.intro }}</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">
-                                       <p class="cTOCcontol" ><strong>Table of contents</strong> &nbsp; <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                        {% include toc.html html=content sanitize=true id="tree" %}
                                     </div>
                                     {{ content }}

--- a/_layouts/ballerina-tooling-guide-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-tooling-guide-left-nav-pages-swanlake.html
@@ -38,7 +38,6 @@
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>{{ page.intro }}</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">
-                                       <p class="cTOCcontol" ><strong>Table of contents</strong> &nbsp; <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                        {% include toc.html html=content sanitize=true id="tree" %}
                                     </div>
                                     {{ content }}

--- a/_layouts/ballerina-visual-studio-code-extension-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-visual-studio-code-extension-left-nav-pages-swanlake.html
@@ -38,7 +38,6 @@
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>{{ page.intro }}</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">
-                                       <p class="cTOCcontol" ><strong>Table of contents</strong> &nbsp; <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                        {% include toc.html html=content sanitize=true id="tree" %}
                                     </div>
                                     {{ content }}

--- a/_layouts/ballerina-why-ballerina-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-why-ballerina-left-nav-pages-swanlake.html
@@ -38,7 +38,6 @@
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>{{ page.intro }}</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">
-                                       <p class="cTOCcontol" ><strong>Table of contents</strong> &nbsp; <a href="#" id="tree-expand-all">Expand all</a> &nbsp; <a href="#" id="tree-collapse-all">Collapse all</a></p>
                                        {% include toc.html html=content sanitize=true id="tree" %}
                                     </div>
                                     {{ content }}


### PR DESCRIPTION
## Purpose
Remove the "Expand/Collapse All" option from the page TOCs.
> Fixes #2901 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
