### PR TITLE
Remove Extra Lines in the GraphQL Layout

### DIFF
--- a/_layouts/ballerina-graphql-support-left-nav-pages-swanlake.html
+++ b/_layouts/ballerina-graphql-support-left-nav-pages-swanlake.html
@@ -42,10 +42,6 @@
                                     </div>
                                     {{ content }}
                                  </div>
-
-
-                                
-                             
                               </div>
                            </div>
                         </div>
@@ -71,8 +67,6 @@
      </script>
      <script src="/js/ballerina-leftnav.js"></script>
 
-
-
      <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
      <script src="/js/abixTreeList.min.js"></script>
      <script>
@@ -90,11 +84,6 @@
                 });
                 $('#tree').abixTreeList();  
          });
-
-
-
-
-
          $(window).scroll(function () {
         var bodyclass = document.body;
 
@@ -106,14 +95,9 @@
           
         }
 
-   
-
-
     });
 
      </script>
-
-
    </body>
 </html>
-
+   


### PR DESCRIPTION
## Purpose
Remove extra lines in the GraphQL layout.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
