### PR TITLE
Add Area Labels as Comments in Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/type_bug.md
+++ b/.github/ISSUE_TEMPLATE/type_bug.md
@@ -15,7 +15,7 @@ labels: 'Type/Bug'
 > The versions that are affected by the issue.
 
 ## Related website/documentation area
-> Add/Uncomment the relevant area out of the following. 
+> Add/Uncomment the relevant area label out of the following. 
 
 <!--Area/BBEs-->
 <!--Area/HomePageSamples-->

--- a/.github/ISSUE_TEMPLATE/type_bug.md
+++ b/.github/ISSUE_TEMPLATE/type_bug.md
@@ -15,7 +15,16 @@ labels: 'Type/Bug'
 > The versions that are affected by the issue.
 
 ## Related website/documentation area
-> Add one of the following: `Area/BBEs`, `Area/HomePageSamples`, `Area/LearnPages`, `Area/Blog`, `Area/CommonPages`,` Area/Backend`, `Area/UIUX`, and `Area/Workflows`.
+> Uncomment the relevant area out of the following. 
+
+<!--Area/BBEs-->
+<!--Area/HomePageSamples-->
+<!--Area/LearnPages-->
+<!--Area/CommonPages-->
+<!--Area/Backend-->
+<!--Area/UIUX-->
+<!--Area/Workflows-->
+<!--Area/Blog-->
 
 ## Related issue(s) (optional)
 > Any related issues such as sub tasks and issues reported in other repositories (e.g., component repositories), similar problems, etc. 

--- a/.github/ISSUE_TEMPLATE/type_bug.md
+++ b/.github/ISSUE_TEMPLATE/type_bug.md
@@ -15,7 +15,7 @@ labels: 'Type/Bug'
 > The versions that are affected by the issue.
 
 ## Related website/documentation area
-> Uncomment the relevant area out of the following. 
+> Add/Uncomment the relevant area out of the following. 
 
 <!--Area/BBEs-->
 <!--Area/HomePageSamples-->

--- a/.github/ISSUE_TEMPLATE/type_improvement.md
+++ b/.github/ISSUE_TEMPLATE/type_improvement.md
@@ -9,7 +9,7 @@ labels: 'Type/Improvement'
 > A brief description of the improvement.
 
 ## Related website/documentation area
-> Uncomment the relevant area out of the following. 
+> Add/Uncomment the relevant area out of the following. 
 
 <!--Area/BBEs-->
 <!--Area/HomePageSamples-->

--- a/.github/ISSUE_TEMPLATE/type_improvement.md
+++ b/.github/ISSUE_TEMPLATE/type_improvement.md
@@ -9,7 +9,16 @@ labels: 'Type/Improvement'
 > A brief description of the improvement.
 
 ## Related website/documentation area
-> One of the following: `Area/BBEs`, `Area/HomePageSamples`, `Area/LearnPages`, `Area/Blog`, `Area/CommonPages`,` Area/Backend`, `Area/UIUX`, and `Area/Workflows`.
+> Uncomment the relevant area out of the following. 
+
+<!--Area/BBEs-->
+<!--Area/HomePageSamples-->
+<!--Area/LearnPages-->
+<!--Area/CommonPages-->
+<!--Area/Backend-->
+<!--Area/UIUX-->
+<!--Area/Workflows-->
+<!--Area/Blog-->
 
 ## Describe the problem(s)
 > A detailed description of the purpose of this improvement.

--- a/.github/ISSUE_TEMPLATE/type_improvement.md
+++ b/.github/ISSUE_TEMPLATE/type_improvement.md
@@ -9,7 +9,7 @@ labels: 'Type/Improvement'
 > A brief description of the improvement.
 
 ## Related website/documentation area
-> Add/Uncomment the relevant area out of the following. 
+> Add/Uncomment the relevant area label out of the following. 
 
 <!--Area/BBEs-->
 <!--Area/HomePageSamples-->

--- a/.github/ISSUE_TEMPLATE/type_new_feature.md
+++ b/.github/ISSUE_TEMPLATE/type_new_feature.md
@@ -9,7 +9,7 @@ labels: 'Type/NewFeature'
 > A brief description of the new feature.
 
 ## Related website/documentation area
-> Add/Uncomment the relevant area out of the following. 
+> Add/Uncomment the relevant area label out of the following. 
 
 <!--Area/BBEs-->
 <!--Area/HomePageSamples-->

