### PR TITLE
Fix the Breadcrumbs of the "Reliable, Maintainable" "Why Ballerina" Page

### DIFF
--- a/learn/guides/why-ballerina/reliable-maintainable.md
+++ b/learn/guides/why-ballerina/reliable-maintainable.md
@@ -174,7 +174,7 @@ int|error result = trap (m + n);
 .nav > li.cVersionItem {
     display: none !important;
 }
-.cBalleinaBreadcrumbs li:nth-child(3) , .cBalleinaBreadcrumbs li:nth-child(2) {
+/* .cBalleinaBreadcrumbs li:nth-child(3) , .cBalleinaBreadcrumbs li:nth-child(2) {
    display:none !important;
-}
+} */
 </style>


### PR DESCRIPTION
## Purpose
Fix the Breadcrumbs of the "Reliable, Maintainable" "Why Ballerina" page.
> Fixes #3196 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
