### PR TITLE
Remove the Detailed Learn Left Nav

### DIFF
--- a/_data/learnleftnav.yml
+++ b/_data/learnleftnav.yml
@@ -1,103 +1,20 @@
 - title: Get Started 
-  url: #
-  sublinks:
-    - title: Install Ballerina
-      url: /learn/#install-ballerina
-      active: set-up-ballerina
-    - title: Get started with Ballerina
-      url: /learn/#get-started-with-ballerina
-      active: get-started-with-ballerina
+  url: /learn/#get-started
+  active: get-started
 
 - title: Learn the language
-  url: #
-  sublinks:
-    - title: Ballerina By Example
-      url: /learn/#ballerina-by-example
-      active: ballerina-by-example
-    - title: Language basics
-      url: /learn/#language-basics
-      active: language-basics
-    - title: Distinctive language features
-      url: /learn/#distinctive-language-features
-      active: distinctive-language-features
-    - title: Language walkthrough
-      url: /learn/#language-walkthrough
-      active: language-walkthrough
-    - title: Library API documentation
-      url: /learn/#library-api-documentation
-      active: library-api-documentation
- 
+  url: /learn/#learn-the-language
+  active: learn-the-language
+
 - title: Use cases
-  url: #
-  sublinks:
-    - title: Write a RESTful API with Ballerina
-      url: /learn/#write-a-restful-api-with-ballerina
-      active: write-a-restful-api-with-ballerina
-    - title: Write a gRPC service with Ballerina
-      url: /learn/#write-a-grpc-service-with-ballerina
-      active: write-a-grpc-service-with-ballerina
-    - title: Deploy Ballerina on Kubernetes
-      url: /learn/#deploy-ballerina-on-kubernetes
-      active: deploy-ballerina-on-kubernetes
-    - title: Write a GraphQL API with Ballerina
-      url: /learn/#write-a-graphql-api-with-ballerina
-      active: write-a-graphql-api-with-ballerina
-    - title: Build a data service in Ballerina
-      url: /learn/#build-a-data-service-in-ballerina
-      active: build-a-data-service-in-ballerina
-    - title: Work with data in Ballerina
-      url: /learn/#work-with-data-in-ballerina
-      active: work-with-data-in-ballerina
-    - title: Call Java code from Ballerina
-      url: /learn/#call-java-code-from-ballerina
-      active: call-java-code-from-ballerina
+  url: /learn/#use-cases
+  active: use-cases
 
 - title: Learn about the platform
-  url: #
-  sublinks:
-    - title: Organize Ballerina code
-      url: /learn/#organize-ballerina-code
-      active: organize-ballerina-code
-    - title: Test Ballerina code
-      url: /learn/#test-ballerina-code
-      active: test-ballerina-code
-    - title: Debug Ballerina programs
-      url: /learn/#debug-ballerina-programs
-      active: debug-ballerina-programs
-    - title: Manage dependencies
-      url: /learn/#manage-dependencies
-      active: manage-dependencies
-    - title: Run Ballerina programs in the cloud
-      url: /learn/#run-ballerina-programs-in-the-cloud
-      active: run-ballerina-programs-in-the-cloud
-    - title: Publish packages to Ballerina Central
-      url: /learn/#publish-packages-to-ballerina-central
-      active: publish-packages-to-ballerina-central
-    - title: Java interoperability
-      url: /learn/#java-interoperability
-      active: java-interoperability
-    - title: Ballerina OpenAPI support
-      url: /learn/#ballerina-openapi-support
-      active: ballerina-openapi-support
-    - title: Visual Studio Code extension
-      url: /learn/#visual-studio-code-extension
-      active: visual-studio-code-extension
-    - title: CLI documentation
-      url: /learn/#cli-documentation
-      active: cli-documentation
-    - title: Ballerina Shell
-      url: /learn/#ballerina-shell
-      active: ballerina-shell
-    - title: Style guide
-      url: /learn/#style-guide
-      active: style-guide
+  url: /learn/#learn-about-the-platform
+  active: learn-about-the-platform
 
 - title: Specifications
-  url: #
-  sublinks:
-    - title: Language specifications
-      url: /learn/#language-specifications
-      active: language-specifications
-    - title: Other specifications
-      url: /learn/#other-specifications
-      active: other-specifications
+  url: /learn/#specifications
+  active: specifications
+    

--- a/css/ballerina-io-docs.css
+++ b/css/ballerina-io-docs.css
@@ -609,7 +609,7 @@ ul.lower-latin li {
 .cBallerina-io .permalinkHeader {
     padding-top: 40px !important;
     margin-top: -20px;
-    margin-bottom: 20px !important;
+    margin-bottom: 0px !important;
 }
 
 /* ul.table-striped{

--- a/css/ballerina-io.css
+++ b/css/ballerina-io.css
@@ -893,9 +893,9 @@ a.cMobileLogo {
 }
 
 .wy-nav-content h1 {
-    font-size: 38px;
-    color: #585a5e;
-    font-weight: 200;
+    font-size: 45px;
+    color: #1c1e21;
+    font-weight: 500;
     margin-bottom: 30px;
 }
 
@@ -990,9 +990,9 @@ h7 {
     font-size: 32px;
     margin-top: 40px;
     margin-bottom: 30px;
-    font-weight: 600;
+    font-weight: normal;
     color: #464646;
-    border-bottom: 2px solid #464646;
+    /*border-bottom: 2px solid #464646;*/
     display: inline-block;
     padding-bottom: 10px;
     scroll-margin-top: 60px;

--- a/learn.md
+++ b/learn.md
@@ -147,12 +147,14 @@ redirect_from:
 
 <div class="row" style=" margin-bottom:30px">
 <div class="col-lg-12 col-md-12 col-sm-12 card">
- <a href="https://lib.ballerina.io/">
-  	<h3 id="library-api-documentation">Library API documentation</h3></a>
-		<p>Ballerina library API documentation. </p>
+ <a href="/learn/language-specifications/">
+  <h3 id="language-specifications-1">Language specifications</h3></a>
+		<p>Details of the Ballerina language specifications and proposals.  </p>
 </div>
 <div class="col-lg-12 col-md-12 col-sm-12 card" style="margin-right:0px !important;">
-
+         <a href="https://lib.ballerina.io/">
+  	<h3 id="library-api-documentation">Library API documentation</h3></a>
+		<p>Ballerina library API documentation. </p>
 </div>
 </div>
 
@@ -284,7 +286,7 @@ redirect_from:
 <h2 id="specifications">Specifications</h2>
 <div class="col-lg-12 col-md-12 col-sm-12 card" >
  <a href="/learn/language-specifications/">
-  <h3 id="language-specifications">Language specifications</h3></a>
+  <h3 id="language-specifications-2">Language specifications</h3></a>
 		<p>Details of the Ballerina language specifications and proposals.  </p>
 </div>
 <div class="col-lg-12 col-md-12 col-sm-12 card" style="margin-right:0px !important;">


### PR DESCRIPTION
## Purpose
Remove the detailed learn left nav.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
