### PR TITLE
Improve the `Configurable` learn pages

### DIFF
--- a/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/configure-a-sample-ballerina-service.md
+++ b/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/configure-a-sample-ballerina-service.md
@@ -72,7 +72,7 @@ Consider the following step-by-step guide to configuring a Ballerina package tha
    the program will finish the execution abruptly with a runtime exception, if the value is not provided at the runtime.
 
 3. To provide the values for `port` and `greeting` through a configuration file, create a file named `Config.toml`
-   with the following content in the package root directory.
+   with the following content in the current working directory.
 
    ```toml
    port = 8080

--- a/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/provide-values-to-configurable-variables.md
+++ b/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/provide-values-to-configurable-variables.md
@@ -28,8 +28,7 @@ given through multiple ways when retrieving configurable values:
 - **Configuration files:** The values can be configured through the configuration files in the <a href="https://toml.io/en/v0.4.0" target="_blank">TOML(v0.4) format</a>. 
     The file location can be specified through an environment variable with the name `BAL_CONFIG_FILES`. Ballerina supports
     specifying multiple configuration files using this environment variable with the OS-specific separator. The file
-    precedence order will be as specified in the environment variable. If an environment variable is not specified, the file
-    will be located in the current working directory with the file name `Config.toml` by default.<br/>Configuration 
+    precedence order will be as specified in the environment variable.  If an environment variable is not specified, a file named `Config.toml` will be sought in the current working directory.<br/>Configuration 
  values for testing can be provided in a file named `Config.toml` located in the `tests` directory. For more details, see [Define test-specific configurations](/learn/test-ballerina-code/configure-tests/#define-test-specific-configurations).
 
 - **Environment variables:** Users can provide the configuration values through an environment variable with the name `BAL_CONFIG_DATA` in which the


### PR DESCRIPTION
## Purpose
Improve the `Configurable` learn pages.
> Fixes #5425

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
