### PR TITLE
Update the Banners in 1.2 Learn and API Docs

### DIFF
--- a/1.2/learn/api-docs/ballerina/auth/constants.html
+++ b/1.2/learn/api-docs/ballerina/auth/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/constants.html
+++ b/1.2/learn/api-docs/ballerina/auth/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/auth/errors.html
+++ b/1.2/learn/api-docs/ballerina/auth/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/errors.html
+++ b/1.2/learn/api-docs/ballerina/auth/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/auth/functions.html
+++ b/1.2/learn/api-docs/ballerina/auth/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/functions.html
+++ b/1.2/learn/api-docs/ballerina/auth/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/auth/index.html
+++ b/1.2/learn/api-docs/ballerina/auth/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/index.html
+++ b/1.2/learn/api-docs/ballerina/auth/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
+++ b/1.2/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
+++ b/1.2/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/auth/records/Credential.html
+++ b/1.2/learn/api-docs/ballerina/auth/records/Credential.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/records/Credential.html
+++ b/1.2/learn/api-docs/ballerina/auth/records/Credential.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/auth/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/auth/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/auth/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/auth/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/constants.html
+++ b/1.2/learn/api-docs/ballerina/cache/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/constants.html
+++ b/1.2/learn/api-docs/ballerina/cache/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/errors.html
+++ b/1.2/learn/api-docs/ballerina/cache/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/errors.html
+++ b/1.2/learn/api-docs/ballerina/cache/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/index.html
+++ b/1.2/learn/api-docs/ballerina/cache/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/index.html
+++ b/1.2/learn/api-docs/ballerina/cache/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/objects/AbstractCache.html
+++ b/1.2/learn/api-docs/ballerina/cache/objects/AbstractCache.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/objects/AbstractCache.html
+++ b/1.2/learn/api-docs/ballerina/cache/objects/AbstractCache.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/objects/AbstractEvictionPolicy.html
+++ b/1.2/learn/api-docs/ballerina/cache/objects/AbstractEvictionPolicy.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/objects/AbstractEvictionPolicy.html
+++ b/1.2/learn/api-docs/ballerina/cache/objects/AbstractEvictionPolicy.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/objects/Cache.html
+++ b/1.2/learn/api-docs/ballerina/cache/objects/Cache.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/objects/Cache.html
+++ b/1.2/learn/api-docs/ballerina/cache/objects/Cache.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/objects/LinkedList.html
+++ b/1.2/learn/api-docs/ballerina/cache/objects/LinkedList.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/objects/LinkedList.html
+++ b/1.2/learn/api-docs/ballerina/cache/objects/LinkedList.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/objects/LruEvictionPolicy.html
+++ b/1.2/learn/api-docs/ballerina/cache/objects/LruEvictionPolicy.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/objects/LruEvictionPolicy.html
+++ b/1.2/learn/api-docs/ballerina/cache/objects/LruEvictionPolicy.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/records/CacheConfig.html
+++ b/1.2/learn/api-docs/ballerina/cache/records/CacheConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/records/CacheConfig.html
+++ b/1.2/learn/api-docs/ballerina/cache/records/CacheConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/cache/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/cache/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/cache/records/Node.html
+++ b/1.2/learn/api-docs/ballerina/cache/records/Node.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/cache/records/Node.html
+++ b/1.2/learn/api-docs/ballerina/cache/records/Node.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/config/functions.html
+++ b/1.2/learn/api-docs/ballerina/config/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/config/functions.html
+++ b/1.2/learn/api-docs/ballerina/config/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/config/index.html
+++ b/1.2/learn/api-docs/ballerina/config/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/config/index.html
+++ b/1.2/learn/api-docs/ballerina/config/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/constants.html
+++ b/1.2/learn/api-docs/ballerina/crypto/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/crypto/constants.html
+++ b/1.2/learn/api-docs/ballerina/crypto/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/errors.html
+++ b/1.2/learn/api-docs/ballerina/crypto/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/crypto/errors.html
+++ b/1.2/learn/api-docs/ballerina/crypto/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/functions.html
+++ b/1.2/learn/api-docs/ballerina/crypto/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/crypto/functions.html
+++ b/1.2/learn/api-docs/ballerina/crypto/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/index.html
+++ b/1.2/learn/api-docs/ballerina/crypto/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/crypto/index.html
+++ b/1.2/learn/api-docs/ballerina/crypto/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/records/Certificate.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/Certificate.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/crypto/records/Certificate.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/Certificate.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/crypto/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/records/KeyStore.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/KeyStore.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/crypto/records/KeyStore.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/KeyStore.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/records/PrivateKey.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/PrivateKey.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/crypto/records/PrivateKey.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/PrivateKey.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/records/PublicKey.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/PublicKey.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/crypto/records/PublicKey.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/PublicKey.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/records/TrustStore.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/TrustStore.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/crypto/records/TrustStore.html
+++ b/1.2/learn/api-docs/ballerina/crypto/records/TrustStore.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/crypto/types.html
+++ b/1.2/learn/api-docs/ballerina/crypto/types.html
@@ -71,7 +71,11 @@
         <div class="cTopLine"></div>
       </div>
     </div>
-    <div class="row cBallerina-io-Nav" id="iMainNavigation"></div>
+    <a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
     <div class="clearfix"></div>
     <div class="navi-wrapper">
       <div class="navi-wrapper-content">

--- a/1.2/learn/api-docs/ballerina/crypto/types.html
+++ b/1.2/learn/api-docs/ballerina/crypto/types.html
@@ -72,7 +72,7 @@
       </div>
     </div>
     <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 </div>

--- a/1.2/learn/api-docs/ballerina/email/clients/ImapClient.html
+++ b/1.2/learn/api-docs/ballerina/email/clients/ImapClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/clients/ImapClient.html
+++ b/1.2/learn/api-docs/ballerina/email/clients/ImapClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/clients/PopClient.html
+++ b/1.2/learn/api-docs/ballerina/email/clients/PopClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/clients/PopClient.html
+++ b/1.2/learn/api-docs/ballerina/email/clients/PopClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/clients/SmtpClient.html
+++ b/1.2/learn/api-docs/ballerina/email/clients/SmtpClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/clients/SmtpClient.html
+++ b/1.2/learn/api-docs/ballerina/email/clients/SmtpClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/constants.html
+++ b/1.2/learn/api-docs/ballerina/email/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/constants.html
+++ b/1.2/learn/api-docs/ballerina/email/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/errors.html
+++ b/1.2/learn/api-docs/ballerina/email/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/errors.html
+++ b/1.2/learn/api-docs/ballerina/email/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/index.html
+++ b/1.2/learn/api-docs/ballerina/email/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/index.html
+++ b/1.2/learn/api-docs/ballerina/email/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/email/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/email/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/records/Email.html
+++ b/1.2/learn/api-docs/ballerina/email/records/Email.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/records/Email.html
+++ b/1.2/learn/api-docs/ballerina/email/records/Email.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/records/ImapConfig.html
+++ b/1.2/learn/api-docs/ballerina/email/records/ImapConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/records/ImapConfig.html
+++ b/1.2/learn/api-docs/ballerina/email/records/ImapConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/records/PopConfig.html
+++ b/1.2/learn/api-docs/ballerina/email/records/PopConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/records/PopConfig.html
+++ b/1.2/learn/api-docs/ballerina/email/records/PopConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/records/SmtpConfig.html
+++ b/1.2/learn/api-docs/ballerina/email/records/SmtpConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/records/SmtpConfig.html
+++ b/1.2/learn/api-docs/ballerina/email/records/SmtpConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/email/types.html
+++ b/1.2/learn/api-docs/ballerina/email/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/email/types.html
+++ b/1.2/learn/api-docs/ballerina/email/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/encoding/constants.html
+++ b/1.2/learn/api-docs/ballerina/encoding/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/encoding/constants.html
+++ b/1.2/learn/api-docs/ballerina/encoding/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/encoding/errors.html
+++ b/1.2/learn/api-docs/ballerina/encoding/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/encoding/errors.html
+++ b/1.2/learn/api-docs/ballerina/encoding/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/encoding/functions.html
+++ b/1.2/learn/api-docs/ballerina/encoding/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/encoding/functions.html
+++ b/1.2/learn/api-docs/ballerina/encoding/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/encoding/index.html
+++ b/1.2/learn/api-docs/ballerina/encoding/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/encoding/index.html
+++ b/1.2/learn/api-docs/ballerina/encoding/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/encoding/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/encoding/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/encoding/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/encoding/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/file/constants.html
+++ b/1.2/learn/api-docs/ballerina/file/constants.html
@@ -30,6 +30,23 @@ file/directory, and retrieve metadata of the file.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ file/directory, and retrieve metadata of the file.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/file/constants.html
+++ b/1.2/learn/api-docs/ballerina/file/constants.html
@@ -67,7 +67,7 @@ file/directory, and retrieve metadata of the file.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/file/errors.html
+++ b/1.2/learn/api-docs/ballerina/file/errors.html
@@ -66,7 +66,7 @@ file/directory, and retrieve metadata of the file.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/file/errors.html
+++ b/1.2/learn/api-docs/ballerina/file/errors.html
@@ -30,6 +30,23 @@ file/directory, and retrieve metadata of the file.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@ file/directory, and retrieve metadata of the file.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/file/functions.html
+++ b/1.2/learn/api-docs/ballerina/file/functions.html
@@ -30,6 +30,23 @@ file/directory, and retrieve metadata of the file.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ file/directory, and retrieve metadata of the file.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/file/functions.html
+++ b/1.2/learn/api-docs/ballerina/file/functions.html
@@ -67,7 +67,7 @@ file/directory, and retrieve metadata of the file.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/file/index.html
+++ b/1.2/learn/api-docs/ballerina/file/index.html
@@ -30,6 +30,23 @@ file/directory, and retrieve metadata of the file.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ file/directory, and retrieve metadata of the file.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/file/index.html
+++ b/1.2/learn/api-docs/ballerina/file/index.html
@@ -67,7 +67,7 @@ file/directory, and retrieve metadata of the file.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/file/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/file/listeners/Listener.html
@@ -30,6 +30,23 @@ file/directory, and retrieve metadata of the file.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ file/directory, and retrieve metadata of the file.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/file/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/file/listeners/Listener.html
@@ -67,7 +67,7 @@ file/directory, and retrieve metadata of the file.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/file/objects/FileInfo.html
+++ b/1.2/learn/api-docs/ballerina/file/objects/FileInfo.html
@@ -30,6 +30,23 @@ file/directory, and retrieve metadata of the file.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ file/directory, and retrieve metadata of the file.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/file/objects/FileInfo.html
+++ b/1.2/learn/api-docs/ballerina/file/objects/FileInfo.html
@@ -67,7 +67,7 @@ file/directory, and retrieve metadata of the file.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/file/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/file/records/Detail.html
@@ -30,6 +30,23 @@ file/directory, and retrieve metadata of the file.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ file/directory, and retrieve metadata of the file.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/file/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/file/records/Detail.html
@@ -67,7 +67,7 @@ file/directory, and retrieve metadata of the file.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/file/records/FileEvent.html
+++ b/1.2/learn/api-docs/ballerina/file/records/FileEvent.html
@@ -30,6 +30,23 @@ file/directory, and retrieve metadata of the file.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ file/directory, and retrieve metadata of the file.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/file/records/FileEvent.html
+++ b/1.2/learn/api-docs/ballerina/file/records/FileEvent.html
@@ -67,7 +67,7 @@ file/directory, and retrieve metadata of the file.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/file/records/ListenerConfig.html
+++ b/1.2/learn/api-docs/ballerina/file/records/ListenerConfig.html
@@ -30,6 +30,23 @@ file/directory, and retrieve metadata of the file.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ file/directory, and retrieve metadata of the file.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/file/records/ListenerConfig.html
+++ b/1.2/learn/api-docs/ballerina/file/records/ListenerConfig.html
@@ -67,7 +67,7 @@ file/directory, and retrieve metadata of the file.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/file/types.html
+++ b/1.2/learn/api-docs/ballerina/file/types.html
@@ -30,6 +30,23 @@ file/directory, and retrieve metadata of the file.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ file/directory, and retrieve metadata of the file.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/file/types.html
+++ b/1.2/learn/api-docs/ballerina/file/types.html
@@ -67,7 +67,7 @@ file/directory, and retrieve metadata of the file.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/filepath/constants.html
+++ b/1.2/learn/api-docs/ballerina/filepath/constants.html
@@ -75,7 +75,7 @@
       </div>
     </div>
     <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 </div>

--- a/1.2/learn/api-docs/ballerina/filepath/constants.html
+++ b/1.2/learn/api-docs/ballerina/filepath/constants.html
@@ -74,7 +74,11 @@
         <div class="cTopLine"></div>
       </div>
     </div>
-    <div class="row cBallerina-io-Nav" id="iMainNavigation"></div>
+    <a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
     <div class="clearfix"></div>
     <div class="navi-wrapper">
       <div class="navi-wrapper-content">

--- a/1.2/learn/api-docs/ballerina/filepath/errors.html
+++ b/1.2/learn/api-docs/ballerina/filepath/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/filepath/errors.html
+++ b/1.2/learn/api-docs/ballerina/filepath/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/filepath/functions.html
+++ b/1.2/learn/api-docs/ballerina/filepath/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/filepath/functions.html
+++ b/1.2/learn/api-docs/ballerina/filepath/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/filepath/index.html
+++ b/1.2/learn/api-docs/ballerina/filepath/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/filepath/index.html
+++ b/1.2/learn/api-docs/ballerina/filepath/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/filepath/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/filepath/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/filepath/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/filepath/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/filepath/types.html
+++ b/1.2/learn/api-docs/ballerina/filepath/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/filepath/types.html
+++ b/1.2/learn/api-docs/ballerina/filepath/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/annotations.html
+++ b/1.2/learn/api-docs/ballerina/grpc/annotations.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/annotations.html
+++ b/1.2/learn/api-docs/ballerina/grpc/annotations.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/clients/Caller.html
+++ b/1.2/learn/api-docs/ballerina/grpc/clients/Caller.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/clients/Caller.html
+++ b/1.2/learn/api-docs/ballerina/grpc/clients/Caller.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/clients/Client.html
+++ b/1.2/learn/api-docs/ballerina/grpc/clients/Client.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/clients/Client.html
+++ b/1.2/learn/api-docs/ballerina/grpc/clients/Client.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
+++ b/1.2/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
+++ b/1.2/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/constants.html
+++ b/1.2/learn/api-docs/ballerina/grpc/constants.html
@@ -71,7 +71,11 @@
         <div class="cTopLine"></div>
       </div>
     </div>
