### PR TITLE
Updated language-basics import for lang library

### DIFF
--- a/swan-lake/learn-the-language/language-basics.md
+++ b/swan-lake/learn-the-language/language-basics.md
@@ -227,7 +227,7 @@ int n = s.length();
 
 The ``substring()`` and ``length()`` functions are ``string`` lang library functions called using the convenient method call syntax. However, the functions are called on variables/values of the ``string`` type rather than objects.
 
-Ballerina imports the lang library for **``ballerina/lang.T``** where **``T``** represents a built-in type. Therefore, in the case of the above code example, you can also find the length of the string value by importing the **``ballerina/lang.'string``** module and calling the **``length()``** function using the function call syntax.
+Ballerina imports the lang library for **``ballerina/lang.T``** where **``T``** represents a built-in type. Therefore, in the case of the above code example, you can also find the length of the string value by importing the **``ballerina/lang.string``** module (**``import ballerina/lang.'string``**) and calling the **``length()``** function using the function call syntax.
 
 ```ballerina
 int n = string:length(s);

--- a/swan-lake/learn-the-language/language-basics.md
+++ b/swan-lake/learn-the-language/language-basics.md
@@ -227,7 +227,7 @@ int n = s.length();
 
 The ``substring()`` and ``length()`` functions are ``string`` lang library functions called using the convenient method call syntax. However, the functions are called on variables/values of the ``string`` type rather than objects.
 
-Ballerina imports the lang library for **``ballerina/lang.T``** where **``T``** represents a built-in type. Therefore, in the case of the above code example, you can also find the length of the string value by importing the **``ballerina/lang.string``** module and calling the **``length()``** function using the function call syntax.
+Ballerina imports the lang library for **``ballerina/lang.T``** where **``T``** represents a built-in type. Therefore, in the case of the above code example, you can also find the length of the string value by importing the **``ballerina/lang.'string``** module and calling the **``length()``** function using the function call syntax.
 
 ```ballerina
 int n = string:length(s);


### PR DESCRIPTION
While importing ballerina/lang.string it should be corrected as ballerina/lang.'string else import will throw an error.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
> Fixes # Corrected Docs for language basics in import where given statement will throw import error. Corrected import syntax is import ballerina/'string

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
