### PR TITLE
Add Ballerina Dev Google group to Community page

### DIFF
--- a/community-new.html
+++ b/community-new.html
@@ -857,12 +857,6 @@ td.cEventDateContainer{
        
     </div>
     <div class="row" >
-        <!-- <div class="col-lg-4 col-md-6 col-sm-12 card">
-           
-                <h4 id="running-ballerina-programs-in-the-cloud" class="gTitle1">Contribute to the resource library</h4>
-                <p><a  id="myBtn" class="getStartLinks" >Submit</a> an article, blog, or video to our community-driven collection of resources.</p>
-           
-        </div> -->
         <div class="col-lg-4 col-md-6 col-sm-12 card">
             <span class="bookMarkOnPage" id="submit-a-use-case"></span>
             
@@ -871,11 +865,18 @@ td.cEventDateContainer{
                 <p><a id="submitUseCase" class="getStartLinks">Tell us</a> how you're using Ballerina in your project and be a part of our community stories. </p>
            
         </div>
-        <div class="col-lg-4 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+        <div class="col-lg-4 col-md-6 col-sm-12 card">
             <span class="bookMarkOnPage" id="host-a-ballerina-event"></span>
           
-                     <h4 id="host-a-ballerina-event-title" class="gTitle1">Host a Ballerina event</h4>
-                <p>Want to talk about Ballerina at your local tech meetup? Reach us at <a class="getStartLinks" href="mailto:contact@ballerina.io">contact@ballerina.io</a>, and we will help you with any presentation content.</p>
+            <h4 id="host-a-ballerina-event-title" class="gTitle1">Host a Ballerina event</h4>
+       <p>Want to talk about Ballerina at your local tech meetup? Reach us at <a class="getStartLinks" href="mailto:contact@ballerina.io">contact@ballerina.io</a>, and we will help you with any presentation content.</p>
+           
+        </div>
+        <div class="col-lg-4 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+            <span class="bookMarkOnPage" id="join-dev-google-group"></span>
+          
+                <h4 id="join-dev-google-group-title" class="gTitle1">Join the Dev Google Group </h4>
+                <p>Get invovled in any technical discussions by joining the <a class="getStartLinks" target="_blank" href="https://groups.google.com/g/ballerina-dev">Ballerina Dev Google group</a>.</p>
            
         </div>
     </div>


### PR DESCRIPTION
## Purpose
> Regarding the request made by Ashweni via [1] I added Join the Dev Google Group under get started section in community page
![image](https://user-images.githubusercontent.com/73055030/168981904-ae185b76-37c1-4c7e-8516-01002ed6c418.png)


[1] - Thread <Website update | Ballerina Dev Google group>
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
