### PR TITLE
Fix milestone links in the 2201.2.4 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.4/RELEASE_NOTE.md
@@ -51,8 +51,6 @@ Updated `commons-net` version to 3.9.0.
 
 To view bug fixes, see the [GitHub milestone for 2201.2.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aissue+milestone%3A2201.2.4+label%3AType%2FBug+is%3Aclosed).
 
-### Bug fixes
-
 ## Code to Cloud updates
 
 ### Bug fixes
@@ -61,11 +59,10 @@ To view bug fixes, see the [GitHub milestone for 2201.2.4 (Swan Lake)](https://g
 
 ## Developer tools updates
 
-### Improvements
+### New features
 
-To view improvements, see the [GitHub milestone for 2201.2.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=label%3AArea%2FProjectDesignTool+milestone%3A2201.2.4+is%3Aclosed).
+To view new features, see the [GitHub milestone for 2201.2.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=milestone%3A2201.2.4+is%3Aclosed+label%3ATeam%2FDevTools+label%3AType%2FNewFeature).
 
 ### Bug Fixes
 
-To view bug fixes, see the [GitHub milestone for 2201.2.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=label%3AArea%2FJSONToRecordConverter+milestone%3A2201.2.4+is%3Aclosed).
-
+To view bug fixes, see the [GitHub milestone for 2201.2.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=milestone%3A2201.2.4+is%3Aclosed+label%3ATeam%2FDevTools+label%3AType%2FBug).


### PR DESCRIPTION
## Purpose
Fix milestone links in the 2201.2.4 release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
