### PR TITLE
Fix code highlighting on the dependencies page

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1,7 +1,7 @@
 ---
 layout: ballerina-platform-specifications-left-nav-pages-swanlake
 title: Ballerina specifications
-intro: Read the Ballerina language spec and other specifications that cover the standard library, built-in language extensions, testing, documentation, and more.
+intro: Read the Ballerina language spec and other specifications, which cover the standard library, built-in language extensions, testing, documentation, and more.
 keywords: ballerina, specifications, spec, language specifications, platform specifications, standard library specifications
 permalink: /learn/platform-specifications/
 redirect_from:
@@ -16,9 +16,9 @@ redirect_from:
   
 ---
 
-As a language that is designed to have multiple implementations, Ballerina semantics are defined by a series of specifications and not by the implementation. Currently, there is only one implementation (i.e., jBallerina that compiles Ballerina to Java bytecodes). Others will follow including a compiler that generates native binaries using LLVM.
+As a language, which is designed to have multiple implementations, Ballerina semantics are defined by a series of specifications and not by the implementation. Currently, there is only one implementation (i.e., jBallerina that compiles Ballerina to Java bytecodes). Others will follow including a compiler, which generates native binaries using LLVM.
 
-Ballerina has a collection of specifications starting with the Ballerina Language Specification. Other specifications (that are yet to be moved to the specification repository or, in some cases, yet to be written) will cover the standard library, built-in language extensions such as security, immutability & deprecation, module and project management, testing, documentation, compiler extensions for cloud, and Ballerina Central.
+Ballerina has a collection of specifications starting with the Ballerina Language Specification. Other specifications (which are yet to be moved to the specification repository or, in some cases, yet to be written) will cover the standard library, built-in language extensions such as security, immutability & deprecation, module and project management, testing, documentation, compiler extensions for cloud, and Ballerina Central.
 
 ## Language specifications 
 
@@ -26,7 +26,7 @@ From the start of 2019, Ballerina  specifications are versioned chronologically 
 
 ### Released specifications
 
-The below are the most stable versions of the lanuguage specification that are in sync with the Ballerina releases.
+The below are the most stable versions of the lanuguage specification, which are in sync with the Ballerina releases.
 
 > **Note:** The changes since previous releases section of the specification identifies the changes that have occurred in each version of the specification.
 
@@ -52,33 +52,33 @@ For previous draft language specifications of a Ballerina release, see the <a ta
 
 | Package | Edition | Current snapshot | Description |
 | ------- | ------- | ---------------- | ----------- |
