### PR TITLE
Update the `Downloads` Page for 2201.1.0

### DIFF
--- a/download.html
+++ b/download.html
@@ -31,19 +31,19 @@ redirect_from:
                <!-- <p>For more details, see the <a href="https://blog.ballerina.io/posts/2022-02-01-announcing-ballerina-2201.0.0-swan-lake/">Swan Lake GA release announcement </a> and <a href="/downloads/swan-lake-release-notes/">release note.</a></p><br/>  -->
 					<!-- <h2 id="swanlake">{{ site.data.swanlake-latest.metadata.display-version }} <span id="versionInfo">({{ site.data.swanlake-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2> -->
 					<div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;">
-						<p><strong>If you are already using Ballerina 2201.0.0 (Swan Lake Update 1)</strong>, run either of the commands below to directly update to {{ site.data.swanlake-latest.metadata.display-version }} using the <a href="/learn/tooling-guide/cli-tools/update-tool/">Ballerina Update Tool.</a></p><br> 
-                  <p><code class="highlighter-rouge language-plaintext">bal dist update</code> (or <code class="highlighter-rouge language-plaintext">bal dist pull {{ site.data.swanlake-latest.metadata.version }})</code></p>
+						<p><strong>If you are already using Ballerina 2201.0.0 (Swan Lake)</strong>, run the command below to directly update to {{ site.data.swanlake-latest.metadata.display-version }} using the <a href="/learn/tooling-guide/cli-tools/update-tool/">Ballerina Update Tool.</a></p><br> 
+                  <p><code>bal dist pull {{ site.data.swanlake-latest.metadata.version }}</code></p>
                   </br> 
-                  <p><strong>If you are using a version below 2201.0.0 (Swan Lake Update 1)</strong>, run the commands below to update to {{ site.data.swanlake-latest.metadata.display-version }}.</p><br> 
+                  <p><strong>If you are using a version below 2201.0.0 (Swan Lake)</strong>, run the commands below to update to {{ site.data.swanlake-latest.metadata.display-version }}.</p><br> 
                   <p>1. Run <code class="highlighter-rouge language-plaintext">bal update</code> to get the latest version of the update tool.</p> 
                   <!-- <p><pre>bal update</pre></p> -->
                   <!-- <p>2. Run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p> -->
-                  <p>2. Run <code class="highlighter-rouge language-plaintext">bal dist update</code> (or <code class="highlighter-rouge language-plaintext">bal dist pull {{ site.data.swanlake-latest.metadata.version }}</code>) to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>
+                  <p>2. Run <code class="highlighter-rouge language-plaintext">bal dist pull {{ site.data.swanlake-latest.metadata.version }}</code> to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>
                   <!-- <p><pre>bal dist update</pre></p> -->
                   <!-- <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	 -->
                   <!-- <p>If you already ran <code class="highlighter-rouge language-plaintext">bal dist update</code> (or <code class="highlighter-rouge language-plaintext">bal dist pull {{ site.data.swanlake-latest.metadata.display-version }})</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Updating Ballerina</a> to recover your installation.</p> -->
                   </br> 
-                  <p>However, if you are using a version below 2201.0.0 (Swan Lake Update 1) and if you already ran <code class="highlighter-rouge language-plaintext">bal dist update</code> (or <code class="highlighter-rouge language-plaintext">bal dist pull {{ site.data.swanlake-latest.metadata.version }})</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Troubleshooting</a> to recover your installation.</p>
+                  <p>However, if you are using a version below 2201.0.0 (Swan Lake) and if you already ran <code class="highlighter-rouge language-plaintext">bal dist update</code> (or <code class="highlighter-rouge language-plaintext">bal dist pull {{ site.data.swanlake-latest.metadata.version }})</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Troubleshooting</a> to recover your installation.</p>
                </div>
             </br> 
          </div> 

--- a/download.html
+++ b/download.html
@@ -31,10 +31,10 @@ redirect_from:
                <!-- <p>For more details, see the <a href="https://blog.ballerina.io/posts/2022-02-01-announcing-ballerina-2201.0.0-swan-lake/">Swan Lake GA release announcement </a> and <a href="/downloads/swan-lake-release-notes/">release note.</a></p><br/>  -->
 					<!-- <h2 id="swanlake">{{ site.data.swanlake-latest.metadata.display-version }} <span id="versionInfo">({{ site.data.swanlake-latest.metadata.release-date | date: "%B %e, %Y" }})</span></h2> -->
 					<div class="alert alert-info" style="border: 1px solid #20b6b0; background: #fff;">
-						<p><strong>If you are already using Ballerina 2201.0.0 (Swan Lake)</strong>, run either of the commands below to directly update to {{ site.data.swanlake-latest.metadata.display-version }} using the <a href="/learn/tooling-guide/cli-tools/update-tool/">Ballerina Update Tool.</a></p><br> 
+						<p><strong>If you are already using Ballerina 2201.0.0 (Swan Lake Update 1)</strong>, run either of the commands below to directly update to {{ site.data.swanlake-latest.metadata.display-version }} using the <a href="/learn/tooling-guide/cli-tools/update-tool/">Ballerina Update Tool.</a></p><br> 
                   <p><code class="highlighter-rouge language-plaintext">bal dist update</code> (or <code class="highlighter-rouge language-plaintext">bal dist pull {{ site.data.swanlake-latest.metadata.version }})</code></p>
                   </br> 
-                  <p><strong>If you are using a version below 2201.0.0 (Swan Lake)</strong>, run the commands below to update to {{ site.data.swanlake-latest.metadata.display-version }}.</p><br> 
+                  <p><strong>If you are using a version below 2201.0.0 (Swan Lake Update 1)</strong>, run the commands below to update to {{ site.data.swanlake-latest.metadata.display-version }}.</p><br> 
                   <p>1. Run <code class="highlighter-rouge language-plaintext">bal update</code> to get the latest version of the update tool.</p> 
                   <!-- <p><pre>bal update</pre></p> -->
                   <!-- <p>2. Run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p> -->
@@ -43,7 +43,7 @@ redirect_from:
                   <!-- <p>Next, run the command below to update your Ballerina version to {{ site.data.swanlake-latest.metadata.display-version }}.</p>	 -->
                   <!-- <p>If you already ran <code class="highlighter-rouge language-plaintext">bal dist update</code> (or <code class="highlighter-rouge language-plaintext">bal dist pull {{ site.data.swanlake-latest.metadata.display-version }})</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Updating Ballerina</a> to recover your installation.</p> -->
                   </br> 
-                  <p>However, if you are using a version below 2201.0.0 (Swan Lake) and if you already ran <code class="highlighter-rouge language-plaintext">bal dist update</code> (or <code class="highlighter-rouge language-plaintext">bal dist pull {{ site.data.swanlake-latest.metadata.version }})</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Troubleshooting</a> to recover your installation.</p>
+                  <p>However, if you are using a version below 2201.0.0 (Swan Lake Update 1) and if you already ran <code class="highlighter-rouge language-plaintext">bal dist update</code> (or <code class="highlighter-rouge language-plaintext">bal dist pull {{ site.data.swanlake-latest.metadata.version }})</code> before <code class="highlighter-rouge language-plaintext">bal update</code>, see <a href="/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting">Troubleshooting</a> to recover your installation.</p>
                </div>
             </br> 
          </div> 


### PR DESCRIPTION
## Purpose
Update the `Downloads` page for 2201.1.0.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
