### PR TITLE
Remove the "Why Ballerina" Pages and Update Learn Sections

### DIFF
--- a/_data/whyballerinanavswanlake.yml
+++ b/_data/whyballerinanavswanlake.yml
@@ -1,24 +1,24 @@
 
 - title: Cloud Native
-  url: /learn/why-ballerina/cloud-native/
+  url: /why-ballerina/cloud-native/
   active: cloud-native
 
 - title: Flexibly Typed
-  url: /learn/why-ballerina/flexibly-typed/
+  url: /why-ballerina/flexibly-typed/
   active: flexibly-typed
 
 - title: Data Oriented
-  url: /learn/why-ballerina/data-oriented/
+  url: /why-ballerina/data-oriented/
   active: data-oriented
 
 - title: Graphical
-  url: /learn/why-ballerina/graphical/ 
+  url: /why-ballerina/graphical/ 
   active: graphical
 
 - title: Concurrent
-  url: /learn/why-ballerina/concurrent/ 
+  url: /why-ballerina/concurrent/ 
   active: concurrent
 
 - title: Reliable, Maintainable
-  url: /learn/why-ballerina/reliable-maintainable/ 
+  url: /why-ballerina/reliable-maintainable/ 
   active: reliable-maintainable 

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
             <h3>Cloud Native</h3>
             <p>Network primitives in the language make it simpler to write services and run them in the cloud.
             <ul class="cInlinelinklist">
-               <li><a class="cGreenLinkArrow" href="/learn/why-ballerina/cloud-native/">More
+               <li><a class="cGreenLinkArrow" href="/why-ballerina/cloud-native/">More
                      Info</a></li>
             </ul>
          </div>
@@ -98,7 +98,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
             <p>Structural types with support for openness are used both for static typing within a program and for
                describing service interfaces.</p>
             <ul class="cInlinelinklist">
-               <li><a class="cGreenLinkArrow" href="/learn/why-ballerina/flexibly-typed/">More
+               <li><a class="cGreenLinkArrow" href="/why-ballerina/flexibly-typed/">More
                      Info</a></li>
             </ul>
          </div>
@@ -110,7 +110,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
             <h3>Data Oriented</h3> 
          <p>Type-safe, declarative processing of JSON, XML, and tabular data with language-integrated queries.</p>
       <ul class="cInlinelinklist">
-            <li><a class="cGreenLinkArrow" href="/learn/why-ballerina/data-oriented/">More Info</a></li>
+            <li><a class="cGreenLinkArrow" href="/why-ballerina/data-oriented/">More Info</a></li>
          </ul>
          </div>
       </div>
@@ -128,7 +128,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
             <p>Programs have both a textual syntax and an equivalent graphical form based on sequence diagrams.
             </p>
             <ul class="cInlinelinklist">
-               <li><a class="cGreenLinkArrow" href="/learn/why-ballerina/graphical/">More Info</a></li>
+               <li><a class="cGreenLinkArrow" href="/why-ballerina/graphical/">More Info</a></li>
             </ul>
          </div>
       </div>
@@ -141,7 +141,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          <p>Easy and efficient  concurrency with sequence diagrams and language-managed threads without the complexity of asynchronous functions.
          </p>
          <ul class="cInlinelinklist">
-            <li><a class="cGreenLinkArrow" href="/learn/why-ballerina/concurrent/">More Info</a></li>
+            <li><a class="cGreenLinkArrow" href="/why-ballerina/concurrent/">More Info</a></li>
          </ul>
          </div>
       </div>
@@ -152,7 +152,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
             <h3>Reliable, Maintainable</h3>
             <p>Explicit error handling, static types, and concurrency safety, combined with a  familiar, readable syntax make programs reliable and maintainable.</p>
             <ul class="cInlinelinklist">
-               <li><a class="cGreenLinkArrow" href="/learn/why-ballerina/reliable-maintainable/">More Info</a></li>
+               <li><a class="cGreenLinkArrow" href="/why-ballerina/reliable-maintainable/">More Info</a></li>
             </ul>
             </div>
          </div>

--- a/learn.md
+++ b/learn.md
@@ -150,7 +150,7 @@ redirect_from:
 
 <div class="row">
 <div class="col-lg-6 col-md-6 col-sm-12 card" >
-  <a href="/learn/why-ballerina/cloud-native/">
+  <a href="/why-ballerina/cloud-native/">
    <h3 id="why-ballerina">Why Ballerina</h3></a>
     <p >Why you should use Ballerina.  </p>
 </div>

