### PR TITLE
Rename kafka sample name

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@ td.cEventDateContainer{
              <li><a data-toggle="tab" href="#fourthTab" >gRPC API</a></li>
             <li><a data-toggle="tab" href="#sixthTab" >GraphQL API</a></li>
             <li><a data-toggle="tab" href="#databaseTab" >Working with Databases</a></li>
-            <li><a data-toggle="tab" href="#seventhTab" >Kafka Consumer/Producer</a></li>
+            <li><a data-toggle="tab" href="#seventhTab" >Kafka</a></li>
          </ul>
          <div class="tab-content">
             <div id="secondTab" class="tab-pane fade "  >


### PR DESCRIPTION
## Purpose
$subject
changed the name since the tabs are divided to 2 lines now due to long topic names

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
