### PR TITLE
Remove 1.0 from the Version Drop-Down

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -87,7 +87,6 @@
                                         <option value="swan-lake" data-value="latest">Swan Lake</option>
                                         <option value="1.2">v1.2</option>
                                         <option value="1.1">v1.1</option>
-                                        <option value="1.0">v1.0</option>
 
                                     </select>
                                 </div>

--- a/js/redirections.js
+++ b/js/redirections.js
@@ -138,6 +138,7 @@ let redirections = {
 
     "/downloads/1.2.x-release-notes-old/":"/downloads/1.2.x-release-notes/",
     "/community/slack/":"/community/#ballerina-slack-community",
-    "/community/slack":"/community/#ballerina-slack-community"
+    "/community/slack":"/community/#ballerina-slack-community",
+    "/1.0/learn/*":"/learn/",
 
 }


### PR DESCRIPTION
## Purpose
Remove 1.0 from the version drop-down.
> Fixes #4329 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
