### PR TITLE
Add the Missing Page TOCs to the Left Nav

### DIFF
--- a/_data/clidocumentationnavswanlake.yml
+++ b/_data/clidocumentationnavswanlake.yml
@@ -3,13 +3,58 @@
   sublinks:
     - title: CLI Commands
       url: /learn/cli-documentation/cli-commands/
-      active: cli-commands
+      sublinks:
+        - title: Using the Ballerina Tool
+          url: /learn/cli-documentation/cli-commands/#using-the-ballerina-tool
+          active: using-the-ballerina-tool
+        - title: Core Commands
+          url: /learn/cli-documentation/cli-commands/#core-commands
+          active: core-commands
+        - title: Package Commands
+          url: /learn/cli-documentation/cli-commands/#package-commands
+          active: package-commands
+        - title: Other Commands
+          url: /learn/cli-documentation/cli-commands/#other-commands
+          active: other-commands
+        - title: Update Commands
+          url: /learn/cli-documentation/cli-commands/#update-commands
+          active: update-commands
     - title: Update Tool
       url: /learn/cli-documentation/update-tool/
-      active: update-tool
+      sublinks:
+        - title: Understanding Ballerina Distributions
+          url: /learn/cli-documentation/update-tool/#understanding-ballerina-distributions
+          active: understanding-ballerina-distributions
+        - title: Getting to Know the Release Channels
+          url: /learn/cli-documentation/update-tool/#getting-to-know-the-release-channels
+          active: getting-to-know-the-release-channels
+        - title: Installing Ballerina
+          url: /learn/cli-documentation/update-tool/#installing-ballerina
+          active: installing-ballerina
+        - title: Updating the Ballerina Tool
+          url: /learn/cli-documentation/update-tool/#updating-the-ballerina-tool
+          active: updating-the-ballerina-tool
+        - title: Managing your Ballerina Distributions
+          url: /learn/cli-documentation/update-tool/#managing-your-ballerina-distributions
+          active: managing-your-ballerina-distributions
     - title: Open API
       url: /learn/cli-documentation/openapi/
-      active: openapi
+      sublinks:
+        - title: Using the Capabilities of the OpenAPI Tools
+          url: /learn/cli-documentation/openapi/#using-the-capabilities-of-the-openapi-tools
+          active: using-the-capabilities-of-the-openapi-tools
+        - title: OpenAPI Validator Compiler Plugin
+          url: /learn/cli-documentation/openapi/#openapi-validator-compiler-plugin
+          active: openapi-validator-compiler-plugin
     - title: GRPC
       url: /learn/cli-documentation/grpc/
-      active: grpc 
+      sublinks:
+        - title: Usage of the Tool
+          url: /learn/cli-documentation/grpc/#usage-of-the-tool
+          active: usage-of-the-tool
+        - title: CLI Command
+          url: /learn/cli-documentation/grpc/#cli-command
+          active: cli-command
+        - title: Sample
+          url: /learn/cli-documentation/grpc/#sample
+          active: sample

--- a/_data/helloworldnavswanlake.yml
+++ b/_data/helloworldnavswanlake.yml
@@ -3,7 +3,25 @@
   sublinks:
     - title: Writing Your First Ballerina Program
       url: /learn/hello-world/writing-your-first-ballerina-program/
-      active: writing-your-first-ballerina-program
+      sublinks:
+        - title: Writing a Simple Service
+          url: /learn/hello-world/writing-a-simple-service/
+          active: writing-a-simple-service
+        - title: Creating an HTTP Client to Invoke the Service
+          url: /learn/hello-world/creating-an-http-client-to-invoke-the-service/
+          active: creating-an-http-client-to-invoke-the-service
+        - title: What’s Next?e
+          url: /learn/hello-world/whats-next
+          active: whats-next
     - title: Creating Your First Ballerina Package
       url: /learn/hello-world/creating-your-first-ballerina-package/
-      active: creating-your-first-ballerina-package    
+      sublinks:
+        - title: Creating the Package
+          url: /learn/hello-world/creating-the-package/
+          active: creating-the-package 
+        - title: Building the Package
+          url: /learn/hello-world/building-the-package/
+          active: building-the-package 
+        - title: Running the Package
+          url: /learn/hello-world/running-the-package/
+          active: running-the-package 

--- a/_data/installingballerinanavswanlake.yml
+++ b/_data/installingballerinanavswanlake.yml
@@ -3,10 +3,64 @@
   sublinks:
     - title: Setting up Ballerina
       url: /learn/installing-ballerina/setting-up-ballerina/
