### PR TITLE
Remove the Edit Option from the 1.2 Learn Pages

### DIFF
--- a/1.2/learn/calling-java-code-from-ballerina/index.html
+++ b/1.2/learn/calling-java-code-from-ballerina/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Calling Java Code from Ballerina</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/calling-java-code-from-ballerina.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>Ballerina offers a straightforward way to call the existing Java code from Ballerina and also provides a Java API to call Ballerina code from Java.  Although Ballerina is not designed to be a JVM language, the current implementation, which targets the JVM, aka jBallerina, provides Java interoperability by adhering to the Ballerina language semantics.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/coding-conventions/annotations_documentation_and_comments/index.html
+++ b/1.2/learn/coding-conventions/annotations_documentation_and_comments/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Annotations, Documentation and Comments</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/coding-conventions/annotations_documentation_and_comments.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include the coding conventions with respect to annotations, documentation, and comments.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/coding-conventions/expressions/index.html
+++ b/1.2/learn/coding-conventions/expressions/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Expressions</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/coding-conventions/expressions.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include the coding conventions with respect to expressions.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/coding-conventions/index.html
+++ b/1.2/learn/coding-conventions/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Coding Conventions</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/coding-conventions.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>This Ballerina Style Guide aims at maintaining a standard coding style among the Ballerina community. Therefore, the Ballerina code formatting tools are based on this guide.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/coding-conventions/operators_keywords_and_types/index.html
+++ b/1.2/learn/coding-conventions/operators_keywords_and_types/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Operators, Keywords, and Types</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/coding-conventions/operators_keywords_and_types.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include the coding conventions with respect to operators, keywords, and types.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/coding-conventions/statements/index.html
+++ b/1.2/learn/coding-conventions/statements/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Statements</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/coding-conventions/statements.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include the coding conventions with respect to statements.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/coding-conventions/top-level-definitions/index.html
+++ b/1.2/learn/coding-conventions/top-level-definitions/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Top-Level Definitions</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/coding-conventions/top-level-definitions.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include the coding conventions with respect to top-level definitions.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/deployment/aws-lambda/index.html
+++ b/1.2/learn/deployment/aws-lambda/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>AWS Lambda</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/deployment/aws-lambda.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The AWS Lambda extension provides the functionality to expose a Ballerina function as an AWS Lambda function.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/deployment/azure-functions/index.html
+++ b/1.2/learn/deployment/azure-functions/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Azure Functions</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/deployment/azure-functions.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The Azure Functions extension provides the functionality to expose a Ballerina function as a serverless function in the Azure Functions platform.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/deployment/docker/index.html
+++ b/1.2/learn/deployment/docker/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Docker</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/deployment/docker.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>Docker helps to package applications and their dependencies in a binary image, which can run in various locations whether on-premise, in a public cloud, or in a private cloud.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/deployment/kubernetes/index.html
+++ b/1.2/learn/deployment/kubernetes/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Kubernetes</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/deployment/kubernetes.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The Kubernetes builder extension offers native support for running Ballerina programs on Kubernetes with the use of annotations that you can include as part of your service code.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/documenting-ballerina-code/index.html
+++ b/1.2/learn/documenting-ballerina-code/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Documenting Ballerina Code</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/documenting-ballerina-code.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>Ballerina has a built-in Ballerina Flavored Markdown (BFM) documentation framework named Docerina. The documentation framework allows you to write unstructured documents with a bit of structure to enable generating HTML content as API documentation.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/extending-with-compiler-extensions/index.html
+++ b/1.2/learn/extending-with-compiler-extensions/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Extending with Compiler Extensions</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/extending-with-compiler-extensions.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include information about extending with compiler extensions.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions/index.html
+++ b/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Generating Ballerina Code for Protocol Buffer Definitions</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The 'Protocol Buffers to Ballerina' tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/installing-ballerina/index.html
+++ b/1.2/learn/installing-ballerina/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Installing Ballerina</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/installing-ballerina.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include information about installing Ballerina.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/keeping-ballerina-up-to-date/index.html
+++ b/1.2/learn/keeping-ballerina-up-to-date/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Keeping Ballerina Up to Date</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/keeping-ballerina-up-to-date.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/observing-ballerina-code/index.html
+++ b/1.2/learn/observing-ballerina-code/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Observing Ballerina Code</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/observing-ballerina-code.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>Observability is a measure of how well internal states of a system can be inferred from knowledge of its external outputs.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/publishing-modules-to-ballerina-central/index.html
+++ b/1.2/learn/publishing-modules-to-ballerina-central/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Publishing Modules to Ballerina Central</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/publishing-modules-to-ballerina-central.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include information about publishing modules to Ballerina Central.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/quick-tour/index.html
+++ b/1.2/learn/quick-tour/index.html
@@ -346,10 +346,10 @@
                                     <h1>Ballerina Quick Tour</h1>
                                  </div>
 
