### PR TITLE
Fix the Typos in the Floating Point Numbers BBE

### DIFF
--- a/_data/all-bbes.json
+++ b/_data/all-bbes.json
@@ -62,7 +62,7 @@
                 "isLearnByExample": true
             },
             {
-                "name": "Floating point Nnmbers",
+                "name": "Floating point Numbers",
                 "url": "floating-point-numbers",
                 "verifyBuild": true,
                 "verifyOutput": true,

--- a/_data/all-bbes.json
+++ b/_data/all-bbes.json
@@ -62,7 +62,7 @@
                 "isLearnByExample": true
             },
             {
-                "name": "Floating point Numbers",
+                "name": "Floating point numbers",
                 "url": "floating-point-numbers",
                 "verifyBuild": true,
                 "verifyOutput": true,

--- a/learn/by-example/all-bbes.json
+++ b/learn/by-example/all-bbes.json
@@ -62,7 +62,7 @@
                 "isLearnByExample": true
             },
             {
-                "name": "Floating point Nnmbers",
+                "name": "Floating point Numbers",
                 "url": "floating-point-numbers",
                 "verifyBuild": true,
                 "verifyOutput": true,

--- a/learn/by-example/all-bbes.json
+++ b/learn/by-example/all-bbes.json
@@ -62,7 +62,7 @@
                 "isLearnByExample": true
             },
             {
-                "name": "Floating point Numbers",
+                "name": "Floating point numbers",
                 "url": "floating-point-numbers",
                 "verifyBuild": true,
                 "verifyOutput": true,

--- a/learn/by-example/floating-point-numbers.html
+++ b/learn/by-example/floating-point-numbers.html
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-example-page-old
-title: Floating point Numbers
+title: Floating point numbers
 description: This BBE introduces the float type in Ballerina.
 keywords: ballerina, ballerina by example, bbe, floating point numbers, float, NaN
 permalink: /learn/by-example/floating-point-numbers

--- a/learn/by-example/floating-point-numbers.html
+++ b/learn/by-example/floating-point-numbers.html
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-example-page-old
-title: Floating point Nnmbers
+title: Floating point Numbers
 description: This BBE introduces the float type in Ballerina.
 keywords: ballerina, ballerina by example, bbe, floating point numbers, float, NaN
 permalink: /learn/by-example/floating-point-numbers


### PR DESCRIPTION
## Purpose
Fix the typos in the Floating Point Numbers BBE.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
