### PR TITLE
Fix sentence Case in Table Headings

### DIFF
--- a/learn/guides/configure-ballerina-programs/provide-values-to-configurable-variables.md
+++ b/learn/guides/configure-ballerina-programs/provide-values-to-configurable-variables.md
@@ -35,11 +35,7 @@ given through multiple ways when retrieving configurable values:
 content is expected to be in the [TOML(v0.4.0) format](https://toml.io/en/v0.4.0).
 >**Note:** Providing multiple configuration values through separate environment variables is not supported.
 
-<<<<<<< HEAD:learn/guides/configuring-ballerina-programs/providing-values-to-configurable-variables.md
-### Providing configuration values through command-line arguments
-=======
 ### Provide configuration values through command line arguments
->>>>>>> b5e38bc28daeb5f7dafcd1a9169d1a862fbd18f0:learn/guides/configure-ballerina-programs/provide-values-to-configurable-variables.md
 
 The following syntax can be used to provide values for the variables through the command line parameters:
 
@@ -72,7 +68,7 @@ the respective types.
 
 The mapping of Ballerina types to TOML types can be explained through the following examples:
 
-| Ballerina Type     | Ballerina Example                                                                                                                                                                       | TOML Type                        | TOML Example                                                                                                                                |
+| Ballerina type     | Ballerina example                                                                                                                                                                       | TOML type                        | TOML example                                                                                                                                |
 |--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------|
 | int, byte          | <code>configurable   byte  age = ?;</code><br/>  <code>configurable   int  port = ?;</code>                                                                                             | Integer                          | `age = 25` <br/>  `port = 9090`                                                                                                             |
 | string             | <code>configurable   string  name = ?; </code>                                                                                                                                          | String                           | `name = "John"`                                                                                                                             |
@@ -102,7 +98,7 @@ The module information requirement can be explained in the following table accor
 <thead>
 <tr>
 <th style="text-align:center" colspan="2"><strong>Place where the variable is defined</strong></th>
-<th style="text-align:center" colspan="2"><strong>Module Information</strong></th>
+<th style="text-align:center" colspan="2"><strong>Module information</strong></th>
 </tr>
 </thead>
 <tbody>

--- a/learn/guides/observe-ballerina-programs.md
+++ b/learn/guides/observe-ballerina-programs.md
@@ -203,7 +203,7 @@ host="0.0.0.0"
 
 The descriptions of each configuration option are provided below with possible values.
 
-Configuration Key | Description | Default Value | Possible Values 
+Configuration key | Description | Default value | Possible values 
 --- | --- | --- | --- 
 ballerina.observe. metricsEnabled | Whether metrics monitoring is enabled (true) or disabled (false) | false | true or false
 ballerina.observe. metricsReporter | Reporter name that reports the collected Metrics to the remote metrics server. This is only required to be modified if a custom reporter is implemented and needs to be used. | choreo | prometheus or if any custom implementation, the name of the reporter.
@@ -320,7 +320,7 @@ tracingProvider="jaeger"
 
 The table below provides the descriptions of each configuration option and possible values that can be assigned.
 
-Configuration Key | Description | Default Value | Possible Values
+Configuration key | Description | Default value | Possible values
 --- | --- | --- | --- 
 ballerina.observe.tracingEnabled | Whether tracing is enabled (true) or disabled (false) | false | true or false
 ballerina.observe.tracingProvider | The tracer name, which implements the tracer interface. | choreo | jaeger or the name of the tracer of any custom implementation.
@@ -344,7 +344,7 @@ reporterBufferSize=1000
 
 The table below provides the descriptions of each configuration option and possible values that can be assigned.
 
-Configuration Key | Description | Default Value | Possible Values 
+Configuration key | Description | Default value | Possible values 
 --- | --- | --- | --- 
 ballerina.observe. agentHostname | Hostname of the Jaeger agent | localhost | IP or hostname of the Jaeger agent. If it is running on the same node as Ballerina, it can be localhost. 
 ballerina.observe. agentPort | Port of the Jaeger agent | 55680 | The port on which the Jaeger agent is listening.

--- a/learn/guides/test-ballerina-code/write-tests.md
+++ b/learn/guides/test-ballerina-code/write-tests.md
@@ -132,7 +132,7 @@ The Ballerina test framework supports the following assertions, which help to ve
 
 <table class="table cCodeTable" >
     <tr>
-       <th class="cDescription">Assertion Function</th>
+       <th class="cDescription">Assertion function</th>
        <th class="cCodeCol">Description</th>
     </tr>
     <tr>

--- a/learn/references/java-interoperability/ballerina-ffi.md
+++ b/learn/references/java-interoperability/ballerina-ffi.md
@@ -170,7 +170,7 @@ public type ConstructorData record {|
 As per the above definition, `paramTypes` field takes an array of Java classes or array types. The following table contains more details.
 
 
-Java Type | Description | Example
+Java type | Description | Example
 --------- | ----------- | -------
 Primitive | The Java class name of a primitive type is the same as the name of the primitive type.  | The `boolean.class.getName()` expression evaluates to `boolean`. Similarly, the `int.class.getName()` expression evaluates to `int`.
 Class | Fully-qualified class name. | `java.lang.String`
@@ -341,13 +341,9 @@ public function main() {
 }
 ```
 
-<<<<<<< HEAD
-### Calling overloaded Java methods
-The [Instantiating Java classes](/learn/java-interoperability/ballerina-ffi/#instantiating-java-classes) section presents how to deal with overloaded constructors. You need to use the same approach to deal with overloaded Java methods. Try to call the overloaded `append` methods in the `java.lang.StringBuffer` class. Below is a subset of those methods.
-=======
 ### Call overloaded Java methods
+
 The [Instantiating Java Classes](/learn/java-interoperability/ballerina-ffi/#instantiating-java-classes) section presents how to deal with overloaded constructors. You need to use the same approach to deal with overloaded Java methods. Try to call the overloaded `append` methods in the `java.lang.StringBuffer` class. Below is a subset of those methods.
->>>>>>> b5e38bc28daeb5f7dafcd1a9169d1a862fbd18f0
 
 ```java
 StringBuffer append(boolean b);

--- a/learn/references/java-interoperability/the-bindgen-tool.md
+++ b/learn/references/java-interoperability/the-bindgen-tool.md
@@ -201,7 +201,7 @@ The Ballerina binding classes will store a handle reference of the Java object u
 
 The following table summarizes how Java primitive types are mapped to the corresponding Ballerina primitive types. This is applicable when mapping a return type of a Java method to a Ballerina type.
 
-Java Type | Ballerina Type
+Java type | Ballerina type
 ---------- | --------------
 boolean | boolean
 byte | byte

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -21,7 +21,7 @@ The below are the most stable versions of the lanuguage specification, which are
 
 > **Note:** The Changes since previous releases section of the specification identifies the changes that have occurred in each version of the specification.
 
-| Version | Release Date | Description |
+| Version | Release date | Description |
 | ------- | ------------ | ----------- | 
 | <a target="_blank" href="/spec/lang/2022R1/">2022R1</a> | 2022-01-31 | First release of 2022. This is the basis for Ballerina 2201.0.0 (Swan Lake). |
 | <a target="_blank" href="/spec/lang/2021R1/">2021R1</a> | 2021-06-02 | First release of 2021. This is the basis for Ballerina Swan Lake Beta1. |


### PR DESCRIPTION
## Purpose
Fix sentence case in table headings.
> Fixes #

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
