### PR TITLE
Fix the permalink of the RESful Get Started Guide

### DIFF
--- a/learn/get-started/write-a-restful-api-with-ballerina.md
+++ b/learn/get-started/write-a-restful-api-with-ballerina.md
@@ -9,7 +9,6 @@ intro: This guide helps you understand the basics of Ballerina constructs, which
 redirect_from:
   - /learn/writing-a-restful-api-with-ballerina
   - /learn/writing-a-restful-api-with-ballerina/
-  - /learn/write-a-restful-api-with-ballerina/
   - /learn/write-a-restful-api-with-ballerina
 ---
 


### PR DESCRIPTION
## Purpose
Fix the permalink of the RESful get started guide.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
