### PR TITLE
Fix the Link in the API Docs Banner

### DIFF
--- a/1.0/learn/api-docs/ballerina/auth/constants.html
+++ b/1.0/learn/api-docs/ballerina/auth/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/auth/errors.html
+++ b/1.0/learn/api-docs/ballerina/auth/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/auth/functions.html
+++ b/1.0/learn/api-docs/ballerina/auth/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/auth/index.html
+++ b/1.0/learn/api-docs/ballerina/auth/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
+++ b/1.0/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
+++ b/1.0/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
+++ b/1.0/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
+++ b/1.0/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
+++ b/1.0/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/auth/records/Credential.html
+++ b/1.0/learn/api-docs/ballerina/auth/records/Credential.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/auth/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/auth/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/awslambda/annotations.html
+++ b/1.0/learn/api-docs/ballerina/awslambda/annotations.html
@@ -65,7 +65,7 @@
         <div class="cTopLine"></div>
     </div>
 </div>
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/awslambda/functions.html
+++ b/1.0/learn/api-docs/ballerina/awslambda/functions.html
@@ -65,7 +65,7 @@
         <div class="cTopLine"></div>
     </div>
 </div>
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/awslambda/index.html
+++ b/1.0/learn/api-docs/ballerina/awslambda/index.html
@@ -65,7 +65,7 @@
         <div class="cTopLine"></div>
     </div>
 </div>
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/awslambda/objects/Context.html
+++ b/1.0/learn/api-docs/ballerina/awslambda/objects/Context.html
@@ -65,7 +65,7 @@
         <div class="cTopLine"></div>
     </div>
 </div>
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/cache/constants.html
+++ b/1.0/learn/api-docs/ballerina/cache/constants.html
@@ -52,7 +52,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/cache/errors.html
+++ b/1.0/learn/api-docs/ballerina/cache/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/cache/index.html
+++ b/1.0/learn/api-docs/ballerina/cache/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/cache/objects/Cache.html
+++ b/1.0/learn/api-docs/ballerina/cache/objects/Cache.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/cache/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/cache/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/config/functions.html
+++ b/1.0/learn/api-docs/ballerina/config/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/config/index.html
+++ b/1.0/learn/api-docs/ballerina/config/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/constants.html
+++ b/1.0/learn/api-docs/ballerina/crypto/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/errors.html
+++ b/1.0/learn/api-docs/ballerina/crypto/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/functions.html
+++ b/1.0/learn/api-docs/ballerina/crypto/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/index.html
+++ b/1.0/learn/api-docs/ballerina/crypto/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/records/Certificate.html
+++ b/1.0/learn/api-docs/ballerina/crypto/records/Certificate.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/crypto/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/records/KeyStore.html
+++ b/1.0/learn/api-docs/ballerina/crypto/records/KeyStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/records/PrivateKey.html
+++ b/1.0/learn/api-docs/ballerina/crypto/records/PrivateKey.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/records/PublicKey.html
+++ b/1.0/learn/api-docs/ballerina/crypto/records/PublicKey.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/records/TrustStore.html
+++ b/1.0/learn/api-docs/ballerina/crypto/records/TrustStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/crypto/types.html
+++ b/1.0/learn/api-docs/ballerina/crypto/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/docker/annotations.html
+++ b/1.0/learn/api-docs/ballerina/docker/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/docker/index.html
+++ b/1.0/learn/api-docs/ballerina/docker/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/docker/records/DockerConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/docker/records/DockerConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/docker/records/ExposeConfig.html
+++ b/1.0/learn/api-docs/ballerina/docker/records/ExposeConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/docker/records/FileConfig.html
+++ b/1.0/learn/api-docs/ballerina/docker/records/FileConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/docker/records/FileConfigs.html
+++ b/1.0/learn/api-docs/ballerina/docker/records/FileConfigs.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/encoding/constants.html
+++ b/1.0/learn/api-docs/ballerina/encoding/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/encoding/errors.html
+++ b/1.0/learn/api-docs/ballerina/encoding/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/encoding/functions.html
+++ b/1.0/learn/api-docs/ballerina/encoding/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/encoding/index.html
+++ b/1.0/learn/api-docs/ballerina/encoding/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/encoding/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/encoding/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/file/constants.html
+++ b/1.0/learn/api-docs/ballerina/file/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/file/errors.html
+++ b/1.0/learn/api-docs/ballerina/file/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/file/functions.html
+++ b/1.0/learn/api-docs/ballerina/file/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/file/index.html
+++ b/1.0/learn/api-docs/ballerina/file/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/file/listeners/Listener.html
+++ b/1.0/learn/api-docs/ballerina/file/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/file/objects/FileInfo.html
+++ b/1.0/learn/api-docs/ballerina/file/objects/FileInfo.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/file/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/file/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/file/records/FileEvent.html
+++ b/1.0/learn/api-docs/ballerina/file/records/FileEvent.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/file/records/ListenerConfig.html
+++ b/1.0/learn/api-docs/ballerina/file/records/ListenerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/file/types.html
+++ b/1.0/learn/api-docs/ballerina/file/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/filepath/constants.html
+++ b/1.0/learn/api-docs/ballerina/filepath/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/filepath/errors.html
+++ b/1.0/learn/api-docs/ballerina/filepath/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/filepath/functions.html
+++ b/1.0/learn/api-docs/ballerina/filepath/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/filepath/index.html
+++ b/1.0/learn/api-docs/ballerina/filepath/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/filepath/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/filepath/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/filepath/types.html
+++ b/1.0/learn/api-docs/ballerina/filepath/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/annotations.html
+++ b/1.0/learn/api-docs/ballerina/grpc/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/clients/Caller.html
+++ b/1.0/learn/api-docs/ballerina/grpc/clients/Caller.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/clients/Client.html
+++ b/1.0/learn/api-docs/ballerina/grpc/clients/Client.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
+++ b/1.0/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/constants.html
+++ b/1.0/learn/api-docs/ballerina/grpc/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/errors.html
+++ b/1.0/learn/api-docs/ballerina/grpc/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/functions.html
+++ b/1.0/learn/api-docs/ballerina/grpc/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/index.html
+++ b/1.0/learn/api-docs/ballerina/grpc/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/listeners/Listener.html
+++ b/1.0/learn/api-docs/ballerina/grpc/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
+++ b/1.0/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/objects/Headers.html
+++ b/1.0/learn/api-docs/ballerina/grpc/objects/Headers.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/Local.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/Local.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/Protocols.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/Protocols.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/Remote.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/Remote.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/SecureSocket.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/SecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/records/ValidateCert.html
+++ b/1.0/learn/api-docs/ballerina/grpc/records/ValidateCert.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/grpc/types.html
+++ b/1.0/learn/api-docs/ballerina/grpc/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/annotations.html
+++ b/1.0/learn/api-docs/ballerina/http/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/Caller.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/Caller.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/Client.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/Client.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/FailoverClient.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/FailoverClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/HttpClient.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/HttpClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/RedirectClient.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/RedirectClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/RetryClient.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/RetryClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/clients/WebSocketClient.html
+++ b/1.0/learn/api-docs/ballerina/http/clients/WebSocketClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/constants.html
+++ b/1.0/learn/api-docs/ballerina/http/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/errors.html
+++ b/1.0/learn/api-docs/ballerina/http/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/functions.html
+++ b/1.0/learn/api-docs/ballerina/http/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/index.html
+++ b/1.0/learn/api-docs/ballerina/http/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/listeners/Listener.html
+++ b/1.0/learn/api-docs/ballerina/http/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/listeners/MockListener.html
+++ b/1.0/learn/api-docs/ballerina/http/listeners/MockListener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/AuthnFilter.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/AuthnFilter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/AuthzFilter.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/AuthzFilter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/AuthzHandler.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/AuthzHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/FilterContext.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/FilterContext.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/HttpCache.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/HttpCache.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/HttpFuture.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/HttpFuture.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/PushPromise.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/PushPromise.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/Request.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/Request.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/RequestFilter.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/RequestFilter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/Response.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/Response.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/objects/ResponseFilter.html
+++ b/1.0/learn/api-docs/ballerina/http/objects/ResponseFilter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/AuthzCacheConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/AuthzCacheConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/Bucket.html
+++ b/1.0/learn/api-docs/ballerina/http/records/Bucket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/CacheConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/CacheConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/CircuitHealth.html
+++ b/1.0/learn/api-docs/ballerina/http/records/CircuitHealth.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ClientConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/CompressionConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/CompressionConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/CorsConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/CorsConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/http/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/FailoverConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/FailoverConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/FollowRedirects.html
+++ b/1.0/learn/api-docs/ballerina/http/records/FollowRedirects.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
+++ b/1.0/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ListenerAuth.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ListenerAuth.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
+++ b/1.0/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/Local.html
+++ b/1.0/learn/api-docs/ballerina/http/records/Local.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
+++ b/1.0/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/PoolConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/http/records/PoolConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/Protocols.html
+++ b/1.0/learn/api-docs/ballerina/http/records/Protocols.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ProxyConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ProxyConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/Remote.html
+++ b/1.0/learn/api-docs/ballerina/http/records/Remote.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/RetryConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/RetryConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/RollingWindow.html
+++ b/1.0/learn/api-docs/ballerina/http/records/RollingWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ServiceResourceAuth.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ServiceResourceAuth.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/TargetService.html
+++ b/1.0/learn/api-docs/ballerina/http/records/TargetService.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/ValidateCert.html
+++ b/1.0/learn/api-docs/ballerina/http/records/ValidateCert.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/Versioning.html
+++ b/1.0/learn/api-docs/ballerina/http/records/Versioning.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/WSServiceConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/WSServiceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
+++ b/1.0/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/http/types.html
+++ b/1.0/learn/api-docs/ballerina/http/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/index.html
+++ b/1.0/learn/api-docs/ballerina/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/constants.html
+++ b/1.0/learn/api-docs/ballerina/io/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/errors.html
+++ b/1.0/learn/api-docs/ballerina/io/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/functions.html
+++ b/1.0/learn/api-docs/ballerina/io/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/index.html
+++ b/1.0/learn/api-docs/ballerina/io/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/StringReader.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/StringReader.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
+++ b/1.0/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/io/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/io/types.html
+++ b/1.0/learn/api-docs/ballerina/io/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/annotations.html
+++ b/1.0/learn/api-docs/ballerina/istio/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/index.html
+++ b/1.0/learn/api-docs/ballerina/istio/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/records/DestinationConfig.html
+++ b/1.0/learn/api-docs/ballerina/istio/records/DestinationConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/records/DestinationWeightConfig.html
+++ b/1.0/learn/api-docs/ballerina/istio/records/DestinationWeightConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/records/GatewayConfig.html
+++ b/1.0/learn/api-docs/ballerina/istio/records/GatewayConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/records/HTTPRouteConfig.html
+++ b/1.0/learn/api-docs/ballerina/istio/records/HTTPRouteConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/records/PortConfig.html
+++ b/1.0/learn/api-docs/ballerina/istio/records/PortConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/records/ServerConfig.html
+++ b/1.0/learn/api-docs/ballerina/istio/records/ServerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/records/TLSOptionConfig.html
+++ b/1.0/learn/api-docs/ballerina/istio/records/TLSOptionConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/records/VirtualServiceConfig.html
+++ b/1.0/learn/api-docs/ballerina/istio/records/VirtualServiceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/istio/types.html
+++ b/1.0/learn/api-docs/ballerina/istio/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.arrays/functions.html
+++ b/1.0/learn/api-docs/ballerina/java.arrays/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.arrays/index.html
+++ b/1.0/learn/api-docs/ballerina/java.arrays/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/clients/Client.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/clients/Client.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/constants.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/errors.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/index.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java.jdbc/types.html
+++ b/1.0/learn/api-docs/ballerina/java.jdbc/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java/annotations.html
+++ b/1.0/learn/api-docs/ballerina/java/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java/functions.html
+++ b/1.0/learn/api-docs/ballerina/java/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java/index.html
+++ b/1.0/learn/api-docs/ballerina/java/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java/records/ArrayType.html
+++ b/1.0/learn/api-docs/ballerina/java/records/ArrayType.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java/records/ConstructorData.html
+++ b/1.0/learn/api-docs/ballerina/java/records/ConstructorData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java/records/FieldData.html
+++ b/1.0/learn/api-docs/ballerina/java/records/FieldData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/java/records/MethodData.html
+++ b/1.0/learn/api-docs/ballerina/java/records/MethodData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jsonutils/functions.html
+++ b/1.0/learn/api-docs/ballerina/jsonutils/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jsonutils/index.html
+++ b/1.0/learn/api-docs/ballerina/jsonutils/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
+++ b/1.0/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/constants.html
+++ b/1.0/learn/api-docs/ballerina/jwt/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/errors.html
+++ b/1.0/learn/api-docs/ballerina/jwt/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/functions.html
+++ b/1.0/learn/api-docs/ballerina/jwt/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/index.html
+++ b/1.0/learn/api-docs/ballerina/jwt/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
+++ b/1.0/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
+++ b/1.0/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/records/CachedJwt.html
+++ b/1.0/learn/api-docs/ballerina/jwt/records/CachedJwt.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/jwt/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/records/JwtHeader.html
+++ b/1.0/learn/api-docs/ballerina/jwt/records/JwtHeader.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
+++ b/1.0/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
+++ b/1.0/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/records/JwtPayload.html
+++ b/1.0/learn/api-docs/ballerina/jwt/records/JwtPayload.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
+++ b/1.0/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
+++ b/1.0/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/jwt/types.html
+++ b/1.0/learn/api-docs/ballerina/jwt/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/clients/Consumer.html
+++ b/1.0/learn/api-docs/ballerina/kafka/clients/Consumer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/clients/Producer.html
+++ b/1.0/learn/api-docs/ballerina/kafka/clients/Producer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/constants.html
+++ b/1.0/learn/api-docs/ballerina/kafka/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/errors.html
+++ b/1.0/learn/api-docs/ballerina/kafka/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/index.html
+++ b/1.0/learn/api-docs/ballerina/kafka/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/records/ConsumerConfig.html
+++ b/1.0/learn/api-docs/ballerina/kafka/records/ConsumerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
+++ b/1.0/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/kafka/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/records/KeyStore.html
+++ b/1.0/learn/api-docs/ballerina/kafka/records/KeyStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
+++ b/1.0/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/records/ProducerConfig.html
+++ b/1.0/learn/api-docs/ballerina/kafka/records/ProducerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/records/Protocols.html
+++ b/1.0/learn/api-docs/ballerina/kafka/records/Protocols.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/records/SecureSocket.html
+++ b/1.0/learn/api-docs/ballerina/kafka/records/SecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/records/TopicPartition.html
+++ b/1.0/learn/api-docs/ballerina/kafka/records/TopicPartition.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/records/TrustStore.html
+++ b/1.0/learn/api-docs/ballerina/kafka/records/TrustStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kafka/types.html
+++ b/1.0/learn/api-docs/ballerina/kafka/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/annotations.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/constants.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/index.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/BuildExtension.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/BuildExtension.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/ConfigMap.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/ConfigMap.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyRef.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyValue.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyValue.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/FieldRef.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/FieldRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/FieldValue.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/FieldValue.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/FileConfig.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/FileConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/IngressConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/IngressConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/Metadata.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/Metadata.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/OpenShiftBuildConfigConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/OpenShiftBuildConfigConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaimConfig.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaimConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/PodAutoscalerConfig.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/PodAutoscalerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/PodTolerationConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/PodTolerationConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/ProbeConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/ProbeConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/ResourceFieldRef.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/ResourceFieldRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/ResourceFieldValue.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/ResourceFieldValue.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/ResourceQuotaConfig.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/ResourceQuotaConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/Secret.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/Secret.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/SecretKeyRef.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/SecretKeyRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/SecretKeyValue.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/SecretKeyValue.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/records/ServiceConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/records/ServiceConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/kubernetes/types.html
+++ b/1.0/learn/api-docs/ballerina/kubernetes/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.array/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.array/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.array/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.array/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.array/objects/$anonType$1.html
+++ b/1.0/learn/api-docs/ballerina/lang.array/objects/$anonType$1.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.decimal/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.decimal/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.decimal/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.decimal/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.error/errors.html
+++ b/1.0/learn/api-docs/ballerina/lang.error/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.error/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.error/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.error/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.error/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.error/objects/CallStack.html
+++ b/1.0/learn/api-docs/ballerina/lang.error/objects/CallStack.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
+++ b/1.0/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.error/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/lang.error/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.float/constants.html
+++ b/1.0/learn/api-docs/ballerina/lang.float/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.float/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.float/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.float/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.float/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.future/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.future/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.future/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.future/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.int/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.int/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.int/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.int/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.map/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.map/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.map/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.map/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.map/objects/$anonType$2.html
+++ b/1.0/learn/api-docs/ballerina/lang.map/objects/$anonType$2.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.object/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.object/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.object/objects/Listener.html
+++ b/1.0/learn/api-docs/ballerina/lang.object/objects/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.stream/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.stream/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.stream/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.stream/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.string/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.string/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.string/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.string/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.string/objects/$anonType$2.html
+++ b/1.0/learn/api-docs/ballerina/lang.string/objects/$anonType$2.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.table/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.table/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.table/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.table/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.table/objects/$anonType$2.html
+++ b/1.0/learn/api-docs/ballerina/lang.table/objects/$anonType$2.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.typedesc/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.typedesc/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.typedesc/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.typedesc/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.value/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.value/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.value/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.value/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.xml/constants.html
+++ b/1.0/learn/api-docs/ballerina/lang.xml/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.xml/functions.html
+++ b/1.0/learn/api-docs/ballerina/lang.xml/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.xml/index.html
+++ b/1.0/learn/api-docs/ballerina/lang.xml/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.xml/objects/$anonType$9.html
+++ b/1.0/learn/api-docs/ballerina/lang.xml/objects/$anonType$9.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/lang.xml/types.html
+++ b/1.0/learn/api-docs/ballerina/lang.xml/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/log/functions.html
+++ b/1.0/learn/api-docs/ballerina/log/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/log/index.html
+++ b/1.0/learn/api-docs/ballerina/log/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/math/constants.html
+++ b/1.0/learn/api-docs/ballerina/math/constants.html
@@ -52,7 +52,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/math/errors.html
+++ b/1.0/learn/api-docs/ballerina/math/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/math/functions.html
+++ b/1.0/learn/api-docs/ballerina/math/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/math/index.html
+++ b/1.0/learn/api-docs/ballerina/math/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/math/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/math/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/mime/constants.html
+++ b/1.0/learn/api-docs/ballerina/mime/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/mime/errors.html
+++ b/1.0/learn/api-docs/ballerina/mime/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/mime/functions.html
+++ b/1.0/learn/api-docs/ballerina/mime/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/mime/index.html
+++ b/1.0/learn/api-docs/ballerina/mime/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
+++ b/1.0/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/mime/objects/Entity.html
+++ b/1.0/learn/api-docs/ballerina/mime/objects/Entity.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/mime/objects/MediaType.html
+++ b/1.0/learn/api-docs/ballerina/mime/objects/MediaType.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/mime/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/mime/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/mime/types.html
+++ b/1.0/learn/api-docs/ballerina/mime/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/annotations.html
+++ b/1.0/learn/api-docs/ballerina/nats/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/clients/Producer.html
+++ b/1.0/learn/api-docs/ballerina/nats/clients/Producer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
+++ b/1.0/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
+++ b/1.0/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/constants.html
+++ b/1.0/learn/api-docs/ballerina/nats/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/errors.html
+++ b/1.0/learn/api-docs/ballerina/nats/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/index.html
+++ b/1.0/learn/api-docs/ballerina/nats/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/listeners/Listener.html
+++ b/1.0/learn/api-docs/ballerina/nats/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
+++ b/1.0/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/objects/Connection.html
+++ b/1.0/learn/api-docs/ballerina/nats/objects/Connection.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/objects/Message.html
+++ b/1.0/learn/api-docs/ballerina/nats/objects/Message.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
+++ b/1.0/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/nats/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/records/PendingLimits.html
+++ b/1.0/learn/api-docs/ballerina/nats/records/PendingLimits.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/records/SecureSocket.html
+++ b/1.0/learn/api-docs/ballerina/nats/records/SecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/records/StreamingConfig.html
+++ b/1.0/learn/api-docs/ballerina/nats/records/StreamingConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
+++ b/1.0/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
+++ b/1.0/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/nats/types.html
+++ b/1.0/learn/api-docs/ballerina/nats/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/constants.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/errors.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/functions.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/index.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/records/CachedToken.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/records/CachedToken.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
+++ b/1.0/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/observe/functions.html
+++ b/1.0/learn/api-docs/ballerina/observe/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/observe/index.html
+++ b/1.0/learn/api-docs/ballerina/observe/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/observe/objects/Counter.html
+++ b/1.0/learn/api-docs/ballerina/observe/objects/Counter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/observe/objects/Gauge.html
+++ b/1.0/learn/api-docs/ballerina/observe/objects/Gauge.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/observe/records/Metric.html
+++ b/1.0/learn/api-docs/ballerina/observe/records/Metric.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/observe/records/PercentileValue.html
+++ b/1.0/learn/api-docs/ballerina/observe/records/PercentileValue.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/observe/records/Snapshot.html
+++ b/1.0/learn/api-docs/ballerina/observe/records/Snapshot.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/observe/records/StatisticConfig.html
+++ b/1.0/learn/api-docs/ballerina/observe/records/StatisticConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/openapi/annotations.html
+++ b/1.0/learn/api-docs/ballerina/openapi/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/openapi/index.html
+++ b/1.0/learn/api-docs/ballerina/openapi/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/openapi/records/ClientInformation.html
+++ b/1.0/learn/api-docs/ballerina/openapi/records/ClientInformation.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
+++ b/1.0/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/openshift/annotations.html
+++ b/1.0/learn/api-docs/ballerina/openshift/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/openshift/constants.html
+++ b/1.0/learn/api-docs/ballerina/openshift/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/openshift/index.html
+++ b/1.0/learn/api-docs/ballerina/openshift/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/openshift/records/RouteConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/openshift/records/RouteConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/openshift/records/RouteDomainConfig.html
+++ b/1.0/learn/api-docs/ballerina/openshift/records/RouteDomainConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/annotations.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/clients/Message.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/clients/Message.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/constants.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/errors.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/index.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/rabbitmq/types.html
+++ b/1.0/learn/api-docs/ballerina/rabbitmq/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/reflect/functions.html
+++ b/1.0/learn/api-docs/ballerina/reflect/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/reflect/index.html
+++ b/1.0/learn/api-docs/ballerina/reflect/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/runtime/functions.html
+++ b/1.0/learn/api-docs/ballerina/runtime/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/runtime/index.html
+++ b/1.0/learn/api-docs/ballerina/runtime/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
+++ b/1.0/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/runtime/records/CallStackElement.html
+++ b/1.0/learn/api-docs/ballerina/runtime/records/CallStackElement.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/runtime/records/InvocationContext.html
+++ b/1.0/learn/api-docs/ballerina/runtime/records/InvocationContext.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/runtime/records/Principal.html
+++ b/1.0/learn/api-docs/ballerina/runtime/records/Principal.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/clients/Client.html
+++ b/1.0/learn/api-docs/ballerina/socket/clients/Client.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/clients/UdpClient.html
+++ b/1.0/learn/api-docs/ballerina/socket/clients/UdpClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/constants.html
+++ b/1.0/learn/api-docs/ballerina/socket/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/errors.html
+++ b/1.0/learn/api-docs/ballerina/socket/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/index.html
+++ b/1.0/learn/api-docs/ballerina/socket/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/listeners/Listener.html
+++ b/1.0/learn/api-docs/ballerina/socket/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/records/Address.html
+++ b/1.0/learn/api-docs/ballerina/socket/records/Address.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/records/ClientConfig.html
+++ b/1.0/learn/api-docs/ballerina/socket/records/ClientConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/socket/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/records/ListenerConfig.html
+++ b/1.0/learn/api-docs/ballerina/socket/records/ListenerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
+++ b/1.0/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/socket/types.html
+++ b/1.0/learn/api-docs/ballerina/socket/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/constants.html
+++ b/1.0/learn/api-docs/ballerina/streams/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/functions.html
+++ b/1.0/learn/api-docs/ballerina/streams/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/index.html
+++ b/1.0/learn/api-docs/ballerina/streams/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/AbstractOperatorProcessor.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/AbstractOperatorProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/AbstractPatternProcessor.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/AbstractPatternProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Aggregator.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Aggregator.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/AndOperatorProcessor.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/AndOperatorProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Average.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Average.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/CompoundPatternProcessor.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/CompoundPatternProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Count.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Count.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/DelayWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/DelayWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/DistinctCount.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/DistinctCount.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/ExternalTimeBatchWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/ExternalTimeBatchWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/ExternalTimeWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/ExternalTimeWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Filter.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Filter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/FollowedByProcessor.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/FollowedByProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/HoppingWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/HoppingWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/IntSort.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/IntSort.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/LengthBatchWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/LengthBatchWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/LengthWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/LengthWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/LinkedList.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/LinkedList.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Max.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Max.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/MaxForever.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/MaxForever.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/MergeSort.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/MergeSort.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Min.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Min.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/MinForever.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/MinForever.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Node.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Node.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/NotOperatorProcessor.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/NotOperatorProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/OperandProcessor.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/OperandProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/OrOperatorProcessor.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/OrOperatorProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/OrderBy.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/OrderBy.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/OutputProcess.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/OutputProcess.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Scheduler.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Scheduler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Select.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Select.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Snapshotable.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Snapshotable.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/SortWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/SortWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/StateMachine.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/StateMachine.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/StdDev.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/StdDev.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/StreamEvent.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/StreamEvent.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/StreamJoinProcessor.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/StreamJoinProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Sum.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Sum.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/TableJoinProcessor.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/TableJoinProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/TimeAccumulatingWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/TimeAccumulatingWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/TimeBatchWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/TimeBatchWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/TimeLengthWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/TimeLengthWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/TimeOrderWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/TimeOrderWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/TimeWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/TimeWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/UniqueLengthWindow.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/UniqueLengthWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/objects/Window.html
+++ b/1.0/learn/api-docs/ballerina/streams/objects/Window.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/records/SnapshottableStreamEvent.html
+++ b/1.0/learn/api-docs/ballerina/streams/records/SnapshottableStreamEvent.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/streams/types.html
+++ b/1.0/learn/api-docs/ballerina/streams/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/stringutils/functions.html
+++ b/1.0/learn/api-docs/ballerina/stringutils/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/stringutils/index.html
+++ b/1.0/learn/api-docs/ballerina/stringutils/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/system/constants.html
+++ b/1.0/learn/api-docs/ballerina/system/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/system/errors.html
+++ b/1.0/learn/api-docs/ballerina/system/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/system/functions.html
+++ b/1.0/learn/api-docs/ballerina/system/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/system/index.html
+++ b/1.0/learn/api-docs/ballerina/system/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/system/objects/Process.html
+++ b/1.0/learn/api-docs/ballerina/system/objects/Process.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/system/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/system/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/system/types.html
+++ b/1.0/learn/api-docs/ballerina/system/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/task/constants.html
+++ b/1.0/learn/api-docs/ballerina/task/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/task/errors.html
+++ b/1.0/learn/api-docs/ballerina/task/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/task/index.html
+++ b/1.0/learn/api-docs/ballerina/task/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/task/listeners/Listener.html
+++ b/1.0/learn/api-docs/ballerina/task/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/task/objects/Scheduler.html
+++ b/1.0/learn/api-docs/ballerina/task/objects/Scheduler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/task/records/AppointmentData.html
+++ b/1.0/learn/api-docs/ballerina/task/records/AppointmentData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/task/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/task/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/task/records/TimerConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/task/records/TimerConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/task/types.html
+++ b/1.0/learn/api-docs/ballerina/task/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/test/annotations.html
+++ b/1.0/learn/api-docs/ballerina/test/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/test/functions.html
+++ b/1.0/learn/api-docs/ballerina/test/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/test/index.html
+++ b/1.0/learn/api-docs/ballerina/test/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/test/records/MockConfig.html
+++ b/1.0/learn/api-docs/ballerina/test/records/MockConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/test/records/TestConfig.html
+++ b/1.0/learn/api-docs/ballerina/test/records/TestConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/time/constants.html
+++ b/1.0/learn/api-docs/ballerina/time/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/time/errors.html
+++ b/1.0/learn/api-docs/ballerina/time/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/time/functions.html
+++ b/1.0/learn/api-docs/ballerina/time/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/time/index.html
+++ b/1.0/learn/api-docs/ballerina/time/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/time/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/time/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/time/records/Time.html
+++ b/1.0/learn/api-docs/ballerina/time/records/Time.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/time/records/TimeZone.html
+++ b/1.0/learn/api-docs/ballerina/time/records/TimeZone.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/time/types.html
+++ b/1.0/learn/api-docs/ballerina/time/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/transactions/annotations.html
+++ b/1.0/learn/api-docs/ballerina/transactions/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/transactions/functions.html
+++ b/1.0/learn/api-docs/ballerina/transactions/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/transactions/index.html
+++ b/1.0/learn/api-docs/ballerina/transactions/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/annotations.html
+++ b/1.0/learn/api-docs/ballerina/websub/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/clients/Caller.html
+++ b/1.0/learn/api-docs/ballerina/websub/clients/Caller.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/clients/PublisherClient.html
+++ b/1.0/learn/api-docs/ballerina/websub/clients/PublisherClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
+++ b/1.0/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/constants.html
+++ b/1.0/learn/api-docs/ballerina/websub/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/errors.html
+++ b/1.0/learn/api-docs/ballerina/websub/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/functions.html
+++ b/1.0/learn/api-docs/ballerina/websub/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/index.html
+++ b/1.0/learn/api-docs/ballerina/websub/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/listeners/Listener.html
+++ b/1.0/learn/api-docs/ballerina/websub/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/objects/Hub.html
+++ b/1.0/learn/api-docs/ballerina/websub/objects/Hub.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
+++ b/1.0/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
+++ b/1.0/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/objects/Notification.html
+++ b/1.0/learn/api-docs/ballerina/websub/objects/Notification.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/Detail.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/HubConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/HubConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
+++ b/1.0/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/websub/types.html
+++ b/1.0/learn/api-docs/ballerina/websub/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/xmlutils/functions.html
+++ b/1.0/learn/api-docs/ballerina/xmlutils/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/xmlutils/index.html
+++ b/1.0/learn/api-docs/ballerina/xmlutils/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
+++ b/1.0/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/xslt/functions.html
+++ b/1.0/learn/api-docs/ballerina/xslt/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerina/xslt/index.html
+++ b/1.0/learn/api-docs/ballerina/xslt/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
-      <a href="https://ballerina.io/learn/" class="cInfoBanner">
+      <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerinax/awslambda.html
+++ b/1.0/learn/api-docs/ballerinax/awslambda.html
@@ -109,7 +109,7 @@
             <div class="cTopLine"></div>
         </div>
     </div>
