### PR TITLE
Add the Level3 Headings to the Interoperability Page Left Nav

### DIFF
--- a/_data/callingjavacodeswanlake.yml
+++ b/_data/callingjavacodeswanlake.yml
@@ -6,8 +6,7 @@
       active: write-ballerina-bindings
     - title: Use the SnakeYAML Java library in Ballerina
       url: /learn/call-java-code-from-ballerina/#use-the-snakeyaml-java-library-in-ballerina
-      active: use-the-snakeyaml-java-library-in-ballerina
-        sublinks:
+      sublinks:
           - title: Step 1 - write the Java code
             url: /learn/call-java-code-from-ballerina/#step-1---write-the-java-code
             active: step-1---write-the-java-code

--- a/_data/callingjavacodeswanlake.yml
+++ b/_data/callingjavacodeswanlake.yml
@@ -7,3 +7,17 @@
     - title: Use the SnakeYAML Java library in Ballerina
       url: /learn/call-java-code-from-ballerina/#use-the-snakeyaml-java-library-in-ballerina
       active: use-the-snakeyaml-java-library-in-ballerina
+        sublinks:
+          - title: Step 1 - write the Java code
+            url: /learn/call-java-code-from-ballerina/#step-1---write-the-java-code
+            active: step-1---write-the-java-code
+          - title: Step 2 - set up the Ballerina package
+            url: /learn/call-java-code-from-ballerina/#step-2---set-up-the-ballerina-package
+            active: step-2---set-up-the-ballerina-package
+          - title: Step 3 - generate the Ballerina bindings
+            url: /learn/call-java-code-from-ballerina/#step-3---generate-the-ballerina-bindings
+            active: step-3---generate-the-ballerina-bindings
+          - title: Step 4 - write the Ballerina code
+            url: /learn/call-java-code-from-ballerina/#step-4---write-the-ballerina-code
+            active: step-4---write-the-ballerina-code
+  


### PR DESCRIPTION
## Purpose
Add the level3 headings to Interoperability page left nav.

> Fixes #4141 

## Check List

- [ ] **Page Addition**
  - [ ] Add `permalink` to pages
  - [ ] If contains empty folder(s), Add front-matter `redirect_to:`

- [ ] **Page Rename**
  - [ ] Add front-matter `redirect_from`
  - [ ] Add front-matter `redirect_to:` (If applicable)
