### PR TITLE
Remove 0.990 dummy text

### DIFF
--- a/0.990/learn/api-docs/ballerina/index.html
+++ b/0.990/learn/api-docs/ballerina/index.html
@@ -81,7 +81,7 @@
                               </link>
                            <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 cBBEtop">
                               <h1>API Docs</h1>
-                              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+                              <p>The following is a list of language and standard library modules that are available with the distribution.</p>
                            </div>
                            <div id="ballerina-by-example">
                               <div>


### PR DESCRIPTION
## Purpose
Remove 0.990 dummy text.
> Fixes #490

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
