### PR TITLE
Remove the 1.2.x Support Reference from VS Code Docs

### DIFF
--- a/learn/guides/visual-studio-code-extension/vs-code-quick-start.md
+++ b/learn/guides/visual-studio-code-extension/vs-code-quick-start.md
@@ -29,8 +29,6 @@ redirect_from:
 
 Before getting started, make sure you have installed the [Visual Studio Code editor](https://code.visualstudio.com/download) and [Ballerina](/downloads).
 
->**Tip:** The VSCode Ballerina extension supports both the Ballerina Swan Lake and 1.2.x versions.
-
 ## Installing the Ballerina Extension
 
 Follow the steps below to install the Ballerina extension.


### PR DESCRIPTION
## Purpose
Remove the 1.2.x support reference from VS Code docs.
> Fixes #3419 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
