### PR TITLE
Fix the Installation Page Links

### DIFF
--- a/learn/get-started/install-ballerina/Installation-options.md
+++ b/learn/get-started/install-ballerina/Installation-options.md
@@ -3,7 +3,7 @@ layout: ballerina-installing-ballerina-left-nav-pages-swanlake
 title: Installation options
 description: Get started with the Ballerina programming language by following these instructions on installing and setting up Ballerina.
 keywords: ballerina, installing ballerina, programming language, ballerina installation
-permalink: /learn/instal-ballerina/installation-options/
+permalink: /learn/install-ballerina/installation-options/
 active: installation-options
 intro: The sections below include information about installing Ballerina.
 redirect_from:


### PR DESCRIPTION
## Purpose
Fix the installation page links.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
