### PR TITLE
Remove the dummy text in 0.990 API Docs

### DIFF
--- a/0.990/learn/api-docs/ballerina/index.html
+++ b/0.990/learn/api-docs/ballerina/index.html
@@ -1,0 +1,389 @@
+<head>
+   <meta charset="utf-8">
+   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+   <meta name="author" content="WSO2, Inc.">
+   <link rel="shortcut icon" href="/img/favicon.ico">
+   <title>Ballerina.io - API Docs</title>
+   <script src="//code.jquery.com/jquery-3.6.0.min.js"></script>
+   <link rel="stylesheet" href="/css/latest-bootstrap.css">
+   <!-- Optional theme -->
+   <link rel="stylesheet" href="/css/latest-bootstrap-theme.css">
+   <!-- Latest compiled and minified JavaScript -->
+   <script src="/js/latest-bootstrap.js"></script>
+   <!--      <script src="../../js/jquery-2.1.1.min.js"></script>-->
+   <!--  <script src="../../js/modernizr-2.8.3.min.js"></script>
+      <script type="text/javascript" src="../../js/highlight.pack.js"></script>-->
+   <script src="/js/jquery-2.1.1.min.js"></script>
+   <script src="/js/modernizr-2.8.3.min.js"></script>
+   <script type="text/javascript" src="../../js/highlight.pack.js"></script>
+   <link rel="stylesheet" href="https://use.typekit.net/son4ymv.css"/>
+   <script src="/js/ballerina-common.js"></script>
+   <link rel="stylesheet" href="/css/theme.css" type="text/css" />
+   <link rel="stylesheet" href="/css/theme_extra.css" type="text/css" />
+   <link rel="stylesheet" href="/css/ballerina-io.css">
+   <link rel="stylesheet" href="/css/ballerina-io-docs.css">
+   <link rel="stylesheet" href="/css/bbe-page.css">
+   <script src="docerina-theme/js/jquery.nanoscroller.min.js"></script>
+   <script type="text/javascript">
+      $(document).ready(function(){
+          $('.nano').nanoScroller();
+      });
+   </script>
+   <script>
+      // Current page data
+      var mkdocs_page_name = "ballerina-by-Examples";
+      var mkdocs_page_input_path = "learn/by-example.md";
+      var mkdocs_page_url = "/learn/by-example/";
+   </script>
+</head>
+<body class="cBallerina-io">
+   <div class="row cBallerina-io-top-row">
+      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6"></div>
+      <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cTopLineContainer">
+         <div class="cTopLine"></div>
+      </div>
+   </div>
+   <div class="row cBallerina-io-Nav" id="iMainNavigation">
+   </div>
+   <div class="row cBallerina-io-Logo-row">
+      <div class="container">
+         <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cBallerina-io-Logo-Container">
+            <a class="cLogo" href="/" ><img src="/img/ballerina-logo.svg" alt="Ballerina"/></a>
+         </div>
+      </div>
+   </div>
+   <div class="row cBallerina-io-Gray-row">
+      <div class="container">
+         <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cBallerina-io-Home-Middle-col">
+            <div class="cBallerina-io-breadcrumbs">
+               <div role="navigation" aria-label="breadcrumbs navigation">
+                  <ul class="wy-breadcrumbs">
+                     <li><a href="/">Home</a> &raquo;</li>
+                     <li>Learn &raquo;</li>
+                     <li>API Docs</li>
+                     <li class="wy-breadcrumbs-aside" id="iGitEdit">
+                        <!--        <a href="https://github.com/ballerinalang/ballerina/edit/master/docs/learn/by-example.md"
+                           class="icon icon-github"> Edit on GitHub</a>-->
+                     </li>
+                  </ul>
+               </div>
+            </div>
+            <div class="cBlallerina-io-docs-content-container">
+               <div>
+                  <div>
+                     <div>
+                        <div>
+                           <p>
+                              <link rel="stylesheet" href="/css/philosophy-page.css">
+                              </link>
+                              <link rel="stylesheet" href="/css/bbe-page.css">
+                              </link>
+                           <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cBBEtop">
+                              <h1>API Docs</h1>
+                              <p>The following is a list of language and standard library modules that are available with the distribution.</p>
+                           </div>
+                           <div id="ballerina-by-example">
+                              <div>
+                                 <div class="cLanguageFeaturesContainer">
+                                    <div class="col-xs-12 col-sm-16 col-md-3 col-lg-3 cLanguageFeatures featureSet0">
+                                       <ul>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="auth.html">
+                                             
+                                             ballerina/<span class="bold">auth</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="bir.html">
+                                             
+                                             ballerina/<span class="bold">bir</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="builtin.html">
+                                             
+                                             ballerina/<span class="bold">builtin</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="cache.html">
+                                             
+                                             ballerina/<span class="bold">cache</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="config.html">
+                                             
+                                             ballerina/<span class="bold">config</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="crypto.html">
+                                             
+                                             ballerina/<span class="bold">crypto</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="file.html">
+                                             
+                                             ballerina/<span class="bold">file</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="grpc.html">
+                                             
+                                             ballerina/<span class="bold">grpc</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="h2.html">
+                                             
+                                             ballerina/<span class="bold">h2</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="http.html">
+                                             
+                                             ballerina/<span class="bold">http</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="internal.html">
+                                             
+                                             ballerina/<span class="bold">internal</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="io.html">
+                                             
+                                             ballerina/<span class="bold">io</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="jms.html">
+                                             
+                                             ballerina/<span class="bold">jms</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="llvm.html">
+                                             
+                                             ballerina/<span class="bold">llvm</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="log.html">
+                                             
+                                             ballerina/<span class="bold">log</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="math.html">
+                                             
+                                             ballerina/<span class="bold">math</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="mime.html">
+                                             
+                                             ballerina/<span class="bold">mime</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="mysql.html">
+                                             
+                                             ballerina/<span class="bold">mysql</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="observe.html">
+                                             
+                                             ballerina/<span class="bold">observe</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="reflect.html">
+                                             
+                                             ballerina/<span class="bold">reflect</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="runtime.html">
+                                             
+                                             ballerina/<span class="bold">runtime</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="socket.html">
+                                             
+                                             ballerina/<span class="bold">socket</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="sql.html">
+                                             
+                                             ballerina/<span class="bold">sql</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="streams.html">
+                                             
+                                             ballerina/<span class="bold">streams</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="swagger.html">
+                                             
+                                             ballerina/<span class="bold">swagger</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="system.html">
+                                             
+                                             ballerina/<span class="bold">system</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="task.html">
+                                             
+                                             ballerina/<span class="bold">task</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="test.html">
+                                             
+                                             ballerina/<span class="bold">test</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="time.html">
+                                             
+                                             ballerina/<span class="bold">time</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="transactions.html">
+                                             
+                                             ballerina/<span class="bold">transactions</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                          <li class="cTableTitle">
+                                             <a href="websub.html">
+                                             
+                                             ballerina/<span class="bold">websub</span>
+                                             
+                                             
+                                             </a>
+                                          </li>
+                                          
+                                       </ul>
+                                       <div class="clearfix"></div>
+                                    </div>
+                                 </div>
+                              </div>
+                           </div>
+                        </div>
+                     </div>
+                  </div>
+               </div>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div id="iBallerinaFooter" class="row cBallerina-io-White-row">
+   </div>
+   <script src="/js/theme.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Purpose
Remove the dummy text in 0.990 API Docs.
> Fixes #4970

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
