### PR TITLE
Update the Update Commands Post SL GA Release

### DIFF
--- a/download.html
+++ b/download.html
@@ -31,8 +31,11 @@ redirect_from:
                <p>For more details, see the <a href="https://blog.ballerina.io/posts/2022-02-01-announcing-ballerina-2201.0.0-swan-lake/">Swan Lake GA release announcement </a> and <a href="/downloads/swan-lake-release-notes/">release note.</a></p><br/> 
 					<!-- <h2 id="swanlake">{{ site.data.swanlake-latest.metadata.display-version }} <span id="versionInfo">({{ site.data.swanlake-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2> -->
 					<div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;">
-						<p>If you are already using Ballerina, use the <a href="/learn/tooling-guide/cli-tools/update-tool/">Ballerina Update Tool</a> to directly update to {{ site.data.swanlake-latest.metadata.display-version }} by running the command below. </p> <pre>bal dist pull 2201.0.0</pre>
-						<p>If your Update Tool is below version 0.8.14, use the <code class="highlighter-rouge language-plaintext">ballerina update</code> command.</p> 
+						<p>If you are already using Ballerina, you can use the <a href="/learn/tooling-guide/cli-tools/update-tool/">Ballerina Update Tool</a> to directly update to {{ site.data.swanlake-latest.metadata.display-version }}. To do this, first, run the command below to get the latest version of the Update Tool. </p> 
+                  <p><pre>bal update</pre></p>
+                  <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
+                  <p><pre>bal dist pull 2201.0.0</pre></p>
+                  <p>If your Update Tool is below version 0.8.14, use the <code class="highlighter-rouge language-plaintext">ballerina update</code> command.</p> 
 					</div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -35,7 +35,7 @@ redirect_from:
                   <p><pre>1. bal update</pre></p>
                   <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
                   <p><pre>2. bal dist pull 2201.0.0</pre></p>
-                  <p>If you already ran <code class="highlighter-rouge language-plaintext">bal dist pull update</code> or <code class="highlighter-rouge language-plaintext">bal dist pull 2201.0.0</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Updating Ballerina</a> to recover your installation.</p>
+                  <p>If you already ran <code class="highlighter-rouge language-plaintext">bal dist update</code> or <code class="highlighter-rouge language-plaintext">bal dist pull 2201.0.0</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Updating Ballerina</a> to recover your installation.</p>
 					</div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -32,10 +32,10 @@ redirect_from:
 					<!-- <h2 id="swanlake">{{ site.data.swanlake-latest.metadata.display-version }} <span id="versionInfo">({{ site.data.swanlake-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2> -->
 					<div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;">
 						<p>If you are already using Ballerina, you can use the <a href="/learn/tooling-guide/cli-tools/update-tool/">Ballerina Update Tool</a> to directly update to {{ site.data.swanlake-latest.metadata.display-version }}. To do this, first, run the command below to get the latest version of the Update Tool. </p> 
-                  <p><pre>bal update</pre></p>
+                  <p><pre>1. bal update</pre></p>
                   <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
-                  <p><pre>bal dist pull 2201.0.0</pre></p>
-                  <p>If you already ran <code class="highlighter-rouge language-plaintext">bal dist pull update</code> or <code class="highlighter-rouge language-plaintext">bal dist pull 2201.0.0</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#updating-ballerina">Updating Ballerina</a> to recover your installation.</p>
+                  <p><pre>2. bal dist pull 2201.0.0</pre></p>
+                  <p>If you already ran <code class="highlighter-rouge language-plaintext">bal dist pull update</code> or <code class="highlighter-rouge language-plaintext">bal dist pull 2201.0.0</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Updating Ballerina</a> to recover your installation.</p>
 					</div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -31,11 +31,13 @@ redirect_from:
                <p>For more details, see the <a href="https://blog.ballerina.io/posts/2022-02-01-announcing-ballerina-2201.0.0-swan-lake/">Swan Lake GA release announcement </a> and <a href="/downloads/swan-lake-release-notes/">release note.</a></p><br/> 
 					<!-- <h2 id="swanlake">{{ site.data.swanlake-latest.metadata.display-version }} <span id="versionInfo">({{ site.data.swanlake-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2> -->
 					<div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;">
-						<p>If you are already using Ballerina, you can use the <a href="/learn/tooling-guide/cli-tools/update-tool/">Ballerina Update Tool</a> to directly update to {{ site.data.swanlake-latest.metadata.display-version }}. To do this, first, run the command below to get the latest version of the Update Tool. </p> 
-                  <p><pre>1. bal update</pre></p>
-                  <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
-                  <p><pre>2. bal dist pull 2201.0.0</pre></p>
-                  <p>If you already ran <code class="highlighter-rouge language-plaintext">bal dist update</code> or <code class="highlighter-rouge language-plaintext">bal dist pull 2201.0.0</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Updating Ballerina</a> to recover your installation.</p>
+						<p>If you are already using Ballerina, you can use the <a href="/learn/tooling-guide/cli-tools/update-tool/">Ballerina Update Tool</a> to directly update to {{ site.data.swanlake-latest.metadata.display-version }}. To do this:</p><br> 
+                  <p>1. Run the command below to get the latest version of the Update Tool.</p> 
+                  <p><pre>bal update</pre></p>
+                  <p>2. Run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>
+                  <p><pre>bal dist update</pre></p>
+                  <!-- <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	 -->
+                  <p>If you already ran <code class="highlighter-rouge language-plaintext">bal dist update</code> (or <code class="highlighter-rouge language-plaintext">bal dist pull 2201.0.0)</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Updating Ballerina</a> to recover your installation.</p>
 					</div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -35,7 +35,7 @@ redirect_from:
                   <p><pre>bal update</pre></p>
                   <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
                   <p><pre>bal dist pull 2201.0.0</pre></p>
-                  <p> If you already ran the <code class="highlighter-rouge language-plaintext">bal dist pull update</code></p> command, for instructions, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#updating-ballerina">Updating Ballerina.</a></p>
+                  <p>If you already ran the <code class="highlighter-rouge language-plaintext">bal dist pull update</code></p> command, for further instructions, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#updating-ballerina">Updating Ballerina.</a></p>
 					</div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -35,7 +35,7 @@ redirect_from:
                   <p><pre>bal update</pre></p>
                   <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
                   <p><pre>bal dist pull 2201.0.0</pre></p>
-                  <p>For more information, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#updating-ballerina">Updating Ballerina</a></p>
+                  <p> If you already ran the <code class="highlighter-rouge language-plaintext">bal dist pull update</code></p> command, for instructions, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#updating-ballerina">Updating Ballerina.</a></p>
 					</div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -35,10 +35,7 @@ redirect_from:
                   <p><pre>bal update</pre></p>
                   <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
                   <p><pre>bal dist pull 2201.0.0</pre></p>
-
-                  <p>If you already ran the <pre>bal dist pull update</pre> command, first run the <pre>rm ~/.ballerina/ballerina-version</pre> command to delete the version configuration, and then, run the <pre>bal dist use 2201.0.0 command to switch to 2201.0.0 version.</pre></p>
-
-
+                  <p>If you already ran the <code class="highlighter-rouge language-plaintext">bal dist pull update</code> command, first run the <code class="highlighter-rouge language-plaintext">rm ~/.ballerina/ballerina-version</code> command to delete the version configuration, and then, run the <code class="highlighter-rouge language-plaintext">al dist use 2201.0.0 command to switch to 2201.0.0 version.</code></p>
 					</div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -35,7 +35,7 @@ redirect_from:
                   <p><pre>bal update</pre></p>
                   <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
                   <p><pre>bal dist pull 2201.0.0</pre></p>
-                  <p>If you already ran the <code class="highlighter-rouge language-plaintext">bal dist pull update</code></p> command, for further instructions, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#updating-ballerina">Updating Ballerina.</a></p>
+                  <p>If you already ran <code class="highlighter-rouge language-plaintext">bal dist pull update</code> or <code class="highlighter-rouge language-plaintext">bal dist pull 2201.0.0</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#updating-ballerina">Updating Ballerina</a> to recover your installation.</p>
 					</div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -35,7 +35,6 @@ redirect_from:
                   <p><pre>bal update</pre></p>
                   <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
                   <p><pre>bal dist pull 2201.0.0</pre></p>
-                  <p>If your Update Tool is below version 0.8.14, use the <code class="highlighter-rouge language-plaintext">ballerina update</code> command.</p> 
 					</div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -35,7 +35,7 @@ redirect_from:
                   <p><pre>bal update</pre></p>
                   <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
                   <p><pre>bal dist pull 2201.0.0</pre></p>
-                  <p>If you already ran the <code class="highlighter-rouge language-plaintext">bal dist pull update</code> command, first run the <code class="highlighter-rouge language-plaintext">rm ~/.ballerina/ballerina-version</code> command to delete the version configuration, and then, run the <code class="highlighter-rouge language-plaintext">al dist use 2201.0.0 command to switch to 2201.0.0 version.</code></p>
+                  <p>For more information, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#updating-ballerina">Updating Ballerina</a></p>
 					</div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -35,6 +35,10 @@ redirect_from:
                   <p><pre>bal update</pre></p>
                   <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	
                   <p><pre>bal dist pull 2201.0.0</pre></p>
+
+                  <p>If you already ran the <pre>bal dist pull update</pre> command, first run the <pre>rm ~/.ballerina/ballerina-version</pre> command to delete the version configuration, and then, run the <pre>bal dist use 2201.0.0 command to switch to 2201.0.0 version.</pre></p>
+
+
 					</div>
             </br> 
          </div> 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -23,7 +23,7 @@ If you are already using Ballerina, use the [Ballerina Update Tool](/learn/cli-d
 
 2. Run the command below to update your Ballerina version to 2201.0.0 (Swan Lake).
 
-   `bal dist pull 2201.0.0`
+   `bal dist update`
 
 The version format has been revised. `2201.0.0 (Swan Lake)` represents the format of `$YYMM.$UPDATE.$PATCH ($CODE_NAME)`. 
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -53,7 +53,6 @@ If you already ran the `bal dist pull update` or `bal dist pull 2201.0.0` before
 
 1. Run the `del %userprofile%\.ballerina\ballerina-version` command to delete the version configuration.
 2. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
-3. Run the `chmod 755 /usr/lib64/ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
 
 ### Installing Ballerina
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -27,7 +27,7 @@ If you are already using Ballerina, use the [Ballerina Update Tool](/learn/cli-d
 
 #### Troubleshooting 
 
->**info:** The version format has been revised. `2201.0.0 (Swan Lake)` represents the format of `$YYMM.$UPDATE.$PATCH ($CODE_NAME)`. For further information, see [Ballerina Swan Lake is on the Horizon](https://blog.ballerina.io/posts/ballerina-swan-lake-is-on-the-horizon/).
+>**Info:** The version format has been revised. `2201.0.0 (Swan Lake)` represents the format of `$YYMM.$UPDATE.$PATCH ($CODE_NAME)`. For further information, see [Ballerina Swan Lake is on the Horizon](https://blog.ballerina.io/posts/ballerina-swan-lake-is-on-the-horizon/).
 
 If you already ran the `bal dist update` (or `bal dist pull 2201.0.0`) before the `bal update` command, follow the instructions below to recover your installation.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -29,7 +29,7 @@ For further information, see [Ballerina Swan Lake is on the Horizon](https://blo
 
 #### Troubleshooting 
 
-If you already ran the `bal dist pull update` or `bal dist pull 2201.0.0` before the `bal update` command, follow the instructions below to recover your installation.
+If you already ran the `bal dist update` or `bal dist pull 2201.0.0` before the `bal update` command, follow the instructions below to recover your installation.
 
 ##### For macOS Users (`.pkg` installations)
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -15,7 +15,11 @@ redirect_from:
 
 ### Updating Ballerina
 
-If you are already using Ballerina, use the [Ballerina Update Tool](/learn/cli-documentation/update-tool/#using-the-update-tool) to directly update to 2201.0.0 (Swan Lake) by running the command below.
+If you are already using Ballerina, use the [Ballerina Update Tool](/learn/cli-documentation/update-tool/#using-the-update-tool) to directly update to 2201.0.0 (Swan Lake). To do this, first run the command below to get the latest version of the Update Tool.
+
+> `bal update`
+
+Next, run the command below to update your Ballerina version to 2201.0.0 (Swan Lake).
 
 > `bal dist pull 2201.0.0`
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -29,25 +29,25 @@ For further information, see [Ballerina Swan Lake is on the Horizon](https://blo
 
 #### Troubleshooting 
 
-If you already ran the `bal dist update` or `bal dist pull 2201.0.0` before the `bal update` command, follow the instructions below to recover your installation.
+If you already ran the `bal dist update` (or `bal dist pull 2201.0.0`) before the `bal update` command, follow the instructions below to recover your installation.
 
 ##### For macOS Users (`.pkg` installations)
 
 1. Run the `rm ~/.ballerina/ballerina-version` command to delete the version configuration.
-2. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
-3. Run the `chmod 755 /Library/Ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
+2. Run the `chmod 755 /Library/Ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
+3. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version. 
 
 ##### For Ubuntu Users (`.deb` installations)
 
 1. Run the `rm ~/.ballerina/ballerina-version` command to delete the version configuration.
-2. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
-3. Run the `chmod 755 /usr/lib/ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
+2. Run the `chmod 755 /usr/lib/ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
+3. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
 
 ##### For CentOS Users (`.rpm` installations)
 
 1. Run the `rm ~/.ballerina/ballerina-version` command to delete the version configuration.
-2. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
-3. Run the `chmod 755 /usr/lib64/ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
+2. Run the `chmod 755 /usr/lib64/ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
+3. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
 
 ##### For Windows Users (`.msi` installations)
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -29,7 +29,7 @@ For further information, see [Ballerina Swan Lake is on the Horizon](https://blo
 
 #### Troubleshooting 
 
-If you already ran the `bal dist pull update` or `bal dist pull 2201.0.0` commands before the `bal update` command, follow the instructions below to recover your installation.
+If you already ran the `bal dist pull update` or `bal dist pull 2201.0.0` before the `bal update` command, follow the instructions below to recover your installation.
 
 ##### For macOS Users (`.pkg` installations)
 
@@ -51,7 +51,7 @@ If you already ran the `bal dist pull update` or `bal dist pull 2201.0.0` comman
 
 ##### For Windows Users (`.msi` installations)
 
-1. Run the `rm ~/.ballerina/ballerina-version` command to delete the version configuration.
+1. Run the `del %userprofile%\.ballerina\ballerina-version` command to delete the version configuration.
 2. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
 3. Run the `chmod 755 /usr/lib64/ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -27,7 +27,33 @@ The version format has been revised. `2201.0.0 (Swan Lake)` represents the forma
 
 For further information, see [Ballerina Swan Lake is on the Horizon](https://blog.ballerina.io/posts/ballerina-swan-lake-is-on-the-horizon/).
 
->**Info:** If you already ran the `bal dist pull update` command, first run the `rm ~/.ballerina/ballerina-version ` command to delete the version configuration, and then, run the `bal dist use 2201.0.0` command to switch to 2201.0.0 version.
+#### Troubleshooting 
+
+If you already ran the `bal dist pull update` or `bal dist pull 2201.0.0` commands before the `bal update` command, follow the instructions below to recover your installation.
+
+##### For macOS Users (`.pkg` installations)
+
+1. Run the `rm ~/.ballerina/ballerina-version` command to delete the version configuration.
+2. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
+3. Run the `chmod 755 /Library/Ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
+
+##### For Ubuntu Users (`.deb` installations)
+
+1. Run the `rm ~/.ballerina/ballerina-version` command to delete the version configuration.
+2. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
+3. Run the `chmod 755 /usr/lib/ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
+
+##### For CentOS Users (`.rpm` installations)
+
+1. Run the `rm ~/.ballerina/ballerina-version` command to delete the version configuration.
+2. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
+3. Run the `chmod 755 /usr/lib64/ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
+
+##### For Windows Users (`.msi` installations)
+
+1. Run the `rm ~/.ballerina/ballerina-version` command to delete the version configuration.
+2. Run the `bal dist use 2201.0.0` command to switch to the 2201.0.0 version.
+3. Run the `chmod 755 /usr/lib64/ballerina/distributions/ballerina-2201.0.0/bin/bal` command to provide execute permissions for the `bal` command.
 
 ### Installing Ballerina
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -27,6 +27,8 @@ The version format has been revised. `2201.0.0 (Swan Lake)` represents the forma
 
 For further information, see [Ballerina Swan Lake is on the Horizon](https://blog.ballerina.io/posts/ballerina-swan-lake-is-on-the-horizon/).
 
+>**Info:** If you already ran the `bal dist pull update` command, first run the `rm ~/.ballerina/ballerina-version ` command to delete the version configuration, and then, run the `bal dist use 2201.0.0` command to switch to 2201.0.0 version.
+
 ### Installing Ballerina
 
 If you have not installed Ballerina, then download the [installers](/downloads/#swanlake) to install.

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -17,11 +17,11 @@ redirect_from:
 
 If you are already using Ballerina, use the [Ballerina Update Tool](/learn/cli-documentation/update-tool/#using-the-update-tool) to directly update to 2201.0.0 (Swan Lake). To do this, first run the command below to get the latest version of the Update Tool.
 
-> `bal update`
+1. `bal update`
 
 Next, run the command below to update your Ballerina version to 2201.0.0 (Swan Lake).
 
-> `bal dist pull 2201.0.0`
+2. `bal dist pull 2201.0.0`
 
 The version format has been revised. `2201.0.0 (Swan Lake)` represents the format of `$YYMM.$UPDATE.$PATCH ($CODE_NAME)`. 
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -25,11 +25,9 @@ If you are already using Ballerina, use the [Ballerina Update Tool](/learn/cli-d
 
    `bal dist update`
 
-The version format has been revised. `2201.0.0 (Swan Lake)` represents the format of `$YYMM.$UPDATE.$PATCH ($CODE_NAME)`. 
-
-For further information, see [Ballerina Swan Lake is on the Horizon](https://blog.ballerina.io/posts/ballerina-swan-lake-is-on-the-horizon/).
-
 #### Troubleshooting 
+
+>**info:** The version format has been revised. `2201.0.0 (Swan Lake)` represents the format of `$YYMM.$UPDATE.$PATCH ($CODE_NAME)`. For further information, see [Ballerina Swan Lake is on the Horizon](https://blog.ballerina.io/posts/ballerina-swan-lake-is-on-the-horizon/).
 
 If you already ran the `bal dist update` (or `bal dist pull 2201.0.0`) before the `bal update` command, follow the instructions below to recover your installation.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -15,6 +15,8 @@ redirect_from:
 
 ### Updating Ballerina
 
+>**Info:** The version format has been revised. `2201.0.0 (Swan Lake)` represents the format of `$YYMM.$UPDATE.$PATCH ($CODE_NAME)`. For further information, see [Ballerina Swan Lake is on the Horizon](https://blog.ballerina.io/posts/ballerina-swan-lake-is-on-the-horizon/).
+
 If you are already using Ballerina, use the [Ballerina Update Tool](/learn/cli-documentation/update-tool/#using-the-update-tool) to directly update to 2201.0.0 (Swan Lake). To do this: 
 
 1. Run the command below to get the latest version of the Update Tool.
@@ -26,8 +28,6 @@ If you are already using Ballerina, use the [Ballerina Update Tool](/learn/cli-d
    `bal dist update`
 
 #### Troubleshooting 
-
->**Info:** The version format has been revised. `2201.0.0 (Swan Lake)` represents the format of `$YYMM.$UPDATE.$PATCH ($CODE_NAME)`. For further information, see [Ballerina Swan Lake is on the Horizon](https://blog.ballerina.io/posts/ballerina-swan-lake-is-on-the-horizon/).
 
 If you already ran the `bal dist update` (or `bal dist pull 2201.0.0`) before the `bal update` command, follow the instructions below to recover your installation.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -15,13 +15,15 @@ redirect_from:
 
 ### Updating Ballerina
 
-If you are already using Ballerina, use the [Ballerina Update Tool](/learn/cli-documentation/update-tool/#using-the-update-tool) to directly update to 2201.0.0 (Swan Lake). To do this, first run the command below to get the latest version of the Update Tool.
+If you are already using Ballerina, use the [Ballerina Update Tool](/learn/cli-documentation/update-tool/#using-the-update-tool) to directly update to 2201.0.0 (Swan Lake). To do this: 
 
-1. `bal update`
+1. Run the command below to get the latest version of the Update Tool.
 
-Next, run the command below to update your Ballerina version to 2201.0.0 (Swan Lake).
+   `bal update`
 
-2. `bal dist pull 2201.0.0`
+2. Run the command below to update your Ballerina version to 2201.0.0 (Swan Lake).
+
+   `bal dist pull 2201.0.0`
 
 The version format has been revised. `2201.0.0 (Swan Lake)` represents the format of `$YYMM.$UPDATE.$PATCH ($CODE_NAME)`. 
 


### PR DESCRIPTION
## Purpose
Update the update commands post SL GA release.

Download page

![Screenshot 2022-02-02 at 03 10 53](https://user-images.githubusercontent.com/11707273/152056090-77495aaf-c101-4f87-8989-fe55ede05a1f.png)

Release Note

![Screenshot 2022-02-02 at 03 15 30](https://user-images.githubusercontent.com/11707273/152056701-a0eb61d9-59fc-48ab-b9c9-36781944a233.png)


> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
