### PR TITLE
Fix the `Subscribe to Our Newsletter` Footer Link

### DIFF
--- a/_includes/ballerina-footer.html
+++ b/_includes/ballerina-footer.html
@@ -27,7 +27,7 @@
             <div class="pdframe"></div>
             </div>
 
-           <a class="cNLButton" href="/community/#subscribe-to-the-newsletter">Subscribe to Our Newsletter</a> 
+           <a class="cNLButton" href="/community/#subscribe-to-newsletter">Subscribe to Our Newsletter</a> 
 
            <div class="modal fade" id="reportissues" tabindex="-1" role="dialog" aria-labelledby="reportissueslabel" aria-hidden="true">
             <div class="modal-dialog" role="document">


### PR DESCRIPTION
## Purpose
Fix the `Subscribe to Our Newsletter` footer link.
> Fixes #3856 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
