### PR TITLE
Improve configurable learn page as per the suggestions

### DIFF
--- a/_data/configurableswanlake.yml
+++ b/_data/configurableswanlake.yml
@@ -1,26 +1,27 @@
 - title: Configuring Ballerina Programs
   url: '#'
   sublinks:
-    - title: Configuring a Sample Ballerina Service
-      url: /learn/configuring-ballerina-programs/configuring-a-sample-ballerina-service
-      active: configuring-a-sample-ballerina-service
+    - title: Quick Start on Using Configurable Variables
+      url: /learn/configuring-ballerina-programs/quick-start-on-configurable-variables
+      sublinks:
+        - title: Configuring a Sample Ballerina Service
+          url: /learn/configuring-ballerina-programs/quick-start-on-configurable-variables/#configuring-a-sample-ballerina-service
+          active: configuring-a-sample-ballerina-service
     - title: Providing Values to Configurable Variables
       url: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables
-      active: providing-values-to-configurable-variables
       sublinks:
-        - title: Providing configuration values through Command Line Arguments
+        - title: Providing Configuration Values Through Command Line Arguments
           url: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-configuration-values-through-command-line-arguments
           active: providing-values-through-command-line-arguments
-        - title: Providing configuration values through TOML Syntax
+        - title: Providing Configuration Values Through TOML Syntax
           url: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-configuration-values-through-toml-syntax
           active: providing-configuration-values-through-toml-syntax
-    - title: Providing module information of the configurable variable
-      url: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-module-information-of-the-configurable-variable
-      active: providing-module-info-of-configurable-variable
-    - title: Configure values in Kubernetes Environments
-      url: /learn/configuring-ballerina-programs/configure-values-in-kubernetes-environment/
-      active: configure-values-in-kubernetes-environment
+        - title: Providing Module Information of the Configurable Variable
+          url: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-module-information-of-the-configurable-variable
+          active: providing-module-info-of-configurable-variable
+    - title: Configuring Values in Kubernetes Environments
+      url: /learn/configuring-ballerina-programs/configuring-values-in-kubernetes-environment/
       sublinks:
-        - title: Securing sensitive data using configurable variables
-          url: /learn/configuring-ballerina-programs/configure-values-in-kubernetes-environment/#securing-sensitive-data-using-configurable-variables
+        - title: Securing Sensitive Data Using Configurable Variables
+          url: /learn/configuring-ballerina-programs/configuring-values-in-kubernetes-environment/#securing-sensitive-data-using-configurable-variables
           active: securing-sensitive-data-using-configurable-variables

--- a/_data/guidesnavswanlake.yml
+++ b/_data/guidesnavswanlake.yml
@@ -56,28 +56,30 @@
 - title: Configuring Ballerina Programs
   url: '#'
   sublinks:
-    - title: Configuring a Sample Ballerina Service
-      url: /learn/configuring-ballerina-programs/configuring-a-sample-ballerina-service
-      active: configuring-a-sample-ballerina-service
+    - title: Quick Start on Using Configurable Variables
+      url: /learn/configuring-ballerina-programs/quick-start-on-configurable-variables
+      active: quick-start-on-configurable-variables
+      sublinks:
+        - title: Configuring a Sample Ballerina Service
+          url: /learn/configuring-ballerina-programs/quick-start-on-configurable-variables/configuring-a-sample-ballerina-service
+          active: configuring-a-sample-ballerina-service
     - title: Providing Values to Configurable Variables
       url: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables
-      active: providing-values-to-configurable-variables
       sublinks:
-        - title: Providing configuration values through Command Line Arguments
+        - title: Providing Configuration Values Through Command Line Arguments
           url: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-configuration-values-through-command-line-arguments
           active: providing-values-through-command-line-arguments
-        - title: Providing configuration values through TOML Syntax
+        - title: Providing Configuration Values Through TOML Syntax
           url: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-configuration-values-through-toml-syntax
           active: providing-configuration-values-through-toml-syntax
-    - title: Providing module information of the configurable variable
-      url: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-module-information-of-the-configurable-variable
-      active: providing-module-info-of-configurable-variable
-    - title: Configure values in Kubernetes Environments
-      url: /learn/configuring-ballerina-programs/configure-values-in-kubernetes-environment/
-      active: configure-values-in-kubernetes-environment
+        - title: Providing Module Information of the Configurable Variable
+          url: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-module-information-of-the-configurable-variable
+          active: providing-module-info-of-configurable-variable
+    - title: Configuring Values in Kubernetes Environments
+      url: /learn/configuring-ballerina-programs/configuring-values-in-kubernetes-environment/
       sublinks:
