### PR TITLE
Improve `Get started` Guide Package References

### DIFF
--- a/learn/get-started/get-started-with-ballerina.md
+++ b/learn/get-started/get-started-with-ballerina.md
@@ -37,9 +37,15 @@ $ bal
 $ bal version
 ```
 
-## Create a new project
+## Create a new project with a package
 
-Let's write a Ballerina program, which prints `Hello, World!`. Use the `bal new` command to create a new Ballerina project. 
+Ballerina code is organized in a single shareable unit called a package. A package is a collection of modules, and a module is a collection of Ballerina source files, test files, and resources. 
+
+Ballerina packages are encapsulated in projects. It is common in small projects to have only one (default) module in a package. As a result, the default module’s content is placed directly in the root of the package directory.
+
+>**Info:** For more information, see [Organize Ballerina code](/learn/organize-ballerina-code/).
+
+Let's write a Ballerina program, which prints `Hello, World!`. Use the `bal new` command to create a new Ballerina project with the default package. 
 
 ```bash
 $ bal new greeter

--- a/learn/get-started/get-started-with-ballerina.md
+++ b/learn/get-started/get-started-with-ballerina.md
@@ -37,7 +37,7 @@ $ bal
 $ bal version
 ```
 
-## Create a new project with a package
+## Create a new project
 
 Ballerina code is organized in a single shareable unit called a package. A package is a collection of modules, and a module is a collection of Ballerina source files, test files, and resources. 
 
@@ -51,7 +51,7 @@ Let's write a Ballerina program, which prints `Hello, World!`. Use the `bal new`
 $ bal new greeter
 ```
 
-This command creates a new directory called `greeter` with the content below.
+This command creates a new package called `greeter` with the content below inside your project.
 
 ```bash
 greeter/
@@ -59,7 +59,7 @@ greeter/
 └── main.bal
 ```
 
-- The `Ballerina.toml` file contains metadata, which describes your project. Also, the `bal` tool uses the `Ballerina.toml` file to identify the root of a project.
+- The `Ballerina.toml` file contains metadata, which describes your package. Also, the `bal` tool uses the `Ballerina.toml` file to identify the root of a package.
 - The `main.bal` file is a source file and it contains the Ballerina code that prints `Hello, World!` to the console. You can add any number of source files into the `greeter` directory.
 
 ## Say `Hello, World!`
@@ -82,9 +82,9 @@ In this code:
 
 >**Info:** To learn more about the language, see [Language basics](/learn/language-basics/). 
 
-## Run the project
+## Run the package
 
-Run `bal run` in your terminal to run this project.
+Run `bal run` in your terminal to run this package.
 
 ```bash
 $ bal run
@@ -147,9 +147,9 @@ Let's take a moment to digest the new constructs in this code:
 
 >**Info:** To learn more about services, see [Network interaction](/learn/distinctive-language-features/network-interaction/). 
 
-## Running the simple REST API
+## Run the simple REST API
 
-Let's run this project in your terminal:
+Let's run this package in your terminal:
 
 ```bash
 $ bal run

--- a/learn/get-started/write-a-restful-api-with-ballerina.md
+++ b/learn/get-started/write-a-restful-api-with-ballerina.md
@@ -125,9 +125,9 @@ public type ErrorMsg record {|
 - It is always a good practice to document your interfaces. However, this example has omitted documentation for brevity. Nevertheless, any production-ready API interface must include API documentation. 
 - You can also try generating an OpenAPI specification for the written service by executing the following command, which creates a `yaml` file in the current folder.
 
-## Create the service project 
+## Create the service 
 
-Ballerina uses projects to group code. You need to create a Ballerina project and write the business logic in it. In the terminal, execute the command below to create the Ballerina project for the API implementation.
+Ballerina uses packages to group code. You need to create a Ballerina package and write the business logic in it. In the terminal, execute the command below to create the Ballerina package for the API implementation.
 
 > **Info:** For more information on Ballerina projects, see [Organizing Ballerina code](/learn/organizing-ballerina-code/).
 
@@ -323,7 +323,7 @@ In this code:
 
 ## Run the service
 
-In the terminal, navigate to the `covid19` directory, and execute the command below to run the service project.
+In the terminal, navigate to the `covid19` directory, and execute the command below to run the service.
 
 > **Info**: The console should have warning logs related to the isolatedness of resources. It is a built-in service concurrency safety feature of Ballerina.
 


### PR DESCRIPTION
## Purpose
Improve `Get started` guide package references.
> Fixes #4371 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
