### PR TITLE
Add no event banner

### DIFF
--- a/community-new.html
+++ b/community-new.html
@@ -599,7 +599,7 @@ td.cEventDateContainer{
                 </td>	
                 <td class="cEventURL"><a class="cEventRegistration" target="_blank" href="/community/tech-talk" target="_blank" style="text-align: center;">Notify Me</a></td>	
             </tr> -->
-            <tr class="event-expiry"  data-expiry="February 5, 2021 12:00:00">	
+            <!-- <tr class="event-expiry"  data-expiry="February 5, 2021 12:00:00">	
                 <td class="cEventDateContainer cEventDateContainer1">	
                    <p class="cEventDate1 cEventDateNum dateDisplay" style="margin-bottom: 15px;">March 10, 2022</p>	
                    <p class="cEventDate1 dateDisplay" style="margin-bottom: 15px">Thur., 7.00 p.m. IST</p>	
@@ -613,14 +613,16 @@ td.cEventDateContainer{
                    <a style="color: #20b6b0 ;font-weight:400;font-size: 16px;" target="_blank" href="https://twitter.com/manurangaperera">Manuranga Perera</a>, Senior Technical Lead, WSO2
                 </td>	
                 <td class="cEventURL"><a class="cEventRegistration" href="https://sliitfoss.org/events/ballerina" target="_blank" style="text-align: center;">More info</a></td>	
-            </tr>
+            </tr> -->
            
         </table>
 
         <!-- <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
             No upcoming events for this month. For details on our upcoming Monthly Tech Talks, please see  <a href="/community/monthly-tech-talk/" target="_blank" style="color: #20b6b0; text-decoration: none; text-align: right;font-weight: 400;font-size: 18px; ">Monthly Tech Talk</a>
         </div> -->
-        
+        <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
+            No upcoming events for this month. 
+        </div>
     </div> 
 
 </section>

--- a/events.html
+++ b/events.html
@@ -47,6 +47,14 @@ redirect_from:
         padding-right: 0px;
         padding-left: 0px;
     }
+    .eventBanner{
+        background-color: #f5f5f5;
+        padding: 30px;
+        font-size: 18px;
+        margin-top: 15px;
+        font-weight: 400;
+        text-align: center;
+}
     .cBoxCard{
   
   border:#E6EAEB solid 0.1px ;
@@ -347,7 +355,7 @@ a.cTopLink{display:none !important;}
       <div class="tab-content" style="border-top: 1px solid #c7c7c7;display:inline-block;width: 100%;margin-top: -1.5px;">
         
         <div id="upcoming-event" class="tab-pane fade in active">
-            <table class="cEventTable cConferencesList" style="width:100% !important;">
+            <!-- <table class="cEventTable cConferencesList" style="width:100% !important;">
                 <tr class="event-expiry"  data-expiry="February 5, 2021 12:00:00">	
                     <td class="cEventDateContainer cEventDateContainer1">	
                        <p class="cEventDate1 cEventDateNum dateDisplay" style="margin-bottom: 15px;">March 10, 2022</p>	
@@ -365,14 +373,16 @@ a.cTopLink{display:none !important;}
                 </tr>
                 
                 
-                <!-- <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
+                
+                
+                
+            </table> -->
+            <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
+                No upcoming events for this month. 
+            </div>
+            <!-- <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
                     No upcoming events for this month. For details on our upcoming Monthly Tech Talks, please see  <a href="/community/monthly-tech-talk/" target="_blank" style="color: #20b6b0; text-decoration: none; text-align: right;font-weight: 400;font-size: 18px; ">Monthly Tech Talk</a>
                 </div> -->
-                
-                
-            </table>
-            
-            </table>
         </div>
         <div id="past-event" class="tab-pane fade">
             <table class="cEventTable cConferencesList" style="width:100% !important;">

--- a/index.html
+++ b/index.html
@@ -47,6 +47,14 @@ a {
    border: 1px #20b6b0 solid !important;
    z-index: 7;
 }
+.eventBanner{
+        background-color: #f5f5f5;
+        padding: 30px;
+        font-size: 18px;
+        margin-top: 15px;
+        font-weight: 400;
+        text-align: center;
+}
 .line-numbers .line-numbers-rows {
 	position: absolute;
 	pointer-events: none;
@@ -780,7 +788,7 @@ service on new kafka:Listener(kafkaEndpoint, consumerConfigs) {
     </div>
   
       <div class="row">
-          <table class="cEventTable cConferencesList" style="width:100% !important;">
+          <!-- <table class="cEventTable cConferencesList" style="width:100% !important;">
               <tr class="event-expiry"  data-expiry="February 5, 2021 12:00:00">	
                   <td class="cEventDateContainer cEventDateContainer1">	
                      <p class="cEventDate1 cEventDateNum dateDisplay" style="margin-bottom: 15px;">March 10, 2022</p>	
@@ -797,13 +805,15 @@ service on new kafka:Listener(kafkaEndpoint, consumerConfigs) {
                   <td class="cEventURL"><a class="cEventRegistration" href="https://sliitfoss.org/events/ballerina" target="_blank" style="text-align: center;">More info</a></td>	
               </tr>
                </td>	
-               
            </tr>
-              
-          </table>
+          </table> -->
           
       </div> 
-
+      <div class="col-sm-12 col-md-12 cColCOntent">
+         <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
+            No upcoming events for this month. 
+         </div>
+      </div>
    <div class="clearfix"></div></br>
      
    </div>


### PR DESCRIPTION
## Purpose
> Remove event and add "No upcoming events for this month banner" in community landing page, events page and home page

![image](https://user-images.githubusercontent.com/73055030/157669388-74aeb29c-4b64-4add-b00f-e6173155dfdc.png)

> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
