### PR TITLE
Add workflow to sync artifacts from dev to prod

### DIFF
--- a/.github/workflows/prod_sync_artifacts_on_demand.yml
+++ b/.github/workflows/prod_sync_artifacts_on_demand.yml
@@ -1,0 +1,44 @@
+name: Sync artifacts from dev to prod on demand
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        default: '2201.1.0'
+
+jobs:
+  prod-artifact-sync:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - name: Checkout dev website
+      uses: actions/checkout@v2
+
+    - name: Install jq for json
+      run: sudo apt-get install jq
+
+    - name: Sync artifacts from dev to prod
+      shell: bash
+      env:
+        s3_acc_id: ${{ secrets.S3_ID }}
+        s3_acc_key: ${{ secrets.S3_KEY }}
+      run: |
+        # There is an issue in the LATEST aws/cli.
+        # curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        # unzip -q awscliv2.zip
+        # sudo ./aws/install
+
+        sudo apt-get install python3-setuptools
+        python3 -m pip install --user awscli
+
+        aws configure set aws_access_key_id $s3_acc_id
+        aws configure set aws_secret_access_key $s3_acc_key
+        aws --version
+
+        version=${{ github.event.inputs.version }}
+        echo "extracted release version: $version"
+
+        aws s3 cp s3://dist-dev.ballerina.io/downloads/$version/ s3://dist.ballerina.io/downloads/$version/ --recursive
+


### PR DESCRIPTION
## Purpose
Currently there is a workflow to sync artifacts from dev to prod when there is a release. But it will only trigger when download page has been updated. There might be scenarios that there will be releases which won't be the latest version (eg: current lastest version is `2201.2.0` and we have a release `2201.1.2`.). 

This workflow will sync artifacts from dev to prod on demand for a given version. 

> Fixes #4658

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
