### PR TITLE
Fix 2201.3.2 release notes to use the term `project design tool` 

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.3.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.3.2/RELEASE_NOTE.md
@@ -65,7 +65,7 @@ To view bug fixes, see the GitHub milestone for 2201.3.2 (Swan Lake) of the repo
 - [OpenAPI](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+milestone%3A%22Swan+Lake+2201.3.2%22+is%3Aclosed)
 - [CLI](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FCLI+is%3Aclosed+milestone%3A2201.3.2+label%3AType%2FBug+)
 - [Test framework](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FTestFramework+is%3Aclosed+milestone%3A2201.3.2+label%3AType%2FBug+)
-- [Component Model Generator](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FProjectDesignTool+is%3Aclosed+milestone%3A2201.3.2+label%3AType%2FBug+)
+- [Project Design View](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FProjectDesignTool+is%3Aclosed+milestone%3A2201.3.2+label%3AType%2FBug+)
 
 ## Ballerina packages updates
 


### PR DESCRIPTION
## Purpose
$subject.

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
