### PR TITLE
Add the 2201.0.2 release note back

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.2/RELEASE_NOTE.md
@@ -1,0 +1,52 @@
+---
+layout: ballerina-left-nav-release-notes
+title: 2201.0.2 (Swan Lake) 
+permalink: /downloads/swan-lake-release-notes/2201-0-2/
+active: 2201-0-2
+redirect_from: 
+    - /downloads/swan-lake-release-notes/2201-0-2-swan-lake/
+    - /downloads/swan-lake-release-notes/2201-0-2-swan-lake
+    - /downloads/swan-lake-release-notes/2201-0-2
+
+## Overview of Ballerina Swan Lake 2201.0.2
+
+<em>Swan Lake 2201.0.2 is the second patch release of Ballerina 2201.0.0 (Swan Lake) and it includes a new set of bug fixes to the compiler, runtime, standard library, and developer tooling.</em> 
+
+## Updating Ballerina
+
+**If you are already using Ballerina 2201.0.0 (Swan Lake)**, run either of the commands below to directly update to 2201.0.2 (Swan Lake) using the [Ballerina Update Tool](/learn/cli-documentation/update-tool/).
+
+`bal dist update` (or `bal dist pull 2201.0.2`)
+
+**If you are using a version below 2201.0.0 (Swan Lake)**, run the commands below to update to 2201.0.2 (Swan Lake).
+
+1. Run `bal update` to get the latest version of the Update Tool.
+
+2. Run `bal dist update` ( or `bal dist pull 2201.0.2`) to update your Ballerina version to 2201.0.2 (Swan Lake).
+
+However, if you are using a version below 2201.0.0 (Swan Lake) and if you already ran `bal dist update` (or `bal dist pull 2201.0.2`) before `bal update`, see [Troubleshooting](/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting) to recover your installation.
+
+## Installing Ballerina
+
+If you have not installed Ballerina, then download the [installers](/downloads/#swanlake) to install.
+
+## Language updates
+
+To view bug fixes, see the [GitHub milestone for Swan Lake 2201.0.2](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+label%3AType%2FBug+label%3ATeam%2FCompilerFE+milestone%3A%22Ballerina+2201.0.2%22).
+
+## Runtime updates
+
+To view bug fixes, see the [GitHub milestone for Swan Lake 2201.0.2](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+label%3AType%2FBug+label%3ATeam%2FjBallerina+milestone%3A%22Ballerina+2201.0.2%22).
+
+## Standard library updates
+
+To view bug fixes, see the [GitHub milestone for Swan Lake 2201.0.2](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aclosed+is%3Aissue+milestone%3A%22Swan+Lake+2201.0.2%22+label%3AType%2FBug).
+
+## Developer tools updates
+
+To view bug fixes, see the GitHub milestone for Swan Lake 2201.0.2 of the repositories below.
+
+- [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+label%3ATeam%2FLanguageServer+milestone%3A%22Ballerina+2201.0.2%22+label%3AType%2FBug)
+- [OpenAPI](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+label%3AType%2FBug+milestone%3A1.0.2+is%3Aclosed)
+
+<!-- <style>.cGitButtonContainer, .cBallerinaTocContainer {display:none;}</style> -->


### PR DESCRIPTION
## Purpose
Add the 2201.0.2 release note back.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
