### PR TITLE
Add the Banner for Old Doc Versions

### DIFF
--- a/1.2/learn/by-example/abstract-objects.html
+++ b/1.2/learn/by-example/abstract-objects.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/access-mutate-java-fields.html
+++ b/1.2/learn/by-example/access-mutate-java-fields.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anonymous-functions.html
+++ b/1.2/learn/by-example/anonymous-functions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anonymous-objects.html
+++ b/1.2/learn/by-example/anonymous-objects.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anonymous-records.html
+++ b/1.2/learn/by-example/anonymous-records.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/any-type.html
+++ b/1.2/learn/by-example/any-type.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anydata-type.html
+++ b/1.2/learn/by-example/anydata-type.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/arrays.html
+++ b/1.2/learn/by-example/arrays.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/async.html
+++ b/1.2/learn/by-example/async.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/aws-lambda-deployment.html
+++ b/1.2/learn/by-example/aws-lambda-deployment.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/azure-functions-deployment.html
+++ b/1.2/learn/by-example/azure-functions-deployment.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/ballerina-to-openapi.html
+++ b/1.2/learn/by-example/ballerina-to-openapi.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/base-path-and-path.html
+++ b/1.2/learn/by-example/base-path-and-path.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/basic-documentation.html
+++ b/1.2/learn/by-example/basic-documentation.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/basic-https-listener-client.html
+++ b/1.2/learn/by-example/basic-https-listener-client.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/binary-bitwise-expressions.html
+++ b/1.2/learn/by-example/binary-bitwise-expressions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/byte-io.html
+++ b/1.2/learn/by-example/byte-io.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/byte-type.html
+++ b/1.2/learn/by-example/byte-type.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/cache.html
+++ b/1.2/learn/by-example/cache.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/character-io.html
+++ b/1.2/learn/by-example/character-io.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/check.html
+++ b/1.2/learn/by-example/check.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/checkpanic.html
+++ b/1.2/learn/by-example/checkpanic.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/client-generation.html
+++ b/1.2/learn/by-example/client-generation.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/clone.html
+++ b/1.2/learn/by-example/clone.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/closures.html
+++ b/1.2/learn/by-example/closures.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/compound-assignment-operators.html
+++ b/1.2/learn/by-example/compound-assignment-operators.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/config-api.html
+++ b/1.2/learn/by-example/config-api.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/constants.html
+++ b/1.2/learn/by-example/constants.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/content-based-routing.html
+++ b/1.2/learn/by-example/content-based-routing.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/counter-metrics.html
+++ b/1.2/learn/by-example/counter-metrics.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/create-java-objects.html
+++ b/1.2/learn/by-example/create-java-objects.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/crypto.html
+++ b/1.2/learn/by-example/crypto.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/csv-io.html
+++ b/1.2/learn/by-example/csv-io.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/data-io.html
+++ b/1.2/learn/by-example/data-io.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/deprecation.html
+++ b/1.2/learn/by-example/deprecation.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/different-payload-types.html
+++ b/1.2/learn/by-example/different-payload-types.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/directory-listener.html
+++ b/1.2/learn/by-example/directory-listener.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/docker-deployment.html
+++ b/1.2/learn/by-example/docker-deployment.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/elvis-operator.html
+++ b/1.2/learn/by-example/elvis-operator.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/equality.html
+++ b/1.2/learn/by-example/equality.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-destructure-binding-pattern.html
+++ b/1.2/learn/by-example/error-destructure-binding-pattern.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-handling.html
+++ b/1.2/learn/by-example/error-handling.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-match-statement.html
+++ b/1.2/learn/by-example/error-match-statement.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-typed-binding-pattern.html
+++ b/1.2/learn/by-example/error-typed-binding-pattern.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/expression-bodied-functions.html
+++ b/1.2/learn/by-example/expression-bodied-functions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/file.html
+++ b/1.2/learn/by-example/file.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/filepath.html
+++ b/1.2/learn/by-example/filepath.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/foreach.html
+++ b/1.2/learn/by-example/foreach.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/fork-variable-access.html
+++ b/1.2/learn/by-example/fork-variable-access.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/fork.html
+++ b/1.2/learn/by-example/fork.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/function-pointers.html
+++ b/1.2/learn/by-example/function-pointers.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functional-iteration.html
+++ b/1.2/learn/by-example/functional-iteration.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions-with-defaultable-parameters.html
+++ b/1.2/learn/by-example/functions-with-defaultable-parameters.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions-with-required-parameters.html
+++ b/1.2/learn/by-example/functions-with-required-parameters.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions-with-rest-parameter.html
+++ b/1.2/learn/by-example/functions-with-rest-parameter.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions.html
+++ b/1.2/learn/by-example/functions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/gauge-metrics.html
+++ b/1.2/learn/by-example/gauge-metrics.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-bidirectional-streaming.html
+++ b/1.2/learn/by-example/grpc-bidirectional-streaming.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-client-streaming.html
+++ b/1.2/learn/by-example/grpc-client-streaming.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-secured-unary.html
+++ b/1.2/learn/by-example/grpc-secured-unary.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-server-streaming.html
+++ b/1.2/learn/by-example/grpc-server-streaming.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-unary-blocking.html
+++ b/1.2/learn/by-example/grpc-unary-blocking.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-unary-non-blocking.html
+++ b/1.2/learn/by-example/grpc-unary-non-blocking.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/header-based-routing.html
+++ b/1.2/learn/by-example/header-based-routing.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world-client.html
+++ b/1.2/learn/by-example/hello-world-client.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world-parallel.html
+++ b/1.2/learn/by-example/hello-world-parallel.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world-service.html
+++ b/1.2/learn/by-example/hello-world-service.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world.html
+++ b/1.2/learn/by-example/hello-world.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-1-1-to-2-0-protocol-switch.html
+++ b/1.2/learn/by-example/http-1-1-to-2-0-protocol-switch.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-100-continue.html
+++ b/1.2/learn/by-example/http-100-continue.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-2-0-server-push.html
+++ b/1.2/learn/by-example/http-2-0-server-push.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-access-logs.html
+++ b/1.2/learn/by-example/http-access-logs.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-caching-client.html
+++ b/1.2/learn/by-example/http-caching-client.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-circuit-breaker.html
+++ b/1.2/learn/by-example/http-circuit-breaker.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-client-endpoint.html
+++ b/1.2/learn/by-example/http-client-endpoint.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-compression.html
+++ b/1.2/learn/by-example/http-compression.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-cookies.html
+++ b/1.2/learn/by-example/http-cookies.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-cors.html
+++ b/1.2/learn/by-example/http-cors.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-data-binding.html
+++ b/1.2/learn/by-example/http-data-binding.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-disable-chunking.html
+++ b/1.2/learn/by-example/http-disable-chunking.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-failover.html
+++ b/1.2/learn/by-example/http-failover.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-filters.html
+++ b/1.2/learn/by-example/http-filters.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-load-balancer.html
+++ b/1.2/learn/by-example/http-load-balancer.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-redirects.html
+++ b/1.2/learn/by-example/http-redirects.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-retry.html
+++ b/1.2/learn/by-example/http-retry.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-streaming.html
+++ b/1.2/learn/by-example/http-streaming.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-timeout.html
+++ b/1.2/learn/by-example/http-timeout.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-to-websocket-upgrade.html
+++ b/1.2/learn/by-example/http-to-websocket-upgrade.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-trace-logs.html
+++ b/1.2/learn/by-example/http-trace-logs.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/https-listener.html
+++ b/1.2/learn/by-example/https-listener.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/if-else.html
+++ b/1.2/learn/by-example/if-else.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/immutable-values.html
+++ b/1.2/learn/by-example/immutable-values.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/index.html
+++ b/1.2/learn/by-example/index.html
@@ -158,9 +158,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/invoke-java-methods.html
+++ b/1.2/learn/by-example/invoke-java-methods.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/iterable-objects.html
+++ b/1.2/learn/by-example/iterable-objects.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/java-arrays.html
+++ b/1.2/learn/by-example/java-arrays.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/java-exceptions.html
+++ b/1.2/learn/by-example/java-exceptions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/java-varargs.html
+++ b/1.2/learn/by-example/java-varargs.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-client-batch-update.html
+++ b/1.2/learn/by-example/jdbc-client-batch-update.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-client-call-procedures.html
+++ b/1.2/learn/by-example/jdbc-client-call-procedures.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-client-crud-operations.html
+++ b/1.2/learn/by-example/jdbc-client-crud-operations.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-streaming-big-dataset.html
+++ b/1.2/learn/by-example/jdbc-streaming-big-dataset.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-complex-type-queries.html
+++ b/1.2/learn/by-example/jdbc2-complex-type-queries.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-execute-operation.html
+++ b/1.2/learn/by-example/jdbc2-execute-operation.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-init-options.html
+++ b/1.2/learn/by-example/jdbc2-init-options.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-query-operation.html
+++ b/1.2/learn/by-example/jdbc2-query-operation.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-access.html
+++ b/1.2/learn/by-example/json-access.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-arrays.html
+++ b/1.2/learn/by-example/json-arrays.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-csv.html
+++ b/1.2/learn/by-example/json-csv.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-io.html
+++ b/1.2/learn/by-example/json-io.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-objects.html
+++ b/1.2/learn/by-example/json-objects.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-record-map-conversion.html
+++ b/1.2/learn/by-example/json-record-map-conversion.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-to-xml-conversion.html
+++ b/1.2/learn/by-example/json-to-xml-conversion.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json.html
+++ b/1.2/learn/by-example/json.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jwt-issue-validate.html
+++ b/1.2/learn/by-example/jwt-issue-validate.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-authentication-sasl-plain-consumer.html
+++ b/1.2/learn/by-example/kafka-authentication-sasl-plain-consumer.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-authentication-sasl-plain-producer.html
+++ b/1.2/learn/by-example/kafka-authentication-sasl-plain-producer.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-consumer-client.html
+++ b/1.2/learn/by-example/kafka-consumer-client.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-consumer-service.html
+++ b/1.2/learn/by-example/kafka-consumer-service.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-group-service.html
+++ b/1.2/learn/by-example/kafka-group-service.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-producer-transactional.html
+++ b/1.2/learn/by-example/kafka-producer-transactional.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-producer.html
+++ b/1.2/learn/by-example/kafka-producer.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/knative-deployment.html
+++ b/1.2/learn/by-example/knative-deployment.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kubernetes-deployment.html
+++ b/1.2/learn/by-example/kubernetes-deployment.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/length.html
+++ b/1.2/learn/by-example/length.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/let-expression.html
+++ b/1.2/learn/by-example/let-expression.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/local-transactions-with-participants.html
+++ b/1.2/learn/by-example/local-transactions-with-participants.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/local-transactions.html
+++ b/1.2/learn/by-example/local-transactions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/locks.html
+++ b/1.2/learn/by-example/locks.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/log-api.html
+++ b/1.2/learn/by-example/log-api.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/maps.html
+++ b/1.2/learn/by-example/maps.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/match.html
+++ b/1.2/learn/by-example/match.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/math-functions.html
+++ b/1.2/learn/by-example/math-functions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/modules.html
+++ b/1.2/learn/by-example/modules.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mutual-ssl.html
+++ b/1.2/learn/by-example/mutual-ssl.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-complex-type-queries.html
+++ b/1.2/learn/by-example/mysql-complex-type-queries.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-execute-operation.html
+++ b/1.2/learn/by-example/mysql-execute-operation.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-init-options.html
+++ b/1.2/learn/by-example/mysql-init-options.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-query-operation.html
+++ b/1.2/learn/by-example/mysql-query-operation.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-basic-client.html
+++ b/1.2/learn/by-example/nats-basic-client.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-client.html
+++ b/1.2/learn/by-example/nats-streaming-client.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-consumer-with-data-binding.html
+++ b/1.2/learn/by-example/nats-streaming-consumer-with-data-binding.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-durable-subscriptions.html
+++ b/1.2/learn/by-example/nats-streaming-durable-subscriptions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-queue-group.html
+++ b/1.2/learn/by-example/nats-streaming-queue-group.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-start-position.html
+++ b/1.2/learn/by-example/nats-streaming-start-position.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-assignability.html
+++ b/1.2/learn/by-example/object-assignability.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-initializer.html
+++ b/1.2/learn/by-example/object-initializer.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-methods.html
+++ b/1.2/learn/by-example/object-methods.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-type-reference.html
+++ b/1.2/learn/by-example/object-type-reference.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/objects.html
+++ b/1.2/learn/by-example/objects.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/openapi-to-ballerina.html
+++ b/1.2/learn/by-example/openapi-to-ballerina.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/openshift-deployment.html
+++ b/1.2/learn/by-example/openshift-deployment.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/optional-field-access.html
+++ b/1.2/learn/by-example/optional-field-access.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/optional-type.html
+++ b/1.2/learn/by-example/optional-type.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/overloaded-methods-constructors.html
+++ b/1.2/learn/by-example/overloaded-methods-constructors.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/panic.html
+++ b/1.2/learn/by-example/panic.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/passthrough.html
+++ b/1.2/learn/by-example/passthrough.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/proto-to-ballerina.html
+++ b/1.2/learn/by-example/proto-to-ballerina.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/query-action.html
+++ b/1.2/learn/by-example/query-action.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/query-expression.html
+++ b/1.2/learn/by-example/query-expression.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/query-path-matrix-param.html
+++ b/1.2/learn/by-example/query-path-matrix-param.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/quoted-identifiers.html
+++ b/1.2/learn/by-example/quoted-identifiers.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html
+++ b/1.2/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer-with-data-binding.html
+++ b/1.2/learn/by-example/rabbitmq-consumer-with-data-binding.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer-with-qos-settings.html
+++ b/1.2/learn/by-example/rabbitmq-consumer-with-qos-settings.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer.html
+++ b/1.2/learn/by-example/rabbitmq-consumer.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-producer.html
+++ b/1.2/learn/by-example/rabbitmq-producer.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/range-expressions.html
+++ b/1.2/learn/by-example/range-expressions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-destructure-binding-pattern.html
+++ b/1.2/learn/by-example/record-destructure-binding-pattern.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-io.html
+++ b/1.2/learn/by-example/record-io.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-match-statement.html
+++ b/1.2/learn/by-example/record-match-statement.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-optional-fields.html
+++ b/1.2/learn/by-example/record-optional-fields.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-type-reference.html
+++ b/1.2/learn/by-example/record-type-reference.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-typed-binding-pattern.html
+++ b/1.2/learn/by-example/record-typed-binding-pattern.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/records.html
+++ b/1.2/learn/by-example/records.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/request-with-multiparts.html
+++ b/1.2/learn/by-example/request-with-multiparts.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/response-with-multiparts.html
+++ b/1.2/learn/by-example/response-with-multiparts.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/restrict-by-media-type.html
+++ b/1.2/learn/by-example/restrict-by-media-type.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-client-with-basic-auth.html
+++ b/1.2/learn/by-example/secured-client-with-basic-auth.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-client-with-jwt-auth.html
+++ b/1.2/learn/by-example/secured-client-with-jwt-auth.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-client-with-oauth2.html
+++ b/1.2/learn/by-example/secured-client-with-oauth2.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-basic-auth.html
+++ b/1.2/learn/by-example/secured-service-with-basic-auth.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-jwt-auth.html
+++ b/1.2/learn/by-example/secured-service-with-jwt-auth.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-ldap.html
+++ b/1.2/learn/by-example/secured-service-with-ldap.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-oauth2.html
+++ b/1.2/learn/by-example/secured-service-with-oauth2.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/send-and-receive-emails.html
+++ b/1.2/learn/by-example/send-and-receive-emails.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/shift-expressions.html
+++ b/1.2/learn/by-example/shift-expressions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/streams.html
+++ b/1.2/learn/by-example/streams.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/string-template.html
+++ b/1.2/learn/by-example/string-template.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/strings.html
+++ b/1.2/learn/by-example/strings.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/table.html
+++ b/1.2/learn/by-example/table.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/taint-checking.html
+++ b/1.2/learn/by-example/taint-checking.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-scheduler-appointment.html
+++ b/1.2/learn/by-example/task-scheduler-appointment.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-scheduler-timer.html
+++ b/1.2/learn/by-example/task-scheduler-timer.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-service-appointment.html
+++ b/1.2/learn/by-example/task-service-appointment.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-service-timer.html
+++ b/1.2/learn/by-example/task-service-timer.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tcp-socket-listener-client.html
+++ b/1.2/learn/by-example/tcp-socket-listener-client.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-assertions.html
+++ b/1.2/learn/by-example/testerina-assertions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-before-and-after-each.html
+++ b/1.2/learn/by-example/testerina-before-and-after-each.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-before-and-after-suite.html
+++ b/1.2/learn/by-example/testerina-before-and-after-suite.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-before-and-after-test.html
+++ b/1.2/learn/by-example/testerina-before-and-after-test.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-data-driven-tests.html
+++ b/1.2/learn/by-example/testerina-data-driven-tests.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-group-tests.html
+++ b/1.2/learn/by-example/testerina-group-tests.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-guarantee-test-execution-order.html
+++ b/1.2/learn/by-example/testerina-guarantee-test-execution-order.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-mocking-functions.html
+++ b/1.2/learn/by-example/testerina-mocking-functions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-mocking-objects.html
+++ b/1.2/learn/by-example/testerina-mocking-objects.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/the-main-function.html
+++ b/1.2/learn/by-example/the-main-function.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/threads-and-strands.html
+++ b/1.2/learn/by-example/threads-and-strands.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/time.html
+++ b/1.2/learn/by-example/time.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tracing.html
+++ b/1.2/learn/by-example/tracing.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/transactions-distributed.html
+++ b/1.2/learn/by-example/transactions-distributed.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/trap.html
+++ b/1.2/learn/by-example/trap.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-destructure-binding-pattern.html
+++ b/1.2/learn/by-example/tuple-destructure-binding-pattern.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-match-statement.html
+++ b/1.2/learn/by-example/tuple-match-statement.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-type.html
+++ b/1.2/learn/by-example/tuple-type.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-typed-binding-pattern.html
+++ b/1.2/learn/by-example/tuple-typed-binding-pattern.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-cast.html
+++ b/1.2/learn/by-example/type-cast.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-conversion.html
+++ b/1.2/learn/by-example/type-conversion.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-guard.html
+++ b/1.2/learn/by-example/type-guard.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-test-expression.html
+++ b/1.2/learn/by-example/type-test-expression.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/udp-socket-client.html
+++ b/1.2/learn/by-example/udp-socket-client.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/union-type.html
+++ b/1.2/learn/by-example/union-type.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/url-encode-decode.html
+++ b/1.2/learn/by-example/url-encode-decode.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/user-defined-error.html
+++ b/1.2/learn/by-example/user-defined-error.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/values.html
+++ b/1.2/learn/by-example/values.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/var.html
+++ b/1.2/learn/by-example/var.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/variables.html
+++ b/1.2/learn/by-example/variables.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-basic-sample.html
+++ b/1.2/learn/by-example/websocket-basic-sample.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-chat-application.html
+++ b/1.2/learn/by-example/websocket-chat-application.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-client.html
+++ b/1.2/learn/by-example/websocket-client.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-failover.html
+++ b/1.2/learn/by-example/websocket-failover.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-proxy-server.html
+++ b/1.2/learn/by-example/websocket-proxy-server.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-retry.html
+++ b/1.2/learn/by-example/websocket-retry.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-hub-client-sample.html
+++ b/1.2/learn/by-example/websub-hub-client-sample.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-internal-hub-sample.html
+++ b/1.2/learn/by-example/websub-internal-hub-sample.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-remote-hub-sample.html
+++ b/1.2/learn/by-example/websub-remote-hub-sample.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-service-integration-sample.html
+++ b/1.2/learn/by-example/websub-service-integration-sample.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/while.html
+++ b/1.2/learn/by-example/while.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/worker-interaction.html
+++ b/1.2/learn/by-example/worker-interaction.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/workers.html
+++ b/1.2/learn/by-example/workers.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xa-transactions.html
+++ b/1.2/learn/by-example/xa-transactions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-access.html
+++ b/1.2/learn/by-example/xml-access.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-attributes.html
+++ b/1.2/learn/by-example/xml-attributes.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-functions.html
+++ b/1.2/learn/by-example/xml-functions.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-io.html
+++ b/1.2/learn/by-example/xml-io.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-literal.html
+++ b/1.2/learn/by-example/xml-literal.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-namespaces.html
+++ b/1.2/learn/by-example/xml-namespaces.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml.html
+++ b/1.2/learn/by-example/xml.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xslt-transformation.html
+++ b/1.2/learn/by-example/xslt-transformation.html
@@ -169,9 +169,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/calling-java-code-from-ballerina/index.html
+++ b/1.2/learn/calling-java-code-from-ballerina/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/annotations_documentation_and_comments/index.html
+++ b/1.2/learn/coding-conventions/annotations_documentation_and_comments/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/expressions/index.html
+++ b/1.2/learn/coding-conventions/expressions/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/index.html
+++ b/1.2/learn/coding-conventions/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/operators_keywords_and_types/index.html
+++ b/1.2/learn/coding-conventions/operators_keywords_and_types/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/statements/index.html
+++ b/1.2/learn/coding-conventions/statements/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/top-level-definitions/index.html
+++ b/1.2/learn/coding-conventions/top-level-definitions/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/aws-lambda/index.html
+++ b/1.2/learn/deployment/aws-lambda/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/azure-functions/index.html
+++ b/1.2/learn/deployment/azure-functions/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/docker/index.html
+++ b/1.2/learn/deployment/docker/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/kubernetes/index.html
+++ b/1.2/learn/deployment/kubernetes/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/documenting-ballerina-code/index.html
+++ b/1.2/learn/documenting-ballerina-code/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/extending-with-compiler-extensions/index.html
+++ b/1.2/learn/extending-with-compiler-extensions/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions/index.html
+++ b/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/index.html
+++ b/1.2/learn/index.html
@@ -156,9 +156,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/installing-ballerina/index.html
+++ b/1.2/learn/installing-ballerina/index.html
@@ -171,9 +171,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/keeping-ballerina-up-to-date/index.html
+++ b/1.2/learn/keeping-ballerina-up-to-date/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/observing-ballerina-code/index.html
+++ b/1.2/learn/observing-ballerina-code/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/publishing-modules-to-ballerina-central/index.html
+++ b/1.2/learn/publishing-modules-to-ballerina-central/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/quick-tour/index.html
+++ b/1.2/learn/quick-tour/index.html
@@ -166,9 +166,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/running-ballerina-code/index.html
+++ b/1.2/learn/running-ballerina-code/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-intellij-idea/index.html
+++ b/1.2/learn/setting-up-intellij-idea/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-intellij-idea/using-intellij-plugin-features/index.html
+++ b/1.2/learn/setting-up-intellij-idea/using-intellij-plugin-features/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-intellij-idea/using-the-intellij-plugin/index.html
+++ b/1.2/learn/setting-up-intellij-idea/using-the-intellij-plugin/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/documentation-viewer/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/documentation-viewer/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/graphical-editor/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/graphical-editor/index.html
@@ -166,9 +166,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/language-intelligence/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/language-intelligence/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/run-all-tests/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/run-all-tests/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/run-and-debug/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/run-and-debug/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/structuring-ballerina-code/index.html
+++ b/1.2/learn/structuring-ballerina-code/index.html
@@ -169,9 +169,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/executing-tests/index.html
+++ b/1.2/learn/testing-ballerina-code/executing-tests/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/mocking/index.html
+++ b/1.2/learn/testing-ballerina-code/mocking/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/testing-quick-start/index.html
+++ b/1.2/learn/testing-ballerina-code/testing-quick-start/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/writing-tests/index.html
+++ b/1.2/learn/testing-ballerina-code/writing-tests/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/using-the-cli-tools/index.html
+++ b/1.2/learn/using-the-cli-tools/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/using-the-openapi-tools/index.html
+++ b/1.2/learn/using-the-openapi-tools/index.html
@@ -167,9 +167,9 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/writing-secure-ballerina-code/index.html
+++ b/1.2/learn/writing-secure-ballerina-code/index.html
@@ -161,9 +161,9 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-<a href="https://ballerina.io/downloads/" class="cInfoBanner">
-    Swan Lake Beta6 is here.
-</a>
+<div class="cInfoBannerVersionHandling">
+    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a ahref="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
+</div>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">


### PR DESCRIPTION
## Purpose
Add the banner for old doc versions.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
