### PR TITLE
Redirect the Old `Events` Page to the New One

### DIFF
--- a/events.html
+++ b/events.html
@@ -5,6 +5,8 @@ description:
 permalink: community/events/
 intro: 
 redirect_from:
+    - /events/ 
+    - /events
 
 ---
 


### PR DESCRIPTION
## Purpose
Redirect the Old `Events` page to the new one.
> Fixes #3822 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
