### PR TITLE
Remove fullstops in the 2201.2.3 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
@@ -61,6 +61,6 @@ To view bug fixes, see the [GitHub milestone for Swan Lake 2201.2.3](https://git
 
 To view bug fixes, see the GitHub milestone for Swan Lake 2201.2.3.
 
-* [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.2.3+is%3Aclosed).
-* [Project API](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FProjectAPI+is%3Aclosed+milestone%3A2201.2.3).
+* [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.2.3+is%3Aclosed)
+* [Project API](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FProjectAPI+is%3Aclosed+milestone%3A2201.2.3)
 


### PR DESCRIPTION
## Purpose
Remove fullstops in the 2201.2.3 release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
