### PR TITLE
Update the VSIX GitHub Link for the 1.2.21 Release

### DIFF
--- a/download.html
+++ b/download.html
@@ -224,7 +224,7 @@ redirect_from:
                               <tr>
                                  <td style="width: 50%">Visual Studio Code Extension</td>
                                  <td style="width: 1%; white-space: nowrap;">
-                                    <a href="https://marketplace.visualstudio.com/items?itemName=wso2.ballerina" target="_blank" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/right-bg-green-fill.svg"></a>
+                                    <a href="https://github.com/wso2/ballerina-plugin-vscode/releases/tag/v2.1.1" target="_blank" class="cGTMDownload cDownloadLinkIcon" data-download="downloads" data-pack="ballerina-{{ site.data.stable-latest.metadata.version }}.vsix"><img src="/img/right-bg-green-fill.svg"></a>
                                  </td>
                                  <td style="width: 1%; white-space: nowrap;">
                                     <a href="{{ site.dist_server }}/downloads/{{ site.data.stable-latest.metadata.version }}/ballerina-{{ site.data.stable-latest.metadata.version }}.vsix.md5"></a>


### PR DESCRIPTION
## Purpose
Update the VSIX GitHub link for the 1.2.21 release.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
