### PR TITLE
Update the active proposals link on the spec page

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -93,7 +93,7 @@ For previous draft language specifications of a Ballerina release, see the <a ta
 
 ## Proposals for improvements/enhancements
 
-For the proposals for improving Ballerina, see the <a target="_blank" href="https://github.com/ballerina-platform/ballerina-spec/blob/master/lang/proposals/README.md">work in progress proposals</a>.
+For the proposals for improving Ballerina, see the <a target="_blank" href="/community/active-proposals/">work in progress proposals</a>.
 
 <style> 
 table {


### PR DESCRIPTION
## Purpose
Update the active proposals link on the spec page.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
