### PR TITLE
Fix the TOCs of the CLI Docs Pages

### DIFF
--- a/_includes/left-nav-cli-documentation-swan-lake.html
+++ b/_includes/left-nav-cli-documentation-swan-lake.html
@@ -8,7 +8,7 @@
 {% endif %}
 {% endfor %}
 <!-- Then we build the nav bar. -->
-<nav class="cLeftNavContainer">
+<nav class="cLeftNavContainer cLeftNavContainerScroll">
    <ul class="cMainLeftNav">
       {% for entry in site.data.clidocumentationnavswanlake %}
       {% if entry.url == current_page %}
@@ -29,7 +29,37 @@
             {% endif %}
             {% for sublink in sublinks %}
             <!-- <li {{ current-sub }} ><a href="{{ site.baseurl }}{{ sublink.url }}">- {{ sublink.title }}</a></li> -->
+            {% assign innerTwoSublinks = sublink.sublinks %}
+            {% if innerTwoSublinks %} 
+          
+            <li {% if sublink.active == page.active %} class="inner-sub-menu current-sub" {% else %} class="inner-sub-menu " {% endif %}>
+                  <div class="cLeftMenuInnerLink cTopiAtag">{{ sublink.title }}</div>  
+                  <ul class="sub-ul-two">
+                     {% for innerTwoSubLink in innerTwoSublinks %} 
+                     {% assign innerThreeSublinks = innerTwoSubLink.sublinks %}
+
+                     {% if innerThreeSublinks %} 
+                     <li {% if innerTwoSubLink.active == page.active %} class="inner-sub-menu-two current-inner-sub"  {% else %}  class="inner-sub-menu-two " {% endif %}> 
+                        <div class="cLeftMenuTwoLink cTopiAtag">{{ innerTwoSubLink.title }}</div>
+                        <ul class="sub-ul-three">
+                           {% for innerThreeSublink in innerThreeSublinks %} 
+                           <li {% if innerThreeSublink.active == page.active %} class="inner-sub-menu-three current-inner-three-sub" {% endif %}>
+                              <a href="{{innerThreeSublink.url}}">{{innerThreeSublink.title}}</a>
+                           </li>
+                           {% endfor %}
+                        </ul>
+                     </li>
+                     {% else %}
+                     <li {% if innerTwoSubLink.active == page.active %} class=" current-inner-sub" {% endif %}>
+                        <a href="{{innerTwoSubLink.url}}">{{innerTwoSubLink.title}}</a>
+                     </li>
+                     {% endif %}
+                     {% endfor %}
+                  </ul>  
+            </li> 
+            {% else %}
             <li{% if sublink.active == page.active %} class="current-sub"{% endif %}><a href="{{ sublink.url }}">{{ sublink.title }}</a></li>
+            {% endif %}
             {% endfor %}
          </ul>
       </li>

--- a/_layouts/ballerina-cli-documentation-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-cli-documentation-left-nav-pages-swanlake.html
@@ -11,7 +11,9 @@
       <div class="row cBallerina-io-Gray-row">
          <div class="container">
             <div class="row">
-               <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 cBallerina-io-Home-Middle-col">
+               <div class="col-xs-12 col-sm-12 col-md-3 col-lg-3 cBallerina-io-Home-Middle-col cLeftNavSticky">
+                  {% include side-nav-menu-button.html %}
+
                   {% include left-nav-cli-documentation-swan-lake.html %}
                </div>
                <div class="col-xs-12 col-sm-12 col-md-9 col-lg-9 cBallerina-io-Home-Middle-col">
@@ -20,21 +22,30 @@
                         {% include nav-breadcrumbs.html %}
                         <div class="cVersionContainer"></div>
                      </div>
-                     <div class="col-md-12 col-lg-2 cBallerina-io-breadcrumbs cGitLink">
-                       <a class="icon icon-github" target="_blank" href="https://www.github.com/{{ site.github_username }}/{{ site.git_repo }}/blob/master/{{ page.path | replace: ".html", ".md"}}"></a>
-                     </div>
+                     <!-- <div class="col-md-12 col-lg-2 cBallerina-io-breadcrumbs cGitLink">
+                      
+                     </div> -->
                   </div>
                   <div class="cBlallerina-io-docs-content-container cPositionRelative">
                      <div class="wy-nav-content">
                         <div class="rst-content">
                            <div role="main">
                               <div class="section">
-                                 <h1>{{ page.title }}</h1>
-                                 <p>{{ page.intro }}</p>
-                                 <div class="cBallerinaTocContainer" id="table-of-content">
-                                    {% include toc.html html=content sanitize=true id="tree" %}
+
+
+                                 <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding"> <h1>{{ page.title }}</h1></div>
+                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer"><a class="icon icon-github" target="_blank" href="https://www.github.com/{{ site.github_username }}/{{ site.git_repo }}/blob/master/{{ page.path | replace: ".html", ".md"}}"></a></div>
+                                 <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
+                                    <p>{{ page.intro }}</p>
+                                    <div class="cBallerinaTocContainer" id="table-of-content">
+                                       {% include toc.html html=content sanitize=true id="tree" %}
+                                    </div>
+                                    {{ content }}
                                  </div>
-                                 {{ content }}
+
+
+                                
+                             
                               </div>
                            </div>
                         </div>
@@ -62,11 +73,22 @@
 
 
 
-     <script src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
+     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
      <script src="/js/abixTreeList.min.js"></script>
      <script>
          $(document).ready(function() {
-             $('#tree').abixTreeList();
+
+             
+                $allHeaders= $(":header"); //Select all header elements such as h1 h2 h3 h4 h5 h6
+                $allHeaders.each(function(){
+                  var link = $(this).attr('id');
+              
+                  var permLink = " <a class=\"permalink\" href=\"#"+link+"\"></a>";
+                  if(link){
+                     $(this).addClass('permalinkHeader').prepend(permLink) 
+                  } 
+                });
+                $('#tree').abixTreeList();  
          });
 
 

--- a/learn/references/cli-documentation/openapi.md
+++ b/learn/references/cli-documentation/openapi.md
@@ -52,7 +52,7 @@ bal openapi -i <openapi-contract-path>
 
 ##### Modes
 
-###### 1. Client Mode
+###### Client Mode
 If you want to generate the Ballerina client only, you can set the mode as  `client` when running the OpenAPI tool. 
 The generated client can be used in your applications to call the service defined in the OpenAPI file. This mode will
  generate tests for the generated remote functions as well.
@@ -60,7 +60,8 @@ The generated client can be used in your applications to call the service define
 ```bash
 bal openapi -i <openapi-contract-path> --mode client [(-o|--output) output file path]
 ```
-###### 2. Service Mode
+
+###### Service Mode
 If you want to generate the Ballerina service only, you can set the mode as `service` when running the OpenAPI tool.
 
 ```bash


### PR DESCRIPTION
## Purpose
Fix the TOCs of the CLI docs pages.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
