### PR TITLE
Remove  `--debug` option from `build` command

### DIFF
--- a/learn/getting-started/visual-studio-code-extension/debugging.md
+++ b/learn/getting-started/visual-studio-code-extension/debugging.md
@@ -110,12 +110,6 @@ Follow the steps below to start a remote debug session.
     ```bash
     bal test --debug <DEBUGGEE_PORT> <PACKAGE_PATH>
     ```
-
-    - Debugging Ballerina tests during the build:  
-
-    ```bash 
-    bal build --debug <DEBUGGEE_PORT> <PACKAGE_PATH>
-    ```
     
     The terminal will show the following log:
 


### PR DESCRIPTION
## Purpose
This PR will remove the `--debug` option from the `build` command.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/34169 | https://github.com/ballerina-platform/ballerina-lang/issues/33748


