### PR TITLE
Add the 2201.2.1 release note to master

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.1/RELEASE_NOTE.md
@@ -1,0 +1,47 @@
+---
+layout: ballerina-left-nav-release-notes
+title: 2201.2.1 (Swan Lake) 
+permalink: /downloads/swan-lake-release-notes/2201.2.1/
+active: 2201.2.1
+redirect_from: 
+    - /downloads/swan-lake-release-notes/2201.2.1
+    - /downloads/swan-lake-release-notes/2201.2.1/
+    - /downloads/swan-lake-release-notes/2201.2.1-swan-lake/
+    - /downloads/swan-lake-release-notes/2201.2.1-swan-lake
+    - /downloads/swan-lake-release-notes/
+    - /downloads/swan-lake-release-notes
+---
+
+## Overview of Ballerina Swan Lake 2201.2.1
+
+<em>Swan Lake 2201.2.1 is the first patch release of Ballerina 2201.2.0 (Swan Lake Update 2) and it includes a new set of bug fixes to the language server and developer tooling.</em> 
+
+## Update Ballerina
+
+**If you are already using Ballerina 2201.0.0 (Swan Lake)**, run either of the commands below to directly update to 2201.2.1 using the [Ballerina Update Tool](/learn/cli-documentation/update-tool/).
+
+`bal dist update` (or `bal dist pull 2201.2.1`)
+
+**If you are using a version below 2201.0.0 (Swan Lake)**, run the commands below to update to 2201.2.1.
+
+1. Run `bal update` to get the latest version of the Update Tool.
+
+2. Run `bal dist update` ( or `bal dist pull 2201.2.1`) to update your Ballerina version to 2201.2.1.
+
+However, if you are using a version below 2201.0.0 (Swan Lake) and if you already ran `bal dist update` (or `bal dist pull 2201.2.1`) before `bal update`, see [Troubleshooting](/downloads/swan-lake-release-notes/2201-0-0-swan-lake/#troubleshooting) to recover your installation.
+
+## Install Ballerina
+
+If you have not installed Ballerina, then download the [installers](/downloads/#swanlake) to install.
+
+## Developer tools updates
+
+### Bug Fixes
+
+To view bug fixes, see the GitHub milestone for Swan Lake 2201.2.1 of the repositories below.
+
+- [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer%2FExtensions+milestone%3A2201.2.1+is%3Aclosed)
+- [CLI](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+milestone%3A2201.2.1+label%3AArea%2FCLI)
+- [Project API](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.2.1+is%3Aclosed+label%3AArea%2FProjectAPI)
+
+<!-- <style>.cGitButtonContainer, .cBallerinaTocContainer {display:none;}</style> -->

--- a/utils/rl.json
+++ b/utils/rl.json
@@ -15,6 +15,14 @@
             "id": "swan-lake-release-notes",
             "subDirectories": [
                 {
+                    "dirName": "2201.2.1 (Swan Lake Update 2)",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.1",
+                    "id": "swan-lake-2201.2.1"
+                },
+                {
                     "dirName": "2201.2.0 (Swan Lake Update 2)",
                     "level": 2,
                     "position": 1,


### PR DESCRIPTION
## Purpose
Add the 2201.2.1 release note to master.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
