### PR TITLE
Revert New Learn Design and Title Styles from 2201.1.0

### DIFF
--- a/_data/ballerinaasyncapisupportswanlake.yml
+++ b/_data/ballerinaasyncapisupportswanlake.yml
@@ -1,6 +1,6 @@
-- title: Ballerina AsyncAPI support
+- title: AsyncAPI Tool
   url: #
   sublinks:
     - title: Generate Ballerina services from AsyncAPI contracts
-      url: /learn/ballerina-asyncapi-support/#generate-ballerina-services-from-asyncapi-contracts
+      url: /learn/asyncapi-tool/#generate-ballerina-services-from-asyncapi-contracts
       active: generate-ballerina-services-from-asyncapi-contracts  

--- a/_data/ballerinaasyncapisupportswanlake.yml
+++ b/_data/ballerinaasyncapisupportswanlake.yml
@@ -1,4 +1,4 @@
-- title: AsyncAPI Tool
+- title: AsyncAPI tool
   url: #
   sublinks:
     - title: Generate Ballerina services from AsyncAPI contracts

--- a/_data/ballerinagraphqlsupportswanlake.yml
+++ b/_data/ballerinagraphqlsupportswanlake.yml
@@ -1,12 +1,12 @@
-- title: Ballerina GraphQL support
+- title: GraphQL Tool
   url: #
   sublinks:
     - title: Generate a client from a GraphQL config
-      url: /learn/ballerina-graphql-support/#generate-a-client-from-a-graphql-config
+      url: /learn/graphql-tool/#generate-a-client-from-a-graphql-config
       active: generate-a-ballerina-client-from-a-graphql-config
     - title: Generate multiple clients from a GraphQL config 
-      url: /learn/ballerina-graphql-support/#generate-multiple-clients-from-a-graphql-config
+      url: /learn/graphql-tool/#generate-multiple-clients-from-a-graphql-config
       active: generate-multiple-clients-from-a-graphql-config
     - title: Generate multiple modules from a GraphQL config 
-      url: /learn/ballerina-graphql-support/#generate-multiple-modules-from-a-graphql-config
+      url: /learn/graphql-tool/#generate-multiple-modules-from-a-graphql-config
       active: generate-multiple-modules-from-a-graphql-config

--- a/_data/ballerinagraphqlsupportswanlake.yml
+++ b/_data/ballerinagraphqlsupportswanlake.yml
@@ -1,4 +1,4 @@
-- title: GraphQL Tool
+- title: GraphQL tool
   url: #
   sublinks:
     - title: Generate a client from a GraphQL config

--- a/_data/ballerinaopenapisupportswanlake.yml
+++ b/_data/ballerinaopenapisupportswanlake.yml
@@ -17,7 +17,7 @@
           url: /learn/openapi-tool/#export-for-a-specific-service
           active: export-for-a-specific-service
         - title: Export with a given title and version
-          url: /learn/bopenapi-tool/#export-with-a-given-title-and-version
+          url: /learn/openapi-tool/#export-with-a-given-title-and-version
           active: export-with-a-given-title-and-version
     - title: OpenAPI validator compiler plugin
       url: /learn/openapi-tool/#openapi-validator-compiler-plugin

--- a/_data/ballerinaopenapisupportswanlake.yml
+++ b/_data/ballerinaopenapisupportswanlake.yml
@@ -1,39 +1,39 @@
-- title: Ballerina OpenAPI support
+- title: OpenAPI Tool
   url: #
   sublinks:
     - title: Generate Ballerina services from OpenAPI contracts 
-      url: /learn/ballerina-openapi-support/#generate-ballerina-services-from-openapi-contracts
+      url: /learn/openapi-tool/#generate-ballerina-services-from-openapi-contracts
       sublinks:
         - title: Generate from tags
-          url: /learn/ballerina-openapi-support/#generate-from-tags
+          url: /learn/openapi-tool/#generate-from-tags
           active: generate-from-tags
     - title: Export OpenAPI contracts from Ballerina services 
-      url: /learn/ballerina-openapi-support/#export-openapi-contracts-from-ballerina-services 
+      url: /learn/openapi-tool/#export-openapi-contracts-from-ballerina-services 
       sublinks:
         - title: Export in JSON format
-          url: /learn/ballerina-openapi-support/#export-in-json-format
+          url: /learn/openapi-tool/#export-in-json-format
           active: export-in-json-format
         - title: Export for a specific service
-          url: /learn/ballerina-openapi-support/#export-for-a-specific-service
+          url: /learn/openapi-tool/#export-for-a-specific-service
           active: export-for-a-specific-service
         - title: Export with a given title and version
-          url: /learn/ballerina-openapi-support/#export-with-a-given-title-and-version
+          url: /learn/bopenapi-tool/#export-with-a-given-title-and-version
           active: export-with-a-given-title-and-version
     - title: OpenAPI validator compiler plugin
-      url: /learn/ballerina-openapi-support/#openapi-validator-compiler-plugin
+      url: /learn/openapi-tool/#openapi-validator-compiler-plugin
       active: openapi-validator-compiler-plugin
     - title: Generate Ballerina clients from OpenAPI definitions
