### PR TITLE
Fix the `Package references` broken link

### DIFF
--- a/swan-lake/learn-the-platform/source-code-dependencies/organize-ballerina-code.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/organize-ballerina-code.md
@@ -160,4 +160,4 @@ Since the `import-prefix` is not given, the module name `util` is used to refer 
 
 ## Package references
 
-For information on the structure of a package directory, see [Package references](/learn/organize-ballerina-code/package-references/).
+For information on the structure of a package directory, see [Package references](/learn/package-references/).


### PR DESCRIPTION
## Purpose
Fix the `Package references` broken link.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