--- a/learn.md
+++ b/learn.md
@@ -125,23 +125,6 @@ redirect_from:
     <p >A series of guided examples to learn the language. </p>
 </div>
 
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
-  <a href="/learn/language-walkthrough/">
-   	<h3 id="language-walkthrough-video">Language Walkthrough</h3></a>
-  <p >A video series, which explains the language and its reference slide deck. </p>
-</div>
-</div>
-
-<div class="row">
-<div class="col-lg-6 col-md-6 col-sm-12 card">
-<h3 id="language-walkthrough-video"><a href="/learn/ballerina-shell/">Ballerina Shell</a></h3>
-<p>Details of the Read-Evaluate-Print Loop (REPL) for Ballerina.</p>
-</div>
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
- <a href="/learn/visual-studio-code-extension/quick-start/">
-    <h3 id="installing-ballerina">Visual Studio Code Extension</h3></a>
-    <p >Details of all the features of the Ballerina Visual Studio Code extension. </p>
-</div>
 </div>
 </div>
 
@@ -149,78 +132,86 @@ redirect_from:
 <h2 id="concepts">Guides</h2>
 
 <div class="row">
-<div class="col-lg-6 col-md-6 col-sm-12 card" >
-  <a href="/why-ballerina/cloud-native/">
-   <h3 id="why-ballerina">Why Ballerina</h3></a>
-    <p >Why you should use Ballerina.  </p>
-</div>
-
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important">
+<div class="col-lg-6 col-md-6 col-sm-12 card">
  <a href="/learn/organizing-ballerina-code/package-layout/">
   <h3 id="organizing-ballerina-code">Organizing Ballerina Code</h3></a>
  	<p>Basics of projects, packages, and modules.  </p>
 </div>
-</div>
-
-<div class="row">
-<div class="col-lg-6 col-md-6 col-sm-12 card" >
+<div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important">
   <a href="/learn/testing-ballerina-code/testing-quick-start/">
    <h3 id="testing-ballerina-code">Testing Ballerina Code</h3> </a>
     <p >Details of writing automated tests using the built-in test framework.  </p>
 </div>
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important" >
+
+</div>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card">
   <a href="/learn/generating-code-documentation/">
   <h3 id="generatinging-code-documentation">Generating Code Documentation
 </h3></a>
   	<p>The usage of the <code class="highlighter-rouge language-plaintext">bal doc</code> CLI command.   </p>
 </div>
-
-</div>
-
-<div class="row">
-<div class="col-lg-6 col-md-6 col-sm-12 card" >
+<div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important" >
  <a href="/learn/making-ballerina-programs-configurable/defining-configurable-variables/">
   	<h3 id="making-ballerina-programs-configurable">Making Ballerina Programs Configurable</h3></a>
  	<p>The language support for configurability.   </p>
 
 </div>
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;" >
-  <a href="/learn/observing-ballerina-programs/observing-your-application-with-prometheus-grafana-and-jaeger/">
- 	<h3 id="observing-ballerina-programs">Observing Ballerina Programs
-</h3></a>
-  		<p>Basics of the observability functionalities that are provided for Ballerina programs. </p>
-</div>
 </div>
 
 <div class="row">
 
 <div class="col-lg-6 col-md-6 col-sm-12 card" >
+  <a href="/learn/observing-ballerina-programs/observing-your-application-with-prometheus-grafana-and-jaeger/">
+ 	<h3 id="observing-ballerina-programs">Observing Ballerina Programs
+</h3></a>
+  		<p>Basics of the observability functionalities that are provided for Ballerina programs. </p>
+</div>
+
+<div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important;">
  <a href="/learn/running-ballerina-programs-in-the-cloud/code-to-cloud/">
   		<h3 id="running-ballerina-programs-in-the-cloud">Running Ballerina Programs in the Cloud
 </h3></a>
  	<p>The cloud offerings for running Ballerina programs.  </p>
 
 </div>
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
-  <a href="/learn/managing-dependencies/">
- 	<h3 id="managing-dependencies">Managing Dependencies </h3></a>
-  			<p>Details of declaring and managing dependencies and using the local repository.</p>
-</div>
 </div>
 
 <div class="row">
 
-<div class="col-lg-6 col-md-6 col-sm-12 card" >
+<div class="col-lg-6 col-md-6 col-sm-12 card">
+  <a href="/learn/managing-dependencies/">
+ 	<h3 id="managing-dependencies">Managing Dependencies </h3></a>
+  			<p>Details of declaring and managing dependencies and using the local repository.</p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important;" >
 <a href="/learn/publishing-packages-to-ballerina-central/">
   		<h3 id="publishing-packages-to-ballerina-central">Publishing Packages to Ballerina Central</h3></a>
 		<p>Details of publishing your library package to Ballerina Central.  </p>
 </div>
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;" >
+</div>	
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card" >
 <a href="/learn/calling-java-code-from-ballerina-and-vice-versa/">
  <h3 id="calling-java-code-from-ballerina-and-vice-versa">Calling Java Code from Ballerina and Vice Versa</h3></a>
 		<p>Instructions on the supported interoperability features. </p>
 </div>
