### PR TITLE
Fix the Page Title of Newsletters

### DIFF
--- a/community/newsletter/2020-1.md
+++ b/community/newsletter/2020-1.md
@@ -6,12 +6,6 @@ keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2020-1/
 ---
 
-# Ballerina Newsletter 2020 Issue #1
-
-
-
-
-
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;background-color: #ffffff;height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
 	<tbody>
 		<tr>

--- a/community/newsletter/2020-2.md
+++ b/community/newsletter/2020-2.md
@@ -6,9 +6,6 @@ keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2020-2/
 ---
 
-# Ballerina Newsletter 2020 Issue #2
-
-
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;background-color: #ffffff;height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
 	<tbody>
 		<tr>

--- a/community/newsletter/2020-3.md
+++ b/community/newsletter/2020-3.md
@@ -6,8 +6,6 @@ keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2020-3/
 ---
 
-# Ballerina Newsletter 2020 Issue #3
-
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%;background-color: #ffffff;height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
 	<tbody>
 		<tr>

--- a/community/newsletter/2020-4.md
+++ b/community/newsletter/2020-4.md
@@ -6,8 +6,6 @@ keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2020-4/
 ---
 
-# Ballerina Newsletter 2020 Issue #4
-
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%; height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
    <tbody>
       <!-- BEGIN PREHEADER // -->

--- a/community/newsletter/2020-5.md
+++ b/community/newsletter/2020-5.md
@@ -6,8 +6,6 @@ keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2020-5/
 ---
 
-# Ballerina Newsletter 2020 Issue #5
-
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%; height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
 	<tbody><!-- BEGIN PREHEADER // -->
 		<tr>

--- a/community/newsletter/2021-1.md
+++ b/community/newsletter/2021-1.md
@@ -6,8 +6,6 @@ keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2021-1/
 ---
 
-# Ballerina Newsletter 2021 Issue #1
-
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%; height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
    <tbody>
       <!-- BEGIN PREHEADER // -->

--- a/community/newsletter/2021-2.md
+++ b/community/newsletter/2021-2.md
@@ -5,8 +5,6 @@ description: This is a periodic newsletter on Ballerina with hand-picked content
 keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2021-2/
 ---
- 
-# Ballerina Newsletter 2021 Issue #2
 
  <table
     align="center"

--- a/community/newsletter/2021-3.md
+++ b/community/newsletter/2021-3.md
@@ -5,8 +5,6 @@ description: This is a periodic newsletter on Ballerina with hand-picked content
 keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2021-3/
 ---
- 
-# Ballerina Newsletter 2021 Issue #3
 
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="m_wso2_full_wrap" style="height:100%!important;margin:0;padding:0" width="100%">
 	<tbody>

--- a/community/newsletter/2021-4.md
+++ b/community/newsletter/2021-4.md
@@ -5,8 +5,6 @@ description: This is a periodic newsletter on Ballerina with hand-picked content
 keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2021-4/
 ---
- 
-# Ballerina Newsletter 2021 Issue #4
 
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%; height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
 	<tbody><!-- BEGIN PREHEADER // -->

--- a/community/newsletter/2021-5.md
+++ b/community/newsletter/2021-5.md
@@ -5,8 +5,6 @@ description: This is a periodic newsletter on Ballerina with hand-picked content
 keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2021-5/
 ---
- 
-# Ballerina Newsletter 2021 Issue #5
 
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%; height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
 	<tbody><!-- BEGIN PREHEADER // -->

--- a/community/newsletter/2021-6.md
+++ b/community/newsletter/2021-6.md
@@ -5,8 +5,6 @@ description: This is a periodic newsletter on Ballerina with hand-picked content
 keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2021-6/
 ---
- 
-# Ballerina Newsletter 2021 Issue #6
 
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%; height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
 	<tbody><!-- BEGIN PREHEADER // -->

--- a/community/newsletter/2021-7.md
+++ b/community/newsletter/2021-7.md
@@ -5,8 +5,6 @@ description: This is a periodic newsletter on Ballerina with hand-picked content
 keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2021-7/
 ---
- 
-# Ballerina Newsletter 2021 Issue #7
 
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%; height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
 	<tbody><!-- BEGIN PREHEADER // -->

--- a/community/newsletter/2022-1.md
+++ b/community/newsletter/2022-1.md
@@ -5,8 +5,6 @@ description: This is a periodic newsletter on Ballerina with hand-picked content
 keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2022-1/
 ---
- 
-# Ballerina Newsletter 2022 Issue #1
 
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%; height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
 	<tbody><!-- BEGIN PREHEADER // -->

--- a/community/newsletter/2022-2.md
+++ b/community/newsletter/2022-2.md
@@ -5,8 +5,6 @@ description: This is a periodic newsletter on Ballerina with hand-picked content
 keywords: ballerina, community, ballerina community, newsletter
 permalink: /community/newsletter/2022-2/
 ---
- 
-# Ballerina Newsletter 2022 Issue #2
 
 <table align="center" border="0" cellpadding="0" cellspacing="0" class="wso2_full_wrap" style="-ms-text-size-adjust: 100%;-webkit-text-size-adjust: 100%; height: 100% !important;margin: 0;mso-table-lspace: 0pt;mso-table-rspace: 0pt;padding: 0;" width="100%">
     <tbody><!-- BEGIN PREHEADER // -->


### PR DESCRIPTION
## Purpose
Fix the page title of newsletters as follows.

<img width="1221" alt="Screen Shot 2022-05-06 at 1 27 09 PM" src="https://user-images.githubusercontent.com/11707273/167091876-bb53af2e-b53e-4456-8283-1357433074da.png">

> Fixes #4326

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
