### PR TITLE
Change `command line` to `command-line` in the config learn page 

### DIFF
--- a/_data/configurableswanlake.yml
+++ b/_data/configurableswanlake.yml
@@ -7,7 +7,7 @@
   - title: Provide values to configurable variables
     url: /learn/configure-ballerina-programs/provide-values-to-configurable-variables
     sublinks:
-      - title: Provide via command line arguments
+      - title: Provide via command-line arguments
         url: /learn/configure-ballerina-programs/provide-values-to-configurable-variables/#provide-via-command-line-arguments
         active: provide-via-command-line-arguments
       - title: Provide via TOML syntax

--- a/_data/guidesnavswanlake.yml
+++ b/_data/guidesnavswanlake.yml
@@ -81,7 +81,7 @@
     - title: Provide values to configurable variables
       url: /learn/configure-ballerina-programs/provide-values-to-configurable-variables
       sublinks:
-        - title: Provide configuration values through Command Line Arguments
+        - title: Provide configuration values through Command-Line Arguments
           url: /learn/configure-ballerina-programs/provide-values-to-configurable-variables/#provide-configuration-values-through-command-line-arguments
           active: provide-values-through-command-line-arguments
         - title: Provide configuration values through TOML syntax

--- a/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/configure-values.md
+++ b/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/configure-values.md
@@ -64,7 +64,7 @@ The module information requirement can be explained in the following table accor
 
 The format of providing module information in each configuration syntax is described below.
 
-#### Command line argument syntax
+#### Command-line argument syntax
 
 The key of a CLI parameter can be specified as,
 

--- a/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/provide-values-to-configurable-variables.md
+++ b/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/provide-values-to-configurable-variables.md
@@ -17,12 +17,12 @@ redirect_from:
 - /learn/guides/configuring-ballerina-programs/providing-values-to-configurable-variables
 ---
 
-The values for configurable variables can be provided through configuration files, command line arguments, and
+The values for configurable variables can be provided through configuration files, command-line arguments, and
 environment variables. The configuration values will be overridden in the following precedence order if the values are
 given through multiple ways when retrieving configurable values:
 
-- **Command line arguments:** The values can be configured through the command line arguments when executing the Ballerina program. The configurable
-    value provided through a command line argument is expected to be the `toString()` representation of the intended 
+- **Command-line arguments:** The values can be configured through the command-line arguments when executing the Ballerina program. The configurable
+    value provided through a command-line argument is expected to be the `toString()` representation of the intended 
     value.
 
 - **Configuration files:** The values can be configured through the configuration files in the <a href="https://toml.io/en/v0.4.0" target="_blank">TOML(v0.4) format</a>. 
@@ -35,21 +35,21 @@ given through multiple ways when retrieving configurable values:
 content is expected to be in the <a href="https://toml.io/en/v0.4.0" target="_blank">TOML(v0.4) format</a>.
 >**Note:** Providing multiple configuration values through separate environment variables is not supported.
 
-### Provide via command line arguments
+### Provide via command-line arguments
 
-The following syntax can be used to provide values for the variables through the command line parameters:
+The following syntax can be used to provide values for the variables through the command-line parameters:
 
 ```
 -Ckey=value
 ```
 
-Currently, the command line based configuration is only supported for configurable variables of types `int`, `byte`,
+Currently, the command-line based configuration is only supported for configurable variables of types `int`, `byte`,
 `float`, `boolean`, `string`, `decimal`, `enum` and `xml`.
 
-The following examples explain the way of providing command line arguments to configure variables of specific Ballerina
+The following examples explain the way of providing command-line arguments to configure variables of specific Ballerina
 types.
 
-| Ballerina type | Ballerina example                                                                                                                                                                     | Command line argument                                             |
+| Ballerina type | Ballerina example                                                                                                                                                                     | Command-line argument                                             |
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
 | boolean        | <code>configurable boolean isAdmin = ?; </code>                                                                                                                                       | `bal run -- -CisAdmin=true` <br> or <br> `bal run -- -CisAdmin=1` |
 | int, byte      | <code>configurable byte age = ?; </code><br> <code>configurable int port = ?;</code>                                                                                                  | `bal run -- -Cage=25 -Cport=9090`                                 |


### PR DESCRIPTION
## Purpose
$subject

> Fixes #6194 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