-        - title: Securing sensitive data using configurable variables
-          url: /learn/configuring-ballerina-programs/configure-values-in-kubernetes-environment/#securing-sensitive-data-using-configurable-variables
+        - title: Securing Sensitive Data Using Configurable Variables
+          url: /learn/configuring-ballerina-programs/configuring-values-in-kubernetes-environment/#securing-sensitive-data-using-configurable-variables
           active: securing-sensitive-data-using-configurable-variables
 
 - title: Observing Ballerina Programs

--- a/learn/guides/configuring-ballerina-programs/configure-values-in-kubernetes-environment.md
+++ b/learn/guides/configuring-ballerina-programs/configure-values-in-kubernetes-environment.md
@@ -1,19 +1,15 @@
 ---
 layout: ballerina-configurable-left-nav-pages-swanlake 
-title: Configure values in Kubernetes Environment 
+title: Configuring Values in Kubernetes Environment 
 description: In Kubernetes environments, the configuration TOML files can be used to configure values at deployment. 
 keywords: ballerina, programming language, configurable, variables, kubernetes, pod 
-permalink: /learn/configuring-ballerina-programs/configure-values-in-kubernetes-environment/ 
-active: configure-values-in-kubernetes-environment 
-intro: In Kubernetes environments, a pod can use the configuration TOML files to configure values at deployment. 
-
+permalink: /learn/configuring-ballerina-programs/configuring-values-in-kubernetes-environment/ 
+active: configuring-values-in-kubernetes-environment 
 redirect_from:
-- /learn/making-ballerina-programs-configurable/configure-values-in-kubernetes-environment
-- /learn/configuring-ballerina-programs/configure-values-in-kubernetes-environment
+- /learn/making-ballerina-programs-configurable/configuring-values-in-kubernetes-environment
+- /learn/configuring-ballerina-programs/configuring-values-in-kubernetes-environment
 
 ---
-
-## Configure values in Kubernetes Environment
 
 In Kubernetes environment, a pod can use the configuration TOML file that contains the configuration values in the
 following ways.
@@ -21,7 +17,7 @@ following ways.
 - as files in a data volume that is mounted on one or more of its containers
 - as environment variables for the containers
 
-### Securing sensitive data using configurable variables
+### Securing Sensitive Data Using Configurable Variables
 
 Configuration values containing passwords or secrets should not be passed with the normal configuration.
 

--- a/learn/guides/configuring-ballerina-programs/configuring-a-sample-ballerina-service.md
+++ b/learn/guides/configuring-ballerina-programs/configuring-a-sample-ballerina-service.md
@@ -1,12 +1,11 @@
 ---
 layout: ballerina-configurable-left-nav-pages-swanlake 
-title: Configuring Ballerina Programs 
+title: Quick Start on Using Configurable Variables
 description: Ballerina supports configurability through the configurable, module-level variables. 
 keywords: ballerina, programming language, configurable, variables
-permalink: /learn/configuring-ballerina-programs/ 
-active: configuring-ballerina-programs 
-intro: Ballerina supports configurability through the configurable, module-level variables. 
-
+permalink: /learn/configuring-ballerina-programs/quick-start-on-configurable-variables
+active: configuring-ballerina-programs
+intro: Configurability enables users to modify the system behavior through external user inputs. Ballerina Language provides an in-built functionality to configure values at runtime through configurable  module-level variables.
 redirect_from:
 - /learn/user-guide/configurability/defining-configurable-variables
 - /learn/user-guide/configurability/defining-configurable-variables/
@@ -21,15 +20,11 @@ redirect_from:
 - /learn/making-ballerina-programs-configurable/trying-it-out/
 - /learn/making-ballerina-programs-configurable/trying-out-configurability
 - /learn/configuring-ballerina-programs
-- /learn/configuring-ballerina-programs/configuring-a-sample-ballerina-service
-- /learn/configuring-ballerina-programs/configuring-a-sample-ballerina-service/
+- /learn/configuring-ballerina-programs/
 
 ---
 
 ## Configuring a Sample Ballerina Service
