### PR TITLE
Fix a minor typo on the `Get involved` section

### DIFF
--- a/.github/scripts/bal_proposals_bot/main.bal
+++ b/.github/scripts/bal_proposals_bot/main.bal
@@ -92,7 +92,7 @@ public function main() returns error? {
         io:println("Repo Count:", repoCount);
     }
 
-    string fileContent = "--- \nlayout: ballerina-inner-page \ntitle: Active proposals \ndescription: This is a collection of active proposals for Ballerina by the Ballerina community. \nintro: The active proposal list for the Ballerina GitHub repositories. \nkeywords: ballerina, community, ballerina community \npermalink: /community/active-proposals \n--- \n" + repoData;
+    string fileContent = "--- \nlayout: ballerina-inner-page \ntitle: Active proposals \ndescription: This is a collection of active proposals for Ballerina by the Ballerina community. \nintro: The active proposals list for the Ballerina GitHub repositories. \nkeywords: ballerina, community, ballerina community \npermalink: /community/active-proposals \n--- \n" + repoData;
     io:println(fileContent);
     check io:fileWriteString("./community/proposals/active-proposals.md", fileContent);
 }


### PR DESCRIPTION
## Purpose
Fix a minor typo on the `Get involved` section.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
