### PR TITLE
Remove Committed Conflicts on the Observability Page

### DIFF
--- a/learn/guides/observe-ballerina-programs.md
+++ b/learn/guides/observe-ballerina-programs.md
@@ -73,11 +73,7 @@ Prometheus, etc. For instructions, go to the [Docker documentation](https://docs
 * Set up Jaeger to analyze tracing as mentioned in the section [Setting up Jaeger](#setting-up-the-jaeger-server)
 * Set up Elastic Stack only if you are interested in analyzing logs by following the section on [Setting up the Elastic Stack](#setting-up-the-elastic-stack)
 
-<<<<<<< HEAD:learn/guides/observing-your-application-with-prometheus-grafana-jaeger-and-elastic-the-stack.md
-### Step 3 - creating a `Hello World` Ballerina service
-=======
-### Step 3 - create a 'Hello World' Ballerina service
->>>>>>> b5e38bc28daeb5f7dafcd1a9169d1a862fbd18f0:learn/guides/observe-your-application-with-prometheus-grafana-jaeger-and-elastic-the-stack.md
+### Step 3 - create a `Hello World` Ballerina service
  
 Create a service as shown below and save it as `hello_world_service.bal`.
 
@@ -361,13 +357,9 @@ ballerina.observe. reporterBufferSize | Queue size of the Jaeger client. | 2000 
 You can configure Ballerina to support distributed tracing with Jaeger. This section focuses on configuring
 Jaeger with Docker as a quick installation.
 
-<<<<<<< HEAD:learn/guides/observing-your-application-with-prometheus-grafana-jaeger-and-elastic-the-stack.md
-#### Setting up the Jaeger server
-There are many possible ways to deploy Jaeger. For more information, see [Jaeger deployment](https://www.jaegertracing.io/docs/deployment/). This focuses on an all-in-one deployment with Docker.
-=======
 #### Set up the Jaeger server
+
 There are many possible ways to deploy Jaeger. For more information, see [Jaeger Deployment](https://www.jaegertracing.io/docs/deployment/). This focuses on an all-in-one deployment with Docker.
->>>>>>> b5e38bc28daeb5f7dafcd1a9169d1a862fbd18f0:learn/guides/observe-your-application-with-prometheus-grafana-jaeger-and-elastic-the-stack.md
 
 1. Install Jaeger via Docker and start the Docker container by executing the command below.
 
@@ -380,8 +372,6 @@ There are many possible ways to deploy Jaeger. For more information, see [Jaeger
     The image below is the sample tracing information you can see in Jaeger.
     
     ![Jaeger Tracing Dashboard](/learn/images/jaeger-tracing-dashboard.png "Jaeger Tracing Dashboard")
-
-
 
 ## Distributed logging
 In Ballerina, distributed logging and analysis are supported by the Elastic Stack. Ballerina has a log module for logging into the console. To monitor the logs, the Ballerina standard output needs to be redirected to a file.


### PR DESCRIPTION
## Purpose
Remove committed conflicts on the Observability page.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