-      url: /learn/ballerina-openapi-support/#generate-ballerina-client-from-openapi-definitions
+      url: /learn/openapi-tool/#generate-ballerina-client-from-openapi-definitions
       sublinks:
         - title: Generate with boiler-plate tests
-          url: /learn/ballerina-openapi-support/#generate-with-boiler-plate-tests
+          url: /learn/openapi-tool/#generate-with-boiler-plate-tests
           active: generate-with-boiler-plate-tests
         - title: Generate with nillable types
-          url: /learn/ballerina-openapi-support/#generate-with-nillable-types
+          url: /learn/openapi-tool/#generate-with-nillable-types
           active: generate-with-nillable-types
     - title: Publish your client
-      url: /learn/ballerina-openapi-support/#publish-your-client
+      url: /learn/openapi-tool/#publish-your-client
       active: publish-your-client
     - title: Annotation reference
-      url: /learn/ballerina-openapi-support/#annotation-reference
+      url: /learn/openapi-tool/#annotation-reference
       active: annotation-reference

--- a/_data/ballerinaopenapisupportswanlake.yml
+++ b/_data/ballerinaopenapisupportswanlake.yml
@@ -1,4 +1,4 @@
-- title: OpenAPI Tool
+- title: OpenAPI tool
   url: #
   sublinks:
     - title: Generate Ballerina services from OpenAPI contracts 

