### PR TITLE
Fix automatically hide expired events

### DIFF
--- a/community-new.html
+++ b/community-new.html
@@ -657,22 +657,6 @@ td.cEventDateContainer{
             No upcoming events for this month. 
         </div> -->
     </div> 
-    <!-- <script>
-        window.setInterval(function() {
-
-var current = new Date();
-var expiry = new Date("2022-02-25T02:00:00")
-
-if (current.getTime() > expiry.getTime()) {
-  $('.bEvent1').hide();
-
-} else if (current.getTime() < expiry.getTime()) {
-  $('.bEvent1').show();
-}
-
-}, 0);
-    </script> -->
-
 </section>
 
 <section  style="padding-bottom: 45px;">

--- a/community-new.html
+++ b/community-new.html
@@ -8,7 +8,7 @@ redirect_from:
 - /community/slack/
 
 ---
-
+<script src="/community/event-date.js"></script>
 <style>
 
  h2 {
@@ -587,7 +587,7 @@ td.cEventDateContainer{
         </table> -->
 
         <table class="cEventTable cConferencesList" style="width:100% !important;">
-            <tr class="event-expiry"  data-expiry="March 24, 2022 19:00:00">	
+            <tr class="bEvent1" style="display: none;" >	
                 <td class="cEventDateContainer cEventDateContainer1">	
                    <p class="cEventDate1 cEventDateNum dateDisplay" style="margin-bottom: 15px;">May 25, 2022</p>	
                    <p class="cEventDate1 dateDisplay" style="margin-bottom: 15px">Wed., 6.30 p.m. PDT</p>	
@@ -602,7 +602,7 @@ td.cEventDateContainer{
                 </td>	
                 <td class="cEventURL"><a class="cEventRegistration" href="https://www.meetup.com/sfjava/events/284669431" target="_blank" style="text-align: center;">More info</a></td>	
             </tr>
-            <tr class="event-expiry"  data-expiry="March 24, 2022 19:00:00">	
+            <tr class="bEvent2" style="display: none;" >	
                 <td class="cEventDateContainer cEventDateContainer1">	
                    <p class="cEventDate1 cEventDateNum dateDisplay" style="margin-bottom: 15px;">June 8, 2022</p>	
                    <p class="cEventDate1 dateDisplay" style="margin-bottom: 15px">Wed., 6.10 a.m. EDT</p>	
@@ -657,6 +657,21 @@ td.cEventDateContainer{
             No upcoming events for this month. 
         </div> -->
     </div> 
+    <!-- <script>
+        window.setInterval(function() {
+
+var current = new Date();
+var expiry = new Date("2022-02-25T02:00:00")
+
+if (current.getTime() > expiry.getTime()) {
+  $('.bEvent1').hide();
+
+} else if (current.getTime() < expiry.getTime()) {
+  $('.bEvent1').show();
+}
+
+}, 0);
+    </script> -->
 
 </section>
 

--- a/community/event-date.js
+++ b/community/event-date.js
@@ -1,0 +1,31 @@
+window.setInterval(function() {
+   /* Time Format - YYYY-MM-DDTHH:MM:SS.0000TimeZone -> Ex 2022-05-25T18:30:00.0000-07:00 */
+   /* Please make sure to add correct time zone */
+   
+   /* Start expire date for event 1 */
+    var current = new Date();
+    var expiry = new Date("2022-05-25T18:30:00.0000-07:00")
+  
+    if (current.getTime() > expiry.getTime()) {
+      $('.bEvent1').hide();
+  
+    } else if (current.getTime() < expiry.getTime()) {
+      $('.bEvent1').show();
+    }
+    /* Finish expire date for event 1 */
+    /* Start expire date for event 2 */
+    var current = new Date();
+    var expiry = new Date("2022-06-08T06:10:00.0000-04:00")
+
+    if (current.getTime() > expiry.getTime()) {
+     $('.bEvent2').hide();
+
+    } else if (current.getTime() < expiry.getTime()) {
+     $('.bEvent2').show();
+    }
+    /* Finish expire date for event 2 */
+  
+}, 0);
+
+
+

--- a/community/events.html
+++ b/community/events.html
@@ -10,7 +10,7 @@ redirect_from:
 
 ---
 
-
+<script src="/community/event-date.js"></script>
 <style>
     .text-feild{
         padding: 20px 20px;
@@ -356,7 +356,7 @@ a.cTopLink{display:none !important;}
         
         <div id="upcoming-event" class="tab-pane fade in active">
             <table class="cEventTable cConferencesList" style="width:100% !important;">
-                <tr class="event-expiry"  data-expiry="March 24, 2022 19:00:00">	
+                <tr class="bEvent1" style="display: none;">	
                     <td class="cEventDateContainer cEventDateContainer1">	
                        <p class="cEventDate1 cEventDateNum dateDisplay" style="margin-bottom: 15px;">May 25, 2022</p>	
                        <p class="cEventDate1 dateDisplay" style="margin-bottom: 15px">Wed., 6.30 p.m. PDT</p>	
@@ -371,7 +371,7 @@ a.cTopLink{display:none !important;}
                     </td>	
                     <td class="cEventURL"><a class="cEventRegistration" href="https://www.meetup.com/sfjava/events/284669431" target="_blank" style="text-align: center;">More info</a></td>	
                 </tr>
-                 <tr class="event-expiry"  data-expiry="March 24, 2022 19:00:00">	
+                <tr class="bEvent2" style="display: none;" >	
                     <td class="cEventDateContainer cEventDateContainer1">	
                        <p class="cEventDate1 cEventDateNum dateDisplay" style="margin-bottom: 15px;">June 8, 2022</p>	
                        <p class="cEventDate1 dateDisplay" style="margin-bottom: 15px">Wed., 6.10 a.m. EDT</p>	
@@ -630,6 +630,7 @@ a.cTopLink{display:none !important;}
     @media only screen and (min-width: 992px) {
     td.cEventDetail{
         padding-left: 0px !important;
+        padding-right: 10px !important;
     }
     }
    

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@ keywords: ballerina, ballerinalang, cloud native, microservices, integration, pr
 <link href="https://fonts.googleapis.com/css?family=Special+Elite&display=swap" rel="stylesheet"/>
 <link rel="stylesheet" href="/css/home-page-2020.css"/>
 <link rel="stylesheet" href="/css/prism.css">
+<script src="/community/event-date.js"></script>
 
 <style>
 .nav-tabs > li.active > a, .nav-tabs > li.active > a:focus, .nav-tabs > li.active > a:hover {
@@ -830,22 +831,22 @@ service on new kafka:Listener(kafkaEndpoint, consumerConfigs) {
   
       <div class="row">
           <table class="cEventTable cConferencesList" style="width:100% !important;">
-           <tr class="event-expiry"  data-expiry="February 5, 2021 12:00:00">	
-            <td class="cEventDateContainer cEventDateContainer1" style="border-bottom: 0 !important;">	
+           <tr class="bEvent1"  style="display: none;">	
+            <td class="cEventDateContainer cEventDateContainer1" >	
                <p class="cEventDate1 cEventDateNum dateDisplay" style="margin-bottom: 15px;">May 25, 2022</p>	
                <p class="cEventDate1 dateDisplay" style="margin-bottom: 15px">Wed., 6.30 p.m. PDT</p>	
                <p class="cEventLocation" style="text-align: right;">Online</p>	
             </td>	
-            <td class="cEventDetail" id="eventDetails" style="border-bottom: 0 !important;">	
+            <td class="cEventDetail" id="eventDetails" >	
                <a target="_blank" href="https://www.meetup.com/sfjava/events/284669431">	
                   <p class="cEventName" style="margin-top: -1px;font-size: 18px;">Meetup</p>	
                </a>
                <h5 style="margin-bottom: 18px;">Ballerina: A Language to Develop, Consume and Combine Network Services</h5>		
                <a style="color: #20b6b0 ;font-weight:400;font-size: 16px;" target="_blank" href="https://twitter.com/sameerajayasoma">Sameera Jayasoma</a>, Senior Director, WSO2
             </td>	
-            <td class="cEventURL" style="border-bottom: 0 !important;"><a class="cEventRegistration" href="https://www.meetup.com/sfjava/events/284669431" target="_blank" style="text-align: center;">More info</a></td>	
+            <td class="cEventURL" ><a class="cEventRegistration" href="https://www.meetup.com/sfjava/events/284669431" target="_blank" style="text-align: center;">More info</a></td>	
         </tr>
-	<tr class="event-expiry"  data-expiry="February 5, 2021 12:00:00">	
+	     <tr class="bEvent2"  style="display: none;">	
             <td class="cEventDateContainer cEventDateContainer1" style="border-bottom: 0 !important;">	
                <p class="cEventDate1 cEventDateNum dateDisplay" style="margin-bottom: 15px;">June 8, 2022</p>	
                <p class="cEventDate1 dateDisplay" style="margin-bottom: 15px">Wed., 6.10 a.m. EDT</p>	


### PR DESCRIPTION
## Purpose
> This will automate hide the expired event once event start at given time zone.

> Fixes #3976 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
