### PR TITLE
Add the "Security Policy" footer link

### DIFF
--- a/_includes/ballerina-footer.html
+++ b/_includes/ballerina-footer.html
@@ -9,6 +9,7 @@
             <li><a class="cBioFooterLink" href="/license-of-site">SITE LICENSE</a></li>
             <li><a class="cBioFooterLink" href="/terms-of-service">TERMS OF SERVICE</a></li>
             <li><a class="cBioFooterLink" href="/privacy-policy">PRIVACY POLICY</a></li>
+            <li><a class="cBioFooterLink" href="/security-policy">SECURITY POLICY</a></li>
             <li><a class="cBioFooterLink" href="/trademark-usage-policy/">TRADEMARK USAGE POLICY</a></li>
             </ul>
         </div>

--- a/security-policy.md
+++ b/security-policy.md
@@ -2,7 +2,11 @@
 layout: ballerina-inner-page
 title: Security Policy
 intro: Ballerina project maintainers take security issues very seriously and all the vulnerability reports are treated with the highest priority and confidentiality.
-permalink: /security/
+permalink: /security-policy/
+redirect_from:
+    - /security/
+    - /security
+    - /security-policy
 ---
 
 ## Reporting a vulnerability


### PR DESCRIPTION
## Purpose
Add the "Security Policy" footer link.
> Fixes #3167 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
