### PR TITLE
Fix more broken links in ballerina packages guides

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -182,7 +182,7 @@ redirect_from:
  	<p>A guide to the language features that make Ballerina distinctive.  </p>
 </div>
 <div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
- <a href="/learn/organizing-ballerina-code/package-layout/">
+ <a href="/learn/organizing-ballerina-code">
   <h3 id="organizing-ballerina-code">Organizing Ballerina Code</h3></a>
  	<p>Basics of projects, packages, and modules.  </p>
 </div>

--- a/learn/guides/managing-dependencies.md
+++ b/learn/guides/managing-dependencies.md
@@ -29,7 +29,7 @@ the remote repository will be queried only if the specified version is not prese
 **Local repository**
 
 The local repository is also a file system repository, which will be created in the `<USER_HOME>` location. The repository location is `<USER_HOME>/.ballerina/repositories/local/repo/bala`. 
-For details on using the local repository, see [local repository](/learn/user-guide/ballerina-packages/dependencies/#local-repository).
+For details on using the local repository, see [local repository](/learn/managing-dependencies/#using-dependencies-from-the-local-repository).
 
 ### Importing a Module
 
@@ -50,7 +50,7 @@ The module name of the default module is always the package name.
 The following example shows how we can import modules from the `ballerina/io` package.
 
 ```bal
-import ballerina/io;`// imports default module of io package
+import ballerina/io; // imports default module of io package
 
 public function main() {
 	io:println("Hello world!");

--- a/learn/guides/organizing-ballerina-code.md
+++ b/learn/guides/organizing-ballerina-code.md
@@ -51,7 +51,7 @@ tree .
 0 directories, 2 files
 ```
 
->**Tip:** You may also try creating a service or a lib package instead of the main function. 
+You may also try creating a service or a lib package instead of the main function as explained in the sections below. 
 
 #### Creating a Ballerina Service Package
 

--- a/learn/guides/publishing-packages-to-ballerina-central.md
+++ b/learn/guides/publishing-packages-to-ballerina-central.md
@@ -35,7 +35,7 @@ hello
 0 directories, 3 files
 ```
 
-It creates the `Ballerina.toml` file. Apart from it, the `hello.bal` source file and the [Package.md](/learn/organizing-ballerina-code/package-layout/#packagemd) files are created. For more information on these, see [Package Layout](/learn/organizing-ballerina-code/package-layout/).
+It creates the `Ballerina.toml` file. Apart from it, the `hello.bal` source file and the [Package.md](/learn/package-references/#packagemd) files are created. For more information on these, see [Package Layout](/learn/organizing-ballerina-code/package-layout/).
 
 You can edit the `Ballerina.toml` file to change the org name, package name and version as you prefer.
 
@@ -85,7 +85,7 @@ password = ""
 
 ### Organizations
 
-When you push a package to Ballerina Central, the organizations are validated against the value of the `org` field defined in the [Ballerina.toml](/learn/organizing-ballerina-code/package-layout/#ballerinatoml) file. Therefore, when you have more than one organizations in Ballerina Central, pick the organization name that you intend to push the package into, set that as the `org` in the `Ballerina.toml` file inside the package directory, and rebuild the package.
+When you push a package to Ballerina Central, the organizations are validated against the value of the `org` field defined in the [Ballerina.toml](/learn/package-references/#ballerinatoml) file. Therefore, when you have more than one organizations in Ballerina Central, pick the organization name that you intend to push the package into, set that as the `org` in the `Ballerina.toml` file inside the package directory, and rebuild the package.
 
 Also, organization names starting with `ballerina` (e.g., `ballerina`, `ballerinax`, `ballerinai`, etc.) are reserved for system use, and thereby, you cannot publish any packages starting with the `ballerina` prefix to Ballerina Central. Therefore, if you have used a name pattern matching this, update the `Ballerina.toml` and rebuild the package.
 
@@ -101,4 +101,4 @@ bal push
 
 After publishing your first package, you can create a second package and use the already-published package in it.
 
-Any package published in Ballerina Central is public and they can be used in packages as explained in [Dependencies](/learn/managing-dependencies/#importing-a-module).
+Any package published in Ballerina Central is public and they can be used in packages. For more information, see [Importing a Module](/learn/managing-dependencies/#importing-a-module).

--- a/learn/references/package-references/package-layout.md
+++ b/learn/references/package-references/package-layout.md
@@ -3,7 +3,7 @@ layout: ballerina-organizing-code-left-nav-pages-swanlake
 title: Package Layout
 description: The sections below include information about the structure of a package directory. It explains the purpose of each file in a package.
 keywords: ballerina, programming language, ballerina packages, package structure, package layout
-permalink: /learn/organizing-ballerina-code/package-layout/
+permalink: /learn/package-references/
 active: package-layout
 intro: The sections below include information about the structure of a package directory. It explains the purpose of each file in a package.
 redirect_from:


### PR DESCRIPTION
## Purpose
> Fix more broken links in ballerina packages guides

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