-
-Configurability enables users to modify the system behavior through external user inputs. Ballerina Language provides an
-in-built functionality to configure values at runtime through configurable variables.
 
 Consider the following step-by-step guide to configure a Ballerina package that contains an HTTP service.
 
@@ -104,14 +99,3 @@ Consider the following step-by-step guide to configure a Ballerina package that 
    ```
    Hello Tom! Good Morning!
    ```
-
-## Additional Information
-
-For more information on the configurable variables, please refer:
-
-- [Providing Values to Configurable Variables](/learn/configuring-ballerina-programs/providing-values-to-configurable-variables/)
-    - [Providing configuration values through Command Line Arguments](/learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-configuration-values-through-command-line-arguments)
-    - [Providing configuration values through TOML Syntax](/learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-configuration-values-through-toml-syntax)
-- [Providing module information of the configurable variable](/learn/configuring-ballerina-programs/providing-values-to-configurable-variables/#providing-module-information-of-the-configurable-variable)
-- [Configure values in Kubernetes Environment](/learn/configuring-ballerina-programs/configure-values-in-kubernetes-environment)
-    - [Securing sensitive data using configurable variables](/learn/configuring-ballerina-programs/configure-values-in-kubernetes-environment/#securing-sensitive-data-using-configurable-variables)

--- a/learn/guides/configuring-ballerina-programs/providing-values-to-configurable-variables.md
+++ b/learn/guides/configuring-ballerina-programs/providing-values-to-configurable-variables.md
@@ -5,8 +5,6 @@ description: You can supply values to configurable variables using the methods b
 keywords: ballerina, programming language, configurable, variables, values, toml 
 permalink: /learn/configuring-ballerina-programs/providing-values-to-configurable-variables/ 
 active: providing-values-to-configurable-variables 
-intro: You can supply values to configurable variables using the methods below. 
-
 redirect_from:
 - /learn/user-guide/configurability/providing-values-to-configurable-variables
 - /learn/user-guide/configurability/providing-values-to-configurable-variables/
@@ -15,8 +13,6 @@ redirect_from:
 - /learn/configuring-ballerina-programs/providing-values-to-configurable-variables
 
 ---
-
-## Providing Configuration Values
 
 The values for configurable variables can be provided through configuration files, command-line arguments, and
 environment variables. The configuration values will be overridden in the following precedence order if the values are
@@ -35,13 +31,13 @@ specifying multiple configuration files using this environment variable with the
 precedence order will be as specified in the environment variable. If an environment variable is not specified, the file
 will be located in the current working directory with the file name `Config.toml` by default.
 
-- **Environment variables**
+- **Environment Variables**
 
 Users can provide the configuration values through an environment variable with the name `BAL_CONFIG_DATA` in which the
 content is expected to be in the [TOML(v0.4) format](https://toml.io/en/v0.4.0). Note that configuring individual values
 through separate environment variables is not supported.
 
-### Providing configuration values through Command Line Arguments
+### Providing Configuration Values Through Command Line Arguments
 
 The following syntax can be used to provide values for the variables through the command line parameters:
 
@@ -64,7 +60,7 @@ types.
 | xml            | <code>configurable xml book = ?; </code>                                                                                                                                              | `bal run -- -CxmlVar="<book>The Lost World</book>"`               |
 | enum           | <code>enum Country { </code><br>    <code>LK = "Sri Lanka", </code><br>    <code>US = "United States" </code><br> <code>} </code><br> <code>configurable Country country = ?; </code> | `bal run -- -Ccountry="Sri Lanka"`                                |
 
-### Providing configuration values through TOML Syntax
+### Providing Configuration Values Through TOML Syntax
 
 Ballerina defines a specific TOML syntax to be used when configuring the variables through the configuration files and
 environment variables. Depending on the type of the configurable variable, the way of providing values in the TOML
@@ -74,26 +70,26 @@ the respective types.
 
 The mapping of Ballerina types to TOML types can be explained through the following examples:
 
-| Ballerina Type        | Ballerina Example                                                                                                                                                                        | TOML Type                        | TOML Example                                                                                                                                    |
-|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| int, byte            | <code>configurable   byte  age = ?;</code><br/>  <code>configurable   int  port = ?;</code>                                                                                                | Integer                           | `age = 25` <br/>  `port = 9090`                                                                                                                |
-| string                | <code>configurable   string  name = ?; </code>                                                                                                                                            | String                           | `name = "John"`                                                                                                                                |
-| float, decimal        | <code>configurable   float  height = ?;</code><br/>  <code>configurable   decimal  salary = ?;</code>                                                                                        | Float                               | `height = 5.6`<br/>  `salary = 50500.65 `                                                                                                        |
-| boolean                | <code>configurable   boolean  isAdmin = ?;</code>                                                                                                                                            | Boolean                           | `isAdmin = true`                                                                                                                               |
-| xml                   | <code>configurable xml book = ?;</code>                                                                                                                                                   | String                           | `book = "<book>The Lost World</book>"`                                                                                                         |
-| enum                | <code>enum  Country {</code><br/>   <code>LK =  "Sri Lanka" ,</code><br/>  <code>US =  "United States"</code><br/> <code>}</code><br/> <code>configurable  Country country = ?;</code>    | String                           | `country = "Sri Lanka"`                                                                                                                        |
-| union                 | <code>configurable int&#124;string code = ?;</code>                                                                                                                                       | Relevant TOML type for the value | `code = "10001A"`                                                                                                                              |
-| int[] , byte[]        | <code>configurable   int[]  ports = ?;</code>                                                                                                                                                | Array of integers                   | `ports = [9090, 9091]`                                                                                                                        |
-| string[]            | <code>configurable   string[]  colors = ?;</code>                                                                                                                                        | Array of strings                   | `colors = ["Red", "Green", "Blue"]`                                                                                                            |
-| float[], decimal[]    | <code>configurable   float[]  rates = ?;</code>                                                                                                                                            | Array of floats                   | `rates = [55.4, 76.3, 38.5]`                                                                                                                    |
-| boolean[]            | <code>configurable   boolean[]  switches = ?;</code>                                                                                                                                    | Array of booleans                   | `switches = [false, false, true]`                                                                                                            |
-| map                    | <code>configurable   map &lt;string&gt; person = ?; </code>                                                                                                                               | TOML table                       | `[person]`<br/> `name = "Anna"`<br/> `city = "London"`                                                                                        |
-| map[]                | <code>configurable   map &lt;string&gt;[] people = ?; </code>                                                                                                                             | Array of TOML tables               | `[[people]]`<br/> `name = "John"`<br/> `city = "Paris"`<br/> `[[people]]`<br/> `name = "Jack"`<br/> `city = "Colombo"`                        |
-| record                | <code>type  Person  record {</code><br/>    <code>string  name;</code><br/>    <code>int  age;</code><br/><code>};</code><br/>  <code>configurable   Person  person = ?;</code>          | TOML table                       | `[person]`<br/>  `name = "John"`<br/> `age = 45`<br/>                                                                                        |
-| record[]            | <code>type  Person  record {</code><br/>    <code>string  name;</code><br/>    <code>int  age;</code><br/><code>};</code><br/>  <code>configurable   Person[]  people = ?;</code>        | Array of TOML tables               | `[[people]]`<br/>  `name = "John"`<br/> `age = 45`<br/> `[[people]]`<br/>  `name = "Jack"`<br/> `age = 32`                                    |
-| table                | <code>configurable   table &lt;map&lt;string&gt;&gt; users = ?; </code>                                                                                                                    | Array of TOML tables               | `[[users]]`<br/> `name = "Tom"`<br/> `occupation = "Software Engineer"`<br/> `[[users]]`<br/> `name = "Harry"`<br/> `occupation = "Doctor"`    |
+| Ballerina Type     | Ballerina Example                                                                                                                                                                       | TOML Type                        | TOML Example                                                                                                                                |
+|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
+| int, byte          | <code>configurable   byte  age = ?;</code><br/>  <code>configurable   int  port = ?;</code>                                                                                             | Integer                          | `age = 25` <br/>  `port = 9090`                                                                                                             |
+| string             | <code>configurable   string  name = ?; </code>                                                                                                                                          | String                           | `name = "John"`                                                                                                                             |
+| float, decimal     | <code>configurable   float  height = ?;</code><br/>  <code>configurable   decimal  salary = ?;</code>                                                                                   | Float                            | `height = 5.6`<br/>  `salary = 50500.65 `                                                                                                   |
+| boolean            | <code>configurable   boolean  isAdmin = ?;</code>                                                                                                                                       | Boolean                          | `isAdmin = true`                                                                                                                            |
+| xml                | <code>configurable xml book = ?;</code>                                                                                                                                                 | String                           | `book = "<book>The Lost World</book>"`                                                                                                      |
+| enum               | <code>enum  Country {</code><br/>   <code>LK =  "Sri Lanka" ,</code><br/>  <code>US =  "United States"</code><br/> <code>}</code><br/> <code>configurable  Country country = ?;</code>  | String                           | `country = "Sri Lanka"`                                                                                                                     |
+| union              | <code>configurable int&#124;string code = ?;</code>                                                                                                                                     | Relevant TOML type for the value | `code = "10001A"`                                                                                                                           |
+| int[] , byte[]     | <code>configurable   int[]  ports = ?;</code>                                                                                                                                           | Array of integers                | `ports = [9090, 9091]`                                                                                                                      |
+| string[]           | <code>configurable   string[]  colors = ?;</code>                                                                                                                                       | Array of strings                 | `colors = ["Red", "Green", "Blue"]`                                                                                                         |
+| float[], decimal[] | <code>configurable   float[]  rates = ?;</code>                                                                                                                                         | Array of floats                  | `rates = [55.4, 76.3, 38.5]`                                                                                                                |
+| boolean[]          | <code>configurable   boolean[]  switches = ?;</code>                                                                                                                                    | Array of booleans                | `switches = [false, false, true]`                                                                                                           |
+| map                | <code>configurable   map &lt;string&gt; person = ?; </code>                                                                                                                             | TOML table                       | `[person]`<br/> `name = "Anna"`<br/> `city = "London"`                                                                                      |
+| map[]              | <code>configurable   map &lt;string&gt;[] people = ?; </code>                                                                                                                           | Array of TOML tables             | `[[people]]`<br/> `name = "John"`<br/> `city = "Paris"`<br/> `[[people]]`<br/> `name = "Jack"`<br/> `city = "Colombo"`                      |
+| record             | <code>type  Person  record {</code><br/>    <code>string  name;</code><br/>    <code>int  age;</code><br/><code>};</code><br/>  <code>configurable   Person  person  ?;</code>          | TOML table                       | `[person]`<br/>  `name = "John"`<br/> `age = 45`<br/>                                                                                       |
+| record[]           | <code>type  Person  record {</code><br/>    <code>string  name;</code><br/>    <code>int  age;</code><br/><code>};</code><br/>  <code>configurable   Person[]  peope = ?;</code>        | Array of TOML tables             | `[[people]]`<br/>  `name = "John"`<br/> `age = 45`<br/> `[[people]]`<br/>  `name = "Jack"`<br/> `age = 32`                                  |
+| table              | <code>configurable   table &lt;map&lt;string&gt;&gt; users = ?; </code>                                                                                                                 | Array of TOML tables             | `[[users]]`<br/> `name = "Tom"`<br/> `occupation = "Software Engineer"`<br/> `[[users]]`<br/> `name = "Harry"`<br/> `occupation = "Doctor"` |
 
-### Providing module information of the configurable variable
+### Providing Module Information of the Configurable Variable
 
 The configurable variables can be defined in different modules. Therefore, it is necessary to provide the information of
 the module in which the variable is defined.
@@ -111,7 +107,7 @@ Note that the module information is not needed for configuring single `bal` file
 
 The format of providing module information in each configuration syntax is described below.
 
-#### Command-line argument syntax
+#### Command Line Argument Syntax
 
 The key of a CLI parameter can be specified as,
 
@@ -125,7 +121,7 @@ The key can contain module information as follows.
 key:= [[org-name .] module-name .] variable
 ```
 
-#### TOML syntax
+#### TOML Syntax
 
 The following format is used to provide the module information of a variable in the TOML based configuration.
 


### PR DESCRIPTION
## Purpose
$subject
- fixed upper case, lower case inconsistency in titles
- fixed title format inconsistency (`ing` format)
- Removed `Additional Information` section
- Improved Page structure

The improved structure will be as follows, 
![Screenshot from 2022-01-25 19-28-14](https://user-images.githubusercontent.com/28644893/150991062-0fc7c06b-d3f2-42db-bbf1-5cb3b7f41901.png)

When enhanced - 

![Screenshot from 2022-01-25 19-28-36](https://user-images.githubusercontent.com/28644893/150991091-240302fc-6cc1-46e4-b5d7-11c9addafef8.png)
## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
