### PR TITLE
Remove Empty Links in the 2201.0.2 Release Note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.2/RELEASE_NOTE.md
@@ -43,16 +43,11 @@ To view bug fixes, see the [GitHub milestone for Swan Lake 2201.0.2](https://git
 
 To view bug fixes, see the [GitHub milestone for Swan Lake 2201.0.2](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aclosed+is%3Aissue+milestone%3A%22Swan+Lake+2201.0.2%22+label%3AType%2FBug).
 
-## Package updates
-
-To view bug fixes, see the [GitHub milestone for Swan Lake 2201.0.2](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FProjectAPI+milestone%3A%22Ballerina+2201.0.2%22+is%3Aclosed+label%3AType%2FBug).
-
 ## Developer tools updates
 
 To view bug fixes, see the GitHub milestone for Swan Lake 2201.0.2 of the repositories below.
 
 - [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+label%3ATeam%2FLanguageServer+milestone%3A%22Ballerina+2201.0.2%22+label%3AType%2FBug)
-- [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AType%2FBug+label%3AArea%2FDebugger+is%3Aclosed+milestone%3A%22Ballerina+2201.0.2%22)
 - [OpenAPI](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+label%3AType%2FBug+milestone%3A1.0.2+is%3Aclosed)
 
 <!-- <style>.cGitButtonContainer, .cBallerinaTocContainer {display:none;}</style> -->


### PR DESCRIPTION
## Purpose
Remove empty links in the 2201.0.2 release note.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