-    <div class="row cBallerina-io-Nav" id="iMainNavigation"></div>
+    <a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
     <div class="clearfix"></div>
     <div class="navi-wrapper">
       <div class="navi-wrapper-content">

--- a/1.2/learn/api-docs/ballerina/grpc/constants.html
+++ b/1.2/learn/api-docs/ballerina/grpc/constants.html
@@ -72,7 +72,7 @@
       </div>
     </div>
     <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 </div>

--- a/1.2/learn/api-docs/ballerina/grpc/errors.html
+++ b/1.2/learn/api-docs/ballerina/grpc/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/errors.html
+++ b/1.2/learn/api-docs/ballerina/grpc/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/functions.html
+++ b/1.2/learn/api-docs/ballerina/grpc/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/functions.html
+++ b/1.2/learn/api-docs/ballerina/grpc/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/index.html
+++ b/1.2/learn/api-docs/ballerina/grpc/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/index.html
+++ b/1.2/learn/api-docs/ballerina/grpc/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/grpc/listeners/Listener.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/grpc/listeners/Listener.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
+++ b/1.2/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
@@ -35,6 +35,23 @@ redirect_from:
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -54,7 +71,11 @@ redirect_from:
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
+++ b/1.2/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
@@ -72,7 +72,7 @@ redirect_from:
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/objects/Headers.html
+++ b/1.2/learn/api-docs/ballerina/grpc/objects/Headers.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/objects/Headers.html
+++ b/1.2/learn/api-docs/ballerina/grpc/objects/Headers.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/Local.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/Local.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/Local.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/Local.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/Protocols.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/Protocols.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/Protocols.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/Protocols.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/Remote.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/Remote.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/Remote.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/Remote.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/RetryConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/RetryConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/RetryConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/RetryConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/SecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/SecureSocket.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/SecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/SecureSocket.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/records/ValidateCert.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ValidateCert.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/records/ValidateCert.html
+++ b/1.2/learn/api-docs/ballerina/grpc/records/ValidateCert.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/grpc/types.html
+++ b/1.2/learn/api-docs/ballerina/grpc/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/grpc/types.html
+++ b/1.2/learn/api-docs/ballerina/grpc/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/annotations.html
+++ b/1.2/learn/api-docs/ballerina/http/annotations.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/annotations.html
+++ b/1.2/learn/api-docs/ballerina/http/annotations.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/Caller.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/Caller.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/Caller.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/Caller.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/Client.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/Client.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/Client.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/Client.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/FailoverClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/FailoverClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/FailoverClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/FailoverClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/HttpClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/HttpClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/HttpClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/HttpClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/RedirectClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/RedirectClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/RedirectClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/RedirectClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/RetryClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/RetryClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/RetryClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/RetryClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/WebSocketClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/WebSocketClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/WebSocketClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/WebSocketClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/clients/WebSocketFailoverClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/WebSocketFailoverClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/clients/WebSocketFailoverClient.html
+++ b/1.2/learn/api-docs/ballerina/http/clients/WebSocketFailoverClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/constants.html
+++ b/1.2/learn/api-docs/ballerina/http/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/constants.html
+++ b/1.2/learn/api-docs/ballerina/http/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/errors.html
+++ b/1.2/learn/api-docs/ballerina/http/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/errors.html
+++ b/1.2/learn/api-docs/ballerina/http/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/functions.html
+++ b/1.2/learn/api-docs/ballerina/http/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/functions.html
+++ b/1.2/learn/api-docs/ballerina/http/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/index.html
+++ b/1.2/learn/api-docs/ballerina/http/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/index.html
+++ b/1.2/learn/api-docs/ballerina/http/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/http/listeners/Listener.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/http/listeners/Listener.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/listeners/MockListener.html
+++ b/1.2/learn/api-docs/ballerina/http/listeners/MockListener.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/listeners/MockListener.html
+++ b/1.2/learn/api-docs/ballerina/http/listeners/MockListener.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/AuthnFilter.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/AuthnFilter.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/AuthnFilter.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/AuthnFilter.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/AuthzFilter.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/AuthzFilter.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/AuthzFilter.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/AuthzFilter.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/AuthzHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/AuthzHandler.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/AuthzHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/AuthzHandler.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/Cookie.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/Cookie.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/Cookie.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/Cookie.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/CookieClient.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/CookieClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/CookieClient.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/CookieClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/CookieStore.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/CookieStore.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/CookieStore.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/CookieStore.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/CsvPersistentCookieHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/CsvPersistentCookieHandler.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/CsvPersistentCookieHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/CsvPersistentCookieHandler.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/FilterContext.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/FilterContext.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/FilterContext.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/FilterContext.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/HttpCache.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/HttpCache.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/HttpCache.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/HttpCache.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/HttpFuture.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/HttpFuture.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/HttpFuture.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/HttpFuture.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/PersistentCookieHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/PersistentCookieHandler.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/PersistentCookieHandler.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/PersistentCookieHandler.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/PushPromise.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/PushPromise.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/PushPromise.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/PushPromise.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/Request.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/Request.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/Request.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/Request.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/RequestFilter.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/RequestFilter.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/RequestFilter.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/RequestFilter.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/Response.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/Response.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/Response.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/Response.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/objects/ResponseFilter.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/ResponseFilter.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/objects/ResponseFilter.html
+++ b/1.2/learn/api-docs/ballerina/http/objects/ResponseFilter.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/Bucket.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Bucket.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/Bucket.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Bucket.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/CacheConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CacheConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/CacheConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CacheConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/CircuitHealth.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CircuitHealth.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/CircuitHealth.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CircuitHealth.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ClientConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ClientConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/CommonClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CommonClientConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/CommonClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CommonClientConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/CompressionConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CompressionConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/CompressionConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CompressionConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/CookieConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CookieConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/CookieConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CookieConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/CorsConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CorsConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/CorsConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/CorsConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/FailoverConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/FailoverConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/FailoverConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/FailoverConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/FollowRedirects.html
+++ b/1.2/learn/api-docs/ballerina/http/records/FollowRedirects.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/FollowRedirects.html
+++ b/1.2/learn/api-docs/ballerina/http/records/FollowRedirects.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
+++ b/1.2/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
+++ b/1.2/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ListenerAuth.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ListenerAuth.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ListenerAuth.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ListenerAuth.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
+++ b/1.2/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
+++ b/1.2/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/Local.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Local.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/Local.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Local.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
+++ b/1.2/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
+++ b/1.2/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/PoolConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/PoolConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/PoolConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/PoolConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/Protocols.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Protocols.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/Protocols.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Protocols.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ProxyConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ProxyConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ProxyConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ProxyConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/Remote.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Remote.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/Remote.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Remote.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/RequestLimitConfigs.html
+++ b/1.2/learn/api-docs/ballerina/http/records/RequestLimitConfigs.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/RequestLimitConfigs.html
+++ b/1.2/learn/api-docs/ballerina/http/records/RequestLimitConfigs.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ResourceAuth.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ResourceAuth.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ResourceAuth.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ResourceAuth.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ResponseLimitConfigs.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ResponseLimitConfigs.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ResponseLimitConfigs.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ResponseLimitConfigs.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/RetryConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/RetryConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/RetryConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/RetryConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/RollingWindow.html
+++ b/1.2/learn/api-docs/ballerina/http/records/RollingWindow.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/RollingWindow.html
+++ b/1.2/learn/api-docs/ballerina/http/records/RollingWindow.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ServiceAuth.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ServiceAuth.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ServiceAuth.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ServiceAuth.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/TargetService.html
+++ b/1.2/learn/api-docs/ballerina/http/records/TargetService.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/TargetService.html
+++ b/1.2/learn/api-docs/ballerina/http/records/TargetService.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/ValidateCert.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ValidateCert.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/ValidateCert.html
+++ b/1.2/learn/api-docs/ballerina/http/records/ValidateCert.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/Versioning.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Versioning.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/Versioning.html
+++ b/1.2/learn/api-docs/ballerina/http/records/Versioning.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/WSServiceConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/WSServiceConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/WSServiceConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/WSServiceConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/WebSocketFailoverClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/WebSocketFailoverClientConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/WebSocketFailoverClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/http/records/WebSocketFailoverClientConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/WebSocketRetryConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/WebSocketRetryConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/WebSocketRetryConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/WebSocketRetryConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
+++ b/1.2/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/http/types.html
+++ b/1.2/learn/api-docs/ballerina/http/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/http/types.html
+++ b/1.2/learn/api-docs/ballerina/http/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/index.html
+++ b/1.2/learn/api-docs/ballerina/index.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/index.html
+++ b/1.2/learn/api-docs/ballerina/index.html
@@ -28,6 +28,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper" > 

--- a/1.2/learn/api-docs/ballerina/io/constants.html
+++ b/1.2/learn/api-docs/ballerina/io/constants.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/constants.html
+++ b/1.2/learn/api-docs/ballerina/io/constants.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/errors.html
+++ b/1.2/learn/api-docs/ballerina/io/errors.html
@@ -66,7 +66,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/errors.html
+++ b/1.2/learn/api-docs/ballerina/io/errors.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/functions.html
+++ b/1.2/learn/api-docs/ballerina/io/functions.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/functions.html
+++ b/1.2/learn/api-docs/ballerina/io/functions.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/index.html
+++ b/1.2/learn/api-docs/ballerina/io/index.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/index.html
+++ b/1.2/learn/api-docs/ballerina/io/index.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/StringReader.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/StringReader.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/StringReader.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/StringReader.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
+++ b/1.2/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/io/records/Detail.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/io/records/Detail.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/io/types.html
+++ b/1.2/learn/api-docs/ballerina/io/types.html
@@ -30,6 +30,23 @@ or non-blocking manner.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ or non-blocking manner.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/io/types.html
+++ b/1.2/learn/api-docs/ballerina/io/types.html
@@ -67,7 +67,7 @@ or non-blocking manner.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.arrays/functions.html
+++ b/1.2/learn/api-docs/ballerina/java.arrays/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.arrays/functions.html
+++ b/1.2/learn/api-docs/ballerina/java.arrays/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.arrays/index.html
+++ b/1.2/learn/api-docs/ballerina/java.arrays/index.html
@@ -75,7 +75,7 @@
       </div>
     </div>
     <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 </div>

--- a/1.2/learn/api-docs/ballerina/java.arrays/index.html
+++ b/1.2/learn/api-docs/ballerina/java.arrays/index.html
@@ -74,7 +74,11 @@
         <div class="cTopLine"></div>
       </div>
     </div>
-    <div class="row cBallerina-io-Nav" id="iMainNavigation"></div>
+    <a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
     <div class="clearfix"></div>
     <div class="navi-wrapper">
       <div class="navi-wrapper-content">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/clients/Client.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/clients/Client.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/clients/Client.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/clients/Client.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/constants.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/constants.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/constants.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/constants.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/errors.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/errors.html
@@ -66,7 +66,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/errors.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/errors.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/index.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/index.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/index.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/index.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java.jdbc/types.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/types.html
@@ -67,7 +67,7 @@ that is accessible via Java Database Connectivity (JDBC).
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java.jdbc/types.html
+++ b/1.2/learn/api-docs/ballerina/java.jdbc/types.html
@@ -30,6 +30,23 @@ that is accessible via Java Database Connectivity (JDBC).
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ that is accessible via Java Database Connectivity (JDBC).
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java/annotations.html
+++ b/1.2/learn/api-docs/ballerina/java/annotations.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java/annotations.html
+++ b/1.2/learn/api-docs/ballerina/java/annotations.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java/functions.html
+++ b/1.2/learn/api-docs/ballerina/java/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java/functions.html
+++ b/1.2/learn/api-docs/ballerina/java/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java/index.html
+++ b/1.2/learn/api-docs/ballerina/java/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java/index.html
+++ b/1.2/learn/api-docs/ballerina/java/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java/objects/JObject.html
+++ b/1.2/learn/api-docs/ballerina/java/objects/JObject.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java/objects/JObject.html
+++ b/1.2/learn/api-docs/ballerina/java/objects/JObject.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java/records/ArrayType.html
+++ b/1.2/learn/api-docs/ballerina/java/records/ArrayType.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java/records/ArrayType.html
+++ b/1.2/learn/api-docs/ballerina/java/records/ArrayType.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java/records/ConstructorData.html
+++ b/1.2/learn/api-docs/ballerina/java/records/ConstructorData.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java/records/ConstructorData.html
+++ b/1.2/learn/api-docs/ballerina/java/records/ConstructorData.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java/records/FieldData.html
+++ b/1.2/learn/api-docs/ballerina/java/records/FieldData.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java/records/FieldData.html
+++ b/1.2/learn/api-docs/ballerina/java/records/FieldData.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java/records/MethodData.html
+++ b/1.2/learn/api-docs/ballerina/java/records/MethodData.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java/records/MethodData.html
+++ b/1.2/learn/api-docs/ballerina/java/records/MethodData.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/java/records/ObjectData.html
+++ b/1.2/learn/api-docs/ballerina/java/records/ObjectData.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/java/records/ObjectData.html
+++ b/1.2/learn/api-docs/ballerina/java/records/ObjectData.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jsonutils/functions.html
+++ b/1.2/learn/api-docs/ballerina/jsonutils/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jsonutils/functions.html
+++ b/1.2/learn/api-docs/ballerina/jsonutils/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jsonutils/index.html
+++ b/1.2/learn/api-docs/ballerina/jsonutils/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jsonutils/index.html
+++ b/1.2/learn/api-docs/ballerina/jsonutils/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
+++ b/1.2/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
+++ b/1.2/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/constants.html
+++ b/1.2/learn/api-docs/ballerina/jwt/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/constants.html
+++ b/1.2/learn/api-docs/ballerina/jwt/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/errors.html
+++ b/1.2/learn/api-docs/ballerina/jwt/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/errors.html
+++ b/1.2/learn/api-docs/ballerina/jwt/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/functions.html
+++ b/1.2/learn/api-docs/ballerina/jwt/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/functions.html
+++ b/1.2/learn/api-docs/ballerina/jwt/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/index.html
+++ b/1.2/learn/api-docs/ballerina/jwt/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/index.html
+++ b/1.2/learn/api-docs/ballerina/jwt/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/records/InboundJwtCacheEntry.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/InboundJwtCacheEntry.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/records/InboundJwtCacheEntry.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/InboundJwtCacheEntry.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwksConfig.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwksConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwksConfig.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwksConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtHeader.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtHeader.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtHeader.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtHeader.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtPayload.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtPayload.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtPayload.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtPayload.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
+++ b/1.2/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/jwt/types.html
+++ b/1.2/learn/api-docs/ballerina/jwt/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/jwt/types.html
+++ b/1.2/learn/api-docs/ballerina/jwt/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/clients/Consumer.html
+++ b/1.2/learn/api-docs/ballerina/kafka/clients/Consumer.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/clients/Consumer.html
+++ b/1.2/learn/api-docs/ballerina/kafka/clients/Consumer.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/clients/Producer.html
+++ b/1.2/learn/api-docs/ballerina/kafka/clients/Producer.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/clients/Producer.html
+++ b/1.2/learn/api-docs/ballerina/kafka/clients/Producer.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/constants.html
+++ b/1.2/learn/api-docs/ballerina/kafka/constants.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/constants.html
+++ b/1.2/learn/api-docs/ballerina/kafka/constants.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/errors.html
+++ b/1.2/learn/api-docs/ballerina/kafka/errors.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/errors.html
+++ b/1.2/learn/api-docs/ballerina/kafka/errors.html
@@ -66,7 +66,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/index.html
+++ b/1.2/learn/api-docs/ballerina/kafka/index.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/index.html
+++ b/1.2/learn/api-docs/ballerina/kafka/index.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/objects/Deserializer.html
+++ b/1.2/learn/api-docs/ballerina/kafka/objects/Deserializer.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/objects/Deserializer.html
+++ b/1.2/learn/api-docs/ballerina/kafka/objects/Deserializer.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/objects/Serializer.html
+++ b/1.2/learn/api-docs/ballerina/kafka/objects/Serializer.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/objects/Serializer.html
+++ b/1.2/learn/api-docs/ballerina/kafka/objects/Serializer.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/AuthenticationConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/AuthenticationConfiguration.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/AuthenticationConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/AuthenticationConfiguration.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/AvroGenericRecord.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/AvroGenericRecord.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/AvroGenericRecord.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/AvroGenericRecord.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/AvroRecord.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/AvroRecord.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/AvroRecord.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/AvroRecord.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/ConsumerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/ConsumerConfiguration.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/ConsumerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/ConsumerConfiguration.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/Detail.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/Detail.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/KeyStore.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/KeyStore.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/KeyStore.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/KeyStore.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/ProducerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/ProducerConfiguration.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/ProducerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/ProducerConfiguration.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/Protocols.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/Protocols.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/Protocols.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/Protocols.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/SecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/SecureSocket.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/SecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/SecureSocket.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/TopicPartition.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/TopicPartition.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/TopicPartition.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/TopicPartition.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/records/TrustStore.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/TrustStore.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/records/TrustStore.html
+++ b/1.2/learn/api-docs/ballerina/kafka/records/TrustStore.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/kafka/types.html
+++ b/1.2/learn/api-docs/ballerina/kafka/types.html
@@ -30,6 +30,23 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/kafka/types.html
+++ b/1.2/learn/api-docs/ballerina/kafka/types.html
@@ -67,7 +67,7 @@ This module supports Kafka 1.x.x and 2.0.0 versions.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.array/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.array/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.array/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.array/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.array/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.array/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.array/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.array/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.boolean/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.boolean/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.boolean/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.boolean/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.boolean/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.boolean/index.html
@@ -75,7 +75,7 @@
       </div>
     </div>
     <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 </div>

