### PR TITLE
Fix the h6 broken title

### DIFF
--- a/css/ballerina-io.css
+++ b/css/ballerina-io.css
@@ -1013,7 +1013,7 @@ h7 {
 }
 .cBallerina-io h6 {
     font-size: 18px;
-    scroll-margin-top: 30px;
+    scroll-margin-top: 40px;
 }
 /* CON BANNER */
 


### PR DESCRIPTION
## Purpose
> Fix  broken title h6 tag issue when scrolling
> Fixes #3086 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