--- a/css/ballerina-io-docs.css
+++ b/css/ballerina-io-docs.css
@@ -609,7 +609,7 @@ ul.lower-latin li {
 .cBallerina-io .permalinkHeader {
     padding-top: 40px !important;
     margin-top: -20px;
-    margin-bottom: 0px !important;
+    margin-bottom: 20px !important;
 }
 
 /* ul.table-striped{

--- a/css/ballerina-io.css
+++ b/css/ballerina-io.css
@@ -893,9 +893,9 @@ a.cMobileLogo {
 }
 
 .wy-nav-content h1 {
-    font-size: 45px;
-    color: #1c1e21;
-    font-weight: 500;
+    font-size: 38px;
+    color: #585a5e;
+    font-weight: 200;
     margin-bottom: 30px;
 }
 
@@ -990,9 +990,9 @@ h7 {
     font-size: 32px;
     margin-top: 40px;
     margin-bottom: 30px;
-    font-weight: normal;
+    font-weight: 600;
     color: #464646;
-    /*border-bottom: 2px solid #464646;*/
+    border-bottom: 2px solid #464646;
     display: inline-block;
     padding-bottom: 10px;
     scroll-margin-top: 60px;

--- a/learn.md
+++ b/learn.md
@@ -11,116 +11,6 @@ redirect_from:
  - /learn
 ---
 
-<div class="container">
-<div class="row" style="background-color:#ffffff; padding-bottom:45px; margin-bottom:25px; border-bottom:1px solid #c7c7c7">
-<h2 id="get-started">Get started</h2>
-<a href="/learn/install-ballerina/set-up-ballerina/">
-    <h3 id="install-ballerina">Install Ballerina</h3> </a>
-    <p >Set up the Ballerina development environment.  </p>
- <a href="/learn/get-started-with-ballerina/">
-    <h3 id="get-started-with-ballerina">Get started with Ballerina</h3></a>
-   <p >Write your first Ballerina program and create your first Ballerina package. </p>
-</div>
-</div>
-
-<div class="container">
-<div class="row" style="background-color:#ffffff; padding-bottom:45px; margin-bottom:25px; border-bottom:1px solid #c7c7c7">
-<h2 id="learn-the-language" style="padding-top:30px;">Learn the language</h2>
-<a href="/learn/by-example/">
-    <h3 id="ballerina-by-example">Ballerina By Example</h3></a>
-    <p >A series of guided examples to learn the language. </p>
-<a href="/learn/language-basics/">
-    <h3 id="language-basics">Language basics</h3></a>
-    <p >Get started with the basics that are common to all C-family programming languages. </p>
- <a href="/learn/distinctive-language-features/">
-  <h3 id="distinctive-language-features">Distinctive language features</h3></a>
- 	<p>A guide to the language features that make Ballerina distinctive.  </p>
-	  <a href="/learn/language-walkthrough/">
-   	<h3 id="language-walkthrough">Language walkthrough</h3></a>
-  <p>A video series, which explains the language and its reference slide deck. </p>
-   <a href="/learn/language-specifications/">
-  <h3 id="language-specifications-1">Language specifications</h3></a>
-		<p>Details of the Ballerina language specifications and proposals.  </p>
-         <a href="https://lib.ballerina.io/">
-  	<h3 id="library-api-documentation">Library API documentation</h3></a>
-		<p>Ballerina library API documentation. </p>
-</div>
-</div>
-
-<div class="container">
-<div class="row" style="background-color:#ffffff; padding-bottom:45px; margin-bottom:25px; border-bottom:1px solid #c7c7c7">
-<h2 id="use-cases" style="padding-top:30px;">Use cases</h2>
-<a href="/learn/write-a-restful-api-with-ballerina/">
-    <h3 id="write-a-restful-api-with-ballerina">Write a RESTful API with Ballerina</h3></a>
-    <p >Understand the basics of Ballerina constructs, which allow you to write RESTful APIs. </p>
-<a href="/learn/write-a-grpc-service-with-ballerina/">
-    <h3 id="write-a-grpc-service-with-ballerina">Write a gRPC service with Ballerina</h3></a>
-    <p >Write a simple Ballerina gRPC service and invoke the service through a Ballerina gRPC client. </p>
- <a href="/learn/deploy-ballerina-on-kubernetes/">
-    <h3 id="deploy-ballerina-on-kubernetes">Deploy Ballerina on Kubernetes</h3></a>
-   <p >Dockerize your application and deploy it on Kubernetes. </p>
-   <a href="/learn/write-a-graphql-api-with-ballerina/">
-    <h3 id="write-a-graphql-api-with-ballerina">Write a GraphQL API with Ballerina</h3></a>
-    <p >Understand the basics of Ballerina constructs, which allow you to write GraphQL APIs. </p>
-	<a href="/learn/build-a-data-service-in-ballerina/">
-    <h3 id="build-a-data-service-in-ballerina">Build a data service in Ballerina</h3></a>
-    <p >Connect to a MySQL database and execute queries using an HTTP RESTful API. </p>
-	<a href="/learn/work-with-data-in-ballerina/">
-    <h3 id="work-with-data-in-ballerina">Work with data in Ballerina</h3></a>
-    <p >Use Ballerina query expressions to filter, sort, and join different iterable collections. </p>
-	<a href="/learn/call-java-code-from-ballerina/">
- <h3 id="call-java-code-from-ballerina">Call Java code from Ballerina</h3></a>
-		<p>Details of calling Java code from Ballerina using Java interoperability.  </p>
-</div>
-
-<div class="container">
-<div class="row" style="background-color:#ffffff; padding-bottom:45px; margin-bottom:25px; border-bottom:1px solid #c7c7c7">
-<h2 id="learn-about-the-platform" style="padding-top:30px;">Learn about the platform</h2>
- <a href="/learn/organize-ballerina-code/">
-  <h3 id="organize-ballerina-code">Organize Ballerina code</h3></a>
- 	<p>Basics of projects, packages, and modules.  </p>
-	   <a href="/learn/test-ballerina-code/">
-   <h3 id="test-ballerina-code">Test Ballerina code</h3> </a>
-    <p>Details of writing automated tests using the built-in test framework.  </p>
-	<a href="/learn/debug-ballerina-programs/">
-  		<h3 id="debug-ballerina-programs">Debug Ballerina programs</h3></a>
-		<p>Details of tooling support for troubleshooting Ballerina applications.  </p>
-	  <a href="/learn/manage-dependencies/">
- 	<h3 id="manage-dependencies">Manage dependencies </h3></a>
-  			<p>Details of declaring and managing dependencies and using the local repository.</p>
- <a href="/learn/run-ballerina-programs-in-the-cloud/">
-  		<h3 id="run-ballerina-programs-in-the-cloud">Run Ballerina programs in the cloud</h3></a>
- 	<p>The cloud offerings for running Ballerina programs.  </p>
-	 <a href="/learn/publish-packages-to-ballerina-central/">
-  		<h3 id="publish-packages-to-ballerina-central">Publish packages to Ballerina Central</h3></a>
-		<p>Details of publishing your library package to Ballerina Central.  </p>
-		  <a href="/learn/java-interoperability/">
-     <h3 id="java-interoperability">Java interoperability</h3></a>
-		<p>Instructions on the supported Java interoperability features.  </p>
-		 <a href="/learn/ballerina-openapi-support/">
-    <h3 id="ballerina-openapi-support">Ballerina OpenAPI support </h3></a>
-    <p >Details of all the features of the Ballerina OpenAPI tools. </p>
-     <a href="/learn/ballerina-graphql-support/">
-    <h3 id="ballerina-graphql-support">Ballerina GraphQL support </h3></a>
-    <p >Details of all the features of the Ballerina GraphQL tools. </p>
-     <a href="/learn/ballerina-asyncapi-support/">
-    <h3 id="ballerina-async-support">Ballerina AsyncAPI support </h3></a>
-    <p >Details of all the features of the Ballerina AsyncAPI tools. </p>
-</div>
-</div>
-
-<div class="container">
-<div class="row" style="background-color:#ffffff; padding-bottom:45px; margin-bottom:25px">
-	<h2 id="specifications" style="padding-top:30px;">Specifications</h2>
- <a href="/learn/language-specifications/">
-  <h3 id="language-specifications-2">Language specifications</h3></a>
-		<p>Details of the Ballerina language specifications and proposals.  </p>
-		 <a href="/learn/other-specifications/">
-  <h3 id="other-specifications">Other specifications</h3></a>
-		<p>Details of the Ballerina specifications other than the language specifications.  </p>
-</div>
-</div>
-
 <style>
 	:not(pre) > code[class*="language-"], pre[class*="language-"]{
 		    background: #e0dede !important;
@@ -134,16 +24,36 @@ redirect_from:
 } 
 .column-gray-box{ 
     padding: 40px 25px 15px 25px;
-    background-color:#efefef;
+    background-color:#fff;
 	height:	100%;
 }
 .row h2{ 
   display:block;
-  margin-top:0;
+  margin-top:10px;
 }
-.row h3{ 
+.card h3{ 
   font-size:20px;
+  margin:0px !important;
 }
+
+.card p{
+    margin-top:15px !important;
+    margin-bottom:0px !important;
+}
+
+.card{
+    border: none;
+    margin: 10px 40px 15px 0px;
+    padding: 0px 0px;
+    /* max-width: 530px; */
+    
+}
+
+.card:hover{
+    color:#464646 !important;
+    /* background-color:#F8F8F8; */
+}
+
 .column-gray-box-row{
 	display: -webkit-box;
     display: -ms-flexbox;
@@ -164,12 +74,278 @@ redirect_from:
 	padding-top:15px;
 
 }
-@media only screen and (min-width: 992px) { 
-	.column-gray-box-grid{
-		-webkit-box-flex: 0;
-		-ms-flex: 0 0 33.333333%;
-		flex: 0 0 33.333333%;
-		max-width: 33.333333%; 
-	}
+/* Add para height to keep consistency Medium devices (landscape tablets, 768px and up) */
+@media only screen and (min-width: 768px) {
+    .card{
+    max-width: 700px !important;
+}
+}
+/* Add para height to keep consistency in Large devices (laptops/desktops, 992px and up) */
+@media only screen and (min-width: 992px) {
+    .card p{
+    height:54px !important;
+}
+.card{
+    max-width: 450px !important;
+}
+}
+
+/* Add para height to keep consistency in Extra large devices (large laptops and desktops, 1200px and up) */
+@media only screen and (min-width: 1200px) {
+    .card p{
+    height:54px !important;
+}
+.card{
+    max-width: 550px !important;
+}
 }
 </style>
+
+
+<div class="row" style=" margin-bottom:30px">
+<h2 id="get-started">Get started</h2>
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card" >
+  <a href="/learn/install-ballerina/set-up-ballerina/">
+    <h3 id="install-ballerina">Install Ballerina</h3> </a>
+    <p >Set up the Ballerina development environment.  </p>
+</div>
+
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+ <a href="/learn/get-started-with-ballerina/">
+    <h3 id="get-started-with-ballerina">Get started with Ballerina</h3></a>
+   <p >Write your first Ballerina program and create your first Ballerina package. </p>
+</div>
+</div>
+
+<div class="row">
+
+
+<div class="col-lg-6 col-md-6 col-sm-12 card">
+<a href="/learn/language-basics/">
+    <h3 id="language-basics">Language basics</h3></a>
+    <p >Get started with the basics that are common to all C-family programming languages. </p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+<a href="/learn/write-a-restful-api-with-ballerina/">
+    <h3 id="working-with-data">Write a RESTful API with Ballerina</h3></a>
+    <p >Understand the basics of Ballerina constructs, which allow you to write RESTful APIs. </p>
+</div>
+</div>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card">
+<a href="/learn/write-a-graphql-api-with-ballerina/">
+    <h3 id="working-with-data">Write a GraphQL API with Ballerina</h3></a>
+    <p >Understand the basics of Ballerina constructs, which allow you to write GraphQL APIs. </p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+<a href="/learn/write-a-grpc-service-with-ballerina/">
+    <h3 id="write-a-grpc-service-with-ballerina">Write a gRPC service with Ballerina</h3></a>
+    <p >Write a simple Ballerina gRPC service and invoke the service through a Ballerina gRPC client. </p>
+</div>
+</div>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card">
+<a href="/learn/work-with-data-in-ballerina/">
+    <h3 id="work-with-data-in-ballerina">Work with data in Ballerina</h3></a>
+    <p >Use Ballerina query expressions to filter, sort, and join different iterable collections. </p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+ <a href="/learn/deploy-ballerina-on-kubernetes/">
+    <h3 id="deploy-ballerina-on-kubernetes">Deploy Ballerina on Kubernetes</h3></a>
+   <p >Dockerize your application and deploy it on Kubernetes. </p>
+</div>
+</div>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card">
+<a href="/learn/build-a-data-service-in-ballerina/">
+    <h3 id="build-a-data-service-in-ballerina">Build a data service in Ballerina</h3></a>
+    <p >Connect to a MySQL database and execute queries using an HTTP RESTful API. </p>
+</div>
+</div>
+
+<div class="row" style="margin-bottom:30px;">
+<h2 id="guides">Guides</h2>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card">
+ <a href="/learn/distinctive-language-features/">
+  <h3 id="distinctive-language-features">Distinctive language features</h3></a>
+ 	<p>A guide to the language features that make Ballerina distinctive.  </p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+ <a href="/learn/organize-ballerina-code/">
+  <h3 id="organize-ballerina-code">Organize Ballerina code</h3></a>
+ 	<p>Basics of projects, packages, and modules.  </p>
+</div>
+
+</div>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card"  >
+  <a href="/learn/test-ballerina-code/">
+   <h3 id="test-ballerina-code">Test Ballerina code</h3> </a>
+    <p>Details of writing automated tests using the built-in test framework.  </p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important">
+  <a href="/learn/generate-code-documentation/">
+  <h3 id="generate-code-documentation">Generate code documentation
+</h3></a>
+  	<p>The usage of the <code class="highlighter-rouge language-plaintext">bal doc</code> CLI command.   </p>
+</div>
+</div>
+
+<div class="row">
+
+<div class="col-lg-6 col-md-6 col-sm-12 card"   >
+ <a href="/learn/configure-ballerina-programs/">
+  	<h3 id="configure-ballerina-programs">Configure Ballerina programs</h3></a>
+ 	<p>The language support for configurability.   </p>
+
+</div>
+
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important">
+  <a href="/learn/observe-ballerina-programs/">
+ 	<h3 id="observe-ballerina-programs">Observe Ballerina programs
+</h3></a>
+  		<p>Basics of the observability functionalities that are provided for Ballerina programs. </p>
+</div>
+</div>
+
+<div class="row">
+
+<div class="col-lg-6 col-md-6 col-sm-12 card"  >
+ <a href="/learn/run-ballerina-programs-in-the-cloud/">
+  		<h3 id="run-ballerina-programs-in-the-cloud">Run Ballerina programs in the cloud
+</h3></a>
+ 	<p>The cloud offerings for running Ballerina programs.  </p>
+
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+  <a href="/learn/manage-dependencies/">
+ 	<h3 id="manage-dependencies">Manage dependencies </h3></a>
+  			<p>Details of declaring and managing dependencies and using the local repository.</p>
+</div>
+</div>	
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card"  >
+<a href="/learn/publish-packages-to-ballerina-central/">
+  		<h3 id="publish-packages-to-ballerina-central">Publish packages to Ballerina Central</h3></a>
+		<p>Details of publishing your library package to Ballerina Central.  </p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important;">
+<a href="/learn/call-java-code-from-ballerina/">
+ <h3 id="call-java-code-from-ballerina">Call Java code from Ballerina</h3></a>
+		<p>Details of calling Java code from Ballerina using Java interoperability.  </p>
+</div>
+</div>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card"  >
+<a href="/learn/debug-ballerina-programs/">
+  		<h3 id="debug-ballerina-programs">Debug Ballerina programs</h3></a>
+		<p>Details of tooling support for troubleshooting Ballerina applications.  </p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important;">
+<h3 id="ballerina-shell"><a href="/learn/ballerina-shell/">Ballerina Shell</a></h3>
+<p>Details of the Read-Evaluate-Print Loop (REPL) for Ballerina.</p>
+</div>
+</div>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card"  >
+ <a href="https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina">
+    <h3 id="visual-studio-code-extension">Visual Studio Code extension</h3></a>
+    <p >Details of all the features of the Ballerina Visual Studio Code extension. </p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important;">
+ <a href="/learn/ballerina-openapi-support/">
+    <h3 id="ballerina-openapi-support">Ballerina OpenAPI support </h3></a>
+    <p >Details of all the features of the Ballerina OpenAPI tools. </p>
+</div>
+</div>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card" >
+ <a href="/learn/ballerina-graphql-support/">
+    <h3 id="ballerina-graphql-support">Ballerina GraphQL support </h3></a>
+    <p >Details of all the features of the Ballerina GraphQL tools. </p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important;">
+ <a href="/learn/ballerina-asyncapi-support/">
+    <h3 id="ballerina-async-support">Ballerina AsyncAPI support </h3></a>
+    <p >Details of all the features of the Ballerina AsyncAPI tools. </p>
+</div>
+</div>
+
+<div class="row" style="margin-bottom:30px">
+	<h2 id="references">References</h2>
+
+  <div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card" >
+<a href="/learn/by-example/">
+    <h3 id="ballerina-by-example">Ballerina by Example</h3></a>
+    <p >A series of guided examples to learn the language. </p>
+</div>
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+ <a href="https://lib.ballerina.io/">
+  	<h3 id="library-documentation">Library documentation</h3></a>
+		<p>Ballerina library API documentation. </p>
+</div>
+
+</div>
+	
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card" >
+  <a href="/learn/cli-documentation/cli-commands/">
+ 	<h3 id="cli-documentation">CLI documentation</h3></a>
+		<p>Details of all the CLI commands of the <code class="highlighter-rouge language-plaintext">bal</code> tool.  </p>
+</div>
+
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+ <a href="/learn/platform-specifications/">
+  <h3 id="platform-specifications">Platform specifications</h3></a>
+		<p>Details of the Ballerina language specifications and proposals.  </p>
+</div>
+</div>
+
+
+<div class="row">
+
+<div class="col-lg-6 col-md-6 col-sm-12 card" >
+  <a href="/learn/style-guide/">
+ 	 <h3 id="style-guide">Style guide</h3></a>
+		<p>Best practices to follow when formatting Ballerina code.   </p>
+</div>
+
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+  <a href="/learn/java-interoperability/">
+     <h3 id="java-interoperability">Java interoperability</h3></a>
+		<p>Instructions on the supported Java interoperability features.  </p>
+</div>
+</div>
+
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card" >
+  <a href="/learn/package-references/">
+ 	 <h3 id="package-references">Package references</h3></a>
+		<p>References related to Ballerina Packages.</p>
+</div>
+</div>
+
+
+<div class="row" style=" margin-bottom:30px">
+<h2 id="talks">Talks</h2>
+<div class="row">
+<div class="col-lg-6 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+  <a href="/learn/language-walkthrough/">
+   	<h3 id="language-walkthrough">Language walkthrough</h3></a>
+  <p >A video series, which explains the language and its reference slide deck. </p>
+</div>
+</div>
+</div>
+ 

--- a/learn.md
+++ b/learn.md
@@ -263,22 +263,22 @@ redirect_from:
     <p >Details of all the features of the Ballerina Visual Studio Code extension. </p>
 </div>
 <div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important;">
- <a href="/learn/ballerina-openapi-support/">
-    <h3 id="ballerina-openapi-support">Ballerina OpenAPI support </h3></a>
-    <p >Details of all the features of the Ballerina OpenAPI tools. </p>
+ <a href="/learn/openapi-tool/">
+    <h3 id="openapi-tool">OpenAPI Tool </h3></a>
+    <p >Details of all the features of the Ballerina OpenAPI Tool. </p>
 </div>
 </div>
 
 <div class="row">
 <div class="col-lg-6 col-md-6 col-sm-12 card" >
- <a href="/learn/ballerina-graphql-support/">
-    <h3 id="ballerina-graphql-support">Ballerina GraphQL support </h3></a>
-    <p >Details of all the features of the Ballerina GraphQL tools. </p>
+ <a href="/learn/graphql-tool/">
+    <h3 id="graphql-tool">GraphQL Tool </h3></a>
+    <p >Details of all the features of the Ballerina GraphQL tool. </p>
 </div>
 <div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important;">
- <a href="/learn/ballerina-asyncapi-support/">
-    <h3 id="ballerina-async-support">Ballerina AsyncAPI support </h3></a>
-    <p >Details of all the features of the Ballerina AsyncAPI tools. </p>
+ <a href="/learn/asyncapi-tool/">
+    <h3 id="asyncapi-tool">AsyncAPI Tool </h3></a>
+    <p >Details of all the features of the Ballerina AsyncAPI tool. </p>
 </div>
 </div>
 

--- a/learn/guides/asyncapi-tool.md
+++ b/learn/guides/asyncapi-tool.md
@@ -1,13 +1,15 @@
 ---
 layout: ballerina-asyncapi-support-left-nav-pages-swanlake
-title: Ballerina AsyncAPI support 
+title: AsyncAPI sTool
 description: Check out how the Ballerina AsyncAPI tooling makes it easy for you to start developing a service documented in an AsyncAPI contract.
 keywords: ballerina, programming language, asyncapi, contract
-permalink: /learn/ballerina-asyncapi-support/
-active: ballerina-asyncapi-support
+permalink: /learn/asyncapi-tool/
+active: asyncapi-tool
 intro: AsyncAPI is a specification, which is used to describe and document message-driven APIs in a machine-readable format for easy development, discovery, and integration. Ballerina Swan Lake supports the AsyncAPI Specification version 2.x.
 redirect_from:
   - /learn/ballerina-asyncapi-support
+  - /learn/ballerina-asyncapi-support/
+  - /learn/asyncapi-tool
 --- 
 
 Ballerina AsyncAPI tooling will make it easy for you to start the development of an event API documented in an AsyncAPI contract in Ballerina by generating a Ballerina service and listener skeletons.

--- a/learn/guides/asyncapi-tool.md
+++ b/learn/guides/asyncapi-tool.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-asyncapi-support-left-nav-pages-swanlake
 title: AsyncAPI tool
-description: Check out how the Ballerina AsyncAPI tooling makes it easy for you to start developing a service documented in an AsyncAPI contract.
+description: Check out how the Ballerina AsyncAPI tool makes it easy for you to start developing a service documented in an AsyncAPI contract.
 keywords: ballerina, programming language, asyncapi, contract
 permalink: /learn/asyncapi-tool/
 active: asyncapi-tool
@@ -12,7 +12,7 @@ redirect_from:
   - /learn/asyncapi-tool
 --- 
 
-Ballerina AsyncAPI tooling will make it easy for you to start the development of an event API documented in an AsyncAPI contract in Ballerina by generating a Ballerina service and listener skeletons.
+Ballerina AsyncAPI tool will make it easy for you to start the development of an event API documented in an AsyncAPI contract in Ballerina by generating a Ballerina service and listener skeletons.
 
 > **Prerequisite:** Install the latest [Ballerina Swan Lake distribution](https://ballerina.io/downloads/).
 

--- a/learn/guides/asyncapi-tool.md
+++ b/learn/guides/asyncapi-tool.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-asyncapi-support-left-nav-pages-swanlake
-title: AsyncAPI sTool
+title: AsyncAPI tool
 description: Check out how the Ballerina AsyncAPI tooling makes it easy for you to start developing a service documented in an AsyncAPI contract.
 keywords: ballerina, programming language, asyncapi, contract
 permalink: /learn/asyncapi-tool/

--- a/learn/guides/asyncapi-tool.md
+++ b/learn/guides/asyncapi-tool.md
@@ -18,7 +18,7 @@ Ballerina AsyncAPI tool will make it easy for you to start the development of an
 
 ## Generate Ballerina services from AsyncAPI contracts
 
-If you prefer the design-first approach, use an existing or your own AsyncAPI definition to generate Ballerina services using the AsyncAPI CLI command below.
+If you prefer the design-first approach, use an existing or your AsyncAPI definition to generate Ballerina services using the AsyncAPI CLI command below.
 
 ```bash
 bal asyncapi -i <asyncapi-contract>

--- a/learn/guides/graphql-tool.md
+++ b/learn/guides/graphql-tool.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-graphql-support-left-nav-pages-swanlake
-title: GraphQL Tool
+title: GraphQL tool
 description: Check out how the Ballerina GraphQL tooling makes it easy for you to start developing a service documented in a GraphQL schema.
 keywords: ballerina, programming language, graphql, sdl, schema definition language
 permalink: /learn/graphql-tool/

--- a/learn/guides/graphql-tool.md
+++ b/learn/guides/graphql-tool.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-graphql-support-left-nav-pages-swanlake
 title: GraphQL tool
-description: Check out how the Ballerina GraphQL tooling makes it easy for you to start developing a service documented in a GraphQL schema.
+description: Check out how the Ballerina GraphQL tool makes it easy for you to start developing a service documented in a GraphQL schema.
 keywords: ballerina, programming language, graphql, sdl, schema definition language
 permalink: /learn/graphql-tool/
 active: graphql-tool
@@ -12,9 +12,9 @@ redirect_from:
   - /learn/graphql-tool
 --- 
 
-GraphQL schemas for a service are now most often specified using what’s known as the GraphQL SDL (schema definition language). It is also sometimes referred to as just GraphQL schema language. Ballerina GraphQL tooling will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. You can generate multiple clients in Ballerina for multiple GraphQL documents for a given GraphQL SDL. It also enables you to generate multiple Ballerina modules for multiple GraphQL projects to work with different GraphQL APIs. 
+GraphQL schemas for a service are now most often specified using what’s known as the GraphQL SDL (schema definition language). It is also sometimes referred to as just GraphQL schema language. Ballerina GraphQL tool will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. You can generate multiple clients in Ballerina for multiple GraphQL documents for a given GraphQL SDL. It also enables you to generate multiple Ballerina modules for multiple GraphQL projects to work with different GraphQL APIs. 
 
-The Ballerina GraphQL tooling support provides the following capabilities.
+The Ballerina GraphQL tool support provides the following capabilities.
 
 > **Prerequisites:** Install the [GraphQL Foundation VSCode plugin](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) and the latest [Ballerina Swan Lake distribution](https://ballerina.io/downloads/).
 

--- a/learn/guides/graphql-tool.md
+++ b/learn/guides/graphql-tool.md
@@ -12,7 +12,7 @@ redirect_from:
   - /learn/graphql-tool
 --- 
 
-GraphQL schemas for a service are now most often specified using what’s known as the GraphQL SDL (schema definition language). It is also sometimes referred to as just GraphQL schema language. Ballerina GraphQL tool will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. You can generate multiple clients in Ballerina for multiple GraphQL documents for a given GraphQL SDL. It also enables you to generate multiple Ballerina modules for multiple GraphQL projects to work with different GraphQL APIs. 
+GraphQL schemas of a service are now most often specified using what’s known as the GraphQL SDL (schema definition language). It is also sometimes referred to as just GraphQL schema language. Ballerina GraphQL tool will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. You can generate multiple clients in Ballerina for multiple GraphQL documents for a given GraphQL SDL. It also enables you to generate multiple Ballerina modules for multiple GraphQL projects to work with different GraphQL APIs. 
 
 The Ballerina GraphQL tool support provides the following capabilities.
 

--- a/learn/guides/graphql-tool.md
+++ b/learn/guides/graphql-tool.md
@@ -1,13 +1,15 @@
 ---
 layout: ballerina-graphql-support-left-nav-pages-swanlake
-title: Ballerina GraphQL support 
+title: GraphQL Tool
 description: Check out how the Ballerina GraphQL tooling makes it easy for you to start developing a service documented in a GraphQL schema.
 keywords: ballerina, programming language, graphql, sdl, schema definition language
-permalink: /learn/ballerina-graphql-support/
-active: ballerina-graphql-support
+permalink: /learn/graphql-tool/
+active: graphql-tool
 intro: Every GraphQL service defines a set of types, which describe the set of possible data you can query on that service and when queries come in, they are validated and executed against that schema. 
 redirect_from:
   - /learn/ballerina-graphql-support
+  - /learn/ballerina-graphql-support/
+  - /learn/graphql-tool
 --- 
 
 GraphQL schemas for a service are now most often specified using what’s known as the GraphQL SDL (schema definition language). It is also sometimes referred to as just GraphQL schema language. Ballerina GraphQL tooling will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. You can generate multiple clients in Ballerina for multiple GraphQL documents for a given GraphQL SDL. It also enables you to generate multiple Ballerina modules for multiple GraphQL projects to work with different GraphQL APIs. 

--- a/learn/guides/openapi-tool.md
+++ b/learn/guides/openapi-tool.md
@@ -36,7 +36,7 @@ The Ballerina OpenAPI tool support provides the following capabilities.
 
 ## Generate Ballerina services from OpenAPI Contracts 
 
-If you are an API developer who prefers the **design-first approach**, you can use an existing or your own OpenAPI definition to generate Ballerina services using the OpenAPI CLI command as follows.
+If you are an API developer who prefers the **design-first approach**, you can use an existing or your OpenAPI definition to generate Ballerina services using the OpenAPI CLI command as follows.
 
 ```bash
 $ bal openapi -i <openapi-contract> --mode service
@@ -78,7 +78,7 @@ Once you execute the command, only the operations related to the given tags will
 
 ## Export OpenAPI contracts from Ballerina services
 
-If you are an API developer who prefer to follow the **code-first approach**, you can convert your Ballerina service APIs into human-readable or machine-readable documents such as OpenAPI documents by using the Ballerina to OpenAPI CLI Tool as follows.
+If you prefer to follow the **code-first approach**, you can convert your Ballerina service APIs into human-readable or machine-readable documents such as OpenAPI documents by using the Ballerina to OpenAPI CLI Tool as follows.
 
 Export the Ballerina service to an OpenAPI Specification 3.0.0 definition. For the export to work properly, the input Ballerina service should be defined using the basic service and resource-level HTTP annotations.
 

--- a/learn/guides/openapi-tool.md
+++ b/learn/guides/openapi-tool.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-openapi-support-left-nav-pages-swanlake
 title: OpenAPI tool
-description: Check out how the Ballerina OpenAPI tooling makes it easy for you to start developing a service documented in an OpenAPI contract.
+description: Check out how the Ballerina OpenAPI tool makes it easy for you to start developing a service documented in an OpenAPI contract.
 keywords: ballerina, programming language, openapi, open api, restful api
 permalink: /learn/openapi-tool/
 active: openapi-tool
@@ -23,9 +23,9 @@ redirect_from:
   - /learn/ballerina-openapi-support/
 --- 
 
-Ballerina OpenAPI tooling will make it easy for you to start the development of a service documented in an OpenAPI contract in Ballerina by generating a Ballerina service and client skeletons. It enables you to take the code-first API design approach by generating an OpenAPI contract for the given service implementation.
+Ballerina OpenAPI tool will make it easy for you to start the development of a service documented in an OpenAPI contract in Ballerina by generating a Ballerina service and client skeletons. It enables you to take the code-first API design approach by generating an OpenAPI contract for the given service implementation.
 
-The Ballerina OpenAPI tooling support provides the following capabilities.
+The Ballerina OpenAPI tool support provides the following capabilities.
 
 > **Prerequisite:** Install the latest [Ballerina Swan Lake distribution](https://ballerina.io/downloads/).
 

--- a/learn/guides/openapi-tool.md
+++ b/learn/guides/openapi-tool.md
@@ -1,10 +1,10 @@
 ---
 layout: ballerina-openapi-support-left-nav-pages-swanlake
-title: Ballerina OpenAPI support 
+title: OpenAPI Tool
 description: Check out how the Ballerina OpenAPI tooling makes it easy for you to start developing a service documented in an OpenAPI contract.
 keywords: ballerina, programming language, openapi, open api, restful api
-permalink: /learn/ballerina-openapi-support/
-active: ballerina-openapi-support
+permalink: /learn/openapi-tool/
+active: openapi-tool
 intro: OpenAPI Specification is a specification that creates a RESTFUL contract for APIs by detailing all of its resources and operations in a human and machine-readable format for easy development, discovery, and integration. Ballerina Swan Lake supports the OpenAPI Specification version 3.0.0 onwards.
 redirect_from:
   - /learn/how-to-use-openapi-tools/
@@ -20,6 +20,7 @@ redirect_from:
   - /learn/cli-documentation/openapi/#openapi-validator-compiler-plugin/
   - /learn/cli-documentation/openapi/#openapi-validator-compiler-plugin
   - /learn/ballerina-openapi-support
+  - /learn/ballerina-openapi-support/
 --- 
 
 Ballerina OpenAPI tooling will make it easy for you to start the development of a service documented in an OpenAPI contract in Ballerina by generating a Ballerina service and client skeletons. It enables you to take the code-first API design approach by generating an OpenAPI contract for the given service implementation.

--- a/learn/guides/openapi-tool.md
+++ b/learn/guides/openapi-tool.md
@@ -1,6 +1,6 @@
 ---
 layout: ballerina-openapi-support-left-nav-pages-swanlake
-title: OpenAPI Tool
+title: OpenAPI tool
 description: Check out how the Ballerina OpenAPI tooling makes it easy for you to start developing a service documented in an OpenAPI contract.
 keywords: ballerina, programming language, openapi, open api, restful api
 permalink: /learn/openapi-tool/


### PR DESCRIPTION
## Purpose
Revert the new learn page design and title style changes from 2201.1.0.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