-          <a href="https://ballerina.io/learn/" class="cInfoBanner">
+          <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerinax/docker.html
+++ b/1.0/learn/api-docs/ballerinax/docker.html
@@ -110,7 +110,7 @@
             <div class="cTopLine"></div>
         </div>
     </div>
-          <a href="https://ballerina.io/learn/" class="cInfoBanner">
+          <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerinax/index.html
+++ b/1.0/learn/api-docs/ballerinax/index.html
@@ -70,7 +70,7 @@
          <div class="cTopLine"></div>
       </div>
    </div>
-         <a href="https://ballerina.io/learn/" class="cInfoBanner">
+         <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerinax/istio.html
+++ b/1.0/learn/api-docs/ballerinax/istio.html
@@ -112,7 +112,7 @@
             <div class="cTopLine"></div>
         </div>
     </div>
-          <a href="https://ballerina.io/learn/" class="cInfoBanner">
+          <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerinax/jdbc.html
+++ b/1.0/learn/api-docs/ballerinax/jdbc.html
@@ -113,7 +113,7 @@ xxxxxxx
             <div class="cTopLine"></div>
         </div>
     </div>
-          <a href="https://ballerina.io/learn/" class="cInfoBanner">
+          <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerinax/kubernetes.html
+++ b/1.0/learn/api-docs/ballerinax/kubernetes.html
@@ -110,7 +110,7 @@
             <div class="cTopLine"></div>
         </div>
     </div>
