### PR TITLE
Remove sub heading from documentation guide

### DIFF
--- a/learn/guides/generating-code-documentation.md
+++ b/learn/guides/generating-code-documentation.md
@@ -81,7 +81,7 @@ public function foo(int i, string s) returns boolean {
 }
 ```
 
-### Sample Usage
+**Sample Usage**
 
 ```ballerina
 # Submits an HTTP request to a service with the specified HTTP verb.


### PR DESCRIPTION
## Purpose
> Convert unnecessary heading to bold text 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
