### PR TITLE
Fix the build error in the 2201.1.1 release branch

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.1.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.1.1/RELEASE_NOTE.md
@@ -1,13 +1,13 @@
 ---
 layout: ballerina-left-nav-release-notes
 title: 2201.1.1 (Swan Lake Update 1) 
-permalink: /downloads/swan-lake-release-notes/2201.1.1/
+permalink: /downloads/swan-lake-release-notes/2201-1-1/
 active: 2201.1.1
 redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.1.1
+    - /downloads/swan-lake-release-notes/2201-1-1-swan-lake/
+    - /downloads/swan-lake-release-notes/2201-1-1-swan-lake
+    - /downloads/swan-lake-release-notes/2201-1-1
     - /downloads/swan-lake-release-notes/2201.1.1/
-    - /downloads/swan-lake-release-notes/2201.1.1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.1.1-swan-lake
     - /downloads/swan-lake-release-notes/
     - /downloads/swan-lake-release-notes
 ---


### PR DESCRIPTION
## Purpose
Fix the build error in the 2201.1.1 release branch.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