--- a/1.2/learn/api-docs/ballerina/lang.boolean/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.boolean/index.html
@@ -74,7 +74,11 @@
         <div class="cTopLine"></div>
       </div>
     </div>
-    <div class="row cBallerina-io-Nav" id="iMainNavigation"></div>
+    <a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
     <div class="clearfix"></div>
     <div class="navi-wrapper">
       <div class="navi-wrapper-content">

--- a/1.2/learn/api-docs/ballerina/lang.decimal/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.decimal/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.decimal/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.decimal/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.decimal/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.decimal/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.decimal/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.decimal/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.error/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.error/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.error/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.error/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.error/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.error/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.error/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.error/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.error/objects/CallStack.html
+++ b/1.2/learn/api-docs/ballerina/lang.error/objects/CallStack.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.error/objects/CallStack.html
+++ b/1.2/learn/api-docs/ballerina/lang.error/objects/CallStack.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
+++ b/1.2/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
+++ b/1.2/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.error/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/lang.error/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.error/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/lang.error/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.float/constants.html
+++ b/1.2/learn/api-docs/ballerina/lang.float/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.float/constants.html
+++ b/1.2/learn/api-docs/ballerina/lang.float/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.float/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.float/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.float/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.float/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.float/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.float/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.float/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.float/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.future/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.future/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.future/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.future/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.future/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.future/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.future/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.future/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.int/constants.html
+++ b/1.2/learn/api-docs/ballerina/lang.int/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.int/constants.html
+++ b/1.2/learn/api-docs/ballerina/lang.int/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.int/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.int/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.int/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.int/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.int/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.int/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.int/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.int/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.map/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.map/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.map/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.map/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.map/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.map/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.map/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.map/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.object/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.object/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.object/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.object/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.object/objects/Listener.html
+++ b/1.2/learn/api-docs/ballerina/lang.object/objects/Listener.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.object/objects/Listener.html
+++ b/1.2/learn/api-docs/ballerina/lang.object/objects/Listener.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.stream/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.stream/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.stream/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.stream/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.stream/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.stream/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.stream/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.stream/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.string/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.string/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.string/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.string/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.string/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.string/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.string/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.string/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.table/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.table/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.table/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.table/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.table/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.table/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.table/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.table/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.typedesc/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.typedesc/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.typedesc/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.typedesc/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.typedesc/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.typedesc/index.html
@@ -75,7 +75,7 @@
       </div>
     </div>
     <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 </div>

--- a/1.2/learn/api-docs/ballerina/lang.typedesc/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.typedesc/index.html
@@ -74,7 +74,11 @@
         <div class="cTopLine"></div>
       </div>
     </div>
-    <div class="row cBallerina-io-Nav" id="iMainNavigation"></div>
+    <a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
     <div class="clearfix"></div>
     <div class="navi-wrapper">
       <div class="navi-wrapper-content">

--- a/1.2/learn/api-docs/ballerina/lang.value/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.value/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.value/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.value/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.value/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.value/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.value/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.value/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.xml/constants.html
+++ b/1.2/learn/api-docs/ballerina/lang.xml/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.xml/constants.html
+++ b/1.2/learn/api-docs/ballerina/lang.xml/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.xml/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.xml/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.xml/functions.html
+++ b/1.2/learn/api-docs/ballerina/lang.xml/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/lang.xml/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.xml/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/lang.xml/index.html
+++ b/1.2/learn/api-docs/ballerina/lang.xml/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/ldap/constants.html
+++ b/1.2/learn/api-docs/ballerina/ldap/constants.html
@@ -71,7 +71,11 @@
         <div class="cTopLine"></div>
       </div>
     </div>
-    <div class="row cBallerina-io-Nav" id="iMainNavigation"></div>
+    <a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
+<div class="row cBallerina-io-Nav" id="iMainNavigation">
+</div>
     <div class="clearfix"></div>
     <div class="navi-wrapper">
       <div class="navi-wrapper-content">

--- a/1.2/learn/api-docs/ballerina/ldap/constants.html
+++ b/1.2/learn/api-docs/ballerina/ldap/constants.html
@@ -72,7 +72,7 @@
       </div>
     </div>
     <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 </div>

