### PR TITLE
 Fix Broken Links & Rename "Ballerina By Examples" to "Ballerina By Example"

### DIFF
--- a/.github/workflows/sw_update_ballerina_by_example.yml
+++ b/.github/workflows/sw_update_ballerina_by_example.yml
@@ -73,6 +73,6 @@ jobs:
       shell: bash
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -m '[Automated] Update Ballerina by examples(BBEs) pages for the new release'
+        bin/hub pull-request -m '[Automated] Update Ballerina By Example(BBEs) pages for the new release'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_ballerina_by_example.yml
+++ b/.github/workflows/update_ballerina_by_example.yml
@@ -1,4 +1,4 @@
-name: Create PR for new Ballerina by examples pages
+name: Create PR for new Ballerina By Example pages
 
 on:
   push:
@@ -75,7 +75,7 @@ jobs:
         git config --global user.name "ballerina-bot"
         
         git add 1.2/learn/by-example
-        git commit --allow-empty -m 'Update Ballerina by examples'
+        git commit --allow-empty -m 'Update Ballerina By Example'
         
         git push --set-upstream origin automate-bbes-$GITHUB_SHA
         echo 'Successfully pushed to automate-bbes-$GITHUB_SHA branch'
@@ -84,6 +84,6 @@ jobs:
       shell: bash
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -m '[Automated] Update Ballerina by examples(BBEs) pages for the new release'
+        bin/hub pull-request -m '[Automated] Update Ballerina By Example(BBEs) pages for the new release'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_ballerina_by_example_master.yml
+++ b/.github/workflows/update_ballerina_by_example_master.yml
@@ -65,6 +65,6 @@ jobs:
       shell: bash
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -b dev -m '[Automated] Update Ballerina by examples(BBEs) pages'
+        bin/hub pull-request -b dev -m '[Automated] Update Ballerina By Example(BBEs) pages'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_ballerina_by_example_on_demand.yml
+++ b/.github/workflows/update_ballerina_by_example_on_demand.yml
@@ -79,6 +79,6 @@ jobs:
       shell: bash
       run: |
         curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -m '[Automated] Update Ballerina by examples(BBEs) pages'
