### PR TITLE
Update the Left Nav Mismatch in the gRPC Guide

### DIFF
--- a/learn/get-started/write-a-grpc-service-with-ballerina.md
+++ b/learn/get-started/write-a-grpc-service-with-ballerina.md
@@ -260,7 +260,7 @@ In this code:
 - The client declaration creates a connection to the remote server which is listening on port 9090. The generated client has remote methods that can use to talk to a remote server.
 - The `main` function contains the statements that call the `sayHello` remote function and prints the response to the console.
 
-## Run the client
+## Run the gRPC client
 
 In the terminal, navigate to the `greeter_client` directory, and execute the command below to run the service project
 


### PR DESCRIPTION
## Purpose
Update the left nav mismatch in gRPC `Get started` guide.
> Fixes #4387 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
