### PR TITLE
Fix the Links of the Learn Landing Page

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -112,7 +112,7 @@ redirect_from:
 </div>
 
 <div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
- <a href="/learn/getting-started/hello-world/writing-your-first-ballerina-program/">
+ <a href="/learn/hello-world/writing-your-first-ballerina-program/">
     <h3 id="hello-world">Hello World</h3></a>
    <p >Writing your first Ballerina program and creating your first Ballerina package. </p>
 </div>
@@ -132,7 +132,7 @@ redirect_from:
 
 <div class="row">
 <div class="col-lg-6 col-md-6 col-sm-12 card">
- <a href="/learn/distinctive-language-features/">
+ <a href="/learn/distinctive-language-features/network-interaction/">
   <h3 id="distinctive-language-features">Distinctive Language Features</h3></a>
  	<p>A guide to the language features that make Ballerina distinctive.  </p>
 </div>
@@ -146,7 +146,7 @@ redirect_from:
 
 <div class="row">
 <div class="col-lg-6 col-md-6 col-sm-12 card"  >
-  <a href="/learn/testing-ballerina-code/testing-quick-start/">
+  <a href="/learn/testing-ballerina-code/quick-start-on-testing/">
    <h3 id="testing-ballerina-code">Testing Ballerina Code</h3> </a>
     <p>Details of writing automated tests using the built-in test framework.  </p>
 </div>
@@ -178,7 +178,7 @@ redirect_from:
 <div class="row">
 
 <div class="col-lg-6 col-md-6 col-sm-12 card"  >
- <a href="/learn/running-ballerina-programs-in-the-cloud/code-to-cloud/">
+ <a href="/learn/running-ballerina-programs-in-the-cloud/code-to-cloud-deployment/">
   		<h3 id="running-ballerina-programs-in-the-cloud">Running Ballerina Programs in the Cloud
 </h3></a>
  	<p>The cloud offerings for running Ballerina programs.  </p>
@@ -210,7 +210,7 @@ redirect_from:
 <p>Details of the Read-Evaluate-Print Loop (REPL) for Ballerina.</p>
 </div>
 <div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
- <a href="/learn/visual-studio-code-extension/quick-start/">
+ <a href="/learn/visual-studio-code-extension/vs-code-quick-start/">
     <h3 id="installing-ballerina">Visual Studio Code Extension</h3></a>
     <p >Details of all the features of the Ballerina Visual Studio Code extension. </p>
 </div>

--- a/learn/guides/distinctive-language-features/network-interaction.md
+++ b/learn/guides/distinctive-language-features/network-interaction.md
@@ -8,8 +8,10 @@ active: network-interaction
 intro: In this part, you will learn about the features of the Ballerina programming language that are distinctive. These features revolve around key design considerations that make Ballerina suitable for cloud application programming using small and medium-sized programs.
 redirect_from:
 - /learn/distinctive-language-features/what-makes-ballerina-distinctive
+- /learn/distinctive-language-features/what-makes-ballerina-distinctive/
 - /learn/distinctive-language-features/
 - /learn/distinctive-language-features
+- /learn/distinctive-language-features/network-interaction
 ---
 
 Ballerina aims to be as pragmatic as possible by taking cues from existing patterns used in programming. It models cloud-era applications that make heavy use of network interaction, network data, and concurrency. In addition, Ballerina focuses on providing integration that acts like glue for orchestrating other programs and ensures reliability and maintainability while also assuring moderate cognitive load on programmers.


### PR DESCRIPTION
## Purpose
Fix the links of the learn landing page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
