### PR TITLE
Update documentation for 2201.4.0 release

### DIFF
--- a/swan-lake/learn-the-platform/source-code-dependencies/package-references.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/package-references.md
@@ -24,6 +24,9 @@ redirect_from:
 ├── Module.md
 ├── main.bal
 ├── utils.bal
+├── generated/
+│     ├── generated_service.bal
+│     └── model/
 ├── tests/
 │     ├── main_tests.bal
 │     └── utils_tests.bal
@@ -266,6 +269,11 @@ The `resources/` directory stores all module resources such as images, default c
 ### The `tests/` directory
 
 The `tests/` directory contains unit tests for the module and tests the module in isolation. The module-level test cases have access to the symbols with module-level visibility.
+
+
+## The `generated/` directory
+
+This directory contains generated Ballerina code. The `.bal` files at the root of the generated directory become a part of the default module. Any direct subdirectory becomes a module in the package. The files will logically merge into existing modules during compilation.
 
 <style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>
 

--- a/swan-lake/learn-the-platform/source-code-dependencies/package-references.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/package-references.md
@@ -273,7 +273,7 @@ The `tests/` directory contains unit tests for the module and tests the module i
 
 ## The `generated/` directory
 
-This directory contains generated Ballerina code. The `.bal` files at the root of the generated directory become a part of the default module. Any direct subdirectory becomes a module in the package. The files will logically merge into existing modules during compilation.
+This directory contains generated Ballerina code. The `.bal` files at the root of the generated directory become a part of the default module. Any direct subdirectory becomes a module in the package. The files will logically merge into the existing modules during compilation.
 
 <style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>
 

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/test-services-and-clients.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/test-services-and-clients.md
@@ -112,8 +112,8 @@ function getMockResponse() returns http:Response {
 
 ### Mock `final` clients
 
-Object mocking cannot be used as final clients cannot be modified. To facilitate testing, it is recommended 
-to write the client initialization logic in a separate function and assign the returned value to the client. 
+Object mocking cannot be used as final clients cannot be modified. It is recommended 
+to write the client initialization logic in a separate function and assign the returned value to the client to facilitate testing. 
 This initialization function can then be mocked using the legacy function mocking feature.
 
 ***Example:***

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/test-services-and-clients.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/test-services-and-clients.md
@@ -114,13 +114,15 @@ function getMockResponse() returns http:Response {
 
 Object mocking cannot be used as final clients cannot be modified. It is recommended 
 to write the client initialization logic in a separate function and assign the returned value to the client to facilitate testing. 
-This initialization function can then be mocked using the legacy function mocking feature.
+This initialization function can then be mocked using the compile-time function mocking feature.
 
 ***Example:***
 The following is a simple example on how to mock a `final` client.
 
 Initialize the client:
 ```bal
+import ballerina/http;
+
 final http:Client clientEndpoint = check intializeClient();
 
 function intializeClient() returns http:Client|error {
@@ -130,6 +132,9 @@ function intializeClient() returns http:Client|error {
 
 Mock the client for testing:
 ```bal
+import ballerina/http;
+import ballerina/test;
+
 @test:Mock { functionName: "intializeClient" }
 function getMockClient() returns http:Client|error {
     return test:mock(http:Client);

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/test-services-and-clients.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/test-services-and-clients.md
@@ -110,6 +110,31 @@ function getMockResponse() returns http:Response {
 }
 ```
 
+### Mock `final` clients
+
+Object mocking cannot be used as final clients cannot be modified. To facilitate testing, it is recommended 
+to write the client initialization logic in a separate function and assign the returned value to the client. 
+This initialization function can then be mocked using the legacy function mocking feature.
+
+***Example:***
+The following is a simple example on how to mock a `final` client.
+
+Initialize the client:
+```bal
+final http:Client clientEndpoint = check intializeClient();
+
+function intializeClient() returns http:Client|error {
+   return new ("https://api.chucknorris.io/jokes/");
+}
+```
+
+Mock the client for testing:
+```bal
+@test:Mock { functionName: "intializeClient" }
+function getMockClient() returns http:Client|error {
+    return test:mock(http:Client);
+}
+```
 To lean more about how to use mocking to test services, see [Mocking](/learn/test-ballerina-code/mocking).
 
 ## Configure services and clients


### PR DESCRIPTION
## Purpose
> Update build tools documentation for 2201.4.0 release

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
