### PR TITLE
Fix URLs to Mandate the Link Checker

### DIFF
--- a/.github/workflows/add_link_checker.yml
+++ b/.github/workflows/add_link_checker.yml
@@ -13,7 +13,7 @@ jobs:
         id: lc
         uses: lycheeverse/lychee-action@v1.0.4
         with:
-          args: /learn/** /1.2/** /_site/** --exclude localhost:4000 --exclude twitter.com --exclude novacodecamp.org --exclude %7B%7B%20site.dist_server%20%7D%7D --exclude %7B%7B%20site.plugin_vscode_repo%20%7D%7D --verbose --base https://pre-prod.ballerina.io *.md *.html
+          args: /learn/** /1.2/** /_site/** --exclude localhost:4000 --exclude twitter.com --exclude disease.sh/v3 --exclude api.github.com --exclude novacodecamp.org --exclude %7B%7B%20site.dist_server%20%7D%7D --exclude %7B%7B%20site.plugin_vscode_repo%20%7D%7D --verbose --base https://pre-prod.ballerina.io *.md *.html
       - name: Archive production artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/home.html
+++ b/home.html
@@ -50,7 +50,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          Try Ballerina
       </h2>
       <div class="embed-responsive embed-responsive-21by9">
-         <iframe class="embed-responsive-item" src="..."></iframe>
+         <iframe class="embed-responsive-item" src="https://play.ballerina.io/"></iframe>
        </div>
       </div>
    </div>
@@ -154,7 +154,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
          <h3>Batteries Included</h3>
          <p>Today’s network is democratized! HTTPS to HTTP/2 to WebSockets to WebSub to AMQP to JSON to XML to ProtoBuf to gRPC to OpenAPI to plain old bytes - Ballerina has it all in the standard library and toolchain to help developers rapidly build applications. At development time, Ballerina covers documentation, testing, sharing, versioning, and more. We plumb, you build!</p>
          <ul class="cInlinelinklist">
-            <li><a class="cGreenLinkArrow" href="/why-ballerina/batteries-included">More info</a></li>
+            <li><a class="cGreenLinkArrow" href="/why-ballerina/">More info</a></li>
          </ul>
       </div>
    </div>

--- a/learn/why-ballerina/cloud-native.md
+++ b/learn/why-ballerina/cloud-native.md
@@ -9,6 +9,8 @@ intro: See how the Ballerina programming language has constructs that seamlessly
 redirect_from:
   - /why/from-code-to-cloud/
   - /why/from-code-to-cloud
+  - /why-ballerina/from-code-to-cloud/
+  - /why-ballerina/from-code-to-cloud
   - /learn/user-guide/why-ballerina/from-code-to-cloud
   - /learn/user-guide/why-ballerina/from-code-to-cloud/
   - /learn/user-guide/why-ballerina/
@@ -22,6 +24,8 @@ redirect_from:
   - /why-ballerina/cloud-native
   - /why-ballerina/
   - /why-ballerina
+  - /why-ballerina/the-network-in-the-language/
+  - /why-ballerina/the-network-in-the-language
 ---
 
 In a microservice architecture, smaller services are developed, deployed, and scaled individually. These disaggregated services communicate with each other over the network forcing developers to deal with the [Fallacies of distributed computing](https://en.wikipedia.org/wiki/Fallacies_of_distributed_computing) in their application logic. For decades, programming languages have treated networks simply as I/O sources. The sections below demonstrate a few of Ballerina's inherent capabilities to develop distributed services effectively and the cloud-native deployment process that is provided as part of the programming experience. 

--- a/learn/why-ballerina/flexibly-typed.md
+++ b/learn/why-ballerina/flexibly-typed.md
@@ -16,6 +16,8 @@ redirect_from:
 - /learn/why-ballerina/flexibly-typed
 - /learn/why-ballerina/flexibly-typed/
 - /why-ballerina/flexibly-typed
+- /why-ballerina/network-aware-type-system/
+- /why-ballerina/network-aware-type-system
 ---
 
 In a programming language, the type system is the foundation for representing data and implementing logic. It provides the means of creating abstractions to the solutions that you provide. While some languages provide basic functionality, others strive to give in-built functionality for specialized domains.

--- a/learn/why-ballerina/graphical.md
+++ b/learn/why-ballerina/graphical.md
@@ -8,6 +8,8 @@ active: graphical
 redirect_from:
   - /why/sequence-diagrams-for-programming/
   - /why/sequence-diagrams-for-programming
+  - /why-ballerina/sequence-diagrams-for-programming/
+  - /why-ballerina/sequence-diagrams-for-programming
   - /learn/user-guide/why-ballerina/sequence-diagrams-for-programming
   - /learn/user-guide/why-ballerina/sequence-diagrams-for-programming/
   - /learn/user-guide/why-ballerina/graphical


### PR DESCRIPTION
## Purpose
Fix URLs to mandate the link checker.
> Fixes #

## Check list

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
