### PR TITLE
Add 2201.0.3 to Archived Versions

### DIFF
--- a/_data/swanlake_release_notes_versions.json
+++ b/_data/swanlake_release_notes_versions.json
@@ -420,5 +420,25 @@
       ],
       "api-docs": "ballerina-api-docs-2201.0.2.zip",
       "release-notes": "ballerina-release-notes-2201.0.2.md"
+   },
+   {
+      "version":"2201.0.3",
+      "short-version":"2201.0.3",
+      "display-version":"2201.0.3 (Swan Lake)",
+      "release-date":"2022-04-22",
+      "windows-installer":"ballerina-2201.0.3-swan-lake-windows-x64.msi",
+      "windows-installer-size":"154mb",
+      "linux-installer":"ballerina-2201.0.3-swan-lake-linux-x64.deb",
+      "linux-installer-size":"179mb",
+      "macos-installer":"ballerina-2201.0.3-swan-lake-macos-x64.pkg",
+      "macos-installer-size":"209mb",
+      "rpm-installer":"ballerina-2201.0.3-swan-lake-linux-x64.rpm",
+      "rpm-installer-size":"213mb",
+      "other-artefacts":[
+         "ballerina-2201.0.3-swan-lake.zip",
+         "ballerina-metrics-grafana-dashboard-prometheus.json"
+      ],
+      "api-docs":"ballerina-api-docs-2201.0.3.zip",
+      "release-notes":"ballerina-release-notes-2201.0.3.md"
    }
 ]


### PR DESCRIPTION
## Purpose
Add 2201.0.3 to archived versions.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
