### PR TITLE
Fix Sentence Case in `Archived Versions` Pages

### DIFF
--- a/downloads/archived.md
+++ b/downloads/archived.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-no-git-inner-page
-title: 1.2.x Archived Versions
+title: 1.2.x archived versions
 permalink: /downloads/1.2.x-archived/
 redirect_from:
   - /downloads/archived/

--- a/downloads/swan-lake-archived.md
+++ b/downloads/swan-lake-archived.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-no-git-inner-page
-title: Swan Lake Archived Versions
+title: Swan Lake archived versions
 permalink: /downloads/swan-lake-archived/
 ---
 <script src="{{ "/js/download/swan_lake_archived_download.js" | prepend: site.baseurl }}"></script>


### PR DESCRIPTION
Fix sentence case in `Archived Versions` pages of both 1.2.x and Swan Lake.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
