### PR TITLE
Remove Inconsistent Match Command Description for Single Statements in Style Guide

### DIFF
--- a/learn/references/style-guide/coding-conventions/statements.md
+++ b/learn/references/style-guide/coding-conventions/statements.md
@@ -73,7 +73,6 @@ if inProperSallaryRange {
 
 * Block indent each pattern clause in its own line.
 * Keep a single space before and after the `=>` sign.
-* If a pattern clause contains only one statement, place it in the same line as the pattern clause enclosing it with curly braces.
 
 **Example,**
 


### PR DESCRIPTION
## Purpose
Removing the incorrect bullet point regarding the pattern clauses with one statement in match command style guide.
Fixes #4453 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