--- a/.github/ISSUE_TEMPLATE/type_new_feature.md
+++ b/.github/ISSUE_TEMPLATE/type_new_feature.md
@@ -9,7 +9,7 @@ labels: 'Type/NewFeature'
 > A brief description of the new feature.
 
 ## Related website/documentation area
-> Uncomment the relevant area out of the following. 
+> Add/Uncomment the relevant area out of the following. 
 
 <!--Area/BBEs-->
 <!--Area/HomePageSamples-->

--- a/.github/ISSUE_TEMPLATE/type_new_feature.md
+++ b/.github/ISSUE_TEMPLATE/type_new_feature.md
@@ -9,7 +9,16 @@ labels: 'Type/NewFeature'
 > A brief description of the new feature.
 
 ## Related website/documentation area
-> One of the following: `Area/BBEs`, `Area/HomePageSamples`, `Area/LearnPages`, `Area/Blog`, `Area/CommonPages`,` Area/Backend`, `Area/UIUX`, and `Area/Workflows`.
+> Uncomment the relevant area out of the following. 
+
+<!--Area/BBEs-->
+<!--Area/HomePageSamples-->
+<!--Area/LearnPages-->
+<!--Area/CommonPages-->
+<!--Area/Backend-->
+<!--Area/UIUX-->
+<!--Area/Workflows-->
+<!--Area/Blog-->
 
 ## Describe the problem(s)
 > A detailed description of the purpose of this new feature.

--- a/.github/ISSUE_TEMPLATE/type_task.md
+++ b/.github/ISSUE_TEMPLATE/type_task.md
@@ -9,7 +9,7 @@ labels: 'Type/Task'
 > A brief description of the task.
 
 ## Related website/documentation area
-> Uncomment the relevant area out of the following. 
+> Add/Uncomment the relevant area out of the following. 
 
 <!--Area/BBEs-->
 <!--Area/HomePageSamples-->

--- a/.github/ISSUE_TEMPLATE/type_task.md
+++ b/.github/ISSUE_TEMPLATE/type_task.md
@@ -9,7 +9,16 @@ labels: 'Type/Task'
 > A brief description of the task.
 
 ## Related website/documentation area
-> Add one of the following: `Area/BBEs`, `Area/HomePageSamples`, `Area/LearnPages`, `Area/Blog`, `Area/CommonPages`,` Area/Backend`, `Area/UIUX`, and `Area/Workflows`.
+> Uncomment the relevant area out of the following. 
+
+<!--Area/BBEs-->
+<!--Area/HomePageSamples-->
+<!--Area/LearnPages-->
+<!--Area/CommonPages-->
+<!--Area/Backend-->
+<!--Area/UIUX-->
+<!--Area/Workflows-->
+<!--Area/Blog-->
 
 ## Describe your task(s)
 > A detailed description of the task.

--- a/.github/ISSUE_TEMPLATE/type_task.md
+++ b/.github/ISSUE_TEMPLATE/type_task.md
@@ -9,7 +9,7 @@ labels: 'Type/Task'
 > A brief description of the task.
 
 ## Related website/documentation area
-> Add/Uncomment the relevant area out of the following. 
+> Add/Uncomment the relevant area label out of the following. 
 
 <!--Area/BBEs-->
 <!--Area/HomePageSamples-->

--- a/learn.md
+++ b/learn.md
@@ -106,7 +106,7 @@ redirect_from:
 <h2 id="get-started">Get started</h2>
 <div class="row">
 <div class="col-lg-6 col-md-6 col-sm-12 card" >
-  <a href="/learn/install-ballerina/">
+  <a href="/learn/install-ballerina/set-up-ballerina/">
     <h3 id="install-ballerina">Install Ballerina</h3> </a>
     <p >Set up the Ballerina development environment.  </p>
 </div>

--- a/learn.md
+++ b/learn.md
@@ -106,7 +106,7 @@ redirect_from:
 <h2 id="get-started">Get started</h2>
 <div class="row">
 <div class="col-lg-6 col-md-6 col-sm-12 card" >
-  <a href="/learn/install-ballerina/set-up-ballerina/">
+  <a href="/learn/install-ballerina/">
     <h3 id="install-ballerina">Install Ballerina</h3> </a>
     <p >Set up the Ballerina development environment.  </p>
 </div>


### PR DESCRIPTION
## Purpose
Add area labels as comments in issue templates.
> Fixes #

## Check list

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
