### PR TITLE
Add `prefix` to BBE landing page URLs

### DIFF
--- a/pages/learn/by-example/index.js
+++ b/pages/learn/by-example/index.js
@@ -25,6 +25,7 @@ import Layout from "../../../layouts/LayoutDocs";
 import { load } from "js-yaml";
 import LeftNavYaml from "../../../components/common/left-nav/LeftNavYaml";
 import { useRouter } from "next/router";
+import { prefix } from "../../../utils/prefix";
 
 function toKebabCase(str) {
   return str.replace(/\s/g, "-").toLowerCase();
@@ -77,7 +78,7 @@ export default function BBEPage({ navContent, bbesJson }) {
       for (let bbe of category.samples) {
         sampleData.push(
           <li className="ps-4 my-1 fw-light">
-            <Link href={`/learn/by-example/${bbe.url}`} passHref>
+            <Link href={`${prefix}/learn/by-example/${bbe.url}`} passHref>
               {bbe.name}
             </Link>
           </li>
@@ -88,7 +89,7 @@ export default function BBEPage({ navContent, bbesJson }) {
         <ul className="p-0 my-1" id={toKebabCase(category.title)}>
           <li className="d-flex align-items-center">
             <Link
-              href={`/learn/by-example#${toKebabCase(category.title)}`}
+              href={`${prefix}/learn/by-example#${toKebabCase(category.title)}`}
               passHref
             >
               <svg


### PR DESCRIPTION
## Purpose
Add `prefix` to BBE landing page URLs.

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
