### PR TITLE
Add macOS and IDE Related Files to the .gitignore File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,4 @@ _site/
 .sass-cache
 
 # macOS
-.DS_Store
-     
-      
+.DS_Store   

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,12 @@ hs_err_pid*
 
 # IDE related
 .idea
+*.iml
 
 # Jekyll related files.
 _site/
 .sass-cache
+
+# macOS
+.DS_Store
+ 

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ _site/
 
 # macOS
 .DS_Store
-   
+      

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ _site/
 .sass-cache
 
 # macOS
-.DS_Store   
+.DS_Store
+             

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ _site/
 
 # macOS
 .DS_Store
- 
+   

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ _site/
 
 # macOS
 .DS_Store
+     
       


### PR DESCRIPTION
## Purpose
Add macOS-related files and IDE-related files to the .gitignore file. This is to avoid these unnecessary files being committed to the repo via PRs.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
