### PR TITLE
Remove the "Language By Examples" View

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
 
    <ul>
      
-      <li style="margin: 0;"><a class="cIconLink" href="/learn/by-example/introduction/" target="_blank">Ballerina by Examples</a></li>
+      <li style="margin: 0;"><a class="cIconLink" href="/learn/by-example/" target="_blank">Ballerina by Examples</a></li>
       <li ><a class="cIconLink" href="/learn/user-guide/getting-started/">Get Started</a></li>
       
       </ul>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
 
    <ul>
      
-      <li style="margin: 0;"><a class="cIconLink" href="/learn/by-example/" target="_blank">Ballerina by Examples</a></li>
+      <li style="margin: 0;"><a class="cIconLink" href="/learn/by-example/" target="_blank">Ballerina by Example</a></li>
       <li ><a class="cIconLink" href="/learn/user-guide/getting-started/">Get Started</a></li>
       
       </ul>

--- a/js/philosophy.js
+++ b/js/philosophy.js
@@ -142,7 +142,7 @@ function printExamples() {
                         let pathValue = window.location.pathname;
                         let splitedPath = pathValue.split("/learn/");
                         let selectedVersion = splitedPath[0];
-                        div_content += '<li><a href="'+selectedVersion+'/learn/by-example/' + link + '.html?is_ref_by_example=true">' + example['name'] + '</a></li>';
+                        div_content += '<li><a href="'+selectedVersion+'/learn/by-example/' + link + '.html">' + example['name'] + '</a></li>';
                     }
                 });
 

--- a/learn.md
+++ b/learn.md
@@ -121,7 +121,7 @@ redirect_from:
 <div class="row">
 <div class="col-lg-6 col-md-6 col-sm-12 card">
 <a href="/learn/by-example/">
-    <h3 id="learn-by-example">Ballerina by Examples</h3></a>
+    <h3 id="learn-by-example">Ballerina by Example</h3></a>
     <p >A series of examples that serve as a reference guide for language constructs, concepts, and standard library modules. </p>
 </div>
 

--- a/learn.md
+++ b/learn.md
@@ -120,9 +120,9 @@ redirect_from:
 </div>
 <div class="row">
 <div class="col-lg-6 col-md-6 col-sm-12 card">
-<a href="/learn/by-example/introduction/">
-    <h3 id="learn-by-example">Learn by Examples</h3></a>
-    <p >A series of guided examples to learn the language. </p>
+<a href="/learn/by-example/">
+    <h3 id="learn-by-example">Ballerina by Examples</h3></a>
+    <p >A series of examples that serve as a reference guide for language constructs, concepts, and standard library modules. </p>
 </div>
 
 <div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
@@ -229,40 +229,34 @@ redirect_from:
 	<h2 id="references">References</h2>
 
 <div class="row">
-<div class="col-lg-6 col-md-6 col-sm-12 card" >
-<a href="/learn/by-example/">
- <h3 id="reference-guide-by-examples">Reference by Examples</h3></a>
-		<p>A series of examples that serve as a reference guide for language constructs, concepts, and standard library modules. </p>
-</div>
-
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+<div class="col-lg-6 col-md-6 col-sm-12 card">
  <a href="https://lib.ballerina.io/">
   	<h3 id="library-documentation">Library Documentation</h3></a>
 		<p>Ballerina library API documentation. </p>
 </div>
-</div>	
 
-<div class="row">
-<div class="col-lg-6 col-md-6 col-sm-12 card" >
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
   <a href="/learn/cli-documentation/cli-commands/">
  	<h3 id="the-bal-tool">CLI Documentation</h3></a>
 		<p>Details of all the CLI commands of the <code class="highlighter-rouge language-plaintext">bal</code> tool.  </p>
 </div>
-
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+</div>
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card" >
  <a href="/learn/platform-specifications/">
   <h3 id="specifications">Platform Specifications</h3></a>
 		<p>Details of the Ballerina language specifications and proposals.  </p>
 </div>
-</div>
-<div class="row">
-<div class="col-lg-6 col-md-6 col-sm-12 card" >
+
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
   <a href="/learn/style-guide/coding-conventions/">
  	 <h3 id="style-guide">Style Guide</h3></a>
 		<p>Best practices to follow when formatting Ballerina code.   </p>
 </div>
