### PR TITLE
Add instructions to delete `Dependencies.toml` to avoid compilation errors

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -59,7 +59,7 @@ If you already ran the `bal dist update` (or `bal dist pull 2201.0.0`) before th
 If you have not installed Ballerina, then download the [installers](/downloads/#swanlake) to install.
 
 ### Migrating from Swan Lake Beta Releases
->**Info:** If you've been using Swan Lake Beta releases, please delete the `Dependencies.toml` files in your Ballerina packages when migrating to the Swan Lake GA. 
+>**Info:** If you've been using Swan Lake Beta releases, delete the `Dependencies.toml` files in your Ballerina packages when migrating to the Swan Lake GA. 
 
 We've introduced a few backward-incompatible changes during the Swan Lake beta program. Therefore some of your existing packages may not compile with Swan Lake GA. We encourage you to delete `Dependencies.toml` files to force the dependency resolver to use the latest versions of your dependencies.  
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -58,6 +58,11 @@ If you already ran the `bal dist update` (or `bal dist pull 2201.0.0`) before th
 
 If you have not installed Ballerina, then download the [installers](/downloads/#swanlake) to install.
 
+### Migrating from Swan Lake Beta Releases
+>**Info:** If you've been using Swan Lake Beta releases, please delete the `Dependencies.toml` files in your Ballerina packages when migrating to the Swan Lake GA. 
+
+We've introduced a few backward-incompatible changes during the Swan Lake beta program. Therefore some of your existing packages may not compile with Swan Lake GA. We encourage you to delete `Dependencies.toml` files to force the dependency resolver to use the latest versions of your dependencies.  
+
 ### Language Updates
 
 #### New Features


### PR DESCRIPTION
This is a required step if someone is migrating from Swan Lake Beta releases. 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
