### PR TITLE
Add Native support section to Learn landing page

### DIFF
--- a/components/learn/platform/Platform.js
+++ b/components/learn/platform/Platform.js
@@ -22,13 +22,27 @@ import { Row, Col } from 'react-bootstrap';
 import styles from './Platform.module.css';
 import { prefix } from '../../../utils/prefix';
 
-export default function Platform() {
+export default function Platform(props) {
 
   return (
     <>
       <Row className="pageContentRow learnRow llanding">
         <Col xs={12} md={12}>
-          <h2>Learn the platform</h2>
+          <h2 id="learn-the-platform" className='section'>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="30"
+              height="30"
+              fill="currentColor"
+              className="bi bi-link-45deg mdButton pe-2"
+              viewBox="0 0 16 16"
+              onClick={(e) => props.getLink(e.target, 'learn-the-platform')}
+            >
+              <path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1.002 1.002 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4.018 4.018 0 0 1-.128-1.287z" />
+              <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243L6.586 4.672z" />
+            </svg>
+            Learn the platform
+          </h2>
         </Col>
       </Row>
 
@@ -133,51 +147,6 @@ export default function Platform() {
 
 
           <div className={styles.pGroup}>
-            <h3>Configure &amp; observe</h3>
-
-            <div className={styles.content}>
-              <p className={styles.title}>
-                <a href={`${prefix}/learn/configure-ballerina-programs/configure-a-sample-ballerina-service`} className={styles.titleLink}>
-                  Configure Ballerina programs
-                </a>
-              </p>
-              <p className={styles.description}>The language support for configurability.</p>
-            </div>
-
-            <div className={styles.content}>
-              <p className={styles.title}>
-                <a href={`${prefix}/learn/observe-ballerina-programs`} className={styles.titleLink}>
-                  Observe Ballerina programs</a>
-              </p>
-              <p className={styles.description}>Basics of the observability functionalities that are provided for Ballerina programs.</p>
-            </div>
-          </div>
-
-          <div className={styles.pGroup}>
-            <h3>Java interoperability</h3>
-
-            <div className={styles.content}>
-              <p className={styles.title}>
-                <a href={`${prefix}/learn/call-java-code-from-ballerina`} className={styles.titleLink}>
-                  Call Java code from Ballerina
-                </a>
-              </p>
-              <p className={styles.description}>Calling Java code from Ballerina.</p>
-            </div>
-
-            <div className={styles.content}>
-              <p className={styles.title}>
-                <a href={`${prefix}/learn/java-interoperability-guide/java-interoperability`} className={styles.titleLink}>
-                  Java interoperability guide
-                </a>
-              </p>
-              <p className={styles.description}>Instructions on the supoorted Java interoperability.</p>
-            </div>
-          </div>
-        </Col>
-        <Col xs={12} lg={4} className={styles.contentCol}>
-
-          <div className={styles.pGroup}>
             <h3>Ballerina Tooling</h3>
 
             <div className={styles.content}>
@@ -242,6 +211,32 @@ export default function Platform() {
             </div>
           </div>
 
+
+
+        </Col>
+        <Col xs={12} lg={4} className={styles.contentCol}>
+
+          <div className={styles.pGroup}>
+            <h3>Configure &amp; observe</h3>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/configure-ballerina-programs/configure-a-sample-ballerina-service`} className={styles.titleLink}>
+                  Configure Ballerina programs
+                </a>
+              </p>
+              <p className={styles.description}>The language support for configurability.</p>
+            </div>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/observe-ballerina-programs`} className={styles.titleLink}>
+                  Observe Ballerina programs</a>
+              </p>
+              <p className={styles.description}>Basics of the observability functionalities that are provided for Ballerina programs.</p>
+            </div>
+          </div>
+
           <div className={styles.pGroup}>
             <h3>Ballerina Central</h3>
 
@@ -252,6 +247,41 @@ export default function Platform() {
                 </a>
               </p>
               <p className={styles.description}>Details of publishing your library package to Ballerina Central.</p>
+            </div>
+          </div>
+
+          <div className={styles.pGroup}>
+            <h3>Java interoperability</h3>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/call-java-code-from-ballerina`} className={styles.titleLink}>
+                  Call Java code from Ballerina
+                </a>
+              </p>
+              <p className={styles.description}>Calling Java code from Ballerina.</p>
+            </div>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/java-interoperability-guide/java-interoperability`} className={styles.titleLink}>
+                  Java interoperability guide
+                </a>
+              </p>
+              <p className={styles.description}>Instructions on the supoorted Java interoperability.</p>
+            </div>
+          </div>
+
+          <div className={styles.pGroup}>
+            <h3>Native Support</h3>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/build-a-native-executable`} className={styles.titleLink}>
+                  Build A Native Executable [Experimental]
+                </a>
+              </p>
+              <p className={styles.description}>Building a GraalVM native executable from Ballerina.</p>
             </div>
           </div>
         </Col>

--- a/utils/learn-lm.json
+++ b/utils/learn-lm.json
@@ -15,6 +15,24 @@
             "id": "learn-the-platform",
             "subDirectories": [
                 {
+                    "dirName": "Native support",
+                    "level": 2,
+                    "position": 9,
+                    "isDir": true,
+                    "url": "/learn/native-support",
+                    "id": "native-support",
+                    "subDirectories": [
+                        {
+                            "dirName": "Build A Native Executable [Experimental]",
+                            "level": 3,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/learn/build-a-native-executable",
+                            "id": "build-a-native-executable"
+                        }
+                    ]
+                },
+                {
                     "dirName": "Ballerina specifications",
                     "level": 2,
                     "position": 8,


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #5838

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