-      active: setting-up-ballerina
+      sublinks:
+          - title: Trying Ballerina in the Playground
+            url: /learn/installing-ballerina/setting-up-ballerina/#trying-ballerina-in-the-playground
+            active: trying-ballerina-in-the-playground
+          - title: Downloading Ballerina
+            url: /learn/installing-ballerina/setting-up-ballerina/#downloading-ballerina
+            active: downloading-ballerina
+          - title: Installing Ballerina
+            url: /learn/installing-ballerina/setting-up-ballerina/#installing-ballerina
+            active: installing-ballerina
+          - title: Updating Ballerina
+            url: /learn/installing-ballerina/setting-up-ballerina/#updating-ballerina
+            active: updating-ballerina
+          - title: Installing the VSCode Extension
+            url: /learn/installing-ballerina/setting-up-ballerina/#installing-the-vscode-extension
+            active: installing-the-vscode-extension
+          - title: What’s Next?
+            url: /learn/installing-ballerina/setting-up-ballerina/#whats-next
+            active: whats-next
     - title: Installation Options
       url: /learn/installing-ballerina/installation-options/
-      active: installation-options
+      sublinks:
+          - title: Installing Ballerina via Installers
+            url: /learn/installing-ballerina/installation-options/#installing-ballerina-via-installers
+            active: installing-ballerina-via-installers
+          - title: Installing via the Ballerina Language ZIP File
+            url: /learn/installing-ballerina/installation-options/#installing-via-the-ballerina-language-zip-file
+            active: installing-via-the-ballerina-language-zip-file
+          - title: Updating Ballerina
+            url: /learn/installing-ballerina/installation-options/#updating-ballerina
+            active: updating-ballerina
+          - title: Building from Source
+            url: /learn/installing-ballerina/installation-options/#building-from-source
+            active: building-from-source
+          - title: Uninstalling Ballerina
+            url: /learn/installing-ballerina/installation-options/#uninstalling-ballerina
+            active: uninstalling-ballerina
+          - title: What’s Next?
+            url: /learn/installing-ballerina/installation-options/#whats-next
+            active: whats-next
     - title: Building from Source
       url: /learn/installing-ballerina/building-from-source/
-      active: building-from-source
+      sublinks:
+          - title: Overview
+            url: /learn/installing-ballerina/building-from-source/#overview
+            active: overview
+          - title: Setting up the Prerequisites
+            url: /learn/installing-ballerina/building-from-source/#setting-up-the-prerequisites
+            active: setting-up-the-prerequisites
+          - title: Building the Complete Ballerina Distribution
+            url: /learn/installing-ballerina/building-from-source/#building-the-complete-ballerina-distribution
+            active: building-the-complete-ballerina-distribution
+          - title: Testing the Distribution Build
+            url: /learn/installing-ballerina/building-from-source/#testing-the-distribution-build
+            active: testing-the-distribution-build
+          - title: Building Only the Ballerina Runtime with the Tools
+            url: /learn/installing-ballerina/building-from-source/#building-only-the-ballerina-runtime-with-the-tools
+            active: building-only-the-ballerina-runtime-with-the-tools
+          - title: Testing the Runtime Build
+            url: /learn/installing-ballerina/building-from-source/#testing-the-runtime-build
+            active: testing-the-runtime-build

--- a/_data/observingprogramsswanlake.yml
+++ b/_data/observingprogramsswanlake.yml
@@ -28,10 +28,10 @@
         - title: Step 2 - Configuring Choreo to Observe a Ballerina Service
           url: /learn/observing-ballerina-programs/observing-your-application-with-choreo/#step-2---configuring-choreo-to-observe-a-ballerina-service
           active: step-2---configuring-choreo-to-observe-a-ballerina-service
-        - title: Step 3 - Observe the Ballerina Service
-          url: /learn/observing-ballerina-programs/observing-your-application-with-choreo/#step-3---observe-the-ballerina-service
-          active: step-3---observe-the-ballerina-service
-        - title: step-4 - sending-few-requests
+        - title: Step 3 - Observing the Ballerina Service
+          url: /learn/observing-ballerina-programs/observing-your-application-with-choreo/#step-3---observing-the-ballerina-service
+          active: step-3---observing-the-ballerina-service
+        - title: Step-4 - Sending Few Requests
           url: /learn/observing-ballerina-programs/observing-your-application-with-choreo/#step-4---sending-few-requests
           active: step-4---sending-few-requests
 

--- a/_data/styleguidenavswanlake.yml
+++ b/_data/styleguidenavswanlake.yml
@@ -3,19 +3,115 @@
   sublinks:
     - title: Coding Conventions
       url: /learn/style-guide/coding-conventions/
