### PR TITLE
Add the 1.2.30 Release Note

### DIFF
--- a/_data/releasenotes.yml
+++ b/_data/releasenotes.yml
@@ -80,6 +80,9 @@
 - title: 1.2 release notes
   url: '#'
   sublinks:
+    - title: 1.2.30
+      url: /downloads/1.2.x-release-notes/1.2.30
+      active: 1.2.30
     - title: 1.2.29
       url: /downloads/1.2.x-release-notes/1.2.29
       active: 1.2.29

--- a/downloads/1.2.x-release-notes/1.2.29.md
+++ b/downloads/1.2.x-release-notes/1.2.29.md
@@ -4,7 +4,6 @@ title: 1.2.29
 permalink: /downloads/1.2.x-release-notes/1.2.29/
 active: 1.2.29
 redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.29

--- a/downloads/1.2.x-release-notes/1.2.30.md
+++ b/downloads/1.2.x-release-notes/1.2.30.md
@@ -1,0 +1,35 @@
+---
+layout: ballerina-left-nav-release-notes
+title: 1.2.30
+permalink: /downloads/1.2.x-release-notes/1.2.30/
+active: 1.2.30
+redirect_from:
+    - /downloads/1.2.x-release-notes/
+---
+
+### Overview of jBallerina 1.2.30
+
+The jBallerina 1.2.30 patch release improves upon the 1.2.29 release by addressing the [issues] below:
+- []()
+- []()
+
+You can use the update tool to update to jBallerina 1.2.30 as follows.
+
+**For existing users:**
+If you are already using jBallerina version 1.2.14, or above, you can directly update your distribution to jBallerina 1.2.30 by executing the following command:
+
+> $ bal dist update
+
+However, if you are using
+
+- jBallerina 1.2.0 to 1.2.13, run `ballerina dist update` to update
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.30` to update
+- a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
+
+**For new users:**
+If you have not installed jBallerina, then download the [installers](https://ballerina.io/downloads/) to install.
+
+<style>.cGitButtonContainer, .cBallerinaTocContainer {display:none;}</style>
+
+
+


### PR DESCRIPTION
## Purpose
Add the 1.2.30 release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