-                                 <div class="col-xs-1 col-sm-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-sm-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/quick-tour.md"></a>
 
-                                 </div>
+                                 </div> -->
 
                                  <div class="col-xs-12 col-sm-12 cNoPadding">
                                     <p>Now, that you know a little bit of Ballerina, let's take it for a spin!</p>

--- a/1.2/learn/running-ballerina-code/index.html
+++ b/1.2/learn/running-ballerina-code/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Running Ballerina Code</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/running-ballerina-code.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include information on running Ballerina programs.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/setting-up-intellij-idea/index.html
+++ b/1.2/learn/setting-up-intellij-idea/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Setting up IntelliJ IDEA</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/tools-ides/setting-up-intellij-idea.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The IntelliJ Ballerina plugin provides the Ballerina development capabilities in IntelliJ IDEA. The below sections include instructions on how to download, install, and use the features of the IntelliJ plugin.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/setting-up-intellij-idea/using-intellij-plugin-features/index.html
+++ b/1.2/learn/setting-up-intellij-idea/using-intellij-plugin-features/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Using the features of the IntelliJ plugin</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include information on the various capabilities that are facilitated by the IntelliJ Ballerina plugin for the development process.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/setting-up-intellij-idea/using-the-intellij-plugin/index.html
+++ b/1.2/learn/setting-up-intellij-idea/using-the-intellij-plugin/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Using the IntelliJ Ballerina Plugin</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include information to start using the IntelliJ Ballerina plugin after installing it.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/setting-up-visual-studio-code/documentation-viewer/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/documentation-viewer/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Documentation Viewer</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/tools-ides/setting-up-visual-studio-code/documentation-viewer.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The VS Code Ballerina extension is shipped with a Documentation Viewer. You can add documentation for the functions and other public entities in your module for the reference of other users of it.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/setting-up-visual-studio-code/graphical-editor/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/graphical-editor/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Graphical View</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/tools-ides/setting-up-visual-studio-code/graphical-editor.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>A rich set of visualization tools will immensely enhance your development experience especially in the integration space. The Graphical Editor of the VS Code Ballerina extension allows you to design your integration scenario graphically. Thus, by using it, you can visualize your code in a sequence diagram, which presents the endpoint interactions and parallel invocations that happen in the code. The sections below discuss how to use the Graphical Editor and explore its capabilities.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/setting-up-visual-studio-code/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Setting Up Visual Studio Code</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/tools-ides/setting-up-visual-studio-code.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The VS Code Ballerina extension provides the Ballerina development capabilities in VS Code. The below sections include instructions on how to download, install, and use the features of the VS Code extension.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/setting-up-visual-studio-code/language-intelligence/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/language-intelligence/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Language Intelligence</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/tools-ides/setting-up-visual-studio-code/language-intelligence.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The VS Code Ballerina extension brings in language intelligence to enhance the development experience and increase its efficiency. Language intelligence is built in to the extension via a Language Server implementation, which consists of the below language intelligence options.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/setting-up-visual-studio-code/run-all-tests/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/run-all-tests/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Run all Tests</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/tools-ides/setting-up-visual-studio-code/run-all-tests.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>This option allows you to run all the tests that belong to multiple modules of your project.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/setting-up-visual-studio-code/run-and-debug/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/run-and-debug/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Run and Debug</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/tools-ides/setting-up-visual-studio-code/run-and-debug.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The VS Code Ballerina extension gives you the same debugging experience as the conventional VS Code Debugger. Thus, you can run or debug your Ballerina programs easily via the VS Code Ballerina extension by launching its debugger.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/structuring-ballerina-code/index.html
+++ b/1.2/learn/structuring-ballerina-code/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Structuring Ballerina Code</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/structuring-ballerina-code.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>This document demonstrates the development of a Ballerina project and shows how to use the `Ballerina Tool` to fetch, build, and install Ballerina modules.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/testing-ballerina-code/executing-tests/index.html
+++ b/1.2/learn/testing-ballerina-code/executing-tests/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Executing Tests</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/testing-ballerina-code/executing-tests.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include information about executing tests in Ballerina.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/testing-ballerina-code/mocking/index.html
+++ b/1.2/learn/testing-ballerina-code/mocking/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Mocking</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/testing-ballerina-code/mocking.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>Mocking is useful to control the behavior of functions and objects to control the communication with other modules and external endpoints. A mock can be created by defining return values or replacing the entire object or function with a user-defined equivalent. This feature will help you to test the Ballerina code independently from other modules and external endpoints.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/testing-ballerina-code/testing-quick-start/index.html
+++ b/1.2/learn/testing-ballerina-code/testing-quick-start/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Quick Start</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/testing-ballerina-code/testing-quick-start.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The Ballerina Language has a built-in robust test framework, which allows you to achieve multiple levels of the test pyramid including unit testing, integration testing, and end to end testing.  It provides features such as assertions, data providers, mocking, and code coverage, which enable the programmers to write comprehensive tests.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/testing-ballerina-code/writing-tests/index.html
+++ b/1.2/learn/testing-ballerina-code/writing-tests/index.html
@@ -620,9 +620,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Writing Tests</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/testing-ballerina-code/writing-tests.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include information about writing tests in Ballerina.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/using-the-cli-tools/index.html
+++ b/1.2/learn/using-the-cli-tools/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Using the CLI Tools</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/using-the-cli-tools.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The Ballerina Tool is your one-stop-shop for all the things you do in Ballerina.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/using-the-openapi-tools/index.html
+++ b/1.2/learn/using-the-openapi-tools/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Using the OpenAPI Tools</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/using-the-openapi-tools.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>OpenAPI Specification is a specification that creates a RESTFUL contract for APIs, detailing all of its resources and operations in a human and machine-readable format for easy development, discovery, and integration. Ballerina OpenAPI tooling will make it easy for users to start the development of a service documented in an OpenAPI contract in Ballerina by generating Ballerina service and client skeletons.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">

--- a/1.2/learn/writing-secure-ballerina-code/index.html
+++ b/1.2/learn/writing-secure-ballerina-code/index.html
@@ -613,9 +613,9 @@
                                  <div class="col-xs-11 col-md-11 col-lg-11 cNoPadding">
                                     <h1>Writing Secure Ballerina Code</h1>
                                  </div>
-                                 <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
+                                 <!-- <div class="col-xs-1 col-md-1 col-lg-1 cNoPadding cGithubContainer">
                                     <a class="icon icon-github" target="_blank" href="https://www.github.com/ballerina-platform/ballerina-dev-website/blob/master/1.2/learn/writing-secure-ballerina-code.md"></a>
-                                 </div>
+                                 </div> -->
                                  <div class="col-xs-12 col-md-12 col-lg-12 cNoPadding">
                                     <p>The sections below include information on the different security features and controls available within Ballerina. Also, they provide guidelines on writing secure Ballerina programs.</p>
                                     <div class="cBallerinaTocContainer" id="table-of-content">


### PR DESCRIPTION
## Purpose
Remove the edit option from the 1.2 learn pages.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
