### PR TITLE
Block Content of Old Doc Versions in Google Search Results

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -10,3 +10,4 @@ Disallow: /1.1/
 
 User-agent: Algolia Crawler
 Allow: * 
+     

--- a/robots.txt
+++ b/robots.txt
@@ -2,3 +2,6 @@ User-Agent: *
 Allow: /
 User-agent: Twitterbot
 Allow: *  
+User-agent: *
+Disallow: /1.0/
+Disallow: /1.1/

--- a/robots.txt
+++ b/robots.txt
@@ -1,7 +1,12 @@
-User-Agent: *	
+User-agent: *	
 Allow: /
+
 User-agent: Twitterbot
-Allow: *  
+Allow: * 
+
 User-agent: *
 Disallow: /1.0/
 Disallow: /1.1/
+
+User-agent: Algolia Crawler
+Allow: * 


### PR DESCRIPTION
## Purpose
Block content of old doc versions in Google search results.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