-          <a href="https://ballerina.io/learn/" class="cInfoBanner">
+          <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.0/learn/api-docs/ballerinax/openshift.html
+++ b/1.0/learn/api-docs/ballerinax/openshift.html
@@ -111,7 +111,7 @@
             <div class="cTopLine"></div>
         </div>
     </div>
-          <a href="https://ballerina.io/learn/" class="cInfoBanner">
+          <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.0.0. View API documentation for the latest release.</a>
 <div class="row cBallerina-io-Nav" id="iMainNavigation">
 

--- a/1.1/learn/api-docs/ballerina/auth/constants.html
+++ b/1.1/learn/api-docs/ballerina/auth/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/auth/errors.html
+++ b/1.1/learn/api-docs/ballerina/auth/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/auth/functions.html
+++ b/1.1/learn/api-docs/ballerina/auth/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/auth/index.html
+++ b/1.1/learn/api-docs/ballerina/auth/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
+++ b/1.1/learn/api-docs/ballerina/auth/objects/InboundAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
+++ b/1.1/learn/api-docs/ballerina/auth/objects/InboundBasicAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
+++ b/1.1/learn/api-docs/ballerina/auth/objects/OutboundAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
+++ b/1.1/learn/api-docs/ballerina/auth/objects/OutboundBasicAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
+++ b/1.1/learn/api-docs/ballerina/auth/records/BasicAuthConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/auth/records/Credential.html
+++ b/1.1/learn/api-docs/ballerina/auth/records/Credential.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/auth/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/auth/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/awslambda/annotations.html
+++ b/1.1/learn/api-docs/ballerina/awslambda/annotations.html
@@ -65,7 +65,7 @@
         <div class="cTopLine"></div>
     </div>
 </div>
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/awslambda/functions.html
+++ b/1.1/learn/api-docs/ballerina/awslambda/functions.html
@@ -65,7 +65,7 @@
         <div class="cTopLine"></div>
     </div>
 </div>
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/awslambda/index.html
+++ b/1.1/learn/api-docs/ballerina/awslambda/index.html
@@ -65,7 +65,7 @@
         <div class="cTopLine"></div>
     </div>
 </div>
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/awslambda/objects/Context.html
+++ b/1.1/learn/api-docs/ballerina/awslambda/objects/Context.html
@@ -65,7 +65,7 @@
         <div class="cTopLine"></div>
     </div>
 </div>
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/cache/constants.html
+++ b/1.1/learn/api-docs/ballerina/cache/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/cache/errors.html
+++ b/1.1/learn/api-docs/ballerina/cache/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/cache/index.html
+++ b/1.1/learn/api-docs/ballerina/cache/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/cache/objects/Cache.html
+++ b/1.1/learn/api-docs/ballerina/cache/objects/Cache.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/cache/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/cache/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/config/functions.html
+++ b/1.1/learn/api-docs/ballerina/config/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/config/index.html
+++ b/1.1/learn/api-docs/ballerina/config/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/constants.html
+++ b/1.1/learn/api-docs/ballerina/crypto/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/errors.html
+++ b/1.1/learn/api-docs/ballerina/crypto/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/functions.html
+++ b/1.1/learn/api-docs/ballerina/crypto/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/index.html
+++ b/1.1/learn/api-docs/ballerina/crypto/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/records/Certificate.html
+++ b/1.1/learn/api-docs/ballerina/crypto/records/Certificate.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/crypto/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/records/KeyStore.html
+++ b/1.1/learn/api-docs/ballerina/crypto/records/KeyStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/records/PrivateKey.html
+++ b/1.1/learn/api-docs/ballerina/crypto/records/PrivateKey.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/records/PublicKey.html
+++ b/1.1/learn/api-docs/ballerina/crypto/records/PublicKey.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/records/TrustStore.html
+++ b/1.1/learn/api-docs/ballerina/crypto/records/TrustStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/crypto/types.html
+++ b/1.1/learn/api-docs/ballerina/crypto/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/docker/annotations.html
+++ b/1.1/learn/api-docs/ballerina/docker/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/docker/index.html
+++ b/1.1/learn/api-docs/ballerina/docker/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/docker/records/DockerConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/docker/records/DockerConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/docker/records/ExposeConfig.html
+++ b/1.1/learn/api-docs/ballerina/docker/records/ExposeConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/docker/records/FileConfig.html
+++ b/1.1/learn/api-docs/ballerina/docker/records/FileConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/docker/records/FileConfigs.html
+++ b/1.1/learn/api-docs/ballerina/docker/records/FileConfigs.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/encoding/constants.html
+++ b/1.1/learn/api-docs/ballerina/encoding/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/encoding/errors.html
+++ b/1.1/learn/api-docs/ballerina/encoding/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/encoding/functions.html
+++ b/1.1/learn/api-docs/ballerina/encoding/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/encoding/index.html
+++ b/1.1/learn/api-docs/ballerina/encoding/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/encoding/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/encoding/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/file/constants.html
+++ b/1.1/learn/api-docs/ballerina/file/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/file/errors.html
+++ b/1.1/learn/api-docs/ballerina/file/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/file/functions.html
+++ b/1.1/learn/api-docs/ballerina/file/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/file/index.html
+++ b/1.1/learn/api-docs/ballerina/file/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/file/listeners/Listener.html
+++ b/1.1/learn/api-docs/ballerina/file/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/file/objects/FileInfo.html
+++ b/1.1/learn/api-docs/ballerina/file/objects/FileInfo.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/file/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/file/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/file/records/FileEvent.html
+++ b/1.1/learn/api-docs/ballerina/file/records/FileEvent.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/file/records/ListenerConfig.html
+++ b/1.1/learn/api-docs/ballerina/file/records/ListenerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/file/types.html
+++ b/1.1/learn/api-docs/ballerina/file/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/filepath/constants.html
+++ b/1.1/learn/api-docs/ballerina/filepath/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/filepath/errors.html
+++ b/1.1/learn/api-docs/ballerina/filepath/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/filepath/functions.html
+++ b/1.1/learn/api-docs/ballerina/filepath/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/filepath/index.html
+++ b/1.1/learn/api-docs/ballerina/filepath/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/filepath/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/filepath/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/filepath/types.html
+++ b/1.1/learn/api-docs/ballerina/filepath/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/annotations.html
+++ b/1.1/learn/api-docs/ballerina/grpc/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/clients/Caller.html
+++ b/1.1/learn/api-docs/ballerina/grpc/clients/Caller.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/clients/Client.html
+++ b/1.1/learn/api-docs/ballerina/grpc/clients/Client.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
+++ b/1.1/learn/api-docs/ballerina/grpc/clients/StreamingClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/constants.html
+++ b/1.1/learn/api-docs/ballerina/grpc/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/errors.html
+++ b/1.1/learn/api-docs/ballerina/grpc/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/functions.html
+++ b/1.1/learn/api-docs/ballerina/grpc/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/index.html
+++ b/1.1/learn/api-docs/ballerina/grpc/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/listeners/Listener.html
+++ b/1.1/learn/api-docs/ballerina/grpc/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
+++ b/1.1/learn/api-docs/ballerina/grpc/objects/AbstractClientEndpoint.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/objects/Headers.html
+++ b/1.1/learn/api-docs/ballerina/grpc/objects/Headers.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/ClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/GrpcResourceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/GrpcServiceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/ListenerConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/ListenerOcspStapling.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/ListenerSecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/Local.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/Local.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/PoolConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/Protocols.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/Protocols.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/Remote.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/Remote.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/SecureSocket.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/SecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/ServiceDescriptorData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/records/ValidateCert.html
+++ b/1.1/learn/api-docs/ballerina/grpc/records/ValidateCert.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/grpc/types.html
+++ b/1.1/learn/api-docs/ballerina/grpc/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/annotations.html
+++ b/1.1/learn/api-docs/ballerina/http/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/Caller.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/Caller.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/CircuitBreakerClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/Client.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/Client.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/FailoverClient.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/FailoverClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/HttpCachingClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/HttpClient.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/HttpClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/HttpSecureClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/LoadBalanceClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/RedirectClient.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/RedirectClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/RetryClient.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/RetryClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/WebSocketCaller.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/clients/WebSocketClient.html
+++ b/1.1/learn/api-docs/ballerina/http/clients/WebSocketClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/constants.html
+++ b/1.1/learn/api-docs/ballerina/http/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/errors.html
+++ b/1.1/learn/api-docs/ballerina/http/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/functions.html
+++ b/1.1/learn/api-docs/ballerina/http/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/index.html
+++ b/1.1/learn/api-docs/ballerina/http/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/listeners/Listener.html
+++ b/1.1/learn/api-docs/ballerina/http/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/listeners/MockListener.html
+++ b/1.1/learn/api-docs/ballerina/http/listeners/MockListener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/AuthnFilter.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/AuthnFilter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/AuthzFilter.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/AuthzFilter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/AuthzHandler.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/AuthzHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/BasicAuthHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/BearerAuthHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/Cookie.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/Cookie.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/CookieClient.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/CookieClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/CookieStore.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/CookieStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/FilterContext.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/FilterContext.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/HttpCache.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/HttpCache.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/HttpFuture.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/HttpFuture.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/InboundAuthHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/LoadBalancerRoundRobinRule.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/LoadBalancerRule.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/OutboundAuthHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/PushPromise.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/PushPromise.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/Request.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/Request.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/RequestCacheControl.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/RequestFilter.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/RequestFilter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/Response.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/Response.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/ResponseCacheControl.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/objects/ResponseFilter.html
+++ b/1.1/learn/api-docs/ballerina/http/objects/ResponseFilter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/AuthzCacheConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/AuthzCacheConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/Bucket.html
+++ b/1.1/learn/api-docs/ballerina/http/records/Bucket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/CacheConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/CacheConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/CircuitBreakerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/CircuitBreakerInferredConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/CircuitHealth.html
+++ b/1.1/learn/api-docs/ballerina/http/records/CircuitHealth.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ClientConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ClientHttp1Settings.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ClientHttp2Settings.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ClientSecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/CompressionConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/CompressionConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/CookieConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/CookieConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/CorsConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/CorsConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/http/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/http/records/FailoverClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/FailoverConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/FailoverConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/FailoverInferredConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/FollowRedirects.html
+++ b/1.1/learn/api-docs/ballerina/http/records/FollowRedirects.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/HttpResourceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/HttpServiceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
+++ b/1.1/learn/api-docs/ballerina/http/records/HttpTimeoutError.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ListenerAuth.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ListenerAuth.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ListenerConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ListenerHttp1Settings.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ListenerOcspStapling.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ListenerSecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
+++ b/1.1/learn/api-docs/ballerina/http/records/LoadBalanceActionErrorData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/http/records/LoadBalanceClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/Local.html
+++ b/1.1/learn/api-docs/ballerina/http/records/Local.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
+++ b/1.1/learn/api-docs/ballerina/http/records/MutualSslHandshake.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/OutboundAuthConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/PoolConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/http/records/PoolConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/Protocols.html
+++ b/1.1/learn/api-docs/ballerina/http/records/Protocols.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ProxyConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ProxyConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/Remote.html
+++ b/1.1/learn/api-docs/ballerina/http/records/Remote.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ResourceAuth.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ResourceAuth.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/RetryConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/RetryConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/RetryInferredConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/RollingWindow.html
+++ b/1.1/learn/api-docs/ballerina/http/records/RollingWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ServiceAuth.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ServiceAuth.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/TargetService.html
+++ b/1.1/learn/api-docs/ballerina/http/records/TargetService.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/ValidateCert.html
+++ b/1.1/learn/api-docs/ballerina/http/records/ValidateCert.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/Versioning.html
+++ b/1.1/learn/api-docs/ballerina/http/records/Versioning.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/WSServiceConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/WSServiceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/http/records/WebSocketClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
+++ b/1.1/learn/api-docs/ballerina/http/records/WebSocketUpgradeConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/http/types.html
+++ b/1.1/learn/api-docs/ballerina/http/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/index.html
+++ b/1.1/learn/api-docs/ballerina/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/constants.html
+++ b/1.1/learn/api-docs/ballerina/io/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/errors.html
+++ b/1.1/learn/api-docs/ballerina/io/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/functions.html
+++ b/1.1/learn/api-docs/ballerina/io/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/index.html
+++ b/1.1/learn/api-docs/ballerina/io/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/ReadableByteChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/ReadableCSVChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/ReadableCharacterChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/ReadableDataChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/ReadableTextRecordChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/StringReader.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/StringReader.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/WritableByteChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/WritableCSVChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/WritableCharacterChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/WritableDataChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
+++ b/1.1/learn/api-docs/ballerina/io/objects/WritableTextRecordChannel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/io/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/io/types.html
+++ b/1.1/learn/api-docs/ballerina/io/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/annotations.html
+++ b/1.1/learn/api-docs/ballerina/istio/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/index.html
+++ b/1.1/learn/api-docs/ballerina/istio/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/records/DestinationConfig.html
+++ b/1.1/learn/api-docs/ballerina/istio/records/DestinationConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/records/DestinationWeightConfig.html
+++ b/1.1/learn/api-docs/ballerina/istio/records/DestinationWeightConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/records/GatewayConfig.html
+++ b/1.1/learn/api-docs/ballerina/istio/records/GatewayConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/records/HTTPRouteConfig.html
+++ b/1.1/learn/api-docs/ballerina/istio/records/HTTPRouteConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/records/PortConfig.html
+++ b/1.1/learn/api-docs/ballerina/istio/records/PortConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/records/ServerConfig.html
+++ b/1.1/learn/api-docs/ballerina/istio/records/ServerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/records/TLSOptionConfig.html
+++ b/1.1/learn/api-docs/ballerina/istio/records/TLSOptionConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/records/VirtualServiceConfig.html
+++ b/1.1/learn/api-docs/ballerina/istio/records/VirtualServiceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/istio/types.html
+++ b/1.1/learn/api-docs/ballerina/istio/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.arrays/functions.html
+++ b/1.1/learn/api-docs/ballerina/java.arrays/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.arrays/index.html
+++ b/1.1/learn/api-docs/ballerina/java.arrays/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/clients/Client.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/clients/Client.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/constants.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/errors.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/index.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/records/ApplicationErrorData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/records/BatchUpdateResult.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/records/ClientConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/records/DatabaseErrorData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/records/Parameter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/records/PoolOptions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/records/UpdateResult.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java.jdbc/types.html
+++ b/1.1/learn/api-docs/ballerina/java.jdbc/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java/annotations.html
+++ b/1.1/learn/api-docs/ballerina/java/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java/functions.html
+++ b/1.1/learn/api-docs/ballerina/java/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java/index.html
+++ b/1.1/learn/api-docs/ballerina/java/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java/records/ArrayType.html
+++ b/1.1/learn/api-docs/ballerina/java/records/ArrayType.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java/records/ConstructorData.html
+++ b/1.1/learn/api-docs/ballerina/java/records/ConstructorData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java/records/FieldData.html
+++ b/1.1/learn/api-docs/ballerina/java/records/FieldData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/java/records/MethodData.html
+++ b/1.1/learn/api-docs/ballerina/java/records/MethodData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jsonutils/functions.html
+++ b/1.1/learn/api-docs/ballerina/jsonutils/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jsonutils/index.html
+++ b/1.1/learn/api-docs/ballerina/jsonutils/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
+++ b/1.1/learn/api-docs/ballerina/jsonutils/records/XmlOptions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/constants.html
+++ b/1.1/learn/api-docs/ballerina/jwt/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/errors.html
+++ b/1.1/learn/api-docs/ballerina/jwt/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/functions.html
+++ b/1.1/learn/api-docs/ballerina/jwt/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/index.html
+++ b/1.1/learn/api-docs/ballerina/jwt/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
+++ b/1.1/learn/api-docs/ballerina/jwt/objects/InboundJwtAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
+++ b/1.1/learn/api-docs/ballerina/jwt/objects/OutboundJwtAuthProvider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/records/CachedJwt.html
+++ b/1.1/learn/api-docs/ballerina/jwt/records/CachedJwt.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/jwt/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/records/JwtHeader.html
+++ b/1.1/learn/api-docs/ballerina/jwt/records/JwtHeader.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
+++ b/1.1/learn/api-docs/ballerina/jwt/records/JwtIssuerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
+++ b/1.1/learn/api-docs/ballerina/jwt/records/JwtKeyStoreConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/records/JwtPayload.html
+++ b/1.1/learn/api-docs/ballerina/jwt/records/JwtPayload.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
+++ b/1.1/learn/api-docs/ballerina/jwt/records/JwtTrustStoreConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
+++ b/1.1/learn/api-docs/ballerina/jwt/records/JwtValidatorConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/jwt/types.html
+++ b/1.1/learn/api-docs/ballerina/jwt/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/clients/Consumer.html
+++ b/1.1/learn/api-docs/ballerina/kafka/clients/Consumer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/clients/Producer.html
+++ b/1.1/learn/api-docs/ballerina/kafka/clients/Producer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/constants.html
+++ b/1.1/learn/api-docs/ballerina/kafka/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/errors.html
+++ b/1.1/learn/api-docs/ballerina/kafka/errors.html
@@ -52,7 +52,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/index.html
+++ b/1.1/learn/api-docs/ballerina/kafka/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/records/ConsumerConfig.html
+++ b/1.1/learn/api-docs/ballerina/kafka/records/ConsumerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
+++ b/1.1/learn/api-docs/ballerina/kafka/records/ConsumerRecord.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/kafka/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/records/KeyStore.html
+++ b/1.1/learn/api-docs/ballerina/kafka/records/KeyStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
+++ b/1.1/learn/api-docs/ballerina/kafka/records/PartitionOffset.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/records/ProducerConfig.html
+++ b/1.1/learn/api-docs/ballerina/kafka/records/ProducerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/records/Protocols.html
+++ b/1.1/learn/api-docs/ballerina/kafka/records/Protocols.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/records/SecureSocket.html
+++ b/1.1/learn/api-docs/ballerina/kafka/records/SecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/records/TopicPartition.html
+++ b/1.1/learn/api-docs/ballerina/kafka/records/TopicPartition.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/records/TrustStore.html
+++ b/1.1/learn/api-docs/ballerina/kafka/records/TrustStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kafka/types.html
+++ b/1.1/learn/api-docs/ballerina/kafka/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/annotations.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/constants.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/index.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/BuildExtension.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/BuildExtension.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/ConfigMap.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/ConfigMap.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyRef.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyValue.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/ConfigMapKeyValue.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/ConfigMapMount.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/DeploymentConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/FieldRef.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/FieldRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/FieldValue.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/FieldValue.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/FileConfig.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/FileConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/IngressConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/IngressConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/JobConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/Metadata.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/Metadata.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/OpenShiftBuildConfigConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/OpenShiftBuildConfigConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaimConfig.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaimConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/PersistentVolumeClaims.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/PodAutoscalerConfig.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/PodAutoscalerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/PodTolerationConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/PodTolerationConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/ProbeConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/ProbeConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/ResourceFieldRef.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/ResourceFieldRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/ResourceFieldValue.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/ResourceFieldValue.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/ResourceQuotaConfig.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/ResourceQuotaConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/ResourceQuotas.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/Secret.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/Secret.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/SecretKeyRef.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/SecretKeyRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/SecretKeyValue.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/SecretKeyValue.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/SecretMount.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/records/ServiceConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/records/ServiceConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/kubernetes/types.html
+++ b/1.1/learn/api-docs/ballerina/kubernetes/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.array/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.array/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.array/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.array/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.array/objects/$anonType$1.html
+++ b/1.1/learn/api-docs/ballerina/lang.array/objects/$anonType$1.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.decimal/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.decimal/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.decimal/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.decimal/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.error/errors.html
+++ b/1.1/learn/api-docs/ballerina/lang.error/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.error/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.error/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.error/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.error/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.error/objects/CallStack.html
+++ b/1.1/learn/api-docs/ballerina/lang.error/objects/CallStack.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
+++ b/1.1/learn/api-docs/ballerina/lang.error/records/CallStackElement.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.error/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/lang.error/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.float/constants.html
+++ b/1.1/learn/api-docs/ballerina/lang.float/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.float/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.float/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.float/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.float/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.future/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.future/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.future/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.future/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.int/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.int/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.int/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.int/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.map/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.map/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.map/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.map/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.map/objects/$anonType$2.html
+++ b/1.1/learn/api-docs/ballerina/lang.map/objects/$anonType$2.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.object/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.object/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.object/objects/Listener.html
+++ b/1.1/learn/api-docs/ballerina/lang.object/objects/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.stream/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.stream/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.stream/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.stream/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.string/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.string/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.string/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.string/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.string/objects/$anonType$2.html
+++ b/1.1/learn/api-docs/ballerina/lang.string/objects/$anonType$2.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.table/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.table/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.table/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.table/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.table/objects/$anonType$2.html
+++ b/1.1/learn/api-docs/ballerina/lang.table/objects/$anonType$2.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.typedesc/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.typedesc/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.typedesc/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.typedesc/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.value/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.value/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.value/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.value/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.xml/constants.html
+++ b/1.1/learn/api-docs/ballerina/lang.xml/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.xml/functions.html
+++ b/1.1/learn/api-docs/ballerina/lang.xml/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.xml/index.html
+++ b/1.1/learn/api-docs/ballerina/lang.xml/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.xml/objects/$anonType$9.html
+++ b/1.1/learn/api-docs/ballerina/lang.xml/objects/$anonType$9.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/lang.xml/types.html
+++ b/1.1/learn/api-docs/ballerina/lang.xml/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/constants.html
+++ b/1.1/learn/api-docs/ballerina/llvm/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/functions.html
+++ b/1.1/learn/api-docs/ballerina/llvm/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/index.html
+++ b/1.1/learn/api-docs/ballerina/llvm/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/ByteBuffer.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/ByteBuffer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/BytePointer.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/BytePointer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/IntPointer.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/IntPointer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMAttributeRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMAttributeRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMBasicBlockRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMBasicBlockRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMBuilderRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMBuilderRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMContextRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMContextRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMDiagnosticHandler.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMDiagnosticHandler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMDiagnosticInfoRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMDiagnosticInfoRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMDisasmContextRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMDisasmContextRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMExecutionEngineRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMExecutionEngineRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMGenericValueRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMGenericValueRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMMCJITCompilerOptions.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMMCJITCompilerOptions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMMCJITMemoryManagerRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMMCJITMemoryManagerRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMMemoryBufferRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMMemoryBufferRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMMemoryManagerAllocateCodeSectionCallback.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMMemoryManagerAllocateCodeSectionCallback.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMMemoryManagerAllocateDataSectionCallback.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMMemoryManagerAllocateDataSectionCallback.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMMemoryManagerDestroyCallback.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMMemoryManagerDestroyCallback.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMMemoryManagerFinalizeMemoryCallback.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMMemoryManagerFinalizeMemoryCallback.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMMetadataRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMMetadataRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMModuleProviderRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMModuleProviderRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMModuleRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMModuleRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMObjectFileRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMObjectFileRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMOpInfoCallback.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMOpInfoCallback.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMPassManagerBuilderRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMPassManagerBuilderRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMPassManagerRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMPassManagerRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMPassRegistryRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMPassRegistryRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMRelocationIteratorRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMRelocationIteratorRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMSectionIteratorRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMSectionIteratorRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMSymbolIteratorRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMSymbolIteratorRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMSymbolLookupCallback.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMSymbolLookupCallback.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMTargetDataRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMTargetDataRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMTargetLibraryInfoRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMTargetLibraryInfoRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMTargetMachineRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMTargetMachineRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMTargetRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMTargetRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMTypeRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMTypeRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMUseRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMUseRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMValueRef.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMValueRef.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/LLVMYieldCallback.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/LLVMYieldCallback.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/Pointer.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/Pointer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/PointerPointer.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/PointerPointer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/llvm/records/SizeTPointer.html
+++ b/1.1/learn/api-docs/ballerina/llvm/records/SizeTPointer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/log/functions.html
+++ b/1.1/learn/api-docs/ballerina/log/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/log/index.html
+++ b/1.1/learn/api-docs/ballerina/log/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/math/constants.html
+++ b/1.1/learn/api-docs/ballerina/math/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/math/errors.html
+++ b/1.1/learn/api-docs/ballerina/math/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/math/functions.html
+++ b/1.1/learn/api-docs/ballerina/math/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/math/index.html
+++ b/1.1/learn/api-docs/ballerina/math/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/math/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/math/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/mime/constants.html
+++ b/1.1/learn/api-docs/ballerina/mime/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/mime/errors.html
+++ b/1.1/learn/api-docs/ballerina/mime/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/mime/functions.html
+++ b/1.1/learn/api-docs/ballerina/mime/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/mime/index.html
+++ b/1.1/learn/api-docs/ballerina/mime/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
+++ b/1.1/learn/api-docs/ballerina/mime/objects/ContentDisposition.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/mime/objects/Entity.html
+++ b/1.1/learn/api-docs/ballerina/mime/objects/Entity.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/mime/objects/MediaType.html
+++ b/1.1/learn/api-docs/ballerina/mime/objects/MediaType.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/mime/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/mime/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/mime/types.html
+++ b/1.1/learn/api-docs/ballerina/mime/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/annotations.html
+++ b/1.1/learn/api-docs/ballerina/nats/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/clients/Producer.html
+++ b/1.1/learn/api-docs/ballerina/nats/clients/Producer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
+++ b/1.1/learn/api-docs/ballerina/nats/clients/StreamingMessage.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
+++ b/1.1/learn/api-docs/ballerina/nats/clients/StreamingProducer.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/constants.html
+++ b/1.1/learn/api-docs/ballerina/nats/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/errors.html
+++ b/1.1/learn/api-docs/ballerina/nats/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/index.html
+++ b/1.1/learn/api-docs/ballerina/nats/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/listeners/Listener.html
+++ b/1.1/learn/api-docs/ballerina/nats/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
+++ b/1.1/learn/api-docs/ballerina/nats/listeners/StreamingListener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/objects/Connection.html
+++ b/1.1/learn/api-docs/ballerina/nats/objects/Connection.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/objects/Message.html
+++ b/1.1/learn/api-docs/ballerina/nats/objects/Message.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
+++ b/1.1/learn/api-docs/ballerina/nats/records/ConnectionConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/nats/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/records/PendingLimits.html
+++ b/1.1/learn/api-docs/ballerina/nats/records/PendingLimits.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/records/SecureSocket.html
+++ b/1.1/learn/api-docs/ballerina/nats/records/SecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/records/StreamingConfig.html
+++ b/1.1/learn/api-docs/ballerina/nats/records/StreamingConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
+++ b/1.1/learn/api-docs/ballerina/nats/records/StreamingSubscriptionConfigData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
+++ b/1.1/learn/api-docs/ballerina/nats/records/SubscriptionConfigData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/nats/types.html
+++ b/1.1/learn/api-docs/ballerina/nats/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/constants.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/errors.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/functions.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/index.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/objects/InboundOAuth2Provider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/objects/OutboundOAuth2Provider.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/records/CachedToken.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/records/CachedToken.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/records/ClientCredentialsGrantConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/records/DirectTokenConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/records/DirectTokenRefreshConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/records/IntrospectionServerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/records/PasswordGrantConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
+++ b/1.1/learn/api-docs/ballerina/oauth2/records/RefreshConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/observe/functions.html
+++ b/1.1/learn/api-docs/ballerina/observe/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/observe/index.html
+++ b/1.1/learn/api-docs/ballerina/observe/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/observe/objects/Counter.html
+++ b/1.1/learn/api-docs/ballerina/observe/objects/Counter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/observe/objects/Gauge.html
+++ b/1.1/learn/api-docs/ballerina/observe/objects/Gauge.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/observe/records/Metric.html
+++ b/1.1/learn/api-docs/ballerina/observe/records/Metric.html
@@ -52,7 +52,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/observe/records/PercentileValue.html
+++ b/1.1/learn/api-docs/ballerina/observe/records/PercentileValue.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/observe/records/Snapshot.html
+++ b/1.1/learn/api-docs/ballerina/observe/records/Snapshot.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/observe/records/StatisticConfig.html
+++ b/1.1/learn/api-docs/ballerina/observe/records/StatisticConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/openapi/annotations.html
+++ b/1.1/learn/api-docs/ballerina/openapi/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/openapi/index.html
+++ b/1.1/learn/api-docs/ballerina/openapi/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/openapi/records/ClientInformation.html
+++ b/1.1/learn/api-docs/ballerina/openapi/records/ClientInformation.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
+++ b/1.1/learn/api-docs/ballerina/openapi/records/ServiceInformation.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/openshift/annotations.html
+++ b/1.1/learn/api-docs/ballerina/openshift/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/openshift/constants.html
+++ b/1.1/learn/api-docs/ballerina/openshift/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/openshift/index.html
+++ b/1.1/learn/api-docs/ballerina/openshift/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/openshift/records/RouteConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/openshift/records/RouteConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/openshift/records/RouteDomainConfig.html
+++ b/1.1/learn/api-docs/ballerina/openshift/records/RouteDomainConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/annotations.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/clients/Channel.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/clients/Message.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/clients/Message.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/constants.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/errors.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/index.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/objects/Connection.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/records/BasicProperties.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/records/ConnectionConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/records/ExchangeConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/records/QueueConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/records/RabbitMQServiceConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/records/SecureSocket.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/rabbitmq/types.html
+++ b/1.1/learn/api-docs/ballerina/rabbitmq/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/reflect/functions.html
+++ b/1.1/learn/api-docs/ballerina/reflect/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/reflect/index.html
+++ b/1.1/learn/api-docs/ballerina/reflect/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/runtime/functions.html
+++ b/1.1/learn/api-docs/ballerina/runtime/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/runtime/index.html
+++ b/1.1/learn/api-docs/ballerina/runtime/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
+++ b/1.1/learn/api-docs/ballerina/runtime/records/AuthenticationContext.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/runtime/records/CallStackElement.html
+++ b/1.1/learn/api-docs/ballerina/runtime/records/CallStackElement.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/runtime/records/InvocationContext.html
+++ b/1.1/learn/api-docs/ballerina/runtime/records/InvocationContext.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/runtime/records/Principal.html
+++ b/1.1/learn/api-docs/ballerina/runtime/records/Principal.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/clients/Client.html
+++ b/1.1/learn/api-docs/ballerina/socket/clients/Client.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/clients/UdpClient.html
+++ b/1.1/learn/api-docs/ballerina/socket/clients/UdpClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/constants.html
+++ b/1.1/learn/api-docs/ballerina/socket/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/errors.html
+++ b/1.1/learn/api-docs/ballerina/socket/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/index.html
+++ b/1.1/learn/api-docs/ballerina/socket/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/listeners/Listener.html
+++ b/1.1/learn/api-docs/ballerina/socket/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/records/Address.html
+++ b/1.1/learn/api-docs/ballerina/socket/records/Address.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/records/ClientConfig.html
+++ b/1.1/learn/api-docs/ballerina/socket/records/ClientConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/socket/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/records/ListenerConfig.html
+++ b/1.1/learn/api-docs/ballerina/socket/records/ListenerConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
+++ b/1.1/learn/api-docs/ballerina/socket/records/UdpClientConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/socket/types.html
+++ b/1.1/learn/api-docs/ballerina/socket/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/constants.html
+++ b/1.1/learn/api-docs/ballerina/streams/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/functions.html
+++ b/1.1/learn/api-docs/ballerina/streams/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/index.html
+++ b/1.1/learn/api-docs/ballerina/streams/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/AbstractOperatorProcessor.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/AbstractOperatorProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/AbstractPatternProcessor.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/AbstractPatternProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Aggregator.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Aggregator.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/AndOperatorProcessor.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/AndOperatorProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Average.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Average.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/CompoundPatternProcessor.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/CompoundPatternProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Count.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Count.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/DelayWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/DelayWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/DistinctCount.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/DistinctCount.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/ExternalTimeBatchWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/ExternalTimeBatchWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/ExternalTimeWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/ExternalTimeWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Filter.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Filter.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/FollowedByProcessor.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/FollowedByProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/HoppingWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/HoppingWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/IntSort.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/IntSort.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/LengthBatchWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/LengthBatchWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/LengthWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/LengthWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/LinkedList.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/LinkedList.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Max.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Max.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/MaxForever.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/MaxForever.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/MergeSort.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/MergeSort.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Min.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Min.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/MinForever.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/MinForever.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Node.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Node.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/NotOperatorProcessor.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/NotOperatorProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/OperandProcessor.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/OperandProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/OrOperatorProcessor.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/OrOperatorProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/OrderBy.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/OrderBy.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/OutputProcess.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/OutputProcess.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Scheduler.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Scheduler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Select.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Select.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Snapshotable.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Snapshotable.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/SortWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/SortWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/StateMachine.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/StateMachine.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/StdDev.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/StdDev.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/StreamEvent.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/StreamEvent.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/StreamJoinProcessor.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/StreamJoinProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Sum.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Sum.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/TableJoinProcessor.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/TableJoinProcessor.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/TimeAccumulatingWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/TimeAccumulatingWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/TimeBatchWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/TimeBatchWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/TimeLengthWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/TimeLengthWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/TimeOrderWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/TimeOrderWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/TimeWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/TimeWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/UniqueLengthWindow.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/UniqueLengthWindow.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/objects/Window.html
+++ b/1.1/learn/api-docs/ballerina/streams/objects/Window.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/records/SnapshottableStreamEvent.html
+++ b/1.1/learn/api-docs/ballerina/streams/records/SnapshottableStreamEvent.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/streams/types.html
+++ b/1.1/learn/api-docs/ballerina/streams/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/stringutils/functions.html
+++ b/1.1/learn/api-docs/ballerina/stringutils/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/stringutils/index.html
+++ b/1.1/learn/api-docs/ballerina/stringutils/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/system/constants.html
+++ b/1.1/learn/api-docs/ballerina/system/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/system/errors.html
+++ b/1.1/learn/api-docs/ballerina/system/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/system/functions.html
+++ b/1.1/learn/api-docs/ballerina/system/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/system/index.html
+++ b/1.1/learn/api-docs/ballerina/system/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/system/objects/Process.html
+++ b/1.1/learn/api-docs/ballerina/system/objects/Process.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/system/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/system/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/system/types.html
+++ b/1.1/learn/api-docs/ballerina/system/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/task/constants.html
+++ b/1.1/learn/api-docs/ballerina/task/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/task/errors.html
+++ b/1.1/learn/api-docs/ballerina/task/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/task/index.html
+++ b/1.1/learn/api-docs/ballerina/task/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/task/listeners/Listener.html
+++ b/1.1/learn/api-docs/ballerina/task/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/task/objects/Scheduler.html
+++ b/1.1/learn/api-docs/ballerina/task/objects/Scheduler.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/task/records/AppointmentConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/task/records/AppointmentData.html
+++ b/1.1/learn/api-docs/ballerina/task/records/AppointmentData.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/task/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/task/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/task/records/TimerConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/task/records/TimerConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/task/types.html
+++ b/1.1/learn/api-docs/ballerina/task/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/test/annotations.html
+++ b/1.1/learn/api-docs/ballerina/test/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/test/functions.html
+++ b/1.1/learn/api-docs/ballerina/test/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/test/index.html
+++ b/1.1/learn/api-docs/ballerina/test/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/test/records/MockConfig.html
+++ b/1.1/learn/api-docs/ballerina/test/records/MockConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/test/records/TestConfig.html
+++ b/1.1/learn/api-docs/ballerina/test/records/TestConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/time/constants.html
+++ b/1.1/learn/api-docs/ballerina/time/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/time/errors.html
+++ b/1.1/learn/api-docs/ballerina/time/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/time/functions.html
+++ b/1.1/learn/api-docs/ballerina/time/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/time/index.html
+++ b/1.1/learn/api-docs/ballerina/time/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/time/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/time/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/time/records/Time.html
+++ b/1.1/learn/api-docs/ballerina/time/records/Time.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/time/records/TimeZone.html
+++ b/1.1/learn/api-docs/ballerina/time/records/TimeZone.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/time/types.html
+++ b/1.1/learn/api-docs/ballerina/time/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/transactions/annotations.html
+++ b/1.1/learn/api-docs/ballerina/transactions/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/transactions/functions.html
+++ b/1.1/learn/api-docs/ballerina/transactions/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/transactions/index.html
+++ b/1.1/learn/api-docs/ballerina/transactions/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/annotations.html
+++ b/1.1/learn/api-docs/ballerina/websub/annotations.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/clients/Caller.html
+++ b/1.1/learn/api-docs/ballerina/websub/clients/Caller.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/clients/PublisherClient.html
+++ b/1.1/learn/api-docs/ballerina/websub/clients/PublisherClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
+++ b/1.1/learn/api-docs/ballerina/websub/clients/SubscriptionClient.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/constants.html
+++ b/1.1/learn/api-docs/ballerina/websub/constants.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/errors.html
+++ b/1.1/learn/api-docs/ballerina/websub/errors.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/functions.html
+++ b/1.1/learn/api-docs/ballerina/websub/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/index.html
+++ b/1.1/learn/api-docs/ballerina/websub/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/listeners/Listener.html
+++ b/1.1/learn/api-docs/ballerina/websub/listeners/Listener.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/objects/Hub.html
+++ b/1.1/learn/api-docs/ballerina/websub/objects/Hub.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
+++ b/1.1/learn/api-docs/ballerina/websub/objects/HubPersistenceStore.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
+++ b/1.1/learn/api-docs/ballerina/websub/objects/IntentVerificationRequest.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/objects/Notification.html
+++ b/1.1/learn/api-docs/ballerina/websub/objects/Notification.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/Detail.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/Detail.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/ExtensionConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/HubConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/HubConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/HubStartedUpError.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/RemotePublishConfig.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/SubscriberDetails.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/SubscriberListenerConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/SubscriberServiceConfiguration.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/SubscriptionChangeRequest.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/SubscriptionChangeResponse.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
+++ b/1.1/learn/api-docs/ballerina/websub/records/SubscriptionDetails.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/websub/types.html
+++ b/1.1/learn/api-docs/ballerina/websub/types.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/xmlutils/functions.html
+++ b/1.1/learn/api-docs/ballerina/xmlutils/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/xmlutils/index.html
+++ b/1.1/learn/api-docs/ballerina/xmlutils/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
+++ b/1.1/learn/api-docs/ballerina/xmlutils/records/JsonOptions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/xslt/functions.html
+++ b/1.1/learn/api-docs/ballerina/xslt/functions.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerina/xslt/index.html
+++ b/1.1/learn/api-docs/ballerina/xslt/index.html
@@ -51,7 +51,7 @@
 
 
 <body class="cBallerina-io pushable">
