### PR TITLE
Update 1.2.32 in archived versions left nav

### DIFF
--- a/utils/archived-lm.json
+++ b/utils/archived-lm.json
@@ -265,6 +265,14 @@
                     "url": "/1.2/learn/api-docs/ballerina/",
                     "id": "1.2.x-api-docs"
                 },
+                                {
+                    "dirName": "1.2.32",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "#1.2.32",
+                    "id": "1.2.32v"
+                },
                 {
                     "dirName": "1.2.31",
                     "level": 2,


### PR DESCRIPTION
## Purpose
Update 1.2.32 in archived versions left nav.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
