### PR TITLE
Update gRPC tooling guide in learn pages

### DIFF
--- a/learn/references/cli-documentation/grpc.md
+++ b/learn/references/cli-documentation/grpc.md
@@ -1,11 +1,11 @@
 ---
 layout: ballerina-cli-documentation-left-nav-pages-swanlake
-title: GRPC
+title: gRPC/Protocol Buffers
 description: The 'Protocol Buffers to Ballerina' tool provides capabilities to generate Ballerina source code for the Protocol Buffer definition.
 keywords: ballerina, protocol buffers, programming language
 permalink: /learn/cli-documentation/grpc/
 active: grpc
-intro: The 'Protocol Buffers to Ballerina' tool provides capabilities to generate Ballerina source code for Protocol Buffer definitions.
+intro: Protocol Buffers is an open-source cross-platform data format used to serialize structured data and gRPC uses Protocol Buffers as Interface Definition Language to create service contracts, detailing all of its remote functions and message formats. The 'Protocol Buffers to Ballerina' tooling makes it easy for users to start the development of a service documented in a Protocol Buffers contract in Ballerina by generating Ballerina service/client stub files and skeletons.
 redirect_from:
   - /learn/how-to-generate-code-for-protocol-buffers
   - /learn/how-to-generate-code-for-protocol-buffers/
@@ -19,70 +19,87 @@ redirect_from:
 
 ## Usage of the Tool
 
-The code generation tool can produce `ballerina stub` and `ballerina service/client template` files.
+The code generation tool can produce `service/client stub files` and `service/client skeletons` in Ballerina Language.
  
 > In Ballerina, Protocol Buffers serialization is only supported in the gRPC module. Therefore, you can only use
 > this tool to generate Ballerina source code for gRPC service definitions.
 
-## CLI Command
+## Protocol Buffers to Ballerina
 
 You can generate Ballerina source code using the following command:
 
 ```
-$ bal grpc --input <proto-file-path> [--output <path>] [--mode client | service]
+$ bal grpc --input <proto-file-path> 
+         [--output <path>] 
+         [--mode client|service]
+         [--proto-path <proto-directory>]
 ```
 
 ### CLI Command Options
 
-`--input`  - Path of the input .proto file. This is a mandatory field. You need to provide the path of the definition
- file.
+`--input` - Path to a '.proto' file or a directory containing multiple '.proto' files. This is a mandatory field. 
+You need to provide the path of the definition file or the directory that contains multiple ‘.proto’ files.
 
 `--output` - Location of the generated Ballerina source files. This is an optional field. 
 If the output path is not specified, the output will be written to a directory corresponding to the package in the Protocol
  Buffers definition. 
 If the package is not specified, the output will be written to a 'temp' directory in the current location.
 
-`--mode`   - Set the mode as client or service to generate code samples. If not specified, only the stub file is generated.
+`--mode` - Set the mode as client or service to generate code samples. If not specified, only the stub file is 
+generated.
+
+`-- proto-path` - Path to a directory in which to look for '.proto' files when resolving import directives. If 
+omitted, the current directory is used. The '.proto' file specified in 'input', must reside in 'proto-path' so that the 
+compiler can determine its canonical name.
+
 
 
 ## Sample
 
-The below example shows how you can generate Ballerina source code from the following Protocol Buffers definition (in the `helloworld_service.proto` file).
+The below example shows how you can generate Ballerina source code from the following Protocol Buffers definition (in the `helloworld.proto` file).
 
 ```proto
 syntax = "proto3";
 
-service helloWorld {
-    rpc sayHello(HelloRequest) returns (HelloResponse);
+package helloworld;
+
+// The greeting service definition.
+service Greeter {
+ // Sends a greeting
+ rpc sayHello (HelloRequest) returns (HelloReply);
 }
 
+// The request message with the user's name.
 message HelloRequest {
-	string name = 1;
+ string name = 1;
 }
-message HelloResponse {
-	string message = 1;
+
+// The response message with the greetings
+message HelloReply {
+ string message = 1;
 }
 ```
+Note: The sample service definition is taken from the quick start guide in gRPC official site.
 
 ### Executing the Sample
 
 * Execute the below command to generate the service template file.
 ```
-$ bal grpc --input helloworld_service.proto --mode service --output service
+$ bal grpc --input helloworld.proto --mode service --output service
 ```
-Once you execute the command, the stub file (`helloworld_service_pb.bal`) and the service template file (`helloWorld_sample_service.bal`) are generated inside the service directory.
+Once you execute the command, the stub file (`helloworld_pb.bal`) and the service template file (`greeter_service.bal`) are generated inside the service directory.
 > **Note:** If you have multiple services in a Protocol Buffers definition, this command will generate a stub file with common message types and a service template file for each service definition. This is to avoid duplicating message types in all the service files.
 
 
 * Execute the below command to generate the client/service stub and client template.
 ```
-$ bal grpc --input helloworld_service.proto --mode client --output client
+$ bal grpc --input helloworld.proto --mode client --output client
 ```
-Once you execute the command, the stub file (`helloworld_service_pb.bal`) and the client template file (`helloWorld_sample_client.bal`) are generated inside the client directory.
+Once you execute the command, the stub file (`helloworld_pb.bal`) and the client template file (`greeter_client.bal`) are generated inside the client directory.
 
 
 * Execute the below command to generate only the client/service stub.
 ```
-$ bal grpc --input helloworld_service.proto --output stubs
+$ bal grpc --input helloworld.proto --output stubs
 ```
-Once you execute the command, only the stub file (`helloworld_service_pb.bal`) is generated inside the `stubs` directory.
+Once you execute the command, only the stub file (`helloworld_pb.bal`) is generated inside the `stubs` directory.

--- a/learn/references/cli-documentation/grpc.md
+++ b/learn/references/cli-documentation/grpc.md
@@ -5,7 +5,7 @@ description: The 'Protocol Buffers to Ballerina' tool provides capabilities to g
 keywords: ballerina, protocol buffers, programming language
 permalink: /learn/cli-documentation/grpc/
 active: grpc
-intro: Protocol Buffers is an open-source cross-platform data format used to serialize structured data and gRPC uses Protocol Buffers as Interface Definition Language to create service contracts, detailing all of its remote functions and message formats. The 'Protocol Buffers to Ballerina' tooling makes it easy for users to start the development of a service documented in a Protocol Buffers contract in Ballerina by generating Ballerina service/client stub files and skeletons.
+intro: Protocol Buffers is an open-source cross-platform data format used to serialize structured data. gRPC uses Protocol Buffers as Interface Definition Language to create service contracts, detailing all of its remote functions and message formats. The 'Protocol Buffers to Ballerina' tooling makes it easy for users to develop service documented in a Protocol Buffers by generating Ballerina service/client stub files and skeletons.
 redirect_from:
   - /learn/how-to-generate-code-for-protocol-buffers
   - /learn/how-to-generate-code-for-protocol-buffers/


### PR DESCRIPTION
## Purpose
This is to update the gRPC tooling guide in learn pages
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