- <a href="https://ballerina.io/learn/" class="cInfoBanner">
+ <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerinax/awslambda.html
+++ b/1.1/learn/api-docs/ballerinax/awslambda.html
@@ -109,7 +109,7 @@
             <div class="cTopLine"></div>
         </div>
     </div>
-     <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerinax/docker.html
+++ b/1.1/learn/api-docs/ballerinax/docker.html
@@ -110,7 +110,7 @@
             <div class="cTopLine"></div>
         </div>
     </div>
-     <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerinax/index.html
+++ b/1.1/learn/api-docs/ballerinax/index.html
@@ -70,7 +70,7 @@
          <div class="cTopLine"></div>
       </div>
    </div>
-    <a href="https://ballerina.io/learn/" class="cInfoBanner">
+    <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerinax/istio.html
+++ b/1.1/learn/api-docs/ballerinax/istio.html
@@ -112,7 +112,7 @@
             <div class="cTopLine"></div>
         </div>
     </div>
-     <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerinax/jdbc.html
+++ b/1.1/learn/api-docs/ballerinax/jdbc.html
@@ -113,7 +113,7 @@ xxxxxxx
             <div class="cTopLine"></div>
         </div>
     </div>
-     <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerinax/kubernetes.html
+++ b/1.1/learn/api-docs/ballerinax/kubernetes.html
@@ -110,7 +110,7 @@
             <div class="cTopLine"></div>
         </div>
     </div>
-     <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">

--- a/1.1/learn/api-docs/ballerinax/openshift.html
+++ b/1.1/learn/api-docs/ballerinax/openshift.html
@@ -111,7 +111,7 @@
             <div class="cTopLine"></div>
         </div>
     </div>
-     <a href="https://ballerina.io/learn/" class="cInfoBanner">
+     <a href="https://lib.ballerina.io" class="cInfoBanner">
     This API documentation is for Ballerina 1.1.0. View API documentation for the latest release.</a>
 
       <div class="row cBallerina-io-Nav" id="iMainNavigation">


### PR DESCRIPTION
## Purpose
Fix the link in the API Docs banner.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