--- a/1.2/learn/api-docs/ballerina/ldap/errors.html
+++ b/1.2/learn/api-docs/ballerina/ldap/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/ldap/errors.html
+++ b/1.2/learn/api-docs/ballerina/ldap/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/ldap/functions.html
+++ b/1.2/learn/api-docs/ballerina/ldap/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/ldap/functions.html
+++ b/1.2/learn/api-docs/ballerina/ldap/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/ldap/index.html
+++ b/1.2/learn/api-docs/ballerina/ldap/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/ldap/index.html
+++ b/1.2/learn/api-docs/ballerina/ldap/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/ldap/objects/InboundLdapAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/ldap/objects/InboundLdapAuthProvider.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/ldap/objects/InboundLdapAuthProvider.html
+++ b/1.2/learn/api-docs/ballerina/ldap/objects/InboundLdapAuthProvider.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/ldap/records/LdapConnection.html
+++ b/1.2/learn/api-docs/ballerina/ldap/records/LdapConnection.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/ldap/records/LdapConnection.html
+++ b/1.2/learn/api-docs/ballerina/ldap/records/LdapConnection.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/ldap/records/LdapConnectionConfig.html
+++ b/1.2/learn/api-docs/ballerina/ldap/records/LdapConnectionConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/ldap/records/LdapConnectionConfig.html
+++ b/1.2/learn/api-docs/ballerina/ldap/records/LdapConnectionConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/ldap/records/SecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/ldap/records/SecureSocket.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/ldap/records/SecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/ldap/records/SecureSocket.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/log/functions.html
+++ b/1.2/learn/api-docs/ballerina/log/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/log/functions.html
+++ b/1.2/learn/api-docs/ballerina/log/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/log/index.html
+++ b/1.2/learn/api-docs/ballerina/log/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/log/index.html
+++ b/1.2/learn/api-docs/ballerina/log/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/math/constants.html
+++ b/1.2/learn/api-docs/ballerina/math/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/math/constants.html
+++ b/1.2/learn/api-docs/ballerina/math/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/math/errors.html
+++ b/1.2/learn/api-docs/ballerina/math/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/math/errors.html
+++ b/1.2/learn/api-docs/ballerina/math/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/math/functions.html
+++ b/1.2/learn/api-docs/ballerina/math/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/math/functions.html
+++ b/1.2/learn/api-docs/ballerina/math/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/math/index.html
+++ b/1.2/learn/api-docs/ballerina/math/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/math/index.html
+++ b/1.2/learn/api-docs/ballerina/math/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/math/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/math/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/math/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/math/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/mime/constants.html
+++ b/1.2/learn/api-docs/ballerina/mime/constants.html
@@ -68,7 +68,7 @@ the RFC 2045 standard.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/mime/constants.html
+++ b/1.2/learn/api-docs/ballerina/mime/constants.html
@@ -31,6 +31,23 @@ the RFC 2045 standard.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -50,7 +67,11 @@ the RFC 2045 standard.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/mime/errors.html
+++ b/1.2/learn/api-docs/ballerina/mime/errors.html
@@ -31,6 +31,23 @@ the RFC 2045 standard.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ the RFC 2045 standard.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/mime/errors.html
+++ b/1.2/learn/api-docs/ballerina/mime/errors.html
@@ -67,7 +67,7 @@ the RFC 2045 standard.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/mime/functions.html
+++ b/1.2/learn/api-docs/ballerina/mime/functions.html
@@ -68,7 +68,7 @@ the RFC 2045 standard.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/mime/functions.html
+++ b/1.2/learn/api-docs/ballerina/mime/functions.html
@@ -31,6 +31,23 @@ the RFC 2045 standard.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -50,7 +67,11 @@ the RFC 2045 standard.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/mime/index.html
+++ b/1.2/learn/api-docs/ballerina/mime/index.html
@@ -68,7 +68,7 @@ the RFC 2045 standard.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/mime/index.html
+++ b/1.2/learn/api-docs/ballerina/mime/index.html
@@ -31,6 +31,23 @@ the RFC 2045 standard.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -50,7 +67,11 @@ the RFC 2045 standard.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
+++ b/1.2/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
@@ -68,7 +68,7 @@ the RFC 2045 standard.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
+++ b/1.2/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
@@ -31,6 +31,23 @@ the RFC 2045 standard.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -50,7 +67,11 @@ the RFC 2045 standard.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/mime/objects/Entity.html
+++ b/1.2/learn/api-docs/ballerina/mime/objects/Entity.html
@@ -68,7 +68,7 @@ the RFC 2045 standard.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/mime/objects/Entity.html
+++ b/1.2/learn/api-docs/ballerina/mime/objects/Entity.html
@@ -31,6 +31,23 @@ the RFC 2045 standard.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -50,7 +67,11 @@ the RFC 2045 standard.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/mime/objects/MediaType.html
+++ b/1.2/learn/api-docs/ballerina/mime/objects/MediaType.html
@@ -68,7 +68,7 @@ the RFC 2045 standard.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/mime/objects/MediaType.html
+++ b/1.2/learn/api-docs/ballerina/mime/objects/MediaType.html
@@ -31,6 +31,23 @@ the RFC 2045 standard.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -50,7 +67,11 @@ the RFC 2045 standard.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/mime/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/mime/records/Detail.html
@@ -68,7 +68,7 @@ the RFC 2045 standard.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/mime/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/mime/records/Detail.html
@@ -31,6 +31,23 @@ the RFC 2045 standard.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -50,7 +67,11 @@ the RFC 2045 standard.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/mime/types.html
+++ b/1.2/learn/api-docs/ballerina/mime/types.html
@@ -68,7 +68,7 @@ the RFC 2045 standard.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/mime/types.html
+++ b/1.2/learn/api-docs/ballerina/mime/types.html
@@ -31,6 +31,23 @@ the RFC 2045 standard.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -50,7 +67,11 @@ the RFC 2045 standard.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/annotations.html
+++ b/1.2/learn/api-docs/ballerina/nats/annotations.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/annotations.html
+++ b/1.2/learn/api-docs/ballerina/nats/annotations.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/clients/Producer.html
+++ b/1.2/learn/api-docs/ballerina/nats/clients/Producer.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/clients/Producer.html
+++ b/1.2/learn/api-docs/ballerina/nats/clients/Producer.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
+++ b/1.2/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
+++ b/1.2/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
+++ b/1.2/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
+++ b/1.2/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/constants.html
+++ b/1.2/learn/api-docs/ballerina/nats/constants.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/constants.html
+++ b/1.2/learn/api-docs/ballerina/nats/constants.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/errors.html
+++ b/1.2/learn/api-docs/ballerina/nats/errors.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/errors.html
+++ b/1.2/learn/api-docs/ballerina/nats/errors.html
@@ -66,7 +66,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/index.html
+++ b/1.2/learn/api-docs/ballerina/nats/index.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/index.html
+++ b/1.2/learn/api-docs/ballerina/nats/index.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/nats/listeners/Listener.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/nats/listeners/Listener.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
+++ b/1.2/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
+++ b/1.2/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/objects/Connection.html
+++ b/1.2/learn/api-docs/ballerina/nats/objects/Connection.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/objects/Connection.html
+++ b/1.2/learn/api-docs/ballerina/nats/objects/Connection.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/objects/Message.html
+++ b/1.2/learn/api-docs/ballerina/nats/objects/Message.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/objects/Message.html
+++ b/1.2/learn/api-docs/ballerina/nats/objects/Message.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/Detail.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/Detail.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/records/PendingLimits.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/PendingLimits.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/records/PendingLimits.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/PendingLimits.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/records/SecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/SecureSocket.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/records/SecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/SecureSocket.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/records/StreamingConfig.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/StreamingConfig.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/records/StreamingConfig.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/StreamingConfig.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
+++ b/1.2/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/nats/types.html
+++ b/1.2/learn/api-docs/ballerina/nats/types.html
@@ -30,6 +30,23 @@ below functionalities.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ below functionalities.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/nats/types.html
+++ b/1.2/learn/api-docs/ballerina/nats/types.html
@@ -67,7 +67,7 @@ below functionalities.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/constants.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/constants.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/errors.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/errors.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/functions.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/functions.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/index.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/index.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/records/InboundOAuth2CacheEntry.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/InboundOAuth2CacheEntry.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/records/InboundOAuth2CacheEntry.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/InboundOAuth2CacheEntry.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/records/OutboundOAuth2CacheEntry.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/OutboundOAuth2CacheEntry.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/records/OutboundOAuth2CacheEntry.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/OutboundOAuth2CacheEntry.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
+++ b/1.2/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/observe/functions.html
+++ b/1.2/learn/api-docs/ballerina/observe/functions.html
@@ -67,7 +67,7 @@ Ballerina supports Observability out of the box. This module provides user api's
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/observe/functions.html
+++ b/1.2/learn/api-docs/ballerina/observe/functions.html
@@ -30,6 +30,23 @@ Ballerina supports Observability out of the box. This module provides user api's
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Ballerina supports Observability out of the box. This module provides user api's
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/observe/index.html
+++ b/1.2/learn/api-docs/ballerina/observe/index.html
@@ -67,7 +67,7 @@ Ballerina supports Observability out of the box. This module provides user api's
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/observe/index.html
+++ b/1.2/learn/api-docs/ballerina/observe/index.html
@@ -30,6 +30,23 @@ Ballerina supports Observability out of the box. This module provides user api's
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Ballerina supports Observability out of the box. This module provides user api's
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/observe/objects/Counter.html
+++ b/1.2/learn/api-docs/ballerina/observe/objects/Counter.html
@@ -67,7 +67,7 @@ Ballerina supports Observability out of the box. This module provides user api's
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/observe/objects/Counter.html
+++ b/1.2/learn/api-docs/ballerina/observe/objects/Counter.html
@@ -30,6 +30,23 @@ Ballerina supports Observability out of the box. This module provides user api's
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Ballerina supports Observability out of the box. This module provides user api's
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/observe/objects/Gauge.html
+++ b/1.2/learn/api-docs/ballerina/observe/objects/Gauge.html
@@ -67,7 +67,7 @@ Ballerina supports Observability out of the box. This module provides user api's
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/observe/objects/Gauge.html
+++ b/1.2/learn/api-docs/ballerina/observe/objects/Gauge.html
@@ -30,6 +30,23 @@ Ballerina supports Observability out of the box. This module provides user api's
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Ballerina supports Observability out of the box. This module provides user api's
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/observe/records/Metric.html
+++ b/1.2/learn/api-docs/ballerina/observe/records/Metric.html
@@ -67,7 +67,7 @@ Ballerina supports Observability out of the box. This module provides user api's
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/observe/records/Metric.html
+++ b/1.2/learn/api-docs/ballerina/observe/records/Metric.html
@@ -30,6 +30,23 @@ Ballerina supports Observability out of the box. This module provides user api's
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Ballerina supports Observability out of the box. This module provides user api's
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/observe/records/PercentileValue.html
+++ b/1.2/learn/api-docs/ballerina/observe/records/PercentileValue.html
@@ -67,7 +67,7 @@ Ballerina supports Observability out of the box. This module provides user api's
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/observe/records/PercentileValue.html
+++ b/1.2/learn/api-docs/ballerina/observe/records/PercentileValue.html
@@ -30,6 +30,23 @@ Ballerina supports Observability out of the box. This module provides user api's
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Ballerina supports Observability out of the box. This module provides user api's
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/observe/records/Snapshot.html
+++ b/1.2/learn/api-docs/ballerina/observe/records/Snapshot.html
@@ -67,7 +67,7 @@ Ballerina supports Observability out of the box. This module provides user api's
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/observe/records/Snapshot.html
+++ b/1.2/learn/api-docs/ballerina/observe/records/Snapshot.html
@@ -30,6 +30,23 @@ Ballerina supports Observability out of the box. This module provides user api's
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Ballerina supports Observability out of the box. This module provides user api's
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/observe/records/StatisticConfig.html
+++ b/1.2/learn/api-docs/ballerina/observe/records/StatisticConfig.html
@@ -67,7 +67,7 @@ Ballerina supports Observability out of the box. This module provides user api's
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/observe/records/StatisticConfig.html
+++ b/1.2/learn/api-docs/ballerina/observe/records/StatisticConfig.html
@@ -30,6 +30,23 @@ Ballerina supports Observability out of the box. This module provides user api's
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Ballerina supports Observability out of the box. This module provides user api's
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/openapi/annotations.html
+++ b/1.2/learn/api-docs/ballerina/openapi/annotations.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/openapi/annotations.html
+++ b/1.2/learn/api-docs/ballerina/openapi/annotations.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/openapi/index.html
+++ b/1.2/learn/api-docs/ballerina/openapi/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/openapi/index.html
+++ b/1.2/learn/api-docs/ballerina/openapi/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/openapi/records/ClientInformation.html
+++ b/1.2/learn/api-docs/ballerina/openapi/records/ClientInformation.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/openapi/records/ClientInformation.html
+++ b/1.2/learn/api-docs/ballerina/openapi/records/ClientInformation.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
+++ b/1.2/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
+++ b/1.2/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/annotations.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/annotations.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/annotations.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/annotations.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/clients/Message.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/clients/Message.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/clients/Message.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/clients/Message.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/constants.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/constants.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/errors.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/errors.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/index.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/index.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/rabbitmq/types.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/rabbitmq/types.html
+++ b/1.2/learn/api-docs/ballerina/rabbitmq/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/reflect/functions.html
+++ b/1.2/learn/api-docs/ballerina/reflect/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/reflect/functions.html
+++ b/1.2/learn/api-docs/ballerina/reflect/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/reflect/index.html
+++ b/1.2/learn/api-docs/ballerina/reflect/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/reflect/index.html
+++ b/1.2/learn/api-docs/ballerina/reflect/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/runtime/functions.html
+++ b/1.2/learn/api-docs/ballerina/runtime/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/runtime/functions.html
+++ b/1.2/learn/api-docs/ballerina/runtime/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/runtime/index.html
+++ b/1.2/learn/api-docs/ballerina/runtime/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/runtime/index.html
+++ b/1.2/learn/api-docs/ballerina/runtime/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
+++ b/1.2/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
+++ b/1.2/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/runtime/records/CallStackElement.html
+++ b/1.2/learn/api-docs/ballerina/runtime/records/CallStackElement.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/runtime/records/CallStackElement.html
+++ b/1.2/learn/api-docs/ballerina/runtime/records/CallStackElement.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/runtime/records/InvocationContext.html
+++ b/1.2/learn/api-docs/ballerina/runtime/records/InvocationContext.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/runtime/records/InvocationContext.html
+++ b/1.2/learn/api-docs/ballerina/runtime/records/InvocationContext.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/runtime/records/Principal.html
+++ b/1.2/learn/api-docs/ballerina/runtime/records/Principal.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/runtime/records/Principal.html
+++ b/1.2/learn/api-docs/ballerina/runtime/records/Principal.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/clients/Client.html
+++ b/1.2/learn/api-docs/ballerina/socket/clients/Client.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/clients/Client.html
+++ b/1.2/learn/api-docs/ballerina/socket/clients/Client.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/clients/UdpClient.html
+++ b/1.2/learn/api-docs/ballerina/socket/clients/UdpClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/clients/UdpClient.html
+++ b/1.2/learn/api-docs/ballerina/socket/clients/UdpClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/constants.html
+++ b/1.2/learn/api-docs/ballerina/socket/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/constants.html
+++ b/1.2/learn/api-docs/ballerina/socket/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/errors.html
+++ b/1.2/learn/api-docs/ballerina/socket/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/errors.html
+++ b/1.2/learn/api-docs/ballerina/socket/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/index.html
+++ b/1.2/learn/api-docs/ballerina/socket/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/index.html
+++ b/1.2/learn/api-docs/ballerina/socket/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/socket/listeners/Listener.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/socket/listeners/Listener.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/records/Address.html
+++ b/1.2/learn/api-docs/ballerina/socket/records/Address.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/records/Address.html
+++ b/1.2/learn/api-docs/ballerina/socket/records/Address.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/records/ClientConfig.html
+++ b/1.2/learn/api-docs/ballerina/socket/records/ClientConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/records/ClientConfig.html
+++ b/1.2/learn/api-docs/ballerina/socket/records/ClientConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/socket/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/socket/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/records/ListenerConfig.html
+++ b/1.2/learn/api-docs/ballerina/socket/records/ListenerConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/records/ListenerConfig.html
+++ b/1.2/learn/api-docs/ballerina/socket/records/ListenerConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
+++ b/1.2/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
+++ b/1.2/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/socket/types.html
+++ b/1.2/learn/api-docs/ballerina/socket/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/socket/types.html
+++ b/1.2/learn/api-docs/ballerina/socket/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/stringutils/functions.html
+++ b/1.2/learn/api-docs/ballerina/stringutils/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/stringutils/functions.html
+++ b/1.2/learn/api-docs/ballerina/stringutils/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/stringutils/index.html
+++ b/1.2/learn/api-docs/ballerina/stringutils/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/stringutils/index.html
+++ b/1.2/learn/api-docs/ballerina/stringutils/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/system/constants.html
+++ b/1.2/learn/api-docs/ballerina/system/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/system/constants.html
+++ b/1.2/learn/api-docs/ballerina/system/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/system/errors.html
+++ b/1.2/learn/api-docs/ballerina/system/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/system/errors.html
+++ b/1.2/learn/api-docs/ballerina/system/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/system/functions.html
+++ b/1.2/learn/api-docs/ballerina/system/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/system/functions.html
+++ b/1.2/learn/api-docs/ballerina/system/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/system/index.html
+++ b/1.2/learn/api-docs/ballerina/system/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/system/index.html
+++ b/1.2/learn/api-docs/ballerina/system/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/system/objects/Process.html
+++ b/1.2/learn/api-docs/ballerina/system/objects/Process.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/system/objects/Process.html
+++ b/1.2/learn/api-docs/ballerina/system/objects/Process.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/system/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/system/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/system/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/system/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/system/types.html
+++ b/1.2/learn/api-docs/ballerina/system/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/system/types.html
+++ b/1.2/learn/api-docs/ballerina/system/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/task/constants.html
+++ b/1.2/learn/api-docs/ballerina/task/constants.html
@@ -30,6 +30,23 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/task/constants.html
+++ b/1.2/learn/api-docs/ballerina/task/constants.html
@@ -67,7 +67,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/task/errors.html
+++ b/1.2/learn/api-docs/ballerina/task/errors.html
@@ -30,6 +30,23 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/task/errors.html
+++ b/1.2/learn/api-docs/ballerina/task/errors.html
@@ -66,7 +66,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/task/index.html
+++ b/1.2/learn/api-docs/ballerina/task/index.html
@@ -30,6 +30,23 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/task/index.html
+++ b/1.2/learn/api-docs/ballerina/task/index.html
@@ -67,7 +67,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/task/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/task/listeners/Listener.html
@@ -30,6 +30,23 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/task/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/task/listeners/Listener.html
@@ -67,7 +67,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/task/objects/Scheduler.html
+++ b/1.2/learn/api-docs/ballerina/task/objects/Scheduler.html
@@ -30,6 +30,23 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/task/objects/Scheduler.html
+++ b/1.2/learn/api-docs/ballerina/task/objects/Scheduler.html
@@ -67,7 +67,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
@@ -30,6 +30,23 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
@@ -67,7 +67,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/task/records/AppointmentData.html
+++ b/1.2/learn/api-docs/ballerina/task/records/AppointmentData.html
@@ -30,6 +30,23 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/task/records/AppointmentData.html
+++ b/1.2/learn/api-docs/ballerina/task/records/AppointmentData.html
@@ -67,7 +67,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/task/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/task/records/Detail.html
@@ -30,6 +30,23 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/task/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/task/records/Detail.html
@@ -67,7 +67,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/task/records/TimerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/task/records/TimerConfiguration.html
@@ -30,6 +30,23 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/task/records/TimerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/task/records/TimerConfiguration.html
@@ -67,7 +67,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/task/types.html
+++ b/1.2/learn/api-docs/ballerina/task/types.html
@@ -30,6 +30,23 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/task/types.html
+++ b/1.2/learn/api-docs/ballerina/task/types.html
@@ -67,7 +67,7 @@ Task Listeners and Task Schedulers can be used to perform tasks periodically.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/annotations.html
+++ b/1.2/learn/api-docs/ballerina/test/annotations.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/annotations.html
+++ b/1.2/learn/api-docs/ballerina/test/annotations.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/constants.html
+++ b/1.2/learn/api-docs/ballerina/test/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/constants.html
+++ b/1.2/learn/api-docs/ballerina/test/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/errors.html
+++ b/1.2/learn/api-docs/ballerina/test/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/errors.html
+++ b/1.2/learn/api-docs/ballerina/test/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/functions.html
+++ b/1.2/learn/api-docs/ballerina/test/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/functions.html
+++ b/1.2/learn/api-docs/ballerina/test/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/index.html
+++ b/1.2/learn/api-docs/ballerina/test/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/index.html
+++ b/1.2/learn/api-docs/ballerina/test/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/objects/FunctionStub.html
+++ b/1.2/learn/api-docs/ballerina/test/objects/FunctionStub.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/objects/FunctionStub.html
+++ b/1.2/learn/api-docs/ballerina/test/objects/FunctionStub.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/objects/MemberFunctionStub.html
+++ b/1.2/learn/api-docs/ballerina/test/objects/MemberFunctionStub.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/objects/MemberFunctionStub.html
+++ b/1.2/learn/api-docs/ballerina/test/objects/MemberFunctionStub.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/objects/MemberVariableStub.html
+++ b/1.2/learn/api-docs/ballerina/test/objects/MemberVariableStub.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/objects/MemberVariableStub.html
+++ b/1.2/learn/api-docs/ballerina/test/objects/MemberVariableStub.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/objects/MockFunction.html
+++ b/1.2/learn/api-docs/ballerina/test/objects/MockFunction.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/objects/MockFunction.html
+++ b/1.2/learn/api-docs/ballerina/test/objects/MockFunction.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/objects/MockObject.html
+++ b/1.2/learn/api-docs/ballerina/test/objects/MockObject.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/objects/MockObject.html
+++ b/1.2/learn/api-docs/ballerina/test/objects/MockObject.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/test/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/test/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/records/MockConfig.html
+++ b/1.2/learn/api-docs/ballerina/test/records/MockConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/records/MockConfig.html
+++ b/1.2/learn/api-docs/ballerina/test/records/MockConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/records/TestConfig.html
+++ b/1.2/learn/api-docs/ballerina/test/records/TestConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/records/TestConfig.html
+++ b/1.2/learn/api-docs/ballerina/test/records/TestConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/test/types.html
+++ b/1.2/learn/api-docs/ballerina/test/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/test/types.html
+++ b/1.2/learn/api-docs/ballerina/test/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/time/constants.html
+++ b/1.2/learn/api-docs/ballerina/time/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/time/constants.html
+++ b/1.2/learn/api-docs/ballerina/time/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/time/errors.html
+++ b/1.2/learn/api-docs/ballerina/time/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/time/errors.html
+++ b/1.2/learn/api-docs/ballerina/time/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/time/functions.html
+++ b/1.2/learn/api-docs/ballerina/time/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/time/functions.html
+++ b/1.2/learn/api-docs/ballerina/time/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/time/index.html
+++ b/1.2/learn/api-docs/ballerina/time/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/time/index.html
+++ b/1.2/learn/api-docs/ballerina/time/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/time/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/time/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/time/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/time/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/time/records/Time.html
+++ b/1.2/learn/api-docs/ballerina/time/records/Time.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/time/records/Time.html
+++ b/1.2/learn/api-docs/ballerina/time/records/Time.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/time/records/TimeZone.html
+++ b/1.2/learn/api-docs/ballerina/time/records/TimeZone.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/time/records/TimeZone.html
+++ b/1.2/learn/api-docs/ballerina/time/records/TimeZone.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/time/types.html
+++ b/1.2/learn/api-docs/ballerina/time/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/time/types.html
+++ b/1.2/learn/api-docs/ballerina/time/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/transactions/annotations.html
+++ b/1.2/learn/api-docs/ballerina/transactions/annotations.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/transactions/annotations.html
+++ b/1.2/learn/api-docs/ballerina/transactions/annotations.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/transactions/functions.html
+++ b/1.2/learn/api-docs/ballerina/transactions/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/transactions/functions.html
+++ b/1.2/learn/api-docs/ballerina/transactions/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/transactions/index.html
+++ b/1.2/learn/api-docs/ballerina/transactions/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/transactions/index.html
+++ b/1.2/learn/api-docs/ballerina/transactions/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/transactions/records/TransactionParticipantConfig.html
+++ b/1.2/learn/api-docs/ballerina/transactions/records/TransactionParticipantConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/transactions/records/TransactionParticipantConfig.html
+++ b/1.2/learn/api-docs/ballerina/transactions/records/TransactionParticipantConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/annotations.html
+++ b/1.2/learn/api-docs/ballerina/websub/annotations.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/annotations.html
+++ b/1.2/learn/api-docs/ballerina/websub/annotations.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/clients/Caller.html
+++ b/1.2/learn/api-docs/ballerina/websub/clients/Caller.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/clients/Caller.html
+++ b/1.2/learn/api-docs/ballerina/websub/clients/Caller.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/clients/PublisherClient.html
+++ b/1.2/learn/api-docs/ballerina/websub/clients/PublisherClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/clients/PublisherClient.html
+++ b/1.2/learn/api-docs/ballerina/websub/clients/PublisherClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
+++ b/1.2/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
+++ b/1.2/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/constants.html
+++ b/1.2/learn/api-docs/ballerina/websub/constants.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/constants.html
+++ b/1.2/learn/api-docs/ballerina/websub/constants.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/errors.html
+++ b/1.2/learn/api-docs/ballerina/websub/errors.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -47,7 +64,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/errors.html
+++ b/1.2/learn/api-docs/ballerina/websub/errors.html
@@ -65,7 +65,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/functions.html
+++ b/1.2/learn/api-docs/ballerina/websub/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/functions.html
+++ b/1.2/learn/api-docs/ballerina/websub/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/index.html
+++ b/1.2/learn/api-docs/ballerina/websub/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/index.html
+++ b/1.2/learn/api-docs/ballerina/websub/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/websub/listeners/Listener.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/listeners/Listener.html
+++ b/1.2/learn/api-docs/ballerina/websub/listeners/Listener.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/objects/Hub.html
+++ b/1.2/learn/api-docs/ballerina/websub/objects/Hub.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/objects/Hub.html
+++ b/1.2/learn/api-docs/ballerina/websub/objects/Hub.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
+++ b/1.2/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
+++ b/1.2/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
+++ b/1.2/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
+++ b/1.2/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/objects/Notification.html
+++ b/1.2/learn/api-docs/ballerina/websub/objects/Notification.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/objects/Notification.html
+++ b/1.2/learn/api-docs/ballerina/websub/objects/Notification.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/Detail.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/Detail.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/Detail.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/HubConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/HubConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/HubConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/HubConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/records/WebSubContent.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/WebSubContent.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/records/WebSubContent.html
+++ b/1.2/learn/api-docs/ballerina/websub/records/WebSubContent.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/websub/types.html
+++ b/1.2/learn/api-docs/ballerina/websub/types.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/websub/types.html
+++ b/1.2/learn/api-docs/ballerina/websub/types.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/xmlutils/functions.html
+++ b/1.2/learn/api-docs/ballerina/xmlutils/functions.html
@@ -67,7 +67,7 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/xmlutils/functions.html
+++ b/1.2/learn/api-docs/ballerina/xmlutils/functions.html
@@ -30,6 +30,23 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/xmlutils/index.html
+++ b/1.2/learn/api-docs/ballerina/xmlutils/index.html
@@ -67,7 +67,7 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/xmlutils/index.html
+++ b/1.2/learn/api-docs/ballerina/xmlutils/index.html
@@ -30,6 +30,23 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
+++ b/1.2/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
@@ -67,7 +67,7 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
+++ b/1.2/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
@@ -30,6 +30,23 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -49,7 +66,11 @@ It provides APIs to convert a json to an xml or convert a table to an xml.
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/xslt/functions.html
+++ b/1.2/learn/api-docs/ballerina/xslt/functions.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/xslt/functions.html
+++ b/1.2/learn/api-docs/ballerina/xslt/functions.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/api-docs/ballerina/xslt/index.html
+++ b/1.2/learn/api-docs/ballerina/xslt/index.html
@@ -29,6 +29,23 @@
     .line-numbers-wrap {
         display: none;
     }
