### PR TITLE
Exclude 1.0 From the Build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,7 @@ latest_version: Swan Lake 2201.0.2
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
-exclude: ["downloads/RELEASE_NOTE.md","vendor","0.991/","v1-2","v1-1","v1-0","v0-991","v-0.990","0.990"]
+exclude: ["downloads/RELEASE_NOTE.md","vendor","0.991/","v1-2","v1-1","v1-0","v0-991","v-0.990","0.990","1.0"]
 #   - Gemfile.lock
 #   - node_modules
 #   - vendor/bundle/


### PR DESCRIPTION
Change 2201.0.3 Release Note Folder Name

## Purpose
Exclude 1.0 from the build.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