-</div>						
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+<h3 id="language-walkthrough-video"><a href="/learn/ballerina-shell/">Ballerina Shell</a></h3>
+<p>Details of the Read-Evaluate-Print Loop (REPL) for Ballerina.</p>
+</div>
+</div>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card">
+ <a href="/learn/visual-studio-code-extension/quick-start/">
+    <h3 id="installing-ballerina">Visual Studio Code Extension</h3></a>
+    <p >Details of all the features of the Ballerina Visual Studio Code extension. </p>
+</div>
+</div>
+
 </div>
 
 
@@ -268,6 +259,21 @@ redirect_from:
 		<p>Presentation slides on the Ballerina language that you can use to talk about the language.</p>
 </div>
 </div>
+
+
+<div class="row" style=" margin-bottom:30px">
+<h2 id="getting-started">Talks</h2>
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+  <a href="/learn/language-walkthrough/">
+   	<h3 id="language-walkthrough-video">Language Walkthrough</h3></a>
+  <p >A video series, which explains the language and its reference slide deck. </p>
+</div>
+</div>
+
+</div>
+
+
 </div>
 
 

--- a/learn/why-ballerina/cloud-native.md
+++ b/learn/why-ballerina/cloud-native.md
@@ -3,7 +3,7 @@ layout: ballerina-guides-left-nav-pages-swanlake
 title: Cloud Native
 description: See how the Ballerina programming language has built-in language constructs for network interactions and cloud support. 
 keywords: ballerina, programming language, cloud, kubernetes, docker
-permalink: /learn/why-ballerina/cloud-native/
+permalink: /why-ballerina/cloud-native/
 active: cloud-native
 intro: See how the Ballerina programming language has constructs that seamlessly map to network programming concepts such as services and network resources. It also comes with built-in language support to deploy Ballerina applications on the cloud using Docker and Kubernetes.
 redirect_from:
@@ -15,9 +15,13 @@ redirect_from:
   - /learn/user-guide/why-ballerina
   - /learn/user-guide/why-ballerina/cloud-native
   - /learn/user-guide/why-ballerina/cloud-native/
-  - /learn/why-ballerina/cloud-native
   - /learn/why-ballerina/
   - /learn/why-ballerina