+        bin/hub pull-request -m '[Automated] Update Ballerina By Example(BBEs) pages'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/1.0/learn/quick-tour/index.html
+++ b/1.0/learn/quick-tour/index.html
@@ -379,7 +379,7 @@ public function main() returns error? {
 <p>Now, that you have taken Ballerina around for a quick tour, you can explore Ballerina more.</p>
 
 <ul>
-    <li>Go through <a href="/1.0/learn/by-example">Ballerina by Examples</a> to learn Ballerina incrementally with commented examples that cover every nuance of the syntax.</li>
+    <li>Go through <a href="/1.0/learn/by-example">Ballerina By Example</a> to learn Ballerina incrementally with commented examples that cover every nuance of the syntax.</li>
     <li>Star the <a href="https://github.com/ballerina-platform/ballerina-lang">Ballerina GitHub repo</a> and show appreciation to the Ballerina maintainers for their work. Also, watch the repo to keep track of Ballerina issues.<div class="cGitButtonContainer"><p data-button="iGitStarText">&quot;Star&quot;</p><p data-button="iGitWatchText">&quot;Watch&quot;</p></div></li>
     </ul>
 

--- a/1.1/learn/quick-tour/index.html
+++ b/1.1/learn/quick-tour/index.html
@@ -389,7 +389,7 @@ public function main() returns @tainted error? {
 <p>Now, that you have taken Ballerina around for a quick tour, you can explore Ballerina more.</p>
 
 <ul>
-  <li>Go through <a href="/1.1/learn/by-example">Ballerina by Examples</a> to learn Ballerina incrementally with commented examples that cover every nuance of the syntax.</li>
+  <li>Go through <a href="/1.1/learn/by-example">Ballerina By Example</a> to learn Ballerina incrementally with commented examples that cover every nuance of the syntax.</li>
   <li>Star the <a href="https://github.com/ballerina-platform/ballerina-lang">Ballerina GitHub repo</a> and show appreciation to the Ballerina maintainers for their work. Also, watch the repo to keep track of Ballerina issues.</li>
 </ul>
 <div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>

--- a/1.2/learn/by-example/index.html
+++ b/1.2/learn/by-example/index.html
@@ -361,8 +361,8 @@
                                 <div class="col-xs-12 cBBEtop">
 
                                     <!--<img src="/img/ballerina-bbe-logo.svg" style="margin-bottom: 34px;">-->
-                                    <h2>Ballerina by Examples</h2>
-                                    <p>Ballerina by Examples enables you to have complete coverage over the language, while emphasizing incremental learning. This is a series of commented example programs.</p>
+                                    <h2>Ballerina By Example</h2>
+                                    <p>Ballerina By Example enables you to have complete coverage over the language, while emphasizing incremental learning. This is a series of commented example programs.</p>
                                 </div>
                                 <div id="ballerina-by-example">
                                     <div class="cLanguageFeaturesContainer clearfix">

--- a/1.2/learn/index.html
+++ b/1.2/learn/index.html
@@ -6,7 +6,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-<meta name="description" content="Learn and master the Ballerina programming language through setting up, Ballerina by examples, the standard library or API documentation, and how to guides." />
+<meta name="description" content="Learn and master the Ballerina programming language through setting up, Ballerina by example, the standard library or API documentation, and how to guides." />
 
 <meta name="author" content="WSO2, Inc.">
 
@@ -20,7 +20,7 @@
 <meta property="og:type" content="article" />
 <meta property="og:title" content="Ballerina - Let’s learn Ballerina!" />
 
-<meta property="og:description" content="Learn and master the Ballerina programming language through setting up, Ballerina by examples, the standard library or API documentation, and how to guides." />
+<meta property="og:description" content="Learn and master the Ballerina programming language through setting up, Ballerina by example, the standard library or API documentation, and how to guides." />
 
  
 <meta property="og:image" itemprop="image" content="https://ballerina.io/img/ballerina-sm-2.jpg" />
@@ -29,7 +29,7 @@
 <!--LINKED IN  -->
 <meta property='og:title' content="Ballerina"/>
 <meta property='og:image' content="https://ballerina.io/img/ballerina-sm-2.jpg"/>
-<meta property='og:description' itemprop="image" content="Learn and master the Ballerina programming language through setting up, Ballerina by examples, the standard library or API documentation, and how to guides."/>
+<meta property='og:description' itemprop="image" content="Learn and master the Ballerina programming language through setting up, Ballerina by example, the standard library or API documentation, and how to guides."/>
 
 <!--TWITTER-->
 <meta name="twitter:card" content="summary" />
@@ -38,11 +38,11 @@
 <meta name="twitter:title" content="Ballerina"> 
 <meta name="twitter:card" content="summary_large_image"> 
 
-<meta property="twitter:description" content="Learn and master the Ballerina programming language through setting up, Ballerina by examples, the standard library or API documentation, and how to guides." />
+<meta property="twitter:description" content="Learn and master the Ballerina programming language through setting up, Ballerina By Example, the standard library or API documentation, and how to guides." />
 
 <meta name="twitter:image" content="https://ballerina.io/img/ballerina-sm-2.jpg ">
 
-<meta property="twitter:text:description" content="Learn and master the Ballerina programming language through setting up, Ballerina by examples, the standard library or API documentation, and how to guides." />
+<meta property="twitter:text:description" content="Learn and master the Ballerina programming language through setting up, Ballerina By Example, the standard library or API documentation, and how to guides." />
 
 <meta property='twitter:image' content="https://ballerina.io/img/ballerina-sm-2.jpg"/>
 
@@ -386,10 +386,10 @@
 
 <div class="col-sm-6 col-md-6 cLearnPageContentCol">
 <h2>Take Ballerina for a Spin</h2>
-    <p>Try out the Ballerina By Examples and use the Playground.</p>
+    <p>Try out the Ballerina By Example and use the Playground.</p>
 
    <ul class="cLearnLandingLinks">
-   <li><a href="/1.2/learn/by-example" class="cGreenLinkArrow">Ballerina By Examples</a></li>
+   <li><a href="/1.2/learn/by-example" class="cGreenLinkArrow">Ballerina By Example</a></li>
      <li><a href="https://play.ballerina.io/" class="cGreenLinkArrow">Try Ballerina</a></li>
    </ul>
 

--- a/1.2/learn/quick-tour/index.html
+++ b/1.2/learn/quick-tour/index.html
@@ -525,7 +525,7 @@ public function main() returns @tainted error? {
 <p>Now, that you have taken Ballerina around for a quick tour, you can explore Ballerina more.</p>
 
 <ul>
-  <li>Go through the <a href="/1.2/learn/by-example">Ballerina by Examples</a> to learn Ballerina incrementally with commented examples that cover every nuance of the syntax.</li>
+  <li>Go through the <a href="/1.2/learn/by-example">Ballerina By Example</a> to learn Ballerina incrementally with commented examples that cover every nuance of the syntax.</li>
   <li>Star the <a href="https://github.com/ballerina-platform/ballerina-lang">Ballerina GitHub repo</a> and show appreciation to the Ballerina maintainers for their work. Also, watch the repo to keep track of Ballerina issues.</li>
 </ul>
 <div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>

--- a/_data/helloworldnavswanlake.yml
+++ b/_data/helloworldnavswanlake.yml
@@ -5,23 +5,20 @@
       url: /learn/hello-world/writing-your-first-ballerina-program/
       sublinks:
         - title: Writing a Simple Service
-          url: /learn/hello-world/writing-a-simple-service/
+          url: /learn/hello-world/writing-your-first-ballerina-program/#writing-a-simple-service/
           active: writing-a-simple-service
         - title: Creating an HTTP Client to Invoke the Service
-          url: /learn/hello-world/creating-an-http-client-to-invoke-the-service/
+          url: /learn/hello-world/writing-your-first-ballerina-program/#creating-an-http-client-to-invoke-the-service/
           active: creating-an-http-client-to-invoke-the-service
-        - title: What’s Next?e
-          url: /learn/hello-world/whats-next
-          active: whats-next
     - title: Creating Your First Ballerina Package
       url: /learn/hello-world/creating-your-first-ballerina-package/
       sublinks:
         - title: Creating the Package
-          url: /learn/hello-world/creating-the-package/
+          url: /learn/hello-world/creating-your-first-ballerina-package/#creating-the-package/
           active: creating-the-package 
         - title: Building the Package
-          url: /learn/hello-world/building-the-package/
+          url: /learn/hello-world/creating-your-first-ballerina-package/#building-the-package/
           active: building-the-package 
         - title: Running the Package
-          url: /learn/hello-world/running-the-package/
+          url: /learn/hello-world/creating-your-first-ballerina-package/#running-the-package/
           active: running-the-package 

--- a/community.md
+++ b/community.md
@@ -432,9 +432,9 @@ body {font-family: Arial;}
          <p class="cEventLocation">Online</p>
       </td>
       <td class="cEventDetail">
-         <a target="_blank" href="https://www.meetup.com/CloudDC/">
+         <!-- <a target="_blank" href="https://www.meetup.com/CloudDC/"> -->
             <h4>Cloud DC Meetup</h4>
-         </a>
+         <!-- </a> -->
          <h5>Cloud Native Development with Ballerina</h5>
          <b>Jadd Jennings,</b> Hub Solutions Engineer, Oracle Cloud Solution Hub<br/>
          <b>Dhvani Sheth,</b> Senior Solutions Engineer, Oracle

--- a/community/newsletter/2021-2.md
+++ b/community/newsletter/2021-2.md
@@ -164,7 +164,7 @@ permalink: /community/newsletter/2021-2/
                                         style="color: #20b6af; text-decoration: underline;"
                                         target="_blank"
                                     >
-                                        Ballerina by Examples</a>
+                                        Ballerina by Example</a>
                                     (BBEs) was the first to go through a complete overhaul. It’s a collection of code examples that illustrate important Ballerina features and concepts. If you are new to Ballerina and learn better from
                                     examples, our new and improved
                                     <a

--- a/home.html
+++ b/home.html
@@ -36,7 +36,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          <div class="col-sm-12 col-md-7">
            <ul>
                <li><a class="cIconLink" href="">Quick Tour</a></li>
-               <li><a class="cIconLink" href="">Ballerina by Examples</a></li>
+               <li><a class="cIconLink" href="">Ballerina By Example</a></li>
             </ul>
          </div>
          </div> -->

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
 
    <ul>
      
-      <li style="margin: 0;"><a class="cIconLink" href="/learn/by-example/introduction/" target="_blank">Ballerina by Examples</a></li>
+      <li style="margin: 0;"><a class="cIconLink" href="/learn/by-example/introduction/" target="_blank">Ballerina By Example</a></li>
       <li ><a class="cIconLink" href="/learn/user-guide/getting-started/">Get Started</a></li>
       
       </ul>

--- a/learn/by-example/cache-basics.html
+++ b/learn/by-example/cache-basics.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Cache Basics
 description: This BBE shows how to perform basic in-memory caching operations with the "Least Recently Used" algorithm in Ballerina.
-keywords: ballerina, ballerina by examples, BBE, cache, put, get, size, hasKey
+keywords: ballerina, Ballerina By Example, BBE, cache, put, get, size, hasKey
 permalink: /learn/by-example/cache-basics
 active: cache-basics
 redirect_from:

--- a/learn/by-example/cache-invalidation.html
+++ b/learn/by-example/cache-invalidation.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Cache Invalidation
 description: This BBE shows how to perform an in-memory caching invalidate operation with the "Least Recently Used" algorithm in Ballerina.
-keywords: ballerina, ballerina by examples, BBE, cache, put, hasKey, invalidate, invalidateAll
+keywords: ballerina, Ballerina By Example, BBE, cache, put, hasKey, invalidate, invalidateAll
 permalink: /learn/by-example/cache-invalidation
 active: cache-invalidation
 redirect_from:

--- a/learn/by-example/directories.html
+++ b/learn/by-example/directories.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Directories
 description: This BBE shows how to perform directory operations in Ballerina.
-keywords: ballerina, ballerina by examples, BBE, directory, file, path
+keywords: ballerina, Ballerina By Example, BBE, directory, file, path
 permalink: /learn/by-example/directories
 active: directories
 redirect_from:

--- a/learn/by-example/environment-variables.html
+++ b/learn/by-example/environment-variables.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Environment Variables
 description: BBE on how to to retrieve information about the OS.
-keywords: ballerina, ballerina by examples, BBE, OS, environment
+keywords: ballerina, Ballerina By Example, BBE, OS, environment
 permalink: /learn/by-example/environment-variables
 active: environment-variables
 redirect_from:

--- a/learn/by-example/filepaths.html
+++ b/learn/by-example/filepaths.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: File Paths
 description: This BBE shows how to manipulate file paths in a way that is compatible with the target Operating System in Ballerina.
-keywords: ballerina, ballerina by examples, BBE, file, directory, path, filepath
+keywords: ballerina, Ballerina By Example, BBE, file, directory, path, filepath
 permalink: /learn/by-example/filepaths
 active: filepaths
 redirect_from:

--- a/learn/by-example/files.html
+++ b/learn/by-example/files.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Files
 description: This BBE shows how to perform file-system operations in Ballerina.
-keywords: ballerina, ballerina by examples, BBE, file, path
+keywords: ballerina, Ballerina By Example, BBE, file, path
 permalink: /learn/by-example/files
 active: files
 redirect_from:

--- a/learn/by-example/http-1-1-to-2-0-protocol-switch.html
+++ b/learn/by-example/http-1-1-to-2-0-protocol-switch.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: HTTP 1.1 to 2.0 Protocol Switch
 description: This BBE shows how the Ballerina HTTP service receives a message over the HTTP/1.1 protocol and forwards it to another service over the HTTP/2.0 protocol.
-keywords: ballerina, ballerina by examples, bbe, http, http/1.1, http/2.0, http/2
+keywords: ballerina, Ballerina By Example, bbe, http, http/1.1, http/2.0, http/2
 permalink: /learn/by-example/http-1-1-to-2-0-protocol-switch
 active: http-1-1-to-2-0-protocol-switch
 redirect_from:

--- a/learn/by-example/http-2-0-server-push.html
+++ b/learn/by-example/http-2-0-server-push.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: HTTP 2.0 Server Push
 description: This BBE demonstrates sending and receiving HTTP/2 Server Push messages in Ballerina HTTP Library.
-keywords: ballerina, ballerina by examples, bbe, http, http/2.0, http/2
+keywords: ballerina, Ballerina By Example, bbe, http, http/2.0, http/2
 permalink: /learn/by-example/http-2-0-server-push
 active: http-2-0-server-push
 redirect_from:

--- a/learn/by-example/http-circuit-breaker.html
+++ b/learn/by-example/http-circuit-breaker.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Circuit Breaker
 description: BBE on how to use an HTTP circuit breaker in Ballerina. This will allow to handle requests when a backend is failing.
-keywords: ballerina, ballerina by examples, bbe, http, resiliency, circuit breaker, circuit break
+keywords: ballerina, Ballerina By Example, bbe, http, resiliency, circuit breaker, circuit break
 permalink: /learn/by-example/http-circuit-breaker
 active: http-circuit-breaker
 redirect_from:

--- a/learn/by-example/http-client-endpoint.html
+++ b/learn/by-example/http-client-endpoint.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Client
 description: BBE on how to interact with an HTTP server using Ballerina HTTP Client Connector.
-keywords: ballerina, ballerina by examples, bbe, http, client
+keywords: ballerina, Ballerina By Example, bbe, http, client
 permalink: /learn/by-example/http-client-endpoint
 active: http-client-endpoint
 redirect_from:

--- a/learn/by-example/http-failover.html
+++ b/learn/by-example/http-failover.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Failover
 description: BBE on how to use an HTTP failover client in Ballerina. The Failover client can be used to handle network-related issues gracefully.
-keywords: ballerina, ballerina by examples, bbe, http, resiliency, failover
+keywords: ballerina, Ballerina By Example, bbe, http, resiliency, failover
 permalink: /learn/by-example/http-failover
 active: http-failover
 redirect_from:

--- a/learn/by-example/http-load-balancer.html
+++ b/learn/by-example/http-load-balancer.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Load Balancer
 description: BBE on how to use an HTTP load balancer in Ballerina. This will allow to balance the load of an endpoint using a given algorithm to select the endpoint.
-keywords: ballerina, ballerina by examples, bbe, http, resiliency, load balancer, load balance
+keywords: ballerina, Ballerina By Example, bbe, http, resiliency, load balancer, load balance
 permalink: /learn/by-example/http-load-balancer
 active: http-load-balancer
 redirect_from:

--- a/learn/by-example/http-retry.html
+++ b/learn/by-example/http-retry.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Retry
 description: BBE on how to use an HTTP retry in Ballerina. The retry client can be used to automatically retry when an erroneous response is received.
-keywords: ballerina, ballerina by examples, bbe, http, resiliency, retry
+keywords: ballerina, Ballerina By Example, bbe, http, resiliency, retry
 permalink: /learn/by-example/http-retry
 active: http-retry
 redirect_from:

--- a/learn/by-example/http-timeout.html
+++ b/learn/by-example/http-timeout.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Timeout
 description: BBE on how to use an HTTP timeout in Ballerina. This will set a timeout for the requests to get a response and will return an error if a response is not returned within the given timeout.
-keywords: ballerina, ballerina by examples, bbe, http, resiliency, timeout
+keywords: ballerina, Ballerina By Example, bbe, http, resiliency, timeout
 permalink: /learn/by-example/http-timeout
 active: http-timeout
 redirect_from:

--- a/learn/by-example/io-bytes.html
+++ b/learn/by-example/io-bytes.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Read/Write Bytes
 description: BBE on how to read/write from/to a bytes file.
-keywords: ballerina, ballerina by examples, bbe, bytes
+keywords: ballerina, Ballerina By Example, bbe, bytes
 permalink: /learn/by-example/io-bytes
 active: io-bytes
 redirect_from:

--- a/learn/by-example/io-csv.html
+++ b/learn/by-example/io-csv.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Read/Write CSV
 description: BBE on how to read/write from/to a CSV file.
-keywords: ballerina, ballerina by examples, bbe, csv, table
+keywords: ballerina, Ballerina By Example, bbe, csv, table
 permalink: /learn/by-example/io-csv
 active: io-csv
 redirect_from:

--- a/learn/by-example/io-json.html
+++ b/learn/by-example/io-json.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Read/Write JSON
 description: BBE on how to read/write from/to a JSON file.
-keywords: ballerina, ballerina by examples, bbe, json
+keywords: ballerina, Ballerina By Example, bbe, json
 permalink: /learn/by-example/io-json
 active: io-json
 redirect_from:

--- a/learn/by-example/io-strings.html
+++ b/learn/by-example/io-strings.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Read/Write Strings
 description: BBE on how to read/write from/to a text file.
-keywords: ballerina, ballerina by examples, bbe, text, strings
+keywords: ballerina, Ballerina By Example, bbe, text, strings
 permalink: /learn/by-example/io-strings
 active: io-strings
 redirect_from:

--- a/learn/by-example/io-xml.html
+++ b/learn/by-example/io-xml.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Read/Write XML
 description: BBE on how to read/write from/to an XML file.
-keywords: ballerina, ballerina by examples, bbe, xml
+keywords: ballerina, Ballerina By Example, bbe, xml
 permalink: /learn/by-example/io-xml
 active: io-xml
 redirect_from:

--- a/learn/by-example/logging-configuration.html
+++ b/learn/by-example/logging-configuration.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Configure Logging
 description: BBE on how to configure Ballerina logging.
-keywords: ballerina, ballerina by examples, bbe, log, level, format
+keywords: ballerina, Ballerina By Example, bbe, log, level, format
 permalink: /learn/by-example/logging-configuration
 active: logging-configuration
 redirect_from:

--- a/learn/by-example/logging-with-context.html
+++ b/learn/by-example/logging-with-context.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Logging with Context
 description: BBE on how to log messages in Ballerina with context values.
-keywords: ballerina, ballerina by examples, bbe, log, function pointer, context, dynamic
+keywords: ballerina, Ballerina By Example, bbe, log, function pointer, context, dynamic
 permalink: /learn/by-example/logging-with-context
 active: logging-with-context
 redirect_from:

--- a/learn/by-example/logging.html
+++ b/learn/by-example/logging.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Logging
 description: BBE on how to log messages in Ballerina at different log levels including 'DEBUG', 'ERROR', 'INFO', and 'WARN'.
-keywords: ballerina, ballerina by examples, bbe, log, level
+keywords: ballerina, Ballerina By Example, bbe, log, level
 permalink: /learn/by-example/logging
 active: logging
 redirect_from:

--- a/learn/by-example/random-numbers.html
+++ b/learn/by-example/random-numbers.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Random Numbers
 description: BBE on how to to generate random numbers.
-keywords: ballerina, ballerina by examples, bbe, random
+keywords: ballerina, Ballerina By Example, bbe, random
 permalink: /learn/by-example/random-numbers
 active: random-numbers
 redirect_from:

--- a/learn/by-example/task-frequency-job-execution.html
+++ b/learn/by-example/task-frequency-job-execution.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Schedule Job recurrence by Frequency
 description: BBE on how to schedule the frequency job execution in Ballerina.
-keywords: ballerina, ballerina by examples, BBE, task, job, scheduler
+keywords: ballerina, Ballerina By Example, BBE, task, job, scheduler
 permalink: /learn/by-example/task-frequency-job-execution
 active: task-frequency-job-execution
 redirect_from:

--- a/learn/by-example/task-one-time-job-execution.html
+++ b/learn/by-example/task-one-time-job-execution.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Schedule one time job
 description: BBE on how to schedule a one-time job execution in Ballerina.
-keywords: ballerina, ballerina by examples, BBE, task, job, scheduler
+keywords: ballerina, Ballerina By Example, BBE, task, job, scheduler
 permalink: /learn/by-example/task-one-time-job-execution
 active: task-one-time-job-execution
 redirect_from:

--- a/learn/by-example/temp-files-directories.html
+++ b/learn/by-example/temp-files-directories.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Temp Files and Directories
 description: This BBE shows how to perform file-system operations in Ballerina.
-keywords: ballerina, ballerina by examples, BBE, file, path, temp
+keywords: ballerina, Ballerina By Example, BBE, file, path, temp
 permalink: /learn/by-example/temp-files-directories
 active: temp-files-directories
 redirect_from:

--- a/learn/by-example/time-formatting-and-parsing.html
+++ b/learn/by-example/time-formatting-and-parsing.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Time formatting/Parsing
 description: BBE on how to format and parse UTC and Civil values to different RFC formats.
-keywords: ballerina, ballerina by examples, bbe, time, utc, rfc3339, rfc5322
+keywords: ballerina, Ballerina By Example, bbe, time, utc, rfc3339, rfc5322
 permalink: /learn/by-example/time-formatting-and-parsing
 active: time-formatting-and-parsing
 redirect_from:

--- a/learn/by-example/time-utc-and-civil.html
+++ b/learn/by-example/time-utc-and-civil.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Time with Zone Offset
 description: BBE on how to convert a given UTC time to a civil record vice versa.
-keywords: ballerina, ballerina by examples, bbe, time, utc, civil
+keywords: ballerina, Ballerina By Example, bbe, time, utc, civil
 permalink: /learn/by-example/time-utc-and-civil
 active: time-utc-and-civil
 redirect_from:

--- a/learn/by-example/time-utc.html
+++ b/learn/by-example/time-utc.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: UTC Time
 description: BBE on how to get the current timestamp in seconds.
-keywords: ballerina, ballerina by examples, bbe, time, current, epoch, utc
+keywords: ballerina, Ballerina By Example, bbe, time, current, epoch, utc
 permalink: /learn/by-example/time-utc
 active: time-utc
 redirect_from:

--- a/learn/by-example/uuid-generation.html
+++ b/learn/by-example/uuid-generation.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: Generate UUID
 description: BBE on how to to generate different types of UUIDs.
-keywords: ballerina, ballerina by examples, bbe, uuid, type
+keywords: ballerina, Ballerina By Example, bbe, uuid, type
 permalink: /learn/by-example/uuid-generation
 active: uuid-generation
 redirect_from:

--- a/learn/by-example/uuid-operations.html
+++ b/learn/by-example/uuid-operations.html
@@ -2,7 +2,7 @@
 layout: ballerina-example-page
 title: UUID Operations
 description: BBE on how to to perform operations on UUIDs.
-keywords: ballerina, ballerina by examples, bbe, uuid, version, validation, string, record, bytes
+keywords: ballerina, Ballerina By Example, bbe, uuid, version, validation, string, record, bytes
 permalink: /learn/by-example/uuid-operations
 active: uuid-operations
 redirect_from:

--- a/learn/getting-started/hello-world/writing-your-first-ballerina-program.md
+++ b/learn/getting-started/hello-world/writing-your-first-ballerina-program.md
@@ -126,8 +126,4 @@ bal run hello_client.bal
 Hello Ballerina!
 ```
 
-## What's Next?
-
-Now, that you have written your first Ballerina program, you can explore more about writing [Ballerina Packages](/learn/user-guide/ballerina-packages/creating-your-first-ballerina-package/).
-
 <style> #tree-expand-all, #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/learn/guides/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda.md
+++ b/learn/guides/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda.md
@@ -15,6 +15,8 @@ redirect_from:
   - /learn/user-guide/deployment/aws-lambda
   - /learn/user-guide/deployment/aws-lambda/
   - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda
+  - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/
+  - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina
 ---
 
 Exposing a Ballerina function as an AWS Lambda function is done by importing the `ballerinax/awslambda` module and simply annotating the Ballerina function with the `awslambda:Function` annotation. Also, the Ballerina function must have the following signature: `function (awslambda:Context, json) returns json|error`. 

--- a/license-of-site.md
+++ b/license-of-site.md
@@ -43,7 +43,7 @@ If you produce non-hypertext works, such as books, audio, or video, we ask that 
 ### Ballerina Website Attributions
 In the creation of this website, we used the following Creative Commons Attribution license: 
 
-* [Ballerina by Examples](https://ballerina.io/learn/by-example/) sample pages are generated using a [tool](https://github.com/mmcgrana/gobyexample/) developed by [mmcgrana](https://github.com/mmcgrana), licensed under [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/) and modified from the original.
+* [Ballerina by Example](https://ballerina.io/learn/by-example/) sample pages are generated using a [tool](https://github.com/mmcgrana/gobyexample/) developed by [mmcgrana](https://github.com/mmcgrana), licensed under [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/) and modified from the original.
 
 ## Contact
 If you have any comments regarding Ballerina.io license policies, please send feedback to [legal@wso2.com](mailto:legal@wso2.com).


### PR DESCRIPTION
## Purpose
Fix broken links & rename "Ballerina By Examples" to "Ballerina By Example".
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
