### PR TITLE
Remove the Language Intro Slides from Learn

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -263,14 +263,6 @@ redirect_from:
  	 <h3 id="style-guide">Style Guide</h3></a>
 		<p>Best practices to follow when formatting Ballerina code.   </p>
 </div>
-<div class="row">
-<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
- <a href="/learn/language-introduction/">
-  	<h3 id="language-introduction-slides">Language Introduction</h3></a>
-		<p>Presentation slides on the Ballerina language that you can use to talk about the language.</p>
-</div>
-
-</div>
 </div>
 
 


### PR DESCRIPTION
## Purpose
Remove the language intro slides from Learn.
> Fixes #3421

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
