### PR TITLE
Add styles for old learn page top banners

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -11,7 +11,20 @@
         font-size: 20px;
         transition : all 0.3s;
     }
-
+    .cInfoBannerVersionHandling {
+        background:  #494949;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 400;
+        font-size: 17px;
+        transition : all 0.3s;
+    }
+    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
+    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
     .cInfoBanner:hover {
         background-color: #c0c0c0;
         color: #494949 !important;

--- a/css/ballerina-io.css
+++ b/css/ballerina-io.css
@@ -1473,6 +1473,20 @@ li pre code span.line-numbers-rows {
         position: absolute;
         z-index: 9999999999999 !important;
     }
+    .cInfoBannerVersionHandling {
+        background:  #494949;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 200;
+        font-size: 15px !important;
+        position: absolute;
+        z-index: 9999999999999 !important;
+    }
+    .cInfoBannerLink{font-weight: 200;font-size: 15px !important;color: #20b6b0;}
     .navbar-nav > li:last-child a.cSerachIcon {
         display: none;
     }


### PR DESCRIPTION
### ## Purpose
> Add styles for old learn page top banners
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