+</div>
 
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card" >
  <a href="/learn/language-introduction/">
   	<h3 id="language-introduction-slides">Language Introduction</h3></a>
 		<p>Presentation slides on the Ballerina language that you can use to talk about the language.</p>

--- a/learn/by-example/index.html
+++ b/learn/by-example/index.html
@@ -1,8 +1,8 @@
 ---
 layout: ballerina-no-git-inner-page
-title: Ballerina by Examples
+title: Ballerina by Example
 keywords: hello world, basics, network interaction, working with data, concurrency, transactions, concurrency safety, testing, rest api, rest client, rest api security, rest api advanced, http2, graphql, graphql security, websockets, websocket security, websub, resiliency, listeners, grpc, nats, stan, kafka, rabbitmq, tcp, udp, email, mysql, jdbc, io, security, url, time, cache, log, file, random, task, uuid, xslt, regex, os, xml data, tracing, metrics, code to cloud, function as a service
-description: Ballerina by Examples enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
+description: Ballerina by Example enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
 ---
 
 <div class="row cBallerina-io-Gray-row">
@@ -31,7 +31,7 @@ description: Ballerina by Examples enables you to have complete coverage over th
                                 <div class="col-xs-12 cBBEtop">
 
                                     <!--<img src="/img/ballerina-bbe-logo.svg" style="margin-bottom: 34px;">-->
-                                    <h2>Ballerina by Examples</h2>
+                                    <h2>Ballerina by Example</h2>
                                     <p>Ballerina by Examples enables you to have complete coverage 
                                     over the language, while emphasizing incremental learning. 
                                     This is a series of commented example programs.</p><br/>

--- a/learn/by-example/index.html
+++ b/learn/by-example/index.html
@@ -1,8 +1,8 @@
 ---
 layout: ballerina-no-git-inner-page
-title: Reference by Examples
+title: Ballerina by Examples
 keywords: hello world, basics, network interaction, working with data, concurrency, transactions, concurrency safety, testing, rest api, rest client, rest api security, rest api advanced, http2, graphql, graphql security, websockets, websocket security, websub, resiliency, listeners, grpc, nats, stan, kafka, rabbitmq, tcp, udp, email, mysql, jdbc, io, security, url, time, cache, log, file, random, task, uuid, xslt, regex, os, xml data, tracing, metrics, code to cloud, function as a service
-description: Reference by Examples enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
+description: Ballerina by Examples enables you to have complete coverage over the Ballerina language, while emphasizing incremental learning.
 ---
 
 <div class="row cBallerina-io-Gray-row">

--- a/learn/by-example/index.html
+++ b/learn/by-example/index.html
@@ -31,8 +31,8 @@ description: Reference by Examples enables you to have complete coverage over th
                                 <div class="col-xs-12 cBBEtop">
 
                                     <!--<img src="/img/ballerina-bbe-logo.svg" style="margin-bottom: 34px;">-->
-                                    <h2>Reference by Examples</h2>
-                                    <p>Reference by Examples enables you to have complete coverage 
+                                    <h2>Ballerina by Examples</h2>
+                                    <p>Ballerina by Examples enables you to have complete coverage 
                                     over the language, while emphasizing incremental learning. 
                                     This is a series of commented example programs.</p><br/>
                                 </div>

--- a/learn/by-example/index.html
+++ b/learn/by-example/index.html
@@ -35,9 +35,6 @@ description: Reference by Examples enables you to have complete coverage over th
                                     <p>Reference by Examples enables you to have complete coverage 
                                     over the language, while emphasizing incremental learning. 
                                     This is a series of commented example programs.</p><br/>
-                                    <blockquote>For a collection of examples 
-                                     to grasp the features and concepts of Ballerina, see <a href="/learn/by-example/introduction/">Learn 
-                                     By Examples.</a></blockquote>
                                 </div>
                                 <div id="ballerina-by-example">
                                     <div class="cLanguageFeaturesContainer clearfix">

--- a/learn/by-example/table-syntax.html
+++ b/learn/by-example/table-syntax.html
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-example-page
+layout: ballerina-example-page-old
 title: Table Syntax
 description: This BBE demonstrates table syntax in Ballerina.
 keywords: ballerina, ballerina by example, bbe, table syntax, table


### PR DESCRIPTION
## Purpose
Remove the "Language By Examples" view.
> Fixes #3084 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
