### PR TITLE
Remove extra space between Related Links in BBE

### DIFF
--- a/.github/scripts/bbe/convertMarkdown.js
+++ b/.github/scripts/bbe/convertMarkdown.js
@@ -702,6 +702,7 @@ const generate = async (examplesDir, outputDir) => {
                 codeSnippetLang,
                 codeSnippetArray = [],
                 listRegex = /^(\s*)(\d|-)(?:\.?)+\s*(.*)/;
+                relatedLinks = false;
 
               for (const line of contentArray) {
                 let convertedLine;
@@ -716,6 +717,10 @@ const generate = async (examplesDir, outputDir) => {
 
                   if (line.match(/^\s+::: code/) || line.match(/^\s+::: out/)) {
                     isIndent = true;
+                  }
+
+                  if (line.includes("## Related links")) {
+                    relatedLinks = true;
                   }
 
                   if (line.includes("::: code")) {
@@ -764,12 +769,22 @@ const generate = async (examplesDir, outputDir) => {
                   } else if (listRegex.test(line)) {
                     let match = line.match(listRegex);
                     let listContent = md.render(match[3]);
-                    convertedLine = `<ul style={{ marginLeft: "${match[1].length * 8}px" }}>
-                    <li>
-                        <span>${match[2] === "-" ? `&#8226;&nbsp;` : `${match[2]}.`}</span>
-                        <span>${listContent.slice(3,listContent.length - 5)}</span>
-                    </li>
-                </ul>`;
+                    convertedLine = `<ul style={{ marginLeft: "${
+                      match[1].length * 8
+                        }px" 
+                      }} ${
+                        relatedLinks ? 'class="relatedLinks"' : ''
+                      }>
+                        <li>
+                            <span>${
+                              match[2] === "-" ? `&#8226;&nbsp;` : `${match[2]}.`
+                            }</span>
+                            <span>${listContent.slice(
+                              3,
+                              listContent.length - 5
+                            )}</span>
+                        </li>
+                    </ul>`;
                   } else {
                     convertedLine = escapeParagraphCharacters(md.render(line));
                   }
@@ -794,6 +809,9 @@ const generate = async (examplesDir, outputDir) => {
               }
 
               codeSection = updatedArray.join("\n");
+              if(relatedLinks) {
+                codeSection = codeSection + "<span style={{marginBottom:'20px'}}></span>";
+              }
             }
           }
         }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1197,6 +1197,10 @@ table.cTopControlsContainer tbody {
   visibility: visible;
 }
 
+.bbeBody .relatedLinks {
+  margin-bottom: 0 !important;
+}
+
 /* CSS for hard coded html content in mds. */
 .cCodeTable.cCodeTableFixedLayout {
   table-layout: fixed;


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #5933 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
