### PR TITLE
Add no event banner

### DIFF
--- a/community-new.html
+++ b/community-new.html
@@ -653,9 +653,9 @@ td.cEventDateContainer{
         <!-- <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
             No upcoming events for this month. For details on our upcoming Monthly Tech Talks, please see  <a href="/community/monthly-tech-talk/" target="_blank" style="color: #20b6b0; text-decoration: none; text-align: right;font-weight: 400;font-size: 18px; ">Monthly Tech Talk</a>
         </div> -->
-        <!-- <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
+        <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
             No upcoming events for this month. 
-        </div> -->
+        </div>
     </div> 
 </section>
 

--- a/community/events.html
+++ b/community/events.html
@@ -388,9 +388,9 @@ a.cTopLink{display:none !important;}
                 </tr>
 
             </table>
-            <!-- <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
+            <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
                 No upcoming events for this month. 
-            </div> -->
+            </div>
             <!-- <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
                     No upcoming events for this month. For details on our upcoming Monthly Tech Talks, please see  <a href="/community/monthly-tech-talk/" target="_blank" style="color: #20b6b0; text-decoration: none; text-align: right;font-weight: 400;font-size: 18px; ">Monthly Tech Talk</a>
                 </div> -->

--- a/index.html
+++ b/index.html
@@ -864,11 +864,11 @@ service on new kafka:Listener(kafkaEndpoint, consumerConfigs) {
           </table>
           
       </div> 
-      <!-- <div class="col-sm-12 col-md-12 cColCOntent">
+      <div class="col-sm-12 col-md-12 cColCOntent">
          <div class="col-lg-12 col-md-12 col-sm-12 eventBanner">
             No upcoming events for this month. 
          </div>
-      </div> -->
+      </div>
    <div class="clearfix"></div></br>
      
    </div>


### PR DESCRIPTION
## Purpose
> Update the no event banner on events section since there is no event available at the moment. It's just uncomment code part in that section
![image](https://user-images.githubusercontent.com/73055030/172989742-a49500c3-7cb6-4cb0-b71e-c1ea05fc22d8.png)

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
