### PR TITLE
Add the `Learn more` Section to the Installation Page Left Nav

### DIFF
--- a/_data/installingballerinanavswanlake.yml
+++ b/_data/installingballerinanavswanlake.yml
@@ -13,6 +13,9 @@
           - title: Install the VS Code extension
             url: /learn/install-ballerina/set-up-ballerina/#install-the-vscode-extension
             active: install-the-vscode-extension
+          - title: Learn more
+            url: /learn/install-ballerina/set-up-ballerina/#learn-more
+            active: learn-more
     - title: Installation options
       url: /learn/install-ballerina/installation-options/
       sublinks:


### PR DESCRIPTION
## Purpose
Add the Learn more section to the installation page left nav.
> Fixes #

## Check list

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
