### PR TITLE
Add the "Security Advisories" Section to the "Security Policy" Page

### DIFF
--- a/security-policy.md
+++ b/security-policy.md
@@ -51,9 +51,13 @@ Your efforts in reporting vulnerabilities or any other issues related to the sec
 
 >**Note:** The reward program is currently applicable to vulnerabilities reported only in the compiler, runtime, CLI tooling, standard library, VS Code plugin and,  [website](https://ballerina.io).
 
-## Publishing Security Advisories
+## Security Advisories
 
-For the Ballerina security advisories that are already published, see [Security Advisories](https://github.com/ballerina-platform/ballerina-lang/security/advisories).
+The below are the Ballerina security advisories that are already published.
+
+### Compiler, Runtime, and CLI Tooling
+
+- [CVE-2021-32700](https://github.com/ballerina-platform/ballerina-lang/security/advisories/GHSA-f5qg-fqrw-v5ww)
 
 <style>
 .nav > li.cVersionItem {

--- a/security-policy.md
+++ b/security-policy.md
@@ -51,6 +51,10 @@ Your efforts in reporting vulnerabilities or any other issues related to the sec
 
 >**Note:** The reward program is currently applicable to vulnerabilities reported only in the compiler, runtime, CLI tooling, standard library, VS Code plugin and,  [website](https://ballerina.io).
 
+## Publishing Security Advisories
+
+For the Ballerina security advisories that are already published, see [Security Advisories](https://github.com/ballerina-platform/ballerina-lang/security/advisories).
+
 <style>
 .nav > li.cVersionItem {
     display: none !important;


### PR DESCRIPTION
## Purpose
Add the "Security Advisories" section to the "Security Policy" page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
