### PR TITLE
Fix the API Docs Links on the WebSocket Text Client BBE

### DIFF
--- a/learn/by-example/websocket-text-client.html
+++ b/learn/by-example/websocket-text-client.html
@@ -128,7 +128,7 @@ import ballerina/websocket;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Create a new <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/ballerina/websocket/latest/clients/Client">WebSocket client</a>.</p>
+                                            <p>Create a new <a href="https://lib.ballerina.io/ballerina/websocket/latest/clients/Client">WebSocket client</a>.</p>
 
                                         </div>
                                     </div>
@@ -147,7 +147,7 @@ import ballerina/websocket;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Write a text message to the server using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/ballerina/websocket/latest/clients/Client#writeTextMessage">writeTextMessage</a>.</p>
+                                            <p>Write a text message to the server using <a href="https://lib.ballerina.io/ballerina/websocket/latest/clients/Client#writeTextMessage">writeTextMessage</a>.</p>
 
                                         </div>
                                     </div>
@@ -168,7 +168,8 @@ import ballerina/websocket;
                                     
                                     <div class="cCodeDesription">
                                         <div>
-                                            <p>Read a text message echoed from the server using <a href="https://ballerina.io/swan-lake/learn/api-docs/ballerina/#/ballerina/websocket/latest/clients/Client#readTextMessage">readTextMessage</a>.</p>
+                                            <p>Read a text message echoed from the server using 
+                                                <a href="https://lib.ballerina.io/ballerina/websocket/latest/clients/Client#readTextMessage">readTextMessage</a>.</p>
 
                                         </div>
                                     </div>


### PR DESCRIPTION
## Purpose
Fix the API Docs links on the WebSocket text client BBE.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