-      active: coding-conventions
+      sublinks:
+        - title: Indentation and Line Length
+          url: /learn/style-guide/coding-conventions/#indentation-and-line-length
+          active: indentation-and-line-length
+        - title: Line Spacing
+          url: /learn/style-guide/coding-conventions/#line-spacing
+          active: line-spacing
+        - title: Blank Lines
+          url: /learn/style-guide/coding-conventions/#blank-lines
+          active: blank-lines
+        - title: Blocks
+          url: /learn/style-guide/coding-conventions/#blocks
+          active: blocks
+        - title: Parentheses and Brackets
+          url: /learn/style-guide/coding-conventions/#parentheses-and-brackets
+          active: parentheses-and-brackets
+        - title: Line Breaks
+          url: /learn/style-guide/coding-conventions/#line-breaks
+          active: line-breaks
+        - title: Top-Level Definitions
+          url: /learn/style-guide/coding-conventions/#top-level-definitions
+          active: top-level-definitions
+        - title: Operators, Keywords, and Types
+          url: /learn/style-guide/coding-conventions/#operators-keywords-and-types
+          active: operators-keywords-and-types
+        - title: Statements
+          url: /learn/style-guide/coding-conventions/#statements
+          active: statements
+        - title: Expressions
+          url: /learn/style-guide/coding-conventions/#expressions
+          active: expressions
+        - title: Annotations, Documentation, and Comments
+          url: /learn/style-guide/coding-conventions/#annotations-documentation-and-comments
+          active: annotations-documentation-and-comments
     - title: Top-Level Definitions
       url: /learn/style-guide/top-level-definitions/
-      active: top-level-definitions
+      sublinks:
+        - title: General Practices
+          url: /learn/style-guide/top-level-definitions/#general-practices
+          active: general-practices
+        - title: Imports
+          url: /learn/style-guide/top-level-definitions/#imports
+          active: imports
+        - title: Function Definition
+          url: /learn/style-guide/top-level-definitions/#function-definition
+          active: function-definition
+        - title: Service Definition
+          url: /learn/style-guide/top-level-definitions/#service-definition
+          active: service-definition
+        - title: Class Definition
+          url: /learn/style-guide/top-level-definitions/#class-definition
+          active: class-definition
+        - title: Record Definition
+          url: /learn/style-guide/top-level-definitions/#record-definition
+          active: record-definition
+        - title: Referencing Record or Object
+          url: /learn/style-guide/top-level-definitions/#referencing-record-or-object
+          active: referencing-record-or-object
     - title: Operators, Keywords, and Types
       url: /learn/style-guide/operators-keywords-and-types/
-      active: operators-keywords-and-types
+      sublinks:
+        - title: Keywords and Types
+          url: /learn/style-guide/operators-keywords-and-types/#keywords-and-types
+          active: keywords-and-types
+        - title: Operators
+          url: /learn/style-guide/operators-keywords-and-types/#operators
+          active: operators
     - title: Statements
       url: /learn/style-guide/statements/
-      active: statements
+      sublinks:
+        - title: If Statement
+          url: /learn/style-guide/statements/#if-statement
+          active: if-statement
+        - title: Match Statement
+          url: /learn/style-guide/statements/#match-statement
+          active: match-statement
     - title: Expressions
       url: /learn/style-guide/expressions/
-      active: expressions
+      sublinks:
+        - title: Function Invocation
+          url: /learn/style-guide/expressions/#function-invocation
+          active: function-invocation
+        - title: Record Literal
+          url: /learn/style-guide/expressions/#record-literal
+          active: record-literal
+        - title: Map Literal
+          url: /learn/style-guide/expressions/#map-literal
+          active: map-literal
+        - title: Tuple
+          url: /learn/style-guide/expressions/#tuple
+          active: tuple
+        - title: Array Literal
+          url: /learn/style-guide/expressions/#array-literal
+          active: array-literal
+        - title: Type Casting
+          url: /learn/style-guide/expressions/#type-casting
+          active: type-casting
+        - title: Table Literal
+          url: /learn/style-guide/expressions/#table-literal
+          active: table-literal
     - title: Annotations, Documentation and Comments
       url: /learn/style-guide/annotations-documentation-and-comments/
-      active: annotations-documentation-and-comments    
+      sublinks:
+        - title: Annotations
+          url: /learn/style-guide/annotations-documentation-and-comments/#annotations
+          active: annotations
+        - title: Comments
+          url: /learn/style-guide/annotations-documentation-and-comments/#comments
+          active: comments
+        - title: Documentation
+          url: /learn/style-guide/annotations-documentation-and-comments/#documentation
+          active: documentation

