### PR TITLE
Integrate the Jekyll Sitemap Generation Plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.6"
   gem 'jekyll-redirect-from'
   gem 'jekyll-algolia'
+  gem 'jekyll-sitemap'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -34,3 +35,5 @@ gem "wdm", "~> 0.1.0" if Gem.win_platform?
 gem "kramdown", ">= 2.3.0"
 
 gem "kramdown-parser-gfm"
+
+gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,7 @@ GEM
     tzinfo-data (1.2021.1)
       tzinfo (>= 1.0.0)
     verbal_expressions (0.1.5)
+    webrick (1.7.0)
 
 PLATFORMS
   java
@@ -125,6 +126,7 @@ DEPENDENCIES
   kramdown-parser-gfm
   minima (~> 2.0)
   tzinfo-data
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   2.2.10
+   2.2.30

--- a/_config.yml
+++ b/_config.yml
@@ -30,6 +30,7 @@ theme: minima
 plugins:
   - jekyll-feed
   - jekyll-redirect-from
+  - jekyll-sitemap
 breadcrumbs:
   root:
     hide: true  # show breadcrumbs on root/home page


### PR DESCRIPTION
## Purpose
Integrate the Jekyll sitemap generation plugin[1].

[1] https://github.com/jekyll/jekyll-sitemap
> Fixes

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
