### PR TITLE
Change the Base of Link Checker to Pre-Prod

### DIFF
--- a/.github/workflows/add_link_checker.yml
+++ b/.github/workflows/add_link_checker.yml
@@ -13,7 +13,7 @@ jobs:
         id: lc
         uses: lycheeverse/lychee-action@v1.0.4
         with:
-          args: /learn/** /1.2/** /_site/** --exclude twitter.com --exclude novacodecamp.org --exclude %7B%7B%20site.dist_server%20%7D%7D --exclude %7B%7B%20site.plugin_vscode_repo%20%7D%7D --verbose --base https://dev.ballerina.io *.md *.html
+          args: /learn/** /1.2/** /_site/** --exclude twitter.com --exclude novacodecamp.org --exclude %7B%7B%20site.dist_server%20%7D%7D --exclude %7B%7B%20site.plugin_vscode_repo%20%7D%7D --verbose --base https://pre-prod.ballerina.io *.md *.html
       - name: Archive production artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Change the base URL of the Lychee link checker to `pre-prod.ballerina.io`.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
> Fixes #

## Check list

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
