### PR TITLE
Fix sendMessage method call on Consume Services example : Distinctive Features page

### DIFF
--- a/learn/guides/distinctive-language-features/network-interaction.md
+++ b/learn/guides/distinctive-language-features/network-interaction.md
@@ -46,7 +46,7 @@ function mailDemo() returns error? {
 
 In the above code example, the client object **``sc``** belongs to a client class **``SmtpClient``**. The connection parameters are passed to ``new`` when creating the object.
 
-The **``sendEmailMessage()``** remote method is called on the client object **``sc``** with the ``->`` call syntax. This notation signifies that it is a remote call to a network service. It augurs well with the sequence diagram view of the application and provides a syntactically distinguished view for better readability.
+The **``sendMessage()``** remote method is called on the client object **``sc``** with the ``->`` call syntax. This notation signifies that it is a remote call to a network service. It augurs well with the sequence diagram view of the application and provides a syntactically distinguished view for better readability.
 
 Remote method calls have some restrictions. For example, they are not allowed in deeply nested expressions. Additionally, there is a separate symbol space for these methods, and they are implicitly public.
 


### PR DESCRIPTION
## Purpose
> Fixes the sendMessage method call in the explanation of the Consume Services example on https://ballerina.io/learn/distinctive-language-features/network-interaction/#consume-services---client-objects

> Fixes #4369 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
