### PR TITLE
Remove the 2021R1 Spec Draft Entry from the `index.md` File

### DIFF
--- a/spec/lang/draft/latest/index.md
+++ b/spec/lang/draft/latest/index.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /spec/lang/draft/v2020-12-17/
+redirect_to: /spec/lang/draft/v2022-01-07/
 ---

--- a/spec/lang/draft/latest/index.md
+++ b/spec/lang/draft/latest/index.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /spec/lang/draft/v2022R1/
+redirect_to: /spec/lang/draft/v2020-12-17/
 ---


### PR DESCRIPTION
## Purpose
Remove the 2021R1 spec draft entry from the `index.md` file.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