-| `auth` | Swan Lake | <a target="_blank" href="/spec/auth/">Snapshot</a> | Auth package of Ballerina language that is used for authorization of listeners and clients (HTTP, gRPC, GraphQL, WebSocket, WebSub, etc.). |
-| `cache` | Swan Lake | <a target="_blank" href="/spec/cache/">Snapshot</a> | Cache package of Ballerina language that provides a mechanism to manage frequently accessed data in-memory by using a semi-persistent mapping from key to value. |
-| `email` | Swan Lake | <a target="_blank" href="/spec/email/">Snapshot</a> | Email package of Ballerina language that provides functionalities related to sending/receiving emails via SMTP, POP3, and IMAP protocols. |
-| `file` | Swan Lake | <a target="_blank" href="/spec/file/">Snapshot</a> | File package of Ballerina language that provides APIs to perform file, file path, and directory operations. |
-| `ftp` | Swan Lake | <a target="_blank" href="/spec/ftp/">Snapshot</a> | FTP package of Ballerina language that provides FTP client/listener functionalities to send and receive files by connecting to FTP/SFTP server. |
-| `graphql` | Swan Lake | <a target="_blank" href="/spec/graphql/">Snapshot</a> | GraphQL package of Ballerina language that provides GraphQL server functionalities to produce GraphQL APIs. |
-| `grpc` | Swan Lake | <a target="_blank" href="/spec/grpc/">Snapshot</a> | gRPC package of Ballerina language that provides APIs for gRPC client and server implementation. |
-| `io` | Swan Lake | <a target="_blank" href="/spec/io/">Snapshot</a> | I/O package of Ballerina language that provides file related I/O operations. |
-| `http` | Swan Lake | <a target="_blank" href="/spec/http/">Snapshot</a> | HTTP package of Ballerina language that provides HTTP client-server functionalities to produce and consume HTTP APIs. |
-| `jwt` | Swan Lake | <a target="_blank" href="/spec/jwt/">Snapshot</a> | JWT package of Ballerina language that is used for authorization of listeners and clients (HTTP, gRPC, GraphQL, WebSocket, WebSub, etc.). |
-| `log` | Swan Lake | <a target="_blank" href="/spec/log/">Snapshot</a> | Log package of Ballerina language that provides APIs to log information when running applications. |
-| `mime` | Swan Lake | <a target="_blank" href="/spec/mime/">Snapshot</a> | MIME package of Ballerina language that provides a set of APIs to work with messages that follow the Multipurpose Internet Mail Extensions (MIME) specification as specified in the RFC 2045 standard. |
-| `oauth2` | Swan Lake | <a target="_blank" href="/spec/oauth2/">Snapshot</a> | OAuth2 package of Ballerina language that is used for authorization of listeners and clients (HTTP, gRPC, GraphQL, WebSocket, WebSub, etc.). |
-| `os` | Swan Lake | <a target="_blank" href="/spec/os/">Snapshot</a> | OS package of Ballerina language that provides APIs to retrieve information about the operating system and its current users. |
-| `protobuf` | Swan Lake | <a target="_blank" href="/spec/protobuf/">Snapshot</a> | Protobuf package of Ballerina language that provides APIs to represent a set of pre-defined protobuf types. |
-| `random` | Swan Lake | <a target="_blank" href="/spec/random/">Snapshot</a> | Random package of Ballerina language that provides APIs to generate pseudo-random numbers. |
-| `regex` | Swan Lake | <a target="_blank" href="/spec/regex/">Snapshot</a> | Regex package of Ballerina language that provides functionalities such as matching, replacing and splitting strings based on regular expressions. |
-| `sql` | Swan Lake | <a target="_blank" href="/spec/sql/">Snapshot</a> | SQL package of Ballerina language that provides the generic interface and functionality to interact with a SQL database. |
-| `task` | Swan Lake | <a target="_blank" href="/spec/task/">Snapshot</a> | Task package of Ballerina language that provides APIs to schedule a Ballerina job either once or periodically and manage the execution of those jobs. |
-| `tcp` | Swan Lake | <a target="_blank" href="/spec/tcp/">Snapshot</a> | TCP package of Ballerina language that provides TCP client-server functionalities. |
-| `time` | Swan Lake | <a target="_blank" href="/spec/time/">Snapshot</a> | Time package of Ballerina language that provides time generation and conversion APIs. |
-| `udp` | Swan Lake | <a target="_blank" href="/spec/udp/">Snapshot</a> | UDP package of Ballerina language that provides UDP client-server functionalities. |
-| `uuid` | Swan Lake | <a target="_blank" href="/spec/uuid/">Snapshot</a> | UUID package of Ballerina language that provides APIs to generate UUIDs based on the RFC 4122. |
-| `websocket` | Swan Lake | <a target="_blank" href="/spec/websocket/">Snapshot</a> | WebSocket package of Ballerina language that provides WebSocket client-server functionalities. |
-| `websub` | Swan Lake | <a target="_blank" href="/spec/websub/">Snapshot</a> | WebSub package of Ballerina language that provides WebSub compliant subscriber related functionalities. |
-| `webusuhub` | Swan Lake | <a target="_blank" href="/spec/websubhub/">Snapshot</a> | WebSubHub package of Ballerina language that provides WebSub compliant hub and publisher related functionalities. |
-| `xmldata` | Swan Lake | <a target="_blank" href="/spec/xmldata/">Snapshot</a> | Xmldata package of Ballerina language that provides APIs to perform conversions between XML and JSON/Ballerina records. |
+| `auth` | Swan Lake | <a target="_blank" href="/spec/auth/">Snapshot</a> | Auth package of Ballerina language, which is used for authorization of listeners and clients (HTTP, gRPC, GraphQL, WebSocket, WebSub, etc.). |
+| `cache` | Swan Lake | <a target="_blank" href="/spec/cache/">Snapshot</a> | Cache package of Ballerina language, which provides a mechanism to manage frequently accessed data in-memory by using a semi-persistent mapping from key to value. |
+| `email` | Swan Lake | <a target="_blank" href="/spec/email/">Snapshot</a> | Email package of Ballerina language, which provides functionalities related to sending/receiving emails via SMTP, POP3, and IMAP protocols. |
+| `file` | Swan Lake | <a target="_blank" href="/spec/file/">Snapshot</a> | File package of Ballerina language, which provides APIs to perform file, file path, and directory operations. |
+| `ftp` | Swan Lake | <a target="_blank" href="/spec/ftp/">Snapshot</a> | FTP package of Ballerina language, which provides FTP client/listener functionalities to send and receive files by connecting to FTP/SFTP server. |
+| `graphql` | Swan Lake | <a target="_blank" href="/spec/graphql/">Snapshot</a> | GraphQL package of Ballerina language, which provides GraphQL server functionalities to produce GraphQL APIs. |
+| `grpc` | Swan Lake | <a target="_blank" href="/spec/grpc/">Snapshot</a> | gRPC package of Ballerina language, which provides APIs for gRPC client and server implementation. |
+| `io` | Swan Lake | <a target="_blank" href="/spec/io/">Snapshot</a> | I/O package of Ballerina language, which provides file related I/O operations. |
+| `http` | Swan Lake | <a target="_blank" href="/spec/http/">Snapshot</a> | HTTP package of Ballerina language, which provides HTTP client-server functionalities to produce and consume HTTP APIs. |
+| `jwt` | Swan Lake | <a target="_blank" href="/spec/jwt/">Snapshot</a> | JWT package of Ballerina language, which is used for authorization of listeners and clients (HTTP, gRPC, GraphQL, WebSocket, WebSub, etc.). |
+| `log` | Swan Lake | <a target="_blank" href="/spec/log/">Snapshot</a> | Log package of Ballerina language, which provides APIs to log information when running applications. |
+| `mime` | Swan Lake | <a target="_blank" href="/spec/mime/">Snapshot</a> | MIME package of Ballerina language, which provides a set of APIs to work with messages, which follow the Multipurpose Internet Mail Extensions (MIME) specification as specified in the RFC 2045 standard. |
+| `oauth2` | Swan Lake | <a target="_blank" href="/spec/oauth2/">Snapshot</a> | OAuth2 package of Ballerina language, which is used for authorization of listeners and clients (HTTP, gRPC, GraphQL, WebSocket, WebSub, etc.). |
+| `os` | Swan Lake | <a target="_blank" href="/spec/os/">Snapshot</a> | OS package of Ballerina language, which provides APIs to retrieve information about the operating system and its current users. |
+| `protobuf` | Swan Lake | <a target="_blank" href="/spec/protobuf/">Snapshot</a> | Protobuf package of Ballerina language, which provides APIs to represent a set of pre-defined protobuf types. |
+| `random` | Swan Lake | <a target="_blank" href="/spec/random/">Snapshot</a> | Random package of Ballerina language, which provides APIs to generate pseudo-random numbers. |
+| `regex` | Swan Lake | <a target="_blank" href="/spec/regex/">Snapshot</a> | Regex package of Ballerina language, which provides functionalities such as matching, replacing and splitting strings based on regular expressions. |
+| `sql` | Swan Lake | <a target="_blank" href="/spec/sql/">Snapshot</a> | SQL package of Ballerina language, which provides the generic interface and functionality to interact with a SQL database. |
+| `task` | Swan Lake | <a target="_blank" href="/spec/task/">Snapshot</a> | Task package of Ballerina language, which provides APIs to schedule a Ballerina job either once or periodically and manage the execution of those jobs. |
+| `tcp` | Swan Lake | <a target="_blank" href="/spec/tcp/">Snapshot</a> | TCP package of Ballerina language, which provides TCP client-server functionalities. |
+| `time` | Swan Lake | <a target="_blank" href="/spec/time/">Snapshot</a> | Time package of Ballerina language, which provides time generation and conversion APIs. |
+| `udp` | Swan Lake | <a target="_blank" href="/spec/udp/">Snapshot</a> | UDP package of Ballerina language, which provides UDP client-server functionalities. |
+| `uuid` | Swan Lake | <a target="_blank" href="/spec/uuid/">Snapshot</a> | UUID package of Ballerina language, which provides APIs to generate UUIDs based on the RFC 4122. |
+| `websocket` | Swan Lake | <a target="_blank" href="/spec/websocket/">Snapshot</a> | WebSocket package of Ballerina language, which provides WebSocket client-server functionalities. |
+| `websub` | Swan Lake | <a target="_blank" href="/spec/websub/">Snapshot</a> | WebSub package of Ballerina language, which provides WebSub compliant subscriber related functionalities. |
+| `webusuhub` | Swan Lake | <a target="_blank" href="/spec/websubhub/">Snapshot</a> | WebSubHub package of Ballerina language, which provides WebSub compliant hub and publisher related functionalities. |
+| `xmldata` | Swan Lake | <a target="_blank" href="/spec/xmldata/">Snapshot</a> | Xmldata package of Ballerina language, which provides APIs to perform conversions between XML and JSON/Ballerina records. |
 
 ## Platform specifications
 

