### PR TITLE
Fix the VSCode Links

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -255,7 +255,7 @@ redirect_from:
 <p>Details of the Read-Evaluate-Print Loop (REPL) for Ballerina.</p>
 </div>
 <div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
- <a href="/learn/visual-studio-code-extension/vs-code-quick-start/">
+ <a href="https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina">
     <h3 id="installing-ballerina">Visual Studio Code Extension</h3></a>
     <p >Details of all the features of the Ballerina Visual Studio Code extension. </p>
 </div>

--- a/learn/getting-started/installing-ballerina/setting-up-ballerina.md
+++ b/learn/getting-started/installing-ballerina/setting-up-ballerina.md
@@ -97,4 +97,4 @@ For more installation options, see [Installation Options](/learn/user-guide/gett
 
 ## Installing the VSCode Extension
 
-Ballerina provides an extension to try out its development capabilities in Visual Studio Code. For instructions on setting it up, go to [The Ballerina Extension for Visual Studio Code](https://github.com/wso2/ballerina-plugin-vscode/blob/main/README.md).
+Ballerina provides an extension to try out its development capabilities in Visual Studio Code. For instructions on setting it up, go to [The Ballerina Extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina).


### PR DESCRIPTION
## Purpose
Fix the VSCode links.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
