### PR TITLE
Fix the typos on the "Why Ballerina" Pages

### DIFF
--- a/learn/why-ballerina/concurrent.md
+++ b/learn/why-ballerina/concurrent.md
@@ -6,7 +6,7 @@ keywords: ballerina, ballerina platform, api documentation, testing, ide, baller
 permalink: /why-ballerina/concurrent/
 active: concurrent
 intro: Concurrency in Ballerina is enabled by strands, which are lightweight threads.
-redirct_from:
+redirect_from:
   - /learn/user-guide/why-ballerina/concurrent
   - /learn/user-guide/why-ballerina/concurrent/
   - /learn/why-ballerina/concurrent

--- a/learn/why-ballerina/reliable-maintainable.md
+++ b/learn/why-ballerina/reliable-maintainable.md
@@ -6,7 +6,7 @@ keywords: ballerina, ballerina platform, api documentation, testing, ide, baller
 permalink: /why-ballerina/reliable-maintainable/
 active: reliable-maintainable
 intro: The sections below explain how the explicit error handling, static types, and concurrency safety combined with a familiar, readable syntax make programs reliable and maintainable. 
-redirct_from:
+redirect_from:
   - /learn/user-guide/why-ballerina/reliable-and-maintainable/
   - /learn/user-guide/why-ballerina/reliable-maintainable
   - /learn/why-ballerina/reliable-maintainable


### PR DESCRIPTION
## Purpose
Fix the typos on the Why Ballerina pages.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
