### PR TITLE
Add the Missing Title in the Installation Options Page to the Left Nav

### DIFF
--- a/_data/installingballerinanavswanlake.yml
+++ b/_data/installingballerinanavswanlake.yml
@@ -31,6 +31,9 @@
           - title: Installing via the Ballerina Language ZIP File
             url: /learn/installing-ballerina/installation-options/#installing-via-the-ballerina-language-zip-file
             active: installing-via-the-ballerina-language-zip-file
+          - title: Verifying the Installation
+            url: /learn/installing-ballerina/installation-options/#verifying-the-installation
+            active: verifying-the-installation
           - title: Updating Ballerina
             url: /learn/installing-ballerina/installation-options/#updating-ballerina
             active: updating-ballerina


### PR DESCRIPTION
## Purpose
Add the missing title in the "Installation Options" page to the left nav.
> Fixes #3443 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