--- a/_data/visualstudiocodeextensionnavswanlake.yml
+++ b/_data/visualstudiocodeextensionnavswanlake.yml
@@ -3,19 +3,142 @@
   sublinks:
     - title: VS Code Quick Start
       url: /learn/visual-studio-code-extension/vs-code-quick-start/
-      active: vs-code-quick-start
+      sublinks:
+        - title: Setting up the Prerequisites
+          url: /learn/visual-studio-code-extension/vs-code-quick-start/#setting-up-the-prerequisites
+          active: setting-up-the-prerequisites
+        - title: Installing the Ballerina Extension
+          url: /learn/visual-studio-code-extension/vs-code-quick-start/#installing-the-ballerina-extension
+          active: installing-the-ballerina-extension
+        - title: Running Your First Ballerina Program
+          url: /learn/visual-studio-code-extension/vs-code-quick-start/#running-your-first-ballerina-program
+          active: running-your-first-ballerina-program
+        - title: What’s Next?
+          url: /learn/visual-studio-code-extension/vs-code-quick-start/#whats-next
+          active: whats-next
     - title: Diagram Editor
       url: /learn/visual-studio-code-extension/diagram-editor/
-      active: diagram-editor
+      sublinks:
+        - title: Diagrams View
+          url: /learn/visual-studio-code-extension/diagram-editor/#diagrams-view
+          active: diagrams-view
+        - title: Show Diagram Button
+          url: /learn/visual-studio-code-extension/diagram-editor/#show-diagram-button
+          active: show-diagram-button
+        - title: Show Diagram Palette Command
+          url: /learn/visual-studio-code-extension/diagram-editor/#show-diagram-palette-command
+          active: show-diagram-palette-command
     - title: Debugging
       url: /learn/visual-studio-code-extension/debugging/
-      active: debugging
+      sublinks:
+        - title: Starting a Debug Session
+          url: /learn/visual-studio-code-extension/debugging/#starting-a-debug-session
+          active: starting-a-debug-session
+        - title: Running Without Debugging
+          url: /learn/visual-studio-code-extension/debugging/#running-without-debugging
+          active: running-without-debugging
+        - title: Using the Debugging Features
+          url: /learn/visual-studio-code-extension/debugging/#using-the-debugging-features
+          active: using-the-debugging-features
+        - title: Debug Configurations
+          url: /learn/visual-studio-code-extension/debugging/#debug-configurations
+          active: debug-configurations
+        - title: Debug Configurations
+          url: /learn/visual-studio-code-extension/debugging/#debug-configurations
+          active: debug-configurations
     - title: VS Code Commands
       url: /learn/visual-studio-code-extension/vs-code-commands/
-      active: vs-code-commands
+      sublinks:
+        - title: Show Examples
+          url: /learn/visual-studio-code-extension/vs-code-commands/#show-examples
+          active: show-examples
+        - title: Build
+          url: /learn/visual-studio-code-extension/vs-code-commands/#build
+          active: build
+        - title: Run
+          url: /learn/visual-studio-code-extension/vs-code-commands/#run
+          active: run
+        - title: Test
+          url: /learn/visual-studio-code-extension/vs-code-commands/#test
+          active: test
+        - title: Build Documentation
+          url: /learn/visual-studio-code-extension/vs-code-commands/#build-documentation
+          active: build-documentation
+        - title: Show Diagram
+          url: /learn/visual-studio-code-extension/vs-code-commands/#show-diagram
+          active: show-diagram
+        - title: Add Module
+          url: /learn/visual-studio-code-extension/vs-code-commands/#add-module
+          active: add-module    
+        - title: Create ‘Cloud.toml’
+          url: /learn/visual-studio-code-extension/vs-code-commands/#create-cloudtoml
+          active: create-cloudtoml
+        - title: Paste JSON as Record
+          url: /learn/visual-studio-code-extension/vs-code-commands/#paste-json-as-record
+          active: paste-json-as-record
+        - title: Paste JSON as Record
+          url: /learn/visual-studio-code-extension/vs-code-commands/#paste-json-as-record
+          active: paste-json-as-record
     - title: Language Support
       url: /learn/visual-studio-code-extension/language-support/
