### PR TITLE
Change the Order of the Footer Icons

### DIFF
--- a/_includes/ballerina-footer.html
+++ b/_includes/ballerina-footer.html
@@ -20,9 +20,9 @@
                 <li>
                     <a class="cBioFooterLink" href="https://github.com/ballerina-platform" target="_blank"><img src="/img/github.svg"/></a>
                     </li>
-                <li><a class="cBioFooterLink" href="https://stackoverflow.com/questions/tagged/ballerina" target="_blank"><img src="/img/stackoverflow.svg"/></a></li>
                 <li><a class="cBioFooterLink" href="https://twitter.com/ballerinalang" target="_blank"><img src="/img/twitter.svg"/></a></li>
                 <li><a class="cBioFooterLink" href="/community/#ballerina-slack-community"><img src="/img/slack.svg"/></a></li>
+                <li><a class="cBioFooterLink" href="https://stackoverflow.com/questions/tagged/ballerina" target="_blank"><img src="/img/stackoverflow.svg"/></a></li>
                 <li><a class="cBioFooterLink" href="https://www.youtube.com/c/Ballerinalang"><img style="width: 15px;" src="/img/youtube-icon.svg"/></a></li>
                 </ul>
             <div class="pdframe"></div>


### PR DESCRIPTION
## Purpose
Change the order of the footer icons. Going with the order below based on how active user interactions are on each of these channels.

1. GitHub
2. Twitter
3. Slack
4. Stack Overflow
5. YouTube

**Current order:**

<img width="202" alt="Screen Shot 2022-05-03 at 6 11 32 PM" src="https://user-images.githubusercontent.com/11707273/166454776-f56f3e8a-1ec6-40eb-a5e0-db825b59d05d.png">

**Proposed order:**

<img width="208" alt="Screen Shot 2022-05-03 at 6 12 05 PM" src="https://user-images.githubusercontent.com/11707273/166454835-4bdb80a4-ccc1-4d4b-b043-5a6aaaead114.png">

> Fixes #4005 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