+    .cInfoBanner {
+        background: #20b6b0;
+        width: 100%;
+        display: inline-block;
+        color: #fff;
+        padding: 10px;
+        width: 100%;
+        text-align: center;
+        font-weight: 600;
+        font-size: 20px;
+        transition : all 0.3s;
+    }
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 </style>
 <!-- BIO THEME END -->
 
@@ -48,7 +65,11 @@
         <div class="cTopLine"></div>
     </div>
 </div>
+<a href="https://lib.ballerina.io/" class="cInfoBanner">
+    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
+
 </div>
 <div class="clearfix"></div>
     <div class="navi-wrapper">

--- a/1.2/learn/api-docs/ballerina/xslt/index.html
+++ b/1.2/learn/api-docs/ballerina/xslt/index.html
@@ -66,7 +66,7 @@
     </div>
 </div>
 <a href="https://lib.ballerina.io/" class="cInfoBanner">
-    This is the 1.2.0 API documentation of Ballerina. Please refer the latest  API documentation.
+    This API documentation is for Ballerina 1.2.0. View API documentation for the latest release.
 </a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.2/learn/by-example/abstract-objects.html
+++ b/1.2/learn/by-example/abstract-objects.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/abstract-objects.html
+++ b/1.2/learn/by-example/abstract-objects.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/access-mutate-java-fields.html
+++ b/1.2/learn/by-example/access-mutate-java-fields.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/access-mutate-java-fields.html
+++ b/1.2/learn/by-example/access-mutate-java-fields.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anonymous-functions.html
+++ b/1.2/learn/by-example/anonymous-functions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anonymous-functions.html
+++ b/1.2/learn/by-example/anonymous-functions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anonymous-objects.html
+++ b/1.2/learn/by-example/anonymous-objects.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anonymous-objects.html
+++ b/1.2/learn/by-example/anonymous-objects.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anonymous-records.html
+++ b/1.2/learn/by-example/anonymous-records.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anonymous-records.html
+++ b/1.2/learn/by-example/anonymous-records.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/any-type.html
+++ b/1.2/learn/by-example/any-type.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/any-type.html
+++ b/1.2/learn/by-example/any-type.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anydata-type.html
+++ b/1.2/learn/by-example/anydata-type.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/anydata-type.html
+++ b/1.2/learn/by-example/anydata-type.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/arrays.html
+++ b/1.2/learn/by-example/arrays.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/arrays.html
+++ b/1.2/learn/by-example/arrays.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/async.html
+++ b/1.2/learn/by-example/async.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/async.html
+++ b/1.2/learn/by-example/async.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/aws-lambda-deployment.html
+++ b/1.2/learn/by-example/aws-lambda-deployment.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/aws-lambda-deployment.html
+++ b/1.2/learn/by-example/aws-lambda-deployment.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/azure-functions-deployment.html
+++ b/1.2/learn/by-example/azure-functions-deployment.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/azure-functions-deployment.html
+++ b/1.2/learn/by-example/azure-functions-deployment.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/ballerina-to-openapi.html
+++ b/1.2/learn/by-example/ballerina-to-openapi.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/ballerina-to-openapi.html
+++ b/1.2/learn/by-example/ballerina-to-openapi.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/base-path-and-path.html
+++ b/1.2/learn/by-example/base-path-and-path.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/base-path-and-path.html
+++ b/1.2/learn/by-example/base-path-and-path.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/basic-documentation.html
+++ b/1.2/learn/by-example/basic-documentation.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/basic-documentation.html
+++ b/1.2/learn/by-example/basic-documentation.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/basic-https-listener-client.html
+++ b/1.2/learn/by-example/basic-https-listener-client.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/basic-https-listener-client.html
+++ b/1.2/learn/by-example/basic-https-listener-client.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/binary-bitwise-expressions.html
+++ b/1.2/learn/by-example/binary-bitwise-expressions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/binary-bitwise-expressions.html
+++ b/1.2/learn/by-example/binary-bitwise-expressions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/byte-io.html
+++ b/1.2/learn/by-example/byte-io.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/byte-io.html
+++ b/1.2/learn/by-example/byte-io.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/byte-type.html
+++ b/1.2/learn/by-example/byte-type.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/byte-type.html
+++ b/1.2/learn/by-example/byte-type.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/cache.html
+++ b/1.2/learn/by-example/cache.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/cache.html
+++ b/1.2/learn/by-example/cache.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/character-io.html
+++ b/1.2/learn/by-example/character-io.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/character-io.html
+++ b/1.2/learn/by-example/character-io.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/check.html
+++ b/1.2/learn/by-example/check.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/check.html
+++ b/1.2/learn/by-example/check.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/checkpanic.html
+++ b/1.2/learn/by-example/checkpanic.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/checkpanic.html
+++ b/1.2/learn/by-example/checkpanic.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/client-generation.html
+++ b/1.2/learn/by-example/client-generation.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/client-generation.html
+++ b/1.2/learn/by-example/client-generation.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/clone.html
+++ b/1.2/learn/by-example/clone.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/clone.html
+++ b/1.2/learn/by-example/clone.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/closures.html
+++ b/1.2/learn/by-example/closures.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/closures.html
+++ b/1.2/learn/by-example/closures.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/compound-assignment-operators.html
+++ b/1.2/learn/by-example/compound-assignment-operators.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/compound-assignment-operators.html
+++ b/1.2/learn/by-example/compound-assignment-operators.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/config-api.html
+++ b/1.2/learn/by-example/config-api.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/config-api.html
+++ b/1.2/learn/by-example/config-api.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/constants.html
+++ b/1.2/learn/by-example/constants.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/constants.html
+++ b/1.2/learn/by-example/constants.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/content-based-routing.html
+++ b/1.2/learn/by-example/content-based-routing.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/content-based-routing.html
+++ b/1.2/learn/by-example/content-based-routing.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/counter-metrics.html
+++ b/1.2/learn/by-example/counter-metrics.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/counter-metrics.html
+++ b/1.2/learn/by-example/counter-metrics.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/create-java-objects.html
+++ b/1.2/learn/by-example/create-java-objects.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/create-java-objects.html
+++ b/1.2/learn/by-example/create-java-objects.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/crypto.html
+++ b/1.2/learn/by-example/crypto.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/crypto.html
+++ b/1.2/learn/by-example/crypto.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/csv-io.html
+++ b/1.2/learn/by-example/csv-io.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/csv-io.html
+++ b/1.2/learn/by-example/csv-io.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/data-io.html
+++ b/1.2/learn/by-example/data-io.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/data-io.html
+++ b/1.2/learn/by-example/data-io.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/deprecation.html
+++ b/1.2/learn/by-example/deprecation.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/deprecation.html
+++ b/1.2/learn/by-example/deprecation.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/different-payload-types.html
+++ b/1.2/learn/by-example/different-payload-types.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/different-payload-types.html
+++ b/1.2/learn/by-example/different-payload-types.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/directory-listener.html
+++ b/1.2/learn/by-example/directory-listener.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/directory-listener.html
+++ b/1.2/learn/by-example/directory-listener.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/docker-deployment.html
+++ b/1.2/learn/by-example/docker-deployment.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/docker-deployment.html
+++ b/1.2/learn/by-example/docker-deployment.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/elvis-operator.html
+++ b/1.2/learn/by-example/elvis-operator.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/elvis-operator.html
+++ b/1.2/learn/by-example/elvis-operator.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/equality.html
+++ b/1.2/learn/by-example/equality.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/equality.html
+++ b/1.2/learn/by-example/equality.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-destructure-binding-pattern.html
+++ b/1.2/learn/by-example/error-destructure-binding-pattern.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-destructure-binding-pattern.html
+++ b/1.2/learn/by-example/error-destructure-binding-pattern.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-handling.html
+++ b/1.2/learn/by-example/error-handling.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-handling.html
+++ b/1.2/learn/by-example/error-handling.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-match-statement.html
+++ b/1.2/learn/by-example/error-match-statement.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-match-statement.html
+++ b/1.2/learn/by-example/error-match-statement.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-typed-binding-pattern.html
+++ b/1.2/learn/by-example/error-typed-binding-pattern.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/error-typed-binding-pattern.html
+++ b/1.2/learn/by-example/error-typed-binding-pattern.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/expression-bodied-functions.html
+++ b/1.2/learn/by-example/expression-bodied-functions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/expression-bodied-functions.html
+++ b/1.2/learn/by-example/expression-bodied-functions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/file.html
+++ b/1.2/learn/by-example/file.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/file.html
+++ b/1.2/learn/by-example/file.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/filepath.html
+++ b/1.2/learn/by-example/filepath.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/filepath.html
+++ b/1.2/learn/by-example/filepath.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/foreach.html
+++ b/1.2/learn/by-example/foreach.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/foreach.html
+++ b/1.2/learn/by-example/foreach.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/fork-variable-access.html
+++ b/1.2/learn/by-example/fork-variable-access.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/fork-variable-access.html
+++ b/1.2/learn/by-example/fork-variable-access.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/fork.html
+++ b/1.2/learn/by-example/fork.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/fork.html
+++ b/1.2/learn/by-example/fork.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/function-pointers.html
+++ b/1.2/learn/by-example/function-pointers.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/function-pointers.html
+++ b/1.2/learn/by-example/function-pointers.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functional-iteration.html
+++ b/1.2/learn/by-example/functional-iteration.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functional-iteration.html
+++ b/1.2/learn/by-example/functional-iteration.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions-with-defaultable-parameters.html
+++ b/1.2/learn/by-example/functions-with-defaultable-parameters.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions-with-defaultable-parameters.html
+++ b/1.2/learn/by-example/functions-with-defaultable-parameters.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions-with-required-parameters.html
+++ b/1.2/learn/by-example/functions-with-required-parameters.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions-with-required-parameters.html
+++ b/1.2/learn/by-example/functions-with-required-parameters.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions-with-rest-parameter.html
+++ b/1.2/learn/by-example/functions-with-rest-parameter.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions-with-rest-parameter.html
+++ b/1.2/learn/by-example/functions-with-rest-parameter.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions.html
+++ b/1.2/learn/by-example/functions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/functions.html
+++ b/1.2/learn/by-example/functions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/gauge-metrics.html
+++ b/1.2/learn/by-example/gauge-metrics.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/gauge-metrics.html
+++ b/1.2/learn/by-example/gauge-metrics.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-bidirectional-streaming.html
+++ b/1.2/learn/by-example/grpc-bidirectional-streaming.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-bidirectional-streaming.html
+++ b/1.2/learn/by-example/grpc-bidirectional-streaming.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-client-streaming.html
+++ b/1.2/learn/by-example/grpc-client-streaming.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-client-streaming.html
+++ b/1.2/learn/by-example/grpc-client-streaming.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-secured-unary.html
+++ b/1.2/learn/by-example/grpc-secured-unary.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-secured-unary.html
+++ b/1.2/learn/by-example/grpc-secured-unary.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-server-streaming.html
+++ b/1.2/learn/by-example/grpc-server-streaming.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-server-streaming.html
+++ b/1.2/learn/by-example/grpc-server-streaming.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-unary-blocking.html
+++ b/1.2/learn/by-example/grpc-unary-blocking.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-unary-blocking.html
+++ b/1.2/learn/by-example/grpc-unary-blocking.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-unary-non-blocking.html
+++ b/1.2/learn/by-example/grpc-unary-non-blocking.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/grpc-unary-non-blocking.html
+++ b/1.2/learn/by-example/grpc-unary-non-blocking.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/header-based-routing.html
+++ b/1.2/learn/by-example/header-based-routing.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/header-based-routing.html
+++ b/1.2/learn/by-example/header-based-routing.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world-client.html
+++ b/1.2/learn/by-example/hello-world-client.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world-client.html
+++ b/1.2/learn/by-example/hello-world-client.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world-parallel.html
+++ b/1.2/learn/by-example/hello-world-parallel.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world-parallel.html
+++ b/1.2/learn/by-example/hello-world-parallel.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world-service.html
+++ b/1.2/learn/by-example/hello-world-service.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world-service.html
+++ b/1.2/learn/by-example/hello-world-service.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world.html
+++ b/1.2/learn/by-example/hello-world.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/hello-world.html
+++ b/1.2/learn/by-example/hello-world.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-1-1-to-2-0-protocol-switch.html
+++ b/1.2/learn/by-example/http-1-1-to-2-0-protocol-switch.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-1-1-to-2-0-protocol-switch.html
+++ b/1.2/learn/by-example/http-1-1-to-2-0-protocol-switch.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-100-continue.html
+++ b/1.2/learn/by-example/http-100-continue.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-100-continue.html
+++ b/1.2/learn/by-example/http-100-continue.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-2-0-server-push.html
+++ b/1.2/learn/by-example/http-2-0-server-push.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-2-0-server-push.html
+++ b/1.2/learn/by-example/http-2-0-server-push.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-access-logs.html
+++ b/1.2/learn/by-example/http-access-logs.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-access-logs.html
+++ b/1.2/learn/by-example/http-access-logs.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-caching-client.html
+++ b/1.2/learn/by-example/http-caching-client.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-caching-client.html
+++ b/1.2/learn/by-example/http-caching-client.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-circuit-breaker.html
+++ b/1.2/learn/by-example/http-circuit-breaker.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-circuit-breaker.html
+++ b/1.2/learn/by-example/http-circuit-breaker.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-client-endpoint.html
+++ b/1.2/learn/by-example/http-client-endpoint.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-client-endpoint.html
+++ b/1.2/learn/by-example/http-client-endpoint.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-compression.html
+++ b/1.2/learn/by-example/http-compression.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-compression.html
+++ b/1.2/learn/by-example/http-compression.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-cookies.html
+++ b/1.2/learn/by-example/http-cookies.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-cookies.html
+++ b/1.2/learn/by-example/http-cookies.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-cors.html
+++ b/1.2/learn/by-example/http-cors.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-cors.html
+++ b/1.2/learn/by-example/http-cors.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-data-binding.html
+++ b/1.2/learn/by-example/http-data-binding.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-data-binding.html
+++ b/1.2/learn/by-example/http-data-binding.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-disable-chunking.html
+++ b/1.2/learn/by-example/http-disable-chunking.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-disable-chunking.html
+++ b/1.2/learn/by-example/http-disable-chunking.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-failover.html
+++ b/1.2/learn/by-example/http-failover.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-failover.html
+++ b/1.2/learn/by-example/http-failover.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-filters.html
+++ b/1.2/learn/by-example/http-filters.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-filters.html
+++ b/1.2/learn/by-example/http-filters.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-load-balancer.html
+++ b/1.2/learn/by-example/http-load-balancer.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-load-balancer.html
+++ b/1.2/learn/by-example/http-load-balancer.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-redirects.html
+++ b/1.2/learn/by-example/http-redirects.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-redirects.html
+++ b/1.2/learn/by-example/http-redirects.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-retry.html
+++ b/1.2/learn/by-example/http-retry.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-retry.html
+++ b/1.2/learn/by-example/http-retry.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-streaming.html
+++ b/1.2/learn/by-example/http-streaming.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-streaming.html
+++ b/1.2/learn/by-example/http-streaming.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-timeout.html
+++ b/1.2/learn/by-example/http-timeout.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-timeout.html
+++ b/1.2/learn/by-example/http-timeout.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-to-websocket-upgrade.html
+++ b/1.2/learn/by-example/http-to-websocket-upgrade.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-to-websocket-upgrade.html
+++ b/1.2/learn/by-example/http-to-websocket-upgrade.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-trace-logs.html
+++ b/1.2/learn/by-example/http-trace-logs.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/http-trace-logs.html
+++ b/1.2/learn/by-example/http-trace-logs.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/https-listener.html
+++ b/1.2/learn/by-example/https-listener.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/https-listener.html
+++ b/1.2/learn/by-example/https-listener.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/if-else.html
+++ b/1.2/learn/by-example/if-else.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/if-else.html
+++ b/1.2/learn/by-example/if-else.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/immutable-values.html
+++ b/1.2/learn/by-example/immutable-values.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/immutable-values.html
+++ b/1.2/learn/by-example/immutable-values.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/index.html
+++ b/1.2/learn/by-example/index.html
@@ -128,20 +128,23 @@
    <body class="cBallerina-io">
       <header data-plugin-header="line-numbers"></header>
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -156,9 +159,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/index.html
+++ b/1.2/learn/by-example/index.html
@@ -160,7 +160,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/invoke-java-methods.html
+++ b/1.2/learn/by-example/invoke-java-methods.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/invoke-java-methods.html
+++ b/1.2/learn/by-example/invoke-java-methods.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/iterable-objects.html
+++ b/1.2/learn/by-example/iterable-objects.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/iterable-objects.html
+++ b/1.2/learn/by-example/iterable-objects.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/java-arrays.html
+++ b/1.2/learn/by-example/java-arrays.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/java-arrays.html
+++ b/1.2/learn/by-example/java-arrays.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/java-exceptions.html
+++ b/1.2/learn/by-example/java-exceptions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/java-exceptions.html
+++ b/1.2/learn/by-example/java-exceptions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/java-varargs.html
+++ b/1.2/learn/by-example/java-varargs.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/java-varargs.html
+++ b/1.2/learn/by-example/java-varargs.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-client-batch-update.html
+++ b/1.2/learn/by-example/jdbc-client-batch-update.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-client-batch-update.html
+++ b/1.2/learn/by-example/jdbc-client-batch-update.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-client-call-procedures.html
+++ b/1.2/learn/by-example/jdbc-client-call-procedures.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-client-call-procedures.html
+++ b/1.2/learn/by-example/jdbc-client-call-procedures.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-client-crud-operations.html
+++ b/1.2/learn/by-example/jdbc-client-crud-operations.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-client-crud-operations.html
+++ b/1.2/learn/by-example/jdbc-client-crud-operations.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-streaming-big-dataset.html
+++ b/1.2/learn/by-example/jdbc-streaming-big-dataset.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc-streaming-big-dataset.html
+++ b/1.2/learn/by-example/jdbc-streaming-big-dataset.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-complex-type-queries.html
+++ b/1.2/learn/by-example/jdbc2-complex-type-queries.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-complex-type-queries.html
+++ b/1.2/learn/by-example/jdbc2-complex-type-queries.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-execute-operation.html
+++ b/1.2/learn/by-example/jdbc2-execute-operation.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-execute-operation.html
+++ b/1.2/learn/by-example/jdbc2-execute-operation.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-init-options.html
+++ b/1.2/learn/by-example/jdbc2-init-options.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-init-options.html
+++ b/1.2/learn/by-example/jdbc2-init-options.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-query-operation.html
+++ b/1.2/learn/by-example/jdbc2-query-operation.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jdbc2-query-operation.html
+++ b/1.2/learn/by-example/jdbc2-query-operation.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-access.html
+++ b/1.2/learn/by-example/json-access.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-access.html
+++ b/1.2/learn/by-example/json-access.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-arrays.html
+++ b/1.2/learn/by-example/json-arrays.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-arrays.html
+++ b/1.2/learn/by-example/json-arrays.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-csv.html
+++ b/1.2/learn/by-example/json-csv.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-csv.html
+++ b/1.2/learn/by-example/json-csv.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-io.html
+++ b/1.2/learn/by-example/json-io.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-io.html
+++ b/1.2/learn/by-example/json-io.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-objects.html
+++ b/1.2/learn/by-example/json-objects.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-objects.html
+++ b/1.2/learn/by-example/json-objects.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-record-map-conversion.html
+++ b/1.2/learn/by-example/json-record-map-conversion.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-record-map-conversion.html
+++ b/1.2/learn/by-example/json-record-map-conversion.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-to-xml-conversion.html
+++ b/1.2/learn/by-example/json-to-xml-conversion.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json-to-xml-conversion.html
+++ b/1.2/learn/by-example/json-to-xml-conversion.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json.html
+++ b/1.2/learn/by-example/json.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/json.html
+++ b/1.2/learn/by-example/json.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jwt-issue-validate.html
+++ b/1.2/learn/by-example/jwt-issue-validate.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/jwt-issue-validate.html
+++ b/1.2/learn/by-example/jwt-issue-validate.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-authentication-sasl-plain-consumer.html
+++ b/1.2/learn/by-example/kafka-authentication-sasl-plain-consumer.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-authentication-sasl-plain-consumer.html
+++ b/1.2/learn/by-example/kafka-authentication-sasl-plain-consumer.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-authentication-sasl-plain-producer.html
+++ b/1.2/learn/by-example/kafka-authentication-sasl-plain-producer.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-authentication-sasl-plain-producer.html
+++ b/1.2/learn/by-example/kafka-authentication-sasl-plain-producer.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-consumer-client.html
+++ b/1.2/learn/by-example/kafka-consumer-client.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-consumer-client.html
+++ b/1.2/learn/by-example/kafka-consumer-client.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-consumer-service.html
+++ b/1.2/learn/by-example/kafka-consumer-service.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-consumer-service.html
+++ b/1.2/learn/by-example/kafka-consumer-service.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-group-service.html
+++ b/1.2/learn/by-example/kafka-group-service.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-group-service.html
+++ b/1.2/learn/by-example/kafka-group-service.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-producer-transactional.html
+++ b/1.2/learn/by-example/kafka-producer-transactional.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-producer-transactional.html
+++ b/1.2/learn/by-example/kafka-producer-transactional.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-producer.html
+++ b/1.2/learn/by-example/kafka-producer.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kafka-producer.html
+++ b/1.2/learn/by-example/kafka-producer.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/knative-deployment.html
+++ b/1.2/learn/by-example/knative-deployment.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/knative-deployment.html
+++ b/1.2/learn/by-example/knative-deployment.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kubernetes-deployment.html
+++ b/1.2/learn/by-example/kubernetes-deployment.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/kubernetes-deployment.html
+++ b/1.2/learn/by-example/kubernetes-deployment.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/length.html
+++ b/1.2/learn/by-example/length.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/length.html
+++ b/1.2/learn/by-example/length.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/let-expression.html
+++ b/1.2/learn/by-example/let-expression.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/let-expression.html
+++ b/1.2/learn/by-example/let-expression.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/local-transactions-with-participants.html
+++ b/1.2/learn/by-example/local-transactions-with-participants.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/local-transactions-with-participants.html
+++ b/1.2/learn/by-example/local-transactions-with-participants.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/local-transactions.html
+++ b/1.2/learn/by-example/local-transactions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/local-transactions.html
+++ b/1.2/learn/by-example/local-transactions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/locks.html
+++ b/1.2/learn/by-example/locks.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/locks.html
+++ b/1.2/learn/by-example/locks.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/log-api.html
+++ b/1.2/learn/by-example/log-api.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/log-api.html
+++ b/1.2/learn/by-example/log-api.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/maps.html
+++ b/1.2/learn/by-example/maps.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/maps.html
+++ b/1.2/learn/by-example/maps.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/match.html
+++ b/1.2/learn/by-example/match.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/match.html
+++ b/1.2/learn/by-example/match.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/math-functions.html
+++ b/1.2/learn/by-example/math-functions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/math-functions.html
+++ b/1.2/learn/by-example/math-functions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/modules.html
+++ b/1.2/learn/by-example/modules.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/modules.html
+++ b/1.2/learn/by-example/modules.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mutual-ssl.html
+++ b/1.2/learn/by-example/mutual-ssl.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mutual-ssl.html
+++ b/1.2/learn/by-example/mutual-ssl.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-complex-type-queries.html
+++ b/1.2/learn/by-example/mysql-complex-type-queries.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-complex-type-queries.html
+++ b/1.2/learn/by-example/mysql-complex-type-queries.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-execute-operation.html
+++ b/1.2/learn/by-example/mysql-execute-operation.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-execute-operation.html
+++ b/1.2/learn/by-example/mysql-execute-operation.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-init-options.html
+++ b/1.2/learn/by-example/mysql-init-options.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-init-options.html
+++ b/1.2/learn/by-example/mysql-init-options.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-query-operation.html
+++ b/1.2/learn/by-example/mysql-query-operation.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/mysql-query-operation.html
+++ b/1.2/learn/by-example/mysql-query-operation.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-basic-client.html
+++ b/1.2/learn/by-example/nats-basic-client.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-basic-client.html
+++ b/1.2/learn/by-example/nats-basic-client.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-client.html
+++ b/1.2/learn/by-example/nats-streaming-client.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-client.html
+++ b/1.2/learn/by-example/nats-streaming-client.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-consumer-with-data-binding.html
+++ b/1.2/learn/by-example/nats-streaming-consumer-with-data-binding.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-consumer-with-data-binding.html
+++ b/1.2/learn/by-example/nats-streaming-consumer-with-data-binding.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-durable-subscriptions.html
+++ b/1.2/learn/by-example/nats-streaming-durable-subscriptions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-durable-subscriptions.html
+++ b/1.2/learn/by-example/nats-streaming-durable-subscriptions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-queue-group.html
+++ b/1.2/learn/by-example/nats-streaming-queue-group.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-queue-group.html
+++ b/1.2/learn/by-example/nats-streaming-queue-group.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-start-position.html
+++ b/1.2/learn/by-example/nats-streaming-start-position.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/nats-streaming-start-position.html
+++ b/1.2/learn/by-example/nats-streaming-start-position.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-assignability.html
+++ b/1.2/learn/by-example/object-assignability.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-assignability.html
+++ b/1.2/learn/by-example/object-assignability.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-initializer.html
+++ b/1.2/learn/by-example/object-initializer.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-initializer.html
+++ b/1.2/learn/by-example/object-initializer.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-methods.html
+++ b/1.2/learn/by-example/object-methods.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-methods.html
+++ b/1.2/learn/by-example/object-methods.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-type-reference.html
+++ b/1.2/learn/by-example/object-type-reference.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/object-type-reference.html
+++ b/1.2/learn/by-example/object-type-reference.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/objects.html
+++ b/1.2/learn/by-example/objects.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/objects.html
+++ b/1.2/learn/by-example/objects.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/openapi-to-ballerina.html
+++ b/1.2/learn/by-example/openapi-to-ballerina.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/openapi-to-ballerina.html
+++ b/1.2/learn/by-example/openapi-to-ballerina.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/openshift-deployment.html
+++ b/1.2/learn/by-example/openshift-deployment.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/openshift-deployment.html
+++ b/1.2/learn/by-example/openshift-deployment.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/optional-field-access.html
+++ b/1.2/learn/by-example/optional-field-access.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/optional-field-access.html
+++ b/1.2/learn/by-example/optional-field-access.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/optional-type.html
+++ b/1.2/learn/by-example/optional-type.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/optional-type.html
+++ b/1.2/learn/by-example/optional-type.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/overloaded-methods-constructors.html
+++ b/1.2/learn/by-example/overloaded-methods-constructors.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/overloaded-methods-constructors.html
+++ b/1.2/learn/by-example/overloaded-methods-constructors.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/panic.html
+++ b/1.2/learn/by-example/panic.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/panic.html
+++ b/1.2/learn/by-example/panic.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/passthrough.html
+++ b/1.2/learn/by-example/passthrough.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/passthrough.html
+++ b/1.2/learn/by-example/passthrough.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/proto-to-ballerina.html
+++ b/1.2/learn/by-example/proto-to-ballerina.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/proto-to-ballerina.html
+++ b/1.2/learn/by-example/proto-to-ballerina.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/query-action.html
+++ b/1.2/learn/by-example/query-action.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/query-action.html
+++ b/1.2/learn/by-example/query-action.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/query-expression.html
+++ b/1.2/learn/by-example/query-expression.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/query-expression.html
+++ b/1.2/learn/by-example/query-expression.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/query-path-matrix-param.html
+++ b/1.2/learn/by-example/query-path-matrix-param.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/query-path-matrix-param.html
+++ b/1.2/learn/by-example/query-path-matrix-param.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/quoted-identifiers.html
+++ b/1.2/learn/by-example/quoted-identifiers.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/quoted-identifiers.html
+++ b/1.2/learn/by-example/quoted-identifiers.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html
+++ b/1.2/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html
+++ b/1.2/learn/by-example/rabbitmq-consumer-with-client-acknowledgement.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer-with-data-binding.html
+++ b/1.2/learn/by-example/rabbitmq-consumer-with-data-binding.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer-with-data-binding.html
+++ b/1.2/learn/by-example/rabbitmq-consumer-with-data-binding.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer-with-qos-settings.html
+++ b/1.2/learn/by-example/rabbitmq-consumer-with-qos-settings.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer-with-qos-settings.html
+++ b/1.2/learn/by-example/rabbitmq-consumer-with-qos-settings.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer.html
+++ b/1.2/learn/by-example/rabbitmq-consumer.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-consumer.html
+++ b/1.2/learn/by-example/rabbitmq-consumer.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-producer.html
+++ b/1.2/learn/by-example/rabbitmq-producer.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/rabbitmq-producer.html
+++ b/1.2/learn/by-example/rabbitmq-producer.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/range-expressions.html
+++ b/1.2/learn/by-example/range-expressions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/range-expressions.html
+++ b/1.2/learn/by-example/range-expressions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-destructure-binding-pattern.html
+++ b/1.2/learn/by-example/record-destructure-binding-pattern.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-destructure-binding-pattern.html
+++ b/1.2/learn/by-example/record-destructure-binding-pattern.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-io.html
+++ b/1.2/learn/by-example/record-io.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-io.html
+++ b/1.2/learn/by-example/record-io.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-match-statement.html
+++ b/1.2/learn/by-example/record-match-statement.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-match-statement.html
+++ b/1.2/learn/by-example/record-match-statement.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-optional-fields.html
+++ b/1.2/learn/by-example/record-optional-fields.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-optional-fields.html
+++ b/1.2/learn/by-example/record-optional-fields.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-type-reference.html
+++ b/1.2/learn/by-example/record-type-reference.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-type-reference.html
+++ b/1.2/learn/by-example/record-type-reference.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-typed-binding-pattern.html
+++ b/1.2/learn/by-example/record-typed-binding-pattern.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/record-typed-binding-pattern.html
+++ b/1.2/learn/by-example/record-typed-binding-pattern.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/records.html
+++ b/1.2/learn/by-example/records.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/records.html
+++ b/1.2/learn/by-example/records.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/request-with-multiparts.html
+++ b/1.2/learn/by-example/request-with-multiparts.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/request-with-multiparts.html
+++ b/1.2/learn/by-example/request-with-multiparts.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/response-with-multiparts.html
+++ b/1.2/learn/by-example/response-with-multiparts.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/response-with-multiparts.html
+++ b/1.2/learn/by-example/response-with-multiparts.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/restrict-by-media-type.html
+++ b/1.2/learn/by-example/restrict-by-media-type.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/restrict-by-media-type.html
+++ b/1.2/learn/by-example/restrict-by-media-type.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-client-with-basic-auth.html
+++ b/1.2/learn/by-example/secured-client-with-basic-auth.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-client-with-basic-auth.html
+++ b/1.2/learn/by-example/secured-client-with-basic-auth.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-client-with-jwt-auth.html
+++ b/1.2/learn/by-example/secured-client-with-jwt-auth.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-client-with-jwt-auth.html
+++ b/1.2/learn/by-example/secured-client-with-jwt-auth.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-client-with-oauth2.html
+++ b/1.2/learn/by-example/secured-client-with-oauth2.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-client-with-oauth2.html
+++ b/1.2/learn/by-example/secured-client-with-oauth2.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-basic-auth.html
+++ b/1.2/learn/by-example/secured-service-with-basic-auth.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-basic-auth.html
+++ b/1.2/learn/by-example/secured-service-with-basic-auth.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-jwt-auth.html
+++ b/1.2/learn/by-example/secured-service-with-jwt-auth.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-jwt-auth.html
+++ b/1.2/learn/by-example/secured-service-with-jwt-auth.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-ldap.html
+++ b/1.2/learn/by-example/secured-service-with-ldap.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-ldap.html
+++ b/1.2/learn/by-example/secured-service-with-ldap.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-oauth2.html
+++ b/1.2/learn/by-example/secured-service-with-oauth2.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/secured-service-with-oauth2.html
+++ b/1.2/learn/by-example/secured-service-with-oauth2.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/send-and-receive-emails.html
+++ b/1.2/learn/by-example/send-and-receive-emails.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/send-and-receive-emails.html
+++ b/1.2/learn/by-example/send-and-receive-emails.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/shift-expressions.html
+++ b/1.2/learn/by-example/shift-expressions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/shift-expressions.html
+++ b/1.2/learn/by-example/shift-expressions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/streams.html
+++ b/1.2/learn/by-example/streams.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/streams.html
+++ b/1.2/learn/by-example/streams.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/string-template.html
+++ b/1.2/learn/by-example/string-template.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/string-template.html
+++ b/1.2/learn/by-example/string-template.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/strings.html
+++ b/1.2/learn/by-example/strings.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/strings.html
+++ b/1.2/learn/by-example/strings.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/table.html
+++ b/1.2/learn/by-example/table.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/table.html
+++ b/1.2/learn/by-example/table.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/taint-checking.html
+++ b/1.2/learn/by-example/taint-checking.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/taint-checking.html
+++ b/1.2/learn/by-example/taint-checking.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-scheduler-appointment.html
+++ b/1.2/learn/by-example/task-scheduler-appointment.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-scheduler-appointment.html
+++ b/1.2/learn/by-example/task-scheduler-appointment.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-scheduler-timer.html
+++ b/1.2/learn/by-example/task-scheduler-timer.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-scheduler-timer.html
+++ b/1.2/learn/by-example/task-scheduler-timer.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-service-appointment.html
+++ b/1.2/learn/by-example/task-service-appointment.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-service-appointment.html
+++ b/1.2/learn/by-example/task-service-appointment.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-service-timer.html
+++ b/1.2/learn/by-example/task-service-timer.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/task-service-timer.html
+++ b/1.2/learn/by-example/task-service-timer.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tcp-socket-listener-client.html
+++ b/1.2/learn/by-example/tcp-socket-listener-client.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tcp-socket-listener-client.html
+++ b/1.2/learn/by-example/tcp-socket-listener-client.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-assertions.html
+++ b/1.2/learn/by-example/testerina-assertions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-assertions.html
+++ b/1.2/learn/by-example/testerina-assertions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-before-and-after-each.html
+++ b/1.2/learn/by-example/testerina-before-and-after-each.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-before-and-after-each.html
+++ b/1.2/learn/by-example/testerina-before-and-after-each.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-before-and-after-suite.html
+++ b/1.2/learn/by-example/testerina-before-and-after-suite.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-before-and-after-suite.html
+++ b/1.2/learn/by-example/testerina-before-and-after-suite.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-before-and-after-test.html
+++ b/1.2/learn/by-example/testerina-before-and-after-test.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-before-and-after-test.html
+++ b/1.2/learn/by-example/testerina-before-and-after-test.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-data-driven-tests.html
+++ b/1.2/learn/by-example/testerina-data-driven-tests.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-data-driven-tests.html
+++ b/1.2/learn/by-example/testerina-data-driven-tests.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-group-tests.html
+++ b/1.2/learn/by-example/testerina-group-tests.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-group-tests.html
+++ b/1.2/learn/by-example/testerina-group-tests.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-guarantee-test-execution-order.html
+++ b/1.2/learn/by-example/testerina-guarantee-test-execution-order.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-guarantee-test-execution-order.html
+++ b/1.2/learn/by-example/testerina-guarantee-test-execution-order.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-mocking-functions.html
+++ b/1.2/learn/by-example/testerina-mocking-functions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-mocking-functions.html
+++ b/1.2/learn/by-example/testerina-mocking-functions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-mocking-objects.html
+++ b/1.2/learn/by-example/testerina-mocking-objects.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/testerina-mocking-objects.html
+++ b/1.2/learn/by-example/testerina-mocking-objects.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/the-main-function.html
+++ b/1.2/learn/by-example/the-main-function.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/the-main-function.html
+++ b/1.2/learn/by-example/the-main-function.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/threads-and-strands.html
+++ b/1.2/learn/by-example/threads-and-strands.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/threads-and-strands.html
+++ b/1.2/learn/by-example/threads-and-strands.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/time.html
+++ b/1.2/learn/by-example/time.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/time.html
+++ b/1.2/learn/by-example/time.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tracing.html
+++ b/1.2/learn/by-example/tracing.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tracing.html
+++ b/1.2/learn/by-example/tracing.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/transactions-distributed.html
+++ b/1.2/learn/by-example/transactions-distributed.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/transactions-distributed.html
+++ b/1.2/learn/by-example/transactions-distributed.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/trap.html
+++ b/1.2/learn/by-example/trap.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/trap.html
+++ b/1.2/learn/by-example/trap.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-destructure-binding-pattern.html
+++ b/1.2/learn/by-example/tuple-destructure-binding-pattern.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-destructure-binding-pattern.html
+++ b/1.2/learn/by-example/tuple-destructure-binding-pattern.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-match-statement.html
+++ b/1.2/learn/by-example/tuple-match-statement.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-match-statement.html
+++ b/1.2/learn/by-example/tuple-match-statement.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-type.html
+++ b/1.2/learn/by-example/tuple-type.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-type.html
+++ b/1.2/learn/by-example/tuple-type.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-typed-binding-pattern.html
+++ b/1.2/learn/by-example/tuple-typed-binding-pattern.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/tuple-typed-binding-pattern.html
+++ b/1.2/learn/by-example/tuple-typed-binding-pattern.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-cast.html
+++ b/1.2/learn/by-example/type-cast.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-cast.html
+++ b/1.2/learn/by-example/type-cast.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-conversion.html
+++ b/1.2/learn/by-example/type-conversion.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-conversion.html
+++ b/1.2/learn/by-example/type-conversion.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-guard.html
+++ b/1.2/learn/by-example/type-guard.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-guard.html
+++ b/1.2/learn/by-example/type-guard.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-test-expression.html
+++ b/1.2/learn/by-example/type-test-expression.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/type-test-expression.html
+++ b/1.2/learn/by-example/type-test-expression.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/udp-socket-client.html
+++ b/1.2/learn/by-example/udp-socket-client.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/udp-socket-client.html
+++ b/1.2/learn/by-example/udp-socket-client.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/union-type.html
+++ b/1.2/learn/by-example/union-type.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/union-type.html
+++ b/1.2/learn/by-example/union-type.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/url-encode-decode.html
+++ b/1.2/learn/by-example/url-encode-decode.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/url-encode-decode.html
+++ b/1.2/learn/by-example/url-encode-decode.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/user-defined-error.html
+++ b/1.2/learn/by-example/user-defined-error.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/user-defined-error.html
+++ b/1.2/learn/by-example/user-defined-error.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/values.html
+++ b/1.2/learn/by-example/values.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/values.html
+++ b/1.2/learn/by-example/values.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/var.html
+++ b/1.2/learn/by-example/var.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/var.html
+++ b/1.2/learn/by-example/var.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/variables.html
+++ b/1.2/learn/by-example/variables.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/variables.html
+++ b/1.2/learn/by-example/variables.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-basic-sample.html
+++ b/1.2/learn/by-example/websocket-basic-sample.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-basic-sample.html
+++ b/1.2/learn/by-example/websocket-basic-sample.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-chat-application.html
+++ b/1.2/learn/by-example/websocket-chat-application.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-chat-application.html
+++ b/1.2/learn/by-example/websocket-chat-application.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-client.html
+++ b/1.2/learn/by-example/websocket-client.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-client.html
+++ b/1.2/learn/by-example/websocket-client.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-failover.html
+++ b/1.2/learn/by-example/websocket-failover.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-failover.html
+++ b/1.2/learn/by-example/websocket-failover.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-proxy-server.html
+++ b/1.2/learn/by-example/websocket-proxy-server.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-proxy-server.html
+++ b/1.2/learn/by-example/websocket-proxy-server.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-retry.html
+++ b/1.2/learn/by-example/websocket-retry.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websocket-retry.html
+++ b/1.2/learn/by-example/websocket-retry.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-hub-client-sample.html
+++ b/1.2/learn/by-example/websub-hub-client-sample.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-hub-client-sample.html
+++ b/1.2/learn/by-example/websub-hub-client-sample.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-internal-hub-sample.html
+++ b/1.2/learn/by-example/websub-internal-hub-sample.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-internal-hub-sample.html
+++ b/1.2/learn/by-example/websub-internal-hub-sample.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-remote-hub-sample.html
+++ b/1.2/learn/by-example/websub-remote-hub-sample.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-remote-hub-sample.html
+++ b/1.2/learn/by-example/websub-remote-hub-sample.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-service-integration-sample.html
+++ b/1.2/learn/by-example/websub-service-integration-sample.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/websub-service-integration-sample.html
+++ b/1.2/learn/by-example/websub-service-integration-sample.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/while.html
+++ b/1.2/learn/by-example/while.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/while.html
+++ b/1.2/learn/by-example/while.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/worker-interaction.html
+++ b/1.2/learn/by-example/worker-interaction.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/worker-interaction.html
+++ b/1.2/learn/by-example/worker-interaction.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/workers.html
+++ b/1.2/learn/by-example/workers.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/workers.html
+++ b/1.2/learn/by-example/workers.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xa-transactions.html
+++ b/1.2/learn/by-example/xa-transactions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xa-transactions.html
+++ b/1.2/learn/by-example/xa-transactions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-access.html
+++ b/1.2/learn/by-example/xml-access.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-access.html
+++ b/1.2/learn/by-example/xml-access.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-attributes.html
+++ b/1.2/learn/by-example/xml-attributes.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-attributes.html
+++ b/1.2/learn/by-example/xml-attributes.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-functions.html
+++ b/1.2/learn/by-example/xml-functions.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-functions.html
+++ b/1.2/learn/by-example/xml-functions.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-io.html
+++ b/1.2/learn/by-example/xml-io.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-io.html
+++ b/1.2/learn/by-example/xml-io.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-literal.html
+++ b/1.2/learn/by-example/xml-literal.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-literal.html
+++ b/1.2/learn/by-example/xml-literal.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-namespaces.html
+++ b/1.2/learn/by-example/xml-namespaces.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml-namespaces.html
+++ b/1.2/learn/by-example/xml-namespaces.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml.html
+++ b/1.2/learn/by-example/xml.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xml.html
+++ b/1.2/learn/by-example/xml.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xslt-transformation.html
+++ b/1.2/learn/by-example/xslt-transformation.html
@@ -139,20 +139,23 @@
 <body class="cBallerina-io">
     <header data-plugin-header="line-numbers"></header>
 <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/by-example/xslt-transformation.html
