### PR TITLE
Fix the Prod Sync Release Note Generation Issue

### DIFF
--- a/.github/workflows/sw_publish_github_release.yml
+++ b/.github/workflows/sw_publish_github_release.yml
@@ -23,7 +23,7 @@ jobs:
         WEBSITE_TOKEN: ${{ secrets.WEBSITE_TOKEN }}
       run: |
         VERSION="`jq -r '.version' _data/swanlake-latest/metadata.json`"
-        cat downloads/swan-lake-release-notes/$VERSION/RELEASE_NOTE.md | sed '/---/d' | sed '/layout: release-note/d' | sed '/title: Release note/d' > RN.md
+        cat downloads/swan-lake-release-notes/swan-lake-$VERSION/RELEASE_NOTE.md | sed '/---/d' | sed '/layout: release-note/d' | sed '/title: Release note/d' > RN.md
         #python script takes RN.md as the input and produces out.json as the output
         python3 .github/scripts/sanitize_rn.py _data/swanlake-latest/metadata.json
 


### PR DESCRIPTION
## Purpose
Fix the prod sync release note generation issue.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
