### PR TITLE
Fix the Edit Option of Removed HTTP BBEs

### DIFF
--- a/learn/by-example/http-request-error-interceptor.html
+++ b/learn/by-example/http-request-error-interceptor.html
@@ -139,7 +139,7 @@ redirect_from:
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/master/examples/http-request-error-interceptor/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/v2201.0.3/examples/http-request-error-interceptor/"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                         
                                     </ul>

--- a/learn/by-example/http-request-interceptor-at-listener.html
+++ b/learn/by-example/http-request-interceptor-at-listener.html
@@ -130,7 +130,7 @@ redirect_from:
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/master/examples/http-request-interceptor-at-listener/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/v2201.0.3/examples/http-request-interceptor-at-listener/"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                         
                                     </ul>

--- a/learn/by-example/http-request-interceptor-at-service.html
+++ b/learn/by-example/http-request-interceptor-at-service.html
@@ -121,7 +121,7 @@ redirect_from:
                                             <a class="copy"><img src="/img/copy-icon.svg" /></a>
                                         </li>
                                         <li>
-                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/master/examples/http-request-interceptor-at-service/"><img src="/img/github-logo-green.svg" /></a>
+                                            <a target="_blank" href="https://github.com/ballerina-platform/ballerina-distribution/tree/v2201.0.3/examples/http-request-interceptor-at-service/"><img src="/img/github-logo-green.svg" /></a>
                                         </li>
                                         
                                     </ul>


### PR DESCRIPTION
## Purpose
Fix the edit option of removed HTTP BBEs. These were removed to go with Update1.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