+++ b/1.2/learn/by-example/xslt-transformation.html
@@ -171,7 +171,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/calling-java-code-from-ballerina/index.html
+++ b/1.2/learn/calling-java-code-from-ballerina/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/calling-java-code-from-ballerina/index.html
+++ b/1.2/learn/calling-java-code-from-ballerina/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/annotations_documentation_and_comments/index.html
+++ b/1.2/learn/coding-conventions/annotations_documentation_and_comments/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/annotations_documentation_and_comments/index.html
+++ b/1.2/learn/coding-conventions/annotations_documentation_and_comments/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/expressions/index.html
+++ b/1.2/learn/coding-conventions/expressions/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/expressions/index.html
+++ b/1.2/learn/coding-conventions/expressions/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/index.html
+++ b/1.2/learn/coding-conventions/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/index.html
+++ b/1.2/learn/coding-conventions/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/operators_keywords_and_types/index.html
+++ b/1.2/learn/coding-conventions/operators_keywords_and_types/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/operators_keywords_and_types/index.html
+++ b/1.2/learn/coding-conventions/operators_keywords_and_types/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/statements/index.html
+++ b/1.2/learn/coding-conventions/statements/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/statements/index.html
+++ b/1.2/learn/coding-conventions/statements/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/top-level-definitions/index.html
+++ b/1.2/learn/coding-conventions/top-level-definitions/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/coding-conventions/top-level-definitions/index.html
+++ b/1.2/learn/coding-conventions/top-level-definitions/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/aws-lambda/index.html
+++ b/1.2/learn/deployment/aws-lambda/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/aws-lambda/index.html
+++ b/1.2/learn/deployment/aws-lambda/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/azure-functions/index.html
+++ b/1.2/learn/deployment/azure-functions/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/azure-functions/index.html
+++ b/1.2/learn/deployment/azure-functions/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/docker/index.html
+++ b/1.2/learn/deployment/docker/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/docker/index.html
+++ b/1.2/learn/deployment/docker/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/kubernetes/index.html
+++ b/1.2/learn/deployment/kubernetes/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/deployment/kubernetes/index.html
+++ b/1.2/learn/deployment/kubernetes/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/documenting-ballerina-code/index.html
+++ b/1.2/learn/documenting-ballerina-code/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/documenting-ballerina-code/index.html
+++ b/1.2/learn/documenting-ballerina-code/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/extending-with-compiler-extensions/index.html
+++ b/1.2/learn/extending-with-compiler-extensions/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/extending-with-compiler-extensions/index.html
+++ b/1.2/learn/extending-with-compiler-extensions/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions/index.html
+++ b/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions/index.html
+++ b/1.2/learn/generating-ballerina-code-for-protocol-buffer-definitions/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/index.html
+++ b/1.2/learn/index.html
@@ -126,20 +126,23 @@
 
 <body class="cBallerina-io">
    <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -154,9 +157,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/index.html
