### PR TITLE
Fix the alignment in other specs page

### DIFF
--- a/spec/other-specifications.md
+++ b/spec/other-specifications.md
@@ -1,5 +1,5 @@
 ---
-layout: ballerina-left-nav-pages-swanlake
+layout: ballerina-inner-page
 title: Other specifications
 intro: Read the Ballerina specifications that cover the standard library, built-in language extensions, testing, documentation, and more.
 description: Read the Ballerina specifications that cover the standard library, built-in language extensions, testing, documentation, and more.


### PR DESCRIPTION
## Purpose
Fix the alignment in other specs page.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
