### PR TITLE
Remove the Version Picker in Release Notes Layout

### DIFF
--- a/_layouts/ballerina-left-nav-release-notes.html
+++ b/_layouts/ballerina-left-nav-release-notes.html
@@ -112,6 +112,6 @@
 
      </script>
 
-
+<style>.cVersionContainer{display: none !important;}</style>
    </body>
 </html>


### PR DESCRIPTION
## Purpose
Remove the version picker in the release notes layout.
> Fixes #4513 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
