### PR TITLE
Fix the Central File System Cache URL 

### DIFF
--- a/learn/guides/managing-dependencies.md
+++ b/learn/guides/managing-dependencies.md
@@ -70,7 +70,7 @@ The distribution repository is a file system repository that comes with the loca
 
 **Ballerina Central repository**
 
-Ballerina Central repository is a remote repository, and thereby, it comes with a local file system cache, which is located at `<USER_HOME>/.ballerina/repositories/central.ballerina.io/repo/bala`. When resolving a dependency, the remote repository will be queried only if the specified version is not present in its local cache.
+Ballerina Central repository is a remote repository, and thereby, it comes with a local file system cache, which is located at `<USER_HOME>/.ballerina/repositories/central.ballerina.io/bala`. When resolving a dependency, the remote repository will be queried only if the specified version is not present in its local cache.
 
 ### Dependencies.toml
 


### PR DESCRIPTION
## Purpose
Fix the Ballerina Central file system cache URL in the "Managing Dependencies" doc.
> Fixes #3067 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