-      active: language-support
+      sublinks:
+        - title: IntelliSense
+          url: /learn/visual-studio-code-extension/language-support/#intellisense
+          active: intellisense
+        - title: Code Navigation
+          url: /learn/visual-studio-code-extension/language-support/#code-navigation
+          active: code-navigation
+        - title: Diagnostics
+          url: /learn/visual-studio-code-extension/language-support/#diagnostics
+          active: diagnostics
+        - title: Data Mapping
+          url: /learn/visual-studio-code-extension/language-support/#data-mapping
+          active: data-mapping
+        - title: Code Formatting
+          url: /learn/visual-studio-code-extension/language-support/#code-formatting
+          active: code-formatting
+        - title: Rename Symbols
+          url: /learn/visual-studio-code-extension/language-support/#rename-symbols
+          active: rename-symbols
+        - title: Code Lenses
+          url: /learn/visual-studio-code-extension/language-support/#code-lenses
+          active: code-lenses
+        - title: Code Actions
+          url: /learn/visual-studio-code-extension/language-support/#code-actions
+          active: code-actions
     - title: Configurations
       url: /learn/visual-studio-code-extension/configurations/
-      active: configurations      
+      sublinks:
+        - title: Code Lens - All Enabled
+          url: /learn/visual-studio-code-extension/configurations/#code-lens---all-enabled
+          active: code-lens---all-enabled  
+        - title: Code Lens - Docs Enabled
+          url: /learn/visual-studio-code-extension/configurations/#code-lens---docs-enabled
+          active: code-lens---docs-enabled
+        - title: Code Lens - Executor Enabled
+          url: /learn/visual-studio-code-extension/configurations/#code-lens---executor-enabled
+          active: code-lens---executor-enabled   
+        - title: Data Mapper Enabled
+          url: /learn/visual-studio-code-extension/configurations/#data-mapper-enabled
+          active: data-mapper-enabled    
+        - title: Data Mapper Url
+          url: /learn/visual-studio-code-extension/configurations/#data-mapper-url
+          active: data-mapper-url   
+        - title: Debug Log
+          url: /learn/visual-studio-code-extension/configurations/#debug-log
+          active: debug-log  
+        - title: Enable File Watcher
+          url: /learn/visual-studio-code-extension/configurations/#enable-file-watcher
+          active: enable-file-watcher
+        - title: Enable Telemetry
+          url: /learn/visual-studio-code-extension/configurations/#enable-telemetry
+          active: enable-telemetry
+        - title: Home
+          url: /learn/visual-studio-code-extension/configurations/#home
+          active: home
+        - title: Plugin - Dev Mod
+          url: /learn/visual-studio-code-extension/configurations/#plugin---dev-mod
+          active: plugin---dev-mod
+        - title: Trace Log
+          url: /learn/visual-studio-code-extension/configurations/#trace-log
+          active: trace-log

--- a/learn.md
+++ b/learn.md
@@ -15,7 +15,7 @@ redirect_from:
 	<div class="column-gray-box-grid">
 		<div class="column-gray-box"> 
 			<h2 id="getting-started">Getting Started</h2>
-			<h3 id="installing-ballerina"><a href="/learn/installing-ballerina/setting-up-ballerina/">Setting Up Ballerina</a></h3>
+			<h3 id="installing-ballerina"><a href="/learn/installing-ballerina/setting-up-ballerina/">Installing Ballerina</a></h3>
 			<p>Setting up the Ballerina development environment.</p>
 			<h3 id="hello-world"><a href="/learn/getting-started/hello-world/writing-your-first-ballerina-program/">Hello World</a></h3>
 			<p>Writing your first Ballerina program and creating your first Ballerina package.</p>

--- a/learn/guides/observing-ballerina-programs/observing-your-application-with-choreo.md
+++ b/learn/guides/observing-ballerina-programs/observing-your-application-with-choreo.md
@@ -53,7 +53,7 @@ Follow the steps below to add observability in the executable created by Balleri
   provider="choreo"
   ```
 
-## Step 3 - Observe the Ballerina Service
+## Step 3 - Observing the Ballerina Service
 
 1. Once the configuration file has been created, execute the command below to pass it to the Ballerina program with the `BAL_CONFIG_FILES` environment variable.
 

--- a/learn/references/cli-documentation/grpc.md
+++ b/learn/references/cli-documentation/grpc.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-cli-documentation-left-nav-pages-swanlake
-title: gRPC
+title: GRPC
 description: The 'Protocol Buffers to Ballerina' tool provides capabilities to generate Ballerina source code for the Protocol Buffer definition.
 keywords: ballerina, protocol buffers, programming language
 permalink: /learn/cli-documentation/grpc/


### PR DESCRIPTION
## Purpose
Add the missing page TOCs to the left nav.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
