### PR TITLE
Fix Fullstop Inconsistencies in 1.2.x Release Notes

### DIFF
--- a/downloads/1.2.x-release-notes/1.2.1.md
+++ b/downloads/1.2.x-release-notes/1.2.1.md
@@ -29,7 +29,7 @@ If you have not installed jBallerina, then download the [installers](https://bal
 
 #### Language
 - Deprecation support for annotations, function parameters, and object fields
-- Runtime validations added to the XML attributes map.
+- Runtime validations added to the XML attributes map
 - Support for map to record assignment
 
 #### Standard library

--- a/downloads/1.2.x-release-notes/1.2.11.md
+++ b/downloads/1.2.x-release-notes/1.2.11.md
@@ -32,9 +32,9 @@ If you have not installed jBallerina, then download the [installers](/downloads/
 
 Introduce inbound response validation for HTTP/1.1 client. 
 
-- `maxStatusLineLength` - The maximum length allowed for the response status line. Exceeding this limit will result in an error.
-- `maxHeaderSize` - The maximum size allowed for headers. Exceeding this limit will result in an error.
-- `maxEntityBodySize` - The maximum size allowed for the entity body. By default, it is set to -1, which means there is no restriction on the`maxEntityBodySize`. Exceeding this limit will result in an error.
+- `maxStatusLineLength` - The maximum length allowed for the response status line. Exceeding this limit will result in an error
+- `maxHeaderSize` - The maximum size allowed for headers. Exceeding this limit will result in an error
+- `maxEntityBodySize` - The maximum size allowed for the entity body. By default, it is set to -1, which means there is no restriction on the`maxEntityBodySize`. Exceeding this limit will result in an error
 
 ##### Cache
 

--- a/downloads/1.2.x-release-notes/1.2.15.md
+++ b/downloads/1.2.x-release-notes/1.2.15.md
@@ -19,7 +19,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but switched to a previous version, run `bal dist pull jballerina-1.2.15` to update.
+- jBallerina 1.2.0 but switched to a previous version, run `bal dist pull jballerina-1.2.15` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.16.md
+++ b/downloads/1.2.x-release-notes/1.2.16.md
@@ -18,7 +18,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 > $ bal dist update
 However, if you are using
 
-- jBallerina 1.2.0 but switched to a previous version, run `bal dist pull jballerina-1.2.16` to update.
+- jBallerina 1.2.0 but switched to a previous version, run `bal dist pull jballerina-1.2.16` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**
@@ -28,4 +28,4 @@ If you have not installed jBallerina, then download the [installers](https://bal
 
 ### Deployment
 
-Updated the [Kubernetes Ingress specification](https://github.com/ballerina-platform/module-ballerina-kubernetes/issues/644)
+Updated the [Kubernetes Ingress specification](https://github.com/ballerina-platform/module-ballerina-kubernetes/issues/644).

--- a/downloads/1.2.x-release-notes/1.2.17.md
+++ b/downloads/1.2.x-release-notes/1.2.17.md
@@ -18,7 +18,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but switched to a previous version, run `ballerina dist pull jballerina-1.2.17` to update.
+- jBallerina 1.2.0 but switched to a previous version, run `ballerina dist pull jballerina-1.2.17` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**
@@ -29,5 +29,5 @@ If you have not installed jBallerina, then download the [installers](https://bal
 Change the Observability http_url tag to return service path + resource path rather than returning inbound request resource url.
 
 ### Cache
-- The default capacity value in the CacheConfig has changed to 20.
-- Fix the OOM issue in the authentication cache when using large JWT tokens.
+- The default capacity value in the CacheConfig has changed to 20
+- Fix the OOM issue in the authentication cache when using large JWT tokens

--- a/downloads/1.2.x-release-notes/1.2.18.md
+++ b/downloads/1.2.x-release-notes/1.2.18.md
@@ -18,7 +18,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.18` to update.
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.18` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.19.md
+++ b/downloads/1.2.x-release-notes/1.2.19.md
@@ -17,7 +17,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.19` to update.
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.19` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.2.md
+++ b/downloads/1.2.x-release-notes/1.2.2.md
@@ -27,7 +27,7 @@ If you have not installed jBallerina, then download the [installers](https://bal
 #### Standard library
 - Attachment/MIME Support to Email Connector: Introduce email attachments with MIME entities where attachment(s) can be attached to an email with an array of MIME Entities and read attachment(s) by reading - an array of MIME Entities
 - Improved API documentation
-- Introduce a few status code specific error remote functions to `http:Caller`. 
+- Introduce a few status code specific error remote functions to `http:Caller` 
 
 #### Dev tools
 - Improvements to API Doc tool

--- a/downloads/1.2.x-release-notes/1.2.20.md
+++ b/downloads/1.2.x-release-notes/1.2.20.md
@@ -17,7 +17,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.20` to update.
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.20` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.21.md
+++ b/downloads/1.2.x-release-notes/1.2.21.md
@@ -18,7 +18,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.21` to update.
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.21` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.22.md
+++ b/downloads/1.2.x-release-notes/1.2.22.md
@@ -21,7 +21,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.22` to update.
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.22` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.23.md
+++ b/downloads/1.2.x-release-notes/1.2.23.md
@@ -18,7 +18,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.23` to update.
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.23` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.24.md
+++ b/downloads/1.2.x-release-notes/1.2.24.md
@@ -18,7 +18,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.24` to update.
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.24` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.25.md
+++ b/downloads/1.2.x-release-notes/1.2.25.md
@@ -18,7 +18,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.25` to update.
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.25` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.26.md
+++ b/downloads/1.2.x-release-notes/1.2.26.md
@@ -18,7 +18,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.26` to update.
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.26` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.27.md
+++ b/downloads/1.2.x-release-notes/1.2.27.md
@@ -18,8 +18,8 @@ If you are already using jBallerina version 1.2.14, or above, you can directly u
 
 However, if you are using
 
-- jBallerina 1.2.0 to 1.2.13, run `ballerina dist update` to update.
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.27` to update.
+- jBallerina 1.2.0 to 1.2.13, run `ballerina dist update` to update
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.27` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.28.md
+++ b/downloads/1.2.x-release-notes/1.2.28.md
@@ -19,8 +19,8 @@ If you are already using jBallerina version 1.2.14, or above, you can directly u
 
 However, if you are using
 
-- jBallerina 1.2.0 to 1.2.13, run `ballerina dist update` to update.
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.28` to update.
+- jBallerina 1.2.0 to 1.2.13, run `ballerina dist update` to update
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.28` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.29.md
+++ b/downloads/1.2.x-release-notes/1.2.29.md
@@ -22,8 +22,8 @@ If you are already using jBallerina version 1.2.14, or above, you can directly u
 
 However, if you are using
 
-- jBallerina 1.2.0 to 1.2.13, run `ballerina dist update` to update.
-- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.29` to update.
+- jBallerina 1.2.0 to 1.2.13, run `ballerina dist update` to update
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.29` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.4.md
+++ b/downloads/1.2.x-release-notes/1.2.4.md
@@ -19,7 +19,7 @@ If you are already using jBallerina version 1.2.0, or above, you can directly up
 
 However, if you are using
 
-- jBallerina 1.2.0 but switched to a previous version, execute `ballerina dist pull jballerina-1.2.4` to update.
+- jBallerina 1.2.0 but switched to a previous version, execute `ballerina dist pull jballerina-1.2.4` to update
 - a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**

--- a/downloads/1.2.x-release-notes/1.2.5.md
+++ b/downloads/1.2.x-release-notes/1.2.5.md
@@ -28,16 +28,16 @@ However, you need to use the following commands instead of the above if you have
 If you have not installed jBallerina, then download the [installers](https://ballerina.io/downloads/) to install.
 
 #### Standard library
-- The capability to validate the JWT signature with JWKs is extended now. With that, the JWT signature can be validated either from the TrustStore configuration or JWKs configuration.
-- Undo the deprecation of the `ballerinax/java.jdbc` module and continue to support it in 1.2.x releases.
+- The capability to validate the JWT signature with JWKs is extended now. With that, the JWT signature can be validated either from the TrustStore configuration or JWKs configuration
+- Undo the deprecation of the `ballerinax/java.jdbc` module and continue to support it in 1.2.x releases
 
 #### Deployment
 - Azure Functions support
 - Prometheus support for kubernetes annotations
 
 #### Tooling 
-- Added `--home-cache` flag to build and run commands to specify an alternative balo cache directory.
-- Maven resolver support and other improvements to the bindgen tool.
+- Added `--home-cache` flag to build and run commands to specify an alternative balo cache directory
+- Maven resolver support and other improvements to the bindgen tool
 - Update tool support for swan lake release channel
 
 

--- a/downloads/1.2.x-release-notes/1.2.7.md
+++ b/downloads/1.2.x-release-notes/1.2.7.md
@@ -30,7 +30,7 @@ If you have not installed jBallerina, then download the [installers](https://bal
 
 ##### I/O
 
-- When a CSV file has an empty record, the previous implementation panicked. This is fixed with this release.
+When a CSV file has an empty record, the previous implementation panicked. This is fixed with this release.
 
 #### Developer tools
 
@@ -45,15 +45,15 @@ Object mocking enables controlling the values of member variables and the behavi
 
 Object mocking is done by using the following functions.
 
-- The `test:mock()` and `test:prepare()` functions are used to initialize the mocking capability.
-- The `test:prepare()` function allows to use the associated mocking functions like `thenReturn()`, `thenReturnSequence()`, `doNothing()`, and `withArguments()`.
+- The `test:mock()` and `test:prepare()` functions are used to initialize the mocking capability
+- The `test:prepare()` function allows to use the associated mocking functions like `thenReturn()`, `thenReturnSequence()`, `doNothing()`, and `withArguments()`
 
 ###### Function mocking
 
-- The `MockFunction` object is added to handle function mocking. `MockFunction` objects are defined by attaching the `@test:Mock` to the `MockFunction` object to specify the function to mock.
-- The mocking API also supports scoping and stubbing of mock functions that are declared for functions in imported modules.
+- The `MockFunction` object is added to handle function mocking. `MockFunction` objects are defined by attaching the `@test:Mock` to the `MockFunction` object to specify the function to mock
+- The mocking API also supports scoping and stubbing of mock functions that are declared for functions in imported modules
 
 Function mocking is done by using the following functions.
 
-- The `test:when(mockObj)` function is used to initialize the mocking capability within a particular test case.
-- This allows you to use the associated mocking functions like `call()`, `thenReturn()`, and `withArguments()`.
+- The `test:when(mockObj)` function is used to initialize the mocking capability within a particular test case
+- This allows you to use the associated mocking functions like `call()`, `thenReturn()`, and `withArguments()`

--- a/downloads/1.2.x-release-notes/1.2.9.md
+++ b/downloads/1.2.x-release-notes/1.2.9.md
@@ -35,14 +35,14 @@ Improved logging for transactions. Redundant info logs were changed to debug log
 
 ##### HTTP
 
-- Upgraded the Netty framework version to 4.1.50 and upgraded the SnakeYAML version to 1.26.
-- Added support for disabling the SSL certificate validation for HTTP2 clients.
+- Upgraded the Netty framework version to 4.1.50 and upgraded the SnakeYAML version to 1.26
+- Added support for disabling the SSL certificate validation for HTTP2 clients
 
 ##### Security
 
-Added support to read custom/optional fields from the OAuth2 introspection response.
+Added support to read custom/optional fields from the OAuth2 introspection response
 
 ##### Cache
 
-Improved the concurrent behavior of the cache.
+Improved the concurrent behavior of the cache
 


### PR DESCRIPTION
## Purpose
Fix fullstop inconsistencies in 1.2.x release notes.
> Fixes #4356

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
