### PR TITLE
Fix the release notes link on the `Downloads` page

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.1.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.1.0/RELEASE_NOTE.md
@@ -7,8 +7,6 @@ redirect_from:
     - /downloads/swan-lake-release-notes/2201-1-0
     - /downloads/swan-lake-release-notes/2201-1-0-swan-lake/
     - /downloads/swan-lake-release-notes/2201-1-0-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina 2201.1.0 (Swan Lake Update 1)


### PR DESCRIPTION
## Purpose
Fix the release notes link on the `Downloads` page.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
