### PR TITLE
Update the `Download` page on VS Code content

### DIFF
--- a/pages/downloads/index.js
+++ b/pages/downloads/index.js
@@ -61,42 +61,6 @@ export default function Downloads() {
                <Packs info={swanlake}/>
             </Row>
 
-            <Row className={`${styles.donwloadVersion} pageContentRow`}>
-               <Col xs={12}>
-               <div className={styles.releaseLinks} >
-                     <div className={styles.releaseNotes} >
-                        <p><a href={`${prefix}/downloads/swan-lake-release-notes/swan-lake-${swanlake.version}`}>RELEASE NOTES &gt;</a></p>
-                     </div>
-                     <div className={styles.releaseNotes} >
-                        <p><a href={`${prefix}/downloads/archived/#swan-lake-archived-versions`}>ARCHIVED VERSIONS &gt;</a></p>
-                     </div>
-                  </div>
-               </Col>
-            </Row>
-
-            <Row className={`${styles.donwloadVersion} pageContentRow`}>
-               <Col xs={12}>
-                  <p>
-                     To <a href={`${prefix}/learn/install-ballerina/installation-options/#verify-the-installation`} className={styles.instructions}>verify that Ballerina was successfully installed</a>, execute 
-                     the <code className="highlighter-rouge language-plaintext">bal version<span aria-hidden="true" className="line-numbers-rows"><span></span></span></code> command 
-                     in the Terminal/Shell. For more information on installing Ballerina, see <a href={`${prefix}/learn/install-ballerina/installation-options/`} className={styles.instructions}>Installation options</a>.
-                  </p>
-                  <p>Next, install the Ballerina Visual Studio Code extension.</p>
-               </Col>
-            </Row>
-
-            <Row className={`${styles.downloadsVSCode} pageContentRow`}>
-               <Col xs={12} sm={12} md={12} lg={4}>
-                  <h3 className={styles.dVSCode} style={vscodeIcon}>Visual Studio Code</h3>
-                  <a id="packWindows" href="https://marketplace.visualstudio.com/items?itemName=wso2.ballerina" 
-                  className={styles.cDownload} data-download="downloads" 
-                  target="_blank" rel="noreferrer">
-                     <div className={styles.cSize}>Ballerina Extension<span id="packWindowsName"></span></div>
-                  </a>
-                  <br/>
-                  <p>Now, you are all set to <a href={`${prefix}/learn/get-started-with-ballerina/`}>get started with Ballerina.</a></p>
-               </Col>
-            </Row>
 
             <Row className={`${styles.downloadsOther} pageContentRow`}>
                <Col xs={12} sm={12} md={6} lg={6}>
@@ -129,6 +93,54 @@ export default function Downloads() {
                         </table>
                      </div>
                   </div>
+               </Col>
+            </Row>
+
+            <Row className={`${styles.donwloadVersion} pageContentRow`}>
+               <Col xs={12}>
+                  <p>
+                     To <a href={`${prefix}/learn/install-ballerina/installation-options/#verify-the-installation`} className={styles.instructions}>verify that Ballerina was successfully installed</a>, execute 
+                     the <code className="highlighter-rouge language-plaintext">bal version<span aria-hidden="true" className="line-numbers-rows"><span></span></span></code> command 
+                     in the Terminal/Shell. For more information on installing Ballerina, see <a href={`${prefix}/learn/install-ballerina/installation-options/`} className={styles.instructions}>Installation options</a>.
+                  </p>
+               </Col>
+            </Row>
+
+            <Row className={`${styles.donwloadVersion} pageContentRow`}>
+               <Col xs={12}>
+               <div className={styles.releaseLinks} >
+                     <div className={styles.releaseNotes} >
+                        <p><a href={`${prefix}/downloads/swan-lake-release-notes/swan-lake-${swanlake.version}`}>RELEASE NOTES &gt;</a></p>
+                     </div>
+                     <div className={styles.releaseNotes} >
+                        <p><a href={`${prefix}/downloads/archived/#swan-lake-archived-versions`}>ARCHIVED VERSIONS &gt;</a></p>
+                     </div>
+                  </div>
+               </Col>
+            </Row>
+
+            <Row className={`${styles.donwloadVersion} pageContentRow`}>
+               <Col xs={12}>
+                  <h2 id="swanlake"><span>Visual Studio Code extension</span></h2>
+               </Col>
+            </Row>
+
+            <Row className={`${styles.donwloadVersion} pageContentRow`}>
+               <Col xs={12}>
+                  <p>Next, install the Ballerina Visual Studio Code extension.</p>
+               </Col>
+            </Row>
+
+            <Row className={`${styles.downloadsVSCode} pageContentRow`}>
+               <Col xs={12} sm={12} md={12} lg={4}>
+                  <h3 className={styles.dVSCode} style={vscodeIcon}>Visual Studio Code</h3>
+                  <a id="packWindows" href="https://marketplace.visualstudio.com/items?itemName=wso2.ballerina" 
+                  className={styles.cDownload} data-download="downloads" 
+                  target="_blank" rel="noreferrer">
+                     <div className={styles.cSize}>Ballerina Extension<span id="packWindowsName"></span></div>
+                  </a>
+                  <br/>
+                  <p>Now, you are all set to <a href={`${prefix}/learn/get-started-with-ballerina/`}>get started with Ballerina.</a></p>
                </Col>
             </Row>
          </Col>

--- a/pages/downloads/index.js
+++ b/pages/downloads/index.js
@@ -125,21 +125,14 @@ export default function Downloads() {
                </Col>
             </Row>
 
-            <Row className={`${styles.donwloadVersion} pageContentRow`}>
+            <Row className={`${styles.downloadsVSCode} pageContentRow`}>
                <Col xs={12}>
-                  <p>Next, install the Ballerina Visual Studio Code extension.</p>
+                  <p>Next, install the Ballerina Visual Studio Code extension from the <a href="https://marketplace.visualstudio.com/items?itemName=wso2.ballerina" target="_blank">VS Code marketplace.</a></p>
                </Col>
             </Row>
 
             <Row className={`${styles.downloadsVSCode} pageContentRow`}>
                <Col xs={12} sm={12} md={12} lg={4}>
-                  <h3 className={styles.dVSCode} style={vscodeIcon}>Visual Studio Code</h3>
-                  <a id="packWindows" href="https://marketplace.visualstudio.com/items?itemName=wso2.ballerina" 
-                  className={styles.cDownload} data-download="downloads" 
-                  target="_blank" rel="noreferrer">
-                     <div className={styles.cSize}>Ballerina Extension<span id="packWindowsName"></span></div>
-                  </a>
-                  <br/>
                   <p>Now, you are all set to <a href={`${prefix}/learn/get-started-with-ballerina/`}>get started with Ballerina.</a></p>
                </Col>
             </Row>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -159,10 +159,15 @@ a {
 
 .mdContent h3,
 .policyContent h3,
-.downloads h3,
 .archiveContent h3 {
   margin-top: 40px;
   /* margin-top: 20px; */
+  color: #585a5e;
+  font-size: 1.3rem;
+  scroll-margin-top: 60px;
+}
+
+.downloads h3 {
   color: #585a5e;
   font-size: 1.3rem;
   scroll-margin-top: 60px;


### PR DESCRIPTION
## Purpose
Update the `Download` page on VS Code content as shown below.

<img width="1680" alt="Screenshot 2022-10-05 at 16 34 08" src="https://user-images.githubusercontent.com/11707273/194046288-4dd1ed6a-62d4-4feb-9533-2f21be806c6d.png">

> Fixes #5597

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
