### PR TITLE
Update the 2201.2.3 release note content

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
@@ -36,7 +36,15 @@ If you have not installed Ballerina, then download the [installers](/downloads/#
 
 ## Language updates
 
+### Bug fixes
+
 To view bug fixes, see the [GitHub milestone for Swan Lake 2201.2.3](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.2.3+is%3Aclosed)
+
+## Standard library updates
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for Swan Lake 2201.2.3](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aclosed+is%3Aissue+milestone%3A%22Swan+Lake+2201.2.3%22+label%3AType%2FBug).
 
 ## Developer tools updates
 
@@ -44,13 +52,12 @@ To view bug fixes, see the [GitHub milestone for Swan Lake 2201.2.3](https://git
 
 #### Language Server
 
-### Improvements
-
-#### Language Server
+* Add a new quick-fix code action to fill in the missing required fields of a mapping constructor
+* Add a new module-level completion item to generate an expression-bodied function snippet
 
 ### Bug Fixes
 
-To view bug fixes, see the GitHub milestone for Swan Lake 2201.2.2 of the repositories below.
+To view bug fixes, see the GitHub milestone for Swan Lake 2201.2.3 of the repositories below.
 
 - [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.2.3+is%3Aclosed)
 - [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.2.3+is%3Aclosed+label%3AArea%2FDebugger)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
@@ -59,4 +59,8 @@ To view bug fixes, see the [GitHub milestone for Swan Lake 2201.2.3](https://git
 
 #### Language Server
 
-To view bug fixes, see the [GitHub milestone for Swan Lake 2201.2.3](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.2.3+is%3Aclosed).
+To view bug fixes, see the GitHub milestone for Swan Lake 2201.2.3.
+
+* [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.2.3+is%3Aclosed).
+* [Project API](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FProjectAPI+is%3Aclosed+milestone%3A2201.2.3).
+

--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
@@ -57,7 +57,6 @@ To view bug fixes, see the [GitHub milestone for Swan Lake 2201.2.3](https://git
 
 ### Bug Fixes
 
-To view bug fixes, see the GitHub milestone for Swan Lake 2201.2.3 of the repositories below.
+#### Language Server
 
-- [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.2.3+is%3Aclosed)
-- [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.2.3+is%3Aclosed+label%3AArea%2FDebugger)
+To view bug fixes, see the [GitHub milestone for Swan Lake 2201.2.3](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.2.3+is%3Aclosed).


### PR DESCRIPTION
## Purpose
Update the 2201.2.3 release note content.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