+++ b/1.2/learn/index.html
@@ -158,7 +158,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/installing-ballerina/index.html
+++ b/1.2/learn/installing-ballerina/index.html
@@ -173,7 +173,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/installing-ballerina/index.html
+++ b/1.2/learn/installing-ballerina/index.html
@@ -141,20 +141,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -169,9 +172,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/keeping-ballerina-up-to-date/index.html
+++ b/1.2/learn/keeping-ballerina-up-to-date/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/keeping-ballerina-up-to-date/index.html
+++ b/1.2/learn/keeping-ballerina-up-to-date/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/observing-ballerina-code/index.html
+++ b/1.2/learn/observing-ballerina-code/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/observing-ballerina-code/index.html
+++ b/1.2/learn/observing-ballerina-code/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/publishing-modules-to-ballerina-central/index.html
+++ b/1.2/learn/publishing-modules-to-ballerina-central/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/publishing-modules-to-ballerina-central/index.html
+++ b/1.2/learn/publishing-modules-to-ballerina-central/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/quick-tour/index.html
+++ b/1.2/learn/quick-tour/index.html
@@ -168,7 +168,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/quick-tour/index.html
+++ b/1.2/learn/quick-tour/index.html
@@ -136,20 +136,23 @@ redirect_from:
    <body class="cBallerina-io" id="top">
       <header data-plugin-header="line-numbers"></header>
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -164,9 +167,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/running-ballerina-code/index.html
+++ b/1.2/learn/running-ballerina-code/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/running-ballerina-code/index.html
+++ b/1.2/learn/running-ballerina-code/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-intellij-idea/index.html
+++ b/1.2/learn/setting-up-intellij-idea/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-intellij-idea/index.html
+++ b/1.2/learn/setting-up-intellij-idea/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-intellij-idea/using-intellij-plugin-features/index.html
+++ b/1.2/learn/setting-up-intellij-idea/using-intellij-plugin-features/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-intellij-idea/using-intellij-plugin-features/index.html
+++ b/1.2/learn/setting-up-intellij-idea/using-intellij-plugin-features/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-intellij-idea/using-the-intellij-plugin/index.html
+++ b/1.2/learn/setting-up-intellij-idea/using-the-intellij-plugin/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-intellij-idea/using-the-intellij-plugin/index.html
+++ b/1.2/learn/setting-up-intellij-idea/using-the-intellij-plugin/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/documentation-viewer/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/documentation-viewer/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/documentation-viewer/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/documentation-viewer/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/graphical-editor/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/graphical-editor/index.html
@@ -168,7 +168,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/graphical-editor/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/graphical-editor/index.html
@@ -136,20 +136,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -164,9 +167,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/language-intelligence/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/language-intelligence/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/language-intelligence/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/language-intelligence/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/run-all-tests/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/run-all-tests/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/run-all-tests/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/run-all-tests/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/run-and-debug/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/run-and-debug/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/setting-up-visual-studio-code/run-and-debug/index.html
+++ b/1.2/learn/setting-up-visual-studio-code/run-and-debug/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/structuring-ballerina-code/index.html
+++ b/1.2/learn/structuring-ballerina-code/index.html
@@ -171,7 +171,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/structuring-ballerina-code/index.html
+++ b/1.2/learn/structuring-ballerina-code/index.html
@@ -139,20 +139,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -167,9 +170,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/executing-tests/index.html
+++ b/1.2/learn/testing-ballerina-code/executing-tests/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/executing-tests/index.html
+++ b/1.2/learn/testing-ballerina-code/executing-tests/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/mocking/index.html
+++ b/1.2/learn/testing-ballerina-code/mocking/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/mocking/index.html
+++ b/1.2/learn/testing-ballerina-code/mocking/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/testing-quick-start/index.html
+++ b/1.2/learn/testing-ballerina-code/testing-quick-start/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/testing-quick-start/index.html
+++ b/1.2/learn/testing-ballerina-code/testing-quick-start/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/writing-tests/index.html
+++ b/1.2/learn/testing-ballerina-code/writing-tests/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/testing-ballerina-code/writing-tests/index.html
+++ b/1.2/learn/testing-ballerina-code/writing-tests/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/using-the-cli-tools/index.html
+++ b/1.2/learn/using-the-cli-tools/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/using-the-cli-tools/index.html
+++ b/1.2/learn/using-the-cli-tools/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/using-the-openapi-tools/index.html
+++ b/1.2/learn/using-the-openapi-tools/index.html
@@ -137,20 +137,23 @@ redirect_from:
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -165,9 +168,8 @@ redirect_from:
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/using-the-openapi-tools/index.html
+++ b/1.2/learn/using-the-openapi-tools/index.html
@@ -169,7 +169,7 @@ redirect_from:
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/writing-secure-ballerina-code/index.html
+++ b/1.2/learn/writing-secure-ballerina-code/index.html
@@ -131,20 +131,23 @@
    </head>
    <body class="cBallerina-io" id="top">
       <style>
