### PR TITLE
Improve descriptions in guides

### DIFF
--- a/learn/guides/managing-dependencies.md
+++ b/learn/guides/managing-dependencies.md
@@ -18,7 +18,7 @@ A package can depend on other packages that are available in Ballerina repositor
 * The distribution repository
 * The Ballerina Central repository
 
-It also supports a third repository named the `local repository`. It temporarily overrides dependencies which, is useful for the package development and bug fixing phases.
+It also supports a third repository named the `local repository`. It temporarily overrides dependencies, which is useful for the package development and bug fixing phases.
 
 **Distribution repository**
 

--- a/learn/guides/testing-ballerina-code/code-coverage-and-reporting.md
+++ b/learn/guides/testing-ballerina-code/code-coverage-and-reporting.md
@@ -2,7 +2,7 @@
 layout: ballerina-testing-code-left-nav-pages-swanlake
 title: Code Coverage and Reporting
 description: Learn how to perform code coverage and reporting for Ballerina tests.
-keywords: ballerina, programming language, testing
+keywords: ballerina, programming language, testing, code coverage, test report
 permalink: /learn/testing-ballerina-code/code-coverage-and-reporting/
 active: code-coverage-and-reporting
 intro: The Ballerina Test Framework allows you to generate test reports and code coverage reports for the executed tests.

--- a/learn/guides/testing-ballerina-code/configuring-tests.md
+++ b/learn/guides/testing-ballerina-code/configuring-tests.md
@@ -2,7 +2,7 @@
 layout: ballerina-testing-code-left-nav-pages-swanlake
 title: Configuring Tests
 description: Learn how to configure Ballerina tests.
-keywords: ballerina, programming language, testing
+keywords: ballerina, programming language, testing, test setup
 permalink: /learn/testing-ballerina-code/configuring-tests/
 active: configuring-tests
 intro: The Ballerina Test framework has configurations at various levels to streamline the testing process and ensure that the tests are written with a comprehensible structure.

--- a/learn/guides/testing-ballerina-code/defining-data-driven-tests.md
+++ b/learn/guides/testing-ballerina-code/defining-data-driven-tests.md
@@ -2,7 +2,7 @@
 layout: ballerina-testing-code-left-nav-pages-swanlake
 title: Defining Data-Driven Tests
 description: Learn how to do write data-driven tests using the ballerina test framework.
-keywords: ballerina, programming language, testing
+keywords: ballerina, programming language, testing, data-driven, data providers
 permalink: /learn/testing-ballerina-code/defining-data-driven-tests/
 active: defining-data-driven-tests
 intro: The Ballerina Test Framework allows you to specify a function that returns a set of data values as a data-provider.

--- a/learn/guides/testing-ballerina-code/defining-test-groups.md
+++ b/learn/guides/testing-ballerina-code/defining-test-groups.md
@@ -1,11 +1,11 @@
 ---
 layout: ballerina-testing-code-left-nav-pages-swanlake
 title: Defining Test Groups
-description: Learn how to use Ballerina Testframework grouping functionality
-keywords: ballerina, programming language, testing
+description: Learn how to use grouping functionality of the Ballerina test framework.
+keywords: ballerina, programming language, testing, test groups
 permalink: /learn/testing-ballerina-code/defining-test-groups/
 active: test-groups
-intro: The Ballerina Testframework allows grouping of tests 
+intro: The Ballerina test framework allows grouping of tests.
 redirect_from:
 - /learn/testing-ballerina-code/
 - /learn/testing-ballerina-code

--- a/learn/guides/testing-ballerina-code/executing-tests.md
+++ b/learn/guides/testing-ballerina-code/executing-tests.md
@@ -2,7 +2,7 @@
 layout: ballerina-testing-code-left-nav-pages-swanlake
 title: Executing Tests
 description: Learn how to use different options for executing Ballerina tests.
-keywords: ballerina, programming language, testing
+keywords: ballerina, programming language, testing, test execution
 permalink: /learn/testing-ballerina-code/executing-tests/
 active: executing-tests
 intro: The sections below include information about executing tests in Ballerina.

--- a/learn/guides/testing-ballerina-code/mocking.md
+++ b/learn/guides/testing-ballerina-code/mocking.md
@@ -1,9 +1,9 @@
 ---
 layout: ballerina-testing-code-left-nav-pages-swanlake
 title: Mocking