+  - /learn/why-ballerina/cloud-native/
+  - /learn/why-ballerina/cloud-native
+  - /why-ballerina/cloud-native
+  - /why-ballerina/
+  - /why-ballerina
 ---
 
 In a microservice architecture, smaller services are developed, deployed, and scaled individually. These disaggregated services communicate with each other over the network forcing developers to deal with the [Fallacies of Distributed Computing](https://en.wikipedia.org/wiki/Fallacies_of_distributed_computing) in their application logic. For decades, programming languages have treated networks simply as I/O sources. The sections below demonstrate a few of Ballerina's inherent capabilities to develop distributed services effectively and the cloud native deployment process that is provided as part of the programming experience. 

--- a/learn/why-ballerina/concurrent.md
+++ b/learn/why-ballerina/concurrent.md
@@ -3,13 +3,15 @@ layout: ballerina-guides-left-nav-pages-swanlake
 title: Concurrent
 description: Concurrency in Ballerina is enabled by strands, which are lightweight threads. 
 keywords: ballerina, ballerina platform, api documentation, testing, ide, ballerina central
-permalink: /learn/why-ballerina/concurrent/
+permalink: /why-ballerina/concurrent/
 active: concurrent
 intro: Concurrency in Ballerina is enabled by strands, which are lightweight threads.
 redirct_from:
   - /learn/user-guide/why-ballerina/concurrent
   - /learn/user-guide/why-ballerina/concurrent/
   - /learn/why-ballerina/concurrent
+  - /learn/why-ballerina/concurrent/
+  - /why-ballerina/concurrent
 ---
 
 Ballerina's concurrency model supports both threads and coroutines and has been designed to have a close correspondence with sequence diagrams.

--- a/learn/why-ballerina/data-oriented.md
+++ b/learn/why-ballerina/data-oriented.md
@@ -3,13 +3,15 @@ layout: ballerina-guides-left-nav-pages-swanlake
 title: Data Oriented
 description: Language-integrated queries specify the logic in SQL-like syntax to process data and events. They are easy to write and understand due to the simplicity of the syntax. See how Ballerina provides first-class support for writing queries that process data.
 keywords: ballerina, networking, microservices, programming language, distributed computing, services, data oriented, data transformation
-permalink: /learn/why-ballerina/data-oriented/
+permalink: /why-ballerina/data-oriented/
 active: data-oriented
 intro: Language-integrated queries specify the logic in SQL-like syntax to process data and events. They are easy to write and understand due to the simplicity of the syntax. See how Ballerina provides first-class support for writing queries that process data.
 redirect_from:
     - /learn/user-guide/why-ballerina/data-oriented/
     - /learn/user-guide/why-ballerina/data-oriented
     - /learn/why-ballerina/data-oriented
+    - /learn/why-ballerina/data-oriented/
+    - /why-ballerina/data-oriented
 ---
 
 As of now, language-integrated queries are supported for iterator implementations such as an array, map, stream, and table. There are two kinds of integrated queries that can be written in Ballerina:

--- a/learn/why-ballerina/flexibly-typed.md
+++ b/learn/why-ballerina/flexibly-typed.md
@@ -3,7 +3,7 @@ layout: ballerina-guides-left-nav-pages-swanlake
 title: Flexibly Typed
 description: See how the Ballerina programming language's flexible type system helps developers work with networked resources in their code.
 keywords: ballerina, programming lanaguage, type system, data binding
-permalink: /learn/why-ballerina/flexibly-typed/
+permalink: /why-ballerina/flexibly-typed/
 active: flexibly-typed
 intro: See how the Ballerina programming language's flexible type system helps developers work with networked resources in their code.
 redirect_from:
@@ -16,6 +16,8 @@ redirect_from:
 - /learn/user-guide/why-ballerina/flexibly-typed
 - /learn/user-guide/why-ballerina/flexibly-typed/
 - /learn/why-ballerina/flexibly-typed
+- /learn/why-ballerina/flexibly-typed/
+- /why-ballerina/flexibly-typed
 ---
 
 In a programming language, the type system is the foundation for representing data and implementing logic. It provides the means of creating abstractions to the solutions that you provide. While some languages provide basic functionality, others strive to give in-built functionality for specialized domains.

--- a/learn/why-ballerina/graphical.md
+++ b/learn/why-ballerina/graphical.md
@@ -3,7 +3,7 @@ layout: ballerina-guides-left-nav-pages-swanlake
 title: Graphical
 description: See why the support for a graphical model lays the foundation for designing the syntax and semantics of the Ballerina programming language.
 keywords: ballerina, programming lanaguage, sequence diagram, graphical, diagram editor, why ballerina
-permalink: /learn/why-ballerina/graphical/
+permalink: /why-ballerina/graphical/
 active: graphical
 intro: See why the support for a graphical model lays the foundation for designing the syntax and semantics of the Ballerina programming language.
 redirect_from:
@@ -14,6 +14,8 @@ redirect_from:
   - /learn/user-guide/why-ballerina/graphical
   - /learn/user-guide/why-ballerina/graphical/
   - /learn/why-ballerina/graphical
+  - /learn/why-ballerina/graphical/
+  - /why-ballerina/graphical
 ---
 
 In today’s cloud-era, you need technologies that can model distributed systems in a more developer-friendly way. This means that for a single use case you need to model a flow that shows how multiple actors interact with each other, how concurrent execution flows, and what remote endpoints are involved. Sequence diagrams are known to be the best way to visually describe this.

--- a/learn/why-ballerina/reliable-maintainable.md
+++ b/learn/why-ballerina/reliable-maintainable.md
@@ -3,13 +3,15 @@ layout: ballerina-guides-left-nav-pages-swanlake
 title: Reliable, Maintainable
 description: The sections below explain how the explicit error handling, static types, and concurrency safety combined with a familiar, readable syntax make programs reliable and maintainable.
 keywords: ballerina, ballerina platform, api documentation, testing, ide, ballerina central
-permalink: /learn/why-ballerina/reliable-maintainable/
+permalink: /why-ballerina/reliable-maintainable/
 active: reliable-maintainable
 intro: The sections below explain how the explicit error handling, static types, and concurrency safety combined with a familiar, readable syntax make programs reliable and maintainable. 
 redirct_from:
   - /learn/user-guide/why-ballerina/reliable-and-maintainable/
   - /learn/user-guide/why-ballerina/reliable-maintainable
   - /learn/why-ballerina/reliable-maintainable
+  - /learn/why-ballerina/reliable-maintainable/
+  - /why-ballerina/reliable-maintainable
 ---
 
 ## Explicit Error Handling  


### PR DESCRIPTION
## Purpose
Need to remove the Why Ballerina pages from the Learn section. They will just be linked from the Home page.

Also, updated a few sections on the Learn landing page as follows.

![screenbud-18d77d05-aa98-4f6d-ad12-ec992decfb3b](https://user-images.githubusercontent.com/11707273/145073939-d28850fc-e708-4192-89f9-38e755595644.png)

> Fixes #3213

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