-    .cInfoBannerVersionHandling {
-        background:  #494949;
+   .cInfoBanner {
+        background: #20b6b0;
         width: 100%;
         display: inline-block;
         color: #fff;
         padding: 10px;
         width: 100%;
         text-align: center;
-        font-weight: 400;
-        font-size: 17px;
+        font-weight: 600;
+        font-size: 20px;
         transition : all 0.3s;
     }
-    .cInfoBannerLink{font-weight: 500;font-size: 18px;color: #20b6b0;}
-    .cInfoBannerLink:hover{text-decoration: underline !important;color: #c0c0c0!important;}
+
+ .cInfoBanner:hover {
+        background-color: #c0c0c0;
+        color: #494949 !important;
+    }
 
     #noscript-warning{
         position: relative;
@@ -159,9 +162,8 @@
 <noscript>
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
-   <div class="cInfoBannerVersionHandling">
-    This is the 1.2.0 documentation of Ballerina. Please refer the <a href="https://ballerina.io/learn/" class="cInfoBannerLink">latest  documentation</a> or download the <a href="https://ballerina.io/downloads/" class="cInfoBannerLink">latest release</a>.
-</div>
+   <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">

--- a/1.2/learn/writing-secure-ballerina-code/index.html
+++ b/1.2/learn/writing-secure-ballerina-code/index.html
@@ -163,7 +163,7 @@
     <div id="noscript-warning">Ballerina works best with JavaScript enabled.</div>
 </noscript>
    <a href="https://ballerina.io/learn/" class="cInfoBanner">
-     This is the 1.2.0 documentation of Ballerina. Please refer the latest  documentation.</a>
+     This documentation is for Ballerina 1.2.0. View documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 
     <div class="container">


### PR DESCRIPTION
## Purpose
Update the banners in 1.2 Learn and API Docs.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
