### PR TITLE
Remove CLI & Project API Links from the 2201.2.2 Release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.2/RELEASE_NOTE.md
@@ -45,6 +45,4 @@ To view bug fixes, see the [GitHub milestone for Swan Lake 2201.2.2](https://git
 To view bug fixes, see the GitHub milestone for Swan Lake 2201.2.2 of the repositories below.
 
 - [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.2.2+is%3Aclosed)
-- [CLI](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+milestone%3A2201.2.2+label%3AArea%2FCLI)
-- [Project API](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.2.2+is%3Aclosed+label%3AArea%2FProjectAPI)
 - [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.2.2+is%3Aclosed+label%3AArea%2FDebugger)


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
