### PR TITLE
Remove Google Dev Group from `Get involved`

### DIFF
--- a/community-new.html
+++ b/community-new.html
@@ -871,13 +871,6 @@ td.cEventDateContainer{
        <p>Want to talk about Ballerina at your local tech meetup? Reach us at <a class="getStartLinks" href="mailto:contact@ballerina.io">contact@ballerina.io</a>, and we will help you with any presentation content.</p>
            
         </div>
-        <!-- <div class="col-lg-4 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
-            <span class="bookMarkOnPage" id="join-dev-google-group"></span>
-          
-                <h4 id="join-dev-google-group-title" class="gTitle1">Join the Dev Google Group </h4>
-                <p>Get invovled in any technical discussions by joining the <a class="getStartLinks" target="_blank" href="https://groups.google.com/g/ballerina-dev">Ballerina Dev Google group</a>.</p>
-           
-        </div> -->
     </div>
 
 </section>

--- a/community-new.html
+++ b/community-new.html
@@ -871,13 +871,13 @@ td.cEventDateContainer{
        <p>Want to talk about Ballerina at your local tech meetup? Reach us at <a class="getStartLinks" href="mailto:contact@ballerina.io">contact@ballerina.io</a>, and we will help you with any presentation content.</p>
            
         </div>
-        <div class="col-lg-4 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
+        <!-- <div class="col-lg-4 col-md-6 col-sm-12 card" style="margin-right:0px !important;">
             <span class="bookMarkOnPage" id="join-dev-google-group"></span>
           
                 <h4 id="join-dev-google-group-title" class="gTitle1">Join the Dev Google Group </h4>
                 <p>Get invovled in any technical discussions by joining the <a class="getStartLinks" target="_blank" href="https://groups.google.com/g/ballerina-dev">Ballerina Dev Google group</a>.</p>
            
-        </div>
+        </div> -->
     </div>
 
 </section>


### PR DESCRIPTION
## Purpose
Remove the Google dev group section from the `Get involved` topic.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
