### PR TITLE
Add the VS Code 3.3.0 release note

### DIFF
--- a/downloads/vs-code-release-notes/3.3.0.md
+++ b/downloads/vs-code-release-notes/3.3.0.md
@@ -1,0 +1,38 @@
+# Ballerina VSCode Plugin (Version 3.3.0) 
+
+We are happy to announce the Ballerina VSCode plugin 3.3.0 release, which has some exciting new features. Following are the highlights of this release.
+- [Visual Data Mapper](#data-mapper) - Helps you write and visualize data transformations easily
+- [GraphQL Tryit](#integrated-graphql-tryit) - Facilitates trying out the GraphQL services with the integrated client 
+- [Improved record editor](#record-editor) - Provides a better editing experience with suggestions 
+- [Project Design View](#record-editor) - Facilitates visualizing service interactions in your project
+
+If you are new to Ballerina, you can download the [installers](/downloads/#swanlake) to install it. You can install the Ballerina VSCode plugin from the [VSCode marketplace](https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina). 
+
+## Data Mapper
+![data-mapper](./../../resources/release-notes/3.3.0/data-mapper.gif)
+- A powerful graphical editor, which allows you to easily create complex data transformations in a few minutes
+- Provides descriptive diagnostics, error highlighting, and code actions, which leverage the editing experience
+- An integrated expression editor to add custom values with the support of lang server suggestions, library browsing, etc.
+- Currently, supports JSON to JSON transformations and will support more in the future
+
+## Integrated GraphQL Tryit
+![graphql-tryit](./../../resources/release-notes/3.3.0/graphql-tryit.gif)
+- You can try out the GraphQL services using the `Tryit` codelens 
+- You can send and test any request with headers to your GraphQL service in VS Code itself without using any third-party tools
+- The GraphQL explorer will help you to explore the available endpoints and generate the query for you
+
+## Record editor
+![record-editor](./../../resources/release-notes/3.3.0/record-editor.gif)
+- The expression editor is now combined with the record editor, which will give a better editing experience with suggestions and library support
+- Now, you can create records by importing a JSON file. All you need to do is select a sample JSON file under the `Import JSON file` section in the record creation.
+- Record creation using JSON samples now supports separate record creation for complex JSON records. 
+
+## Project Design View (Experimental)
+![design-view](./../../resources/release-notes/3.3.0/design-view.gif)
+- This release includes an experimental feature that allows you to visualize service interactions in your project
+- It also comes with a view to see record-type compositions and relationship
+- Use the "Ballerina: Project Design" command to open design view
+
+
+Apart from the above, there are lots of other bug fixes and improvements. For more details, see the [issue list](https://github.com/wso2/ballerina-plugin-vscode/issues?q=is%3Aissue+is%3Aclosed). 
+


### PR DESCRIPTION
## Purpose
Add the VS Code 3.3.0 release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