-description: Learn how to use Ballerina's built-in mocking API provided by the test to test modules
- independent from other modules and external endpoints.
-keywords: ballerina, programming language, testing, mocking
+description: Learn how to use the mocking API of Ballerina test framework to test modules
+ independent from other modules, and external endpoints.
+keywords: ballerina, programming language, testing, mocking, object mocking
 permalink: /learn/testing-ballerina-code/mocking/
 active: mocking
 intro: Mocking is useful to control the behavior of functions and objects to control the communication with other modules and external endpoints. A mock can be created by defining return values or replacing the entire object or function with a user-defined equivalent. This feature will help you to test the Ballerina code independently from other modules and external endpoints.

--- a/learn/guides/testing-ballerina-code/testing-a-simple-function.md
+++ b/learn/guides/testing-ballerina-code/testing-a-simple-function.md
@@ -5,7 +5,7 @@ description: Learn how to use Ballerina's built-in test framework to write testa
 keywords: ballerina, programming language, testing
 permalink: /learn/testing-ballerina-code/testing-a-simple-function/
 active: testing-a-simple-function
-intro: The Ballerina Language has a built-in robust test framework, which allows you to achieve multiple levels of the test pyramid including unit testing, integration testing, and end-to-end testing.  It provides features such as assertions, data providers, mocking, and code coverage, which enable the programmers to write comprehensive tests.
+intro: The Ballerina language has a built-in robust test framework, which allows you to achieve multiple levels of the test pyramid including, unit testing, integration testing, and end-to-end testing. It provides assertions, data providers, mocking, and code coverage features, which enable the programmers to write comprehensive tests.
 redirect_from:
   - /learn/how-to-test-ballerina-code/
   - /learn/how-to-test-ballerina-code

--- a/learn/guides/testing-ballerina-code/testing-services-and-clients.md
+++ b/learn/guides/testing-ballerina-code/testing-services-and-clients.md
@@ -16,12 +16,10 @@ redirect_from:
 
 ## Testing Services
 
-Any services defined in the package will start up on their defined ports and will remain running
-for the duration of the testing phase after which they will be automatically shut down. This allows
-you to send requests directly to the service in order to test its functionality.
+Any services defined in the package will start up on the specified ports and will remain running for the duration of the testing phase. After completing tests, the services will shut down automatically.
+ It allows you to send requests directly to the service to test its functionality.
 
->**Note:** You need to have tests defined in the respective module where the service is defined in
-order for the service to start automatically.
+>**Note:** The service starts automatically, only if you have tests in the module where it is defined.
 
 ***Example:***
 
@@ -72,10 +70,9 @@ public function testGet() returns error? {
 ## Testing Clients
 
 In cases where a fully fledged client is already defined for a particular service, you can make use
-of object mocking to mock the calls to the service and return curated responses to the client.
-This is useful when testing the full extent of the client by mocking responses that normally would
-be difficult to reproduce in an actual scenario. This would cover a variety of scenarios that the
-client is capable of handling without having the service to actually be up and running.
+of `object mocking` to mock the calls to the service and return curated responses to the client.
+It is useful when testing the full extent of the client by mocking responses that are difficult to reproduce in actual scenarios.
+ It would cover a variety of cases that the client can handle without having the service to be up and running.
 
 ***Example:***
 The following is a simple example on how mocking can be used to stub responses to services that you 

--- a/learn/references/package-references.md
+++ b/learn/references/package-references.md
@@ -122,7 +122,7 @@ cloud = "k8s"
 
 ### Packaging Java Libraries
 
-When you compile a Ballerina package with `bal build`, the compiler creates an executable JAR file. However, if the package does not contain an entry point, it will produce a non-executable JAR file (a library package) which, can be used in another package/program.
+When you compile a Ballerina package with `bal build`, the compiler creates an executable JAR file. However, if the package does not contain an entry point, it will produce a non-executable JAR file (a library package), which can be used in another package/program.
 In both cases, the Ballerina compiler creates self-contained archives. There are situations in which you need to package JAR files with these archives.
 
 You can store the JAR files anywhere in your file system. As a best practice, maintain Java libraries inside the package.


### PR DESCRIPTION
## Purpose
Improve descriptions in guides

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
