### PR TITLE
Fix typos of the GraphQL Learn Content

### DIFF
--- a/learn/guides/ballerina-graphql-support.md
+++ b/learn/guides/ballerina-graphql-support.md
@@ -2,7 +2,7 @@
 layout: ballerina-graphql-support-left-nav-pages-swanlake
 title: Ballerina GraphQL support 
 description: Check out how the Ballerina GraphQL tooling makes it easy for you to start developing a service documented in a GraphQL schema.
-keywords: ballerina, programming language, graphql, sdl, schema difinition language
+keywords: ballerina, programming language, graphql, sdl, schema definition language
 permalink: /learn/ballerina-graphql-support/
 active: ballerina-graphql-support
 intro: Every GraphQL service defines a set of types, which describe the set of possible data you can query on that service and when queries come in, they are validated and executed against that schema. 

--- a/learn/references/cli-documentation/graphql.md
+++ b/learn/references/cli-documentation/graphql.md
@@ -18,7 +18,7 @@ The GraphQL to Ballerina command supports several usages in the Ballerina GraphQ
 bal graphql [-i | --input] <graphql-configuration-file-path> [-o | --output] <output-location> 
 ```
 
-The command line arguments below can be used with the command for each particular purpose as described below.
+The command-line arguments below can be used with the command for each particular purpose as described below.
 
 | Argument       | Description                                                                                                                                                                                                                                                                                                                                                                   |
 |----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/learn/references/cli-documentation/openapi.md
+++ b/learn/references/cli-documentation/openapi.md
@@ -25,7 +25,7 @@ bal openapi [-i | --input] <openapi-contract-file-path>
             [--with-tests]
 ```
 
-The command line arguments below can be used with the command for each particular purpose as described below. 
+The command-line arguments below can be used with the command for each particular purpose as described below. 
 
 | Argument          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 |-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## Purpose
Fix typos of the GraphQL Learn content.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
