### PR TITLE
Rename the GraphQL Guide

### DIFF
--- a/_data/ballerinagraphqlsupportswanlake.yml
+++ b/_data/ballerinagraphqlsupportswanlake.yml
@@ -1,12 +1,12 @@
-- title: GraphQL tool
+- title: GraphQL client tool
   url: #
   sublinks:
     - title: Generate a client from a GraphQL config
-      url: /learn/graphql-tool/#generate-a-client-from-a-graphql-config
+      url: /learn/graphql-client-tool/#generate-a-client-from-a-graphql-config
       active: generate-a-ballerina-client-from-a-graphql-config
     - title: Generate multiple clients from a GraphQL config 
-      url: /learn/graphql-tool/#generate-multiple-clients-from-a-graphql-config
+      url: /learn/graphql-client-tool/#generate-multiple-clients-from-a-graphql-config
       active: generate-multiple-clients-from-a-graphql-config
     - title: Generate multiple modules from a GraphQL config 
-      url: /learn/graphql-tool/#generate-multiple-modules-from-a-graphql-config
+      url: /learn/graphql-client-tool/#generate-multiple-modules-from-a-graphql-config
       active: generate-multiple-modules-from-a-graphql-config

--- a/downloads/swan-lake-release-notes/swan-lake-2201.1.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.1.0/RELEASE_NOTE.md
@@ -649,11 +649,11 @@ To view bug fixes, see the [GitHub milestone for Swan Lake 2201.1.0](https://git
 
 #### AsyncAPI tool
 
-Introduced the Ballerina AsyncAPI tool, which will make it easy for you to start the development of an event API documented in an AsyncAPI contract in Ballerina by generating Ballerina service and listener skeletons. Ballerina Swan Lake supports the [AsyncAPI Specification version 2.x](https://www.asyncapi.com/docs/specifications/v2.0.0.). For more information, see [Ballerina AsyncAPI support](/learn/ballerina-asyncapi-support) and [AsyncAPI CLI documentation](/learn/cli-documentation/asyncapi/#asyncapi-to-ballerina).
+Introduced the AsyncAPI tool, which will make it easy for you to start the development of an event API documented in an AsyncAPI contract in Ballerina by generating Ballerina service and listener skeletons. Ballerina Swan Lake supports the [AsyncAPI Specification version 2.x](https://www.asyncapi.com/docs/specifications/v2.0.0.). For more information, see [Ballerina AsyncAPI support](/learn/ballerina-asyncapi-support) and [AsyncAPI CLI documentation](/learn/cli-documentation/asyncapi/#asyncapi-to-ballerina).
 
-#### GraphQL tool
+#### GraphQL client tool
 
-Introduced the Ballerina GraphQL tool, which will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. Ballerina Swan Lake supports the GraphQL specification [October 2021 edition](https://spec.graphql.org/October2021/). For more information, see [Ballerina GraphQL support](/learn/ballerina-graphql-support/) and [GraphQL CLI documentation](/learn/cli-documentation/graphql/#graphql-to-ballerina).
+Introduced the GraphQL client tool, which will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. Ballerina Swan Lake supports the GraphQL specification [October 2021 edition](https://spec.graphql.org/October2021/). For more information, see [Ballerina GraphQL support](/learn/ballerina-graphql-support/) and [GraphQL CLI documentation](/learn/cli-documentation/graphql/#graphql-to-ballerina).
 
 #### Language server
 
@@ -676,7 +676,7 @@ Added runtime breakpoint verification support. With this improvement, the debugg
 - Improved the `Create function` code action to add an isolated qualifier
 - Added signature help for union-typed expressions
 
-#### OpenAPI Tool
+#### OpenAPI tool
 
 ##### Improved the OpenAPI service validator
 

--- a/learn.md
+++ b/learn.md
@@ -271,9 +271,9 @@ redirect_from:
 
 <div class="row">
 <div class="col-lg-6 col-md-6 col-sm-12 card" >
- <a href="/learn/graphql-tool/">
-    <h3 id="graphql-tool">GraphQL tool </h3></a>
-    <p >Details of all the features of the Ballerina GraphQL tool. </p>
+ <a href="/learn/graphql-client-tool/">
+    <h3 id="graphql-client-tool">GraphQL client tool </h3></a>
+    <p >Details of all the features of the Ballerina GraphQL client tool. </p>
 </div>
 <div class="col-lg-6 col-md-6 col-sm-12 card"  style="margin-right:0px !important;">
  <a href="/learn/asyncapi-tool/">

--- a/learn/guides/graphql-client-tool.md
+++ b/learn/guides/graphql-client-tool.md
@@ -1,20 +1,22 @@
 ---
 layout: ballerina-graphql-support-left-nav-pages-swanlake
-title: GraphQL tool
-description: Check out how the Ballerina GraphQL tool makes it easy for you to start developing a service documented in a GraphQL schema.
+title: GraphQL client tool
+description: Check out how the Ballerina GraphQL client tool makes it easy for you to start developing a service documented in a GraphQL schema.
 keywords: ballerina, programming language, graphql, sdl, schema definition language
-permalink: /learn/graphql-tool/
-active: graphql-tool
+permalink: /learn/graphql-client-tool/
+active: graphql-client-tool
 intro: Every GraphQL service defines a set of types, which describe the set of possible data you can query on that service and when queries come in, they are validated and executed against that schema. 
 redirect_from:
   - /learn/ballerina-graphql-support
   - /learn/ballerina-graphql-support/
   - /learn/graphql-tool
+  - /learn/graphql-tool/
+  - /learn/graphql-client-tool
 --- 
 
-GraphQL schemas of a service are now most often specified using what’s known as the GraphQL SDL (schema definition language). It is also sometimes referred to as just GraphQL schema language. Ballerina GraphQL tool will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. You can generate multiple clients in Ballerina for multiple GraphQL documents for a given GraphQL SDL. It also enables you to generate multiple Ballerina modules for multiple GraphQL projects to work with different GraphQL APIs. 
+GraphQL schemas of a service are now most often specified using what’s known as the GraphQL SDL (schema definition language). It is also sometimes referred to as just GraphQL schema language. Ballerina GraphQL client tool will make it easy for you to generate a client in Ballerina given the GraphQL schema (SDL) and GraphQL queries. You can generate multiple clients in Ballerina for multiple GraphQL documents for a given GraphQL SDL. It also enables you to generate multiple Ballerina modules for multiple GraphQL projects to work with different GraphQL APIs. 
 
-The Ballerina GraphQL tool support provides the following capabilities.
+The Ballerina GraphQL client tool support provides the following capabilities.
 
 > **Prerequisites:** Install the [GraphQL Foundation VSCode plugin](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) and the latest [Ballerina Swan Lake distribution](https://ballerina.io/downloads/).
 


### PR DESCRIPTION
## Purpose
Rename the GraphQL guide.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