--- a/swan-lake/learn-the-platform/source-code-dependencies/manage-dependencies.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/manage-dependencies.md
@@ -43,12 +43,12 @@ To use exported modules of any package, add an import statement in the Ballerina
 
 The import declaration syntax is as follows.
 
-```bash
-import [org-name/] module-name [as import-prefix];
+```ballerina
+import [org_name/] module_name [as import_prefix];
 ```
 
-* The `import-prefix` has to be a valid Ballerina identifier, and it is used to refer to public symbols in the declared module.
-* The `import-prefix` is optional. You can use the last part of the module name if an `import-prefix` is unavailable.
+* The `import_prefix` has to be a valid Ballerina identifier, and it is used to refer to public symbols in the declared module.
+* The `import_prefix` is optional. You can use the last part of the module name if an `import_prefix` is unavailable.
 
 You can import a module by providing the organization name, and the module name. The module name consists of the package name, and the name of the module root directory.
 The module name of the default module is always the package name. 
@@ -122,18 +122,18 @@ The local repository is useful to test a package in the development phase or to 
 
 1. Generate the Ballerina archive after editing the package source files as required.
 
-   ```bash
+   ```
    bal pack
    ```
 
 2. Publish to the local repository.
-   ```bash
+   ```
    bal push --repository local
    ```
 
    If you already have the path of Ballerina archive, then you can simply execute the following command.
 
-    ```bash
+    ```
     bal push --repository local <path-to-bala-archive>
     ```
 
@@ -163,7 +163,7 @@ By default, the compiler always looks up the latest compatible versions of the d
 Using the `--sticky` flag with `bal build` will force the compiler to stick to the exact versions locked in the `Dependencies.toml`. 
 In other words, the CLI disables the automatic-update feature when you provide the `--sticky` flag.
    
-```bash
+```
 bal build --sticky
 ```
 
@@ -194,7 +194,7 @@ When building the dependency graph, if there is more than one version for a spec
 
 For example, assume one dependency in your package depends on the `1.0.0` version of the `ballerina/observe` package, and another dependency depends on `0.9.0` of the same. The build fails with the following error message.
 
-```bash
+```
 error: compilation failed: Two incompatible versions exist in the dependency graph:
 ballerina/observe versions: 0.9.0, 1.0.0
 ```


### PR DESCRIPTION
## Purpose
Fix code highlighting on the dependencies page.
> Fixes #4884 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
