### PR TITLE
Fix archived release notes link issue

### DIFF
--- a/_data/releasenotes.yml
+++ b/_data/releasenotes.yml
@@ -2,19 +2,19 @@
   url: '#'
   sublinks:
     - title: 2201.0.4 (Swan Lake)
-      url: /downloads/swan-lake-release-notes/2201-0-4
+      url: /downloads/swan-lake-release-notes/2201.0.4
       active: 2201-0-4
     - title: 2201.0.3 (Swan Lake)
-      url: /downloads/swan-lake-release-notes/2201-0-3
+      url: /downloads/swan-lake-release-notes/2201.0.3
       active: 2201-0-3
     - title: 2201.0.2 (Swan Lake)
-      url: /downloads/swan-lake-release-notes/2201-0-2
+      url: /downloads/swan-lake-release-notes/2201.0.2
       active: 2201-0-2
     - title: 2201.0.1 (Swan Lake)
-      url: /downloads/swan-lake-release-notes/2201-0-1
+      url: /downloads/swan-lake-release-notes/2201.0.1
       active: 2201-0-1
     - title: 2201.0.0 (Swan Lake)
-      url: /downloads/swan-lake-release-notes/2201-0-0
+      url: /downloads/swan-lake-release-notes/2201.0.0
       active: 2201-0-0
     - title: Swan Lake Beta 6
       url: /downloads/swan-lake-release-notes/swan-lake-beta6

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -5,6 +5,7 @@ permalink: /downloads/swan-lake-release-notes/2201-0-0/
 active: 2201-0-0
 redirect_from: 
     - /downloads/swan-lake-release-notes/2201-0-0
+    - /downloads/swan-lake-release-notes/2201.0.0/
     - /downloads/swan-lake-release-notes/2201-0-0-swan-lake/
     - /downloads/swan-lake-release-notes/2201-0-0-swan-lake
 ---

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.1/RELEASE_NOTE.md
@@ -5,6 +5,7 @@ permalink: /downloads/swan-lake-release-notes/2201-0-1/
 active: 2201-0-1
 redirect_from: 
     - /downloads/swan-lake-release-notes/2201-0-1
+    - /downloads/swan-lake-release-notes/2201.0.1/
     - /downloads/swan-lake-release-notes/2201-0-1-swan-lake/
     - /downloads/swan-lake-release-notes/2201-0-1-swan-lake
 ---

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.2/RELEASE_NOTE.md
@@ -7,6 +7,7 @@ redirect_from:
     - /downloads/swan-lake-release-notes/2201-0-2-swan-lake/
     - /downloads/swan-lake-release-notes/2201-0-2-swan-lake
     - /downloads/swan-lake-release-notes/2201-0-2
+    - /downloads/swan-lake-release-notes/2201.0.2/
 ---
 
 ## Overview of Ballerina Swan Lake 2201.0.2

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.3/RELEASE_NOTE.md
@@ -5,6 +5,7 @@ permalink: /downloads/swan-lake-release-notes/2201-0-3/
 active: 2201-0-3
 redirect_from: 
     - /downloads/swan-lake-release-notes/2201-0-3
+    - /downloads/swan-lake-release-notes/2201.0.3/
     - /downloads/swan-lake-release-notes/2201-0-3-swan-lake/
     - /downloads/swan-lake-release-notes/2201-0-3-swan-lake
 ---

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.4/RELEASE_NOTE.md
@@ -5,6 +5,7 @@ permalink: /downloads/swan-lake-release-notes/2201-0-4/
 active: 2201-0-4
 redirect_from: 
     - /downloads/swan-lake-release-notes/2201-0-4
+    - /downloads/swan-lake-release-notes/2201.0.4/
     - /downloads/swan-lake-release-notes/
     - /downloads/swan-lake-release-notes
     - /downloads/swan-lake-release-notes/2201-0-4-swan-lake/

--- a/hbs/archived_list.hbs
+++ b/hbs/archived_list.hbs
@@ -29,7 +29,7 @@
     </div>
 </div>
 <div class="cArchivedReleaseNotes">
-    <a class="cArchivedReleaseNotesLink" id="{{version}}notes" class="collapse">RELEASE NOTES</a>
+    <a class="cArchivedReleaseNotesLink" id="{{version}}notes" class="collapse" href="/downloads/swan-lake-release-notes/{{version}}">RELEASE NOTES</a>
     <!--<div id="{{{releasenotesdiv version}}}" class="collapse">
         Loading...
     </div>-->


### PR DESCRIPTION
## Purpose
> Links were not worked, So I fixed that as follows
> Fixes #4086
https://user-images.githubusercontent.com/73055030/171575406-896eb770-0108-4558-a36d-7f10f69c22d0.mov


- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
