### PR TITLE
Add the 2201.2.4 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
@@ -2,7 +2,7 @@
 layout: ballerina-left-nav-release-notes
 title: 2201.2.3 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.2.3/
-active: 2201.2.2
+active: 2201.2.3
 redirect_from: 
     - /downloads/swan-lake-release-notes/2201.2.3
     - /downloads/swan-lake-release-notes/2201.2.3/

--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.4 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.4 /RELEASE_NOTE.md
@@ -1,0 +1,93 @@
+---
+layout: ballerina-left-nav-release-notes
+title: 2201.2.4 (Swan Lake) 
+permalink: /downloads/swan-lake-release-notes/2201.2.4/
+active: 2201.2.4
+redirect_from: 
+    - /downloads/swan-lake-release-notes/2201.2.4
+    - /downloads/swan-lake-release-notes/2201.2.4/
+    - /downloads/swan-lake-release-notes/2201.2.4-swan-lake/
+    - /downloads/swan-lake-release-notes/2201.2.4-swan-lake
+    - /downloads/swan-lake-release-notes/
+    - /downloads/swan-lake-release-notes
+---
+
+## Overview of Ballerina Swan Lake 2201.2.4
+
+<em>Swan Lake 2201.2.4 is the fourth patch release of Ballerina 2201.2.0 (Swan Lake Update 2) and it includes a new set of bug fixes to the language, language server, and developer tooling.</em> 
+
+## Update Ballerina
+
+**If you are already using Ballerina 2201.0.0 (Swan Lake)**, run either of the commands below to directly update to 2201.2.4 using the [Ballerina Update Tool](/learn/cli-documentation/update-tool/).
+
+`bal dist update` (or `bal dist pull 2201.2.4`)
+
+**If you are using a version below 2201.0.0 (Swan Lake)**, run the commands below to update to 2201.2.4.
+
+1. Run `bal update` to get the latest version of the Update Tool.
+
+2. Run `bal dist update` ( or `bal dist pull 2201.2.4`) to update your Ballerina version to 2201.2.4.
+
+However, if you are using a version below 2201.0.0 (Swan Lake) and if you already ran `bal dist update` (or `bal dist pull 2201.2.4`) before `bal update`, see [Troubleshooting](/downloads/swan-lake-release-notes/swan-lake-2201.0.0#troubleshooting) to recover your installation.
+
+## Install Ballerina
+
+If you have not installed Ballerina, then download the [installers](/downloads/#swanlake) to install.
+
+## Language updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for 2201.2.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.2.4+label%3AType%2FBug+is%3Aclosed).
+
+## Compiler API updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for 2201.2.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.2.4+label%3AType%2FBug+is%3Aclosed+label%3ATeam%2FCompilerFETools).
+
+## Runtime updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for 2201.2.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.2.4+label%3ATeam%2FjBallerina+label%3AType%2FBug+is%3Aclosed+).
+
+## Standard library updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for 2201.2.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aissue+milestone%3A2201.2.4+label%3AType%2FBug+is%3Aclosed).
+
+## Developer tools updates
+
+### New features
+
+#### Language Server
+
+### Improvements
+
+#### OpenAPI Tool
+
+### Bug Fixes
+
+To view bug fixes, see the GitHub milestone for Swan Lake 2201.2.4 of the repositories below.
+
+- [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.2.4+label%3AType%2FBug+label%3ATeam%2FLanguageServer)
+- [OpenAPI](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+milestone%3A%22Swan+Lake+2201.2.4%22+label%3AType%2FBug+is%3Aclosed)
+- [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.2.4+label%3AType%2FBug+label%3AArea%2FDebugger)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.3.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.3.0/RELEASE_NOTE.md
@@ -356,7 +356,7 @@ It will create an array with the `[1,2,0,0,0]` elements because the filler value
 
 ### Bug fixes
 
-To view bug fixes, see the [GitHub milestone for 2201.3.0 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.3.0+label%3ATeam%2FjBallerina+label%3AType%2FBug+is%3Aclosed+)
+To view bug fixes, see the [GitHub milestone for 2201.3.0 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.3.0+label%3ATeam%2FjBallerina+label%3AType%2FBug+is%3Aclosed+).
 
 ## Standard library updates
 


### PR DESCRIPTION
## Purpose
Add the 2201.2.4 release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
