### PR TITLE
Update 2201.4.0 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -34,34 +34,27 @@ However, if you are using a version below 2201.0.0 (Swan Lake) and if you alread
 
 If you have not installed Ballerina, then download the [installers](/downloads/#swanlake) to install.
 
-## Migrate from Swan Lake Beta releases
->**Info:** If you have been using Swan Lake Beta releases, delete the `Dependencies.toml` files in your Ballerina packages when migrating to Ballerina 2201.4.0 (Swan Lake). 
-
-A few backward-incompatible changes have been introduced during the Swan Lake Beta program, and thereby, some of your existing packages may not compile with Ballerina 2201.4.0 (Swan Lake). Therefore, you need to delete the `Dependencies.toml` file to force the dependency resolver to use the latest versions of your dependencies. 
-
 ## Language updates
 
 ### New features
 
 #### Support for annotations on tuple members
 
-Annotations are now supported on tuple members. Tuple members can be annotated using annotations declared with the `field` attachment point.
+- Annotations are now supported on tuple members. Tuple members can be annotated using annotations declared with the `field` attachment point.
 
-```ballerina
-annotation annot on field;
+  ```ballerina
+  annotation annot on field;
 
-type T [int, @annot string];
-```
+  type T [int, @annot string];
+  ```
 
-Annotations are not allowed on the tuple rest descriptor. 
-
-### Improvements
+  Annotations are not allowed on the tuple rest descriptor. 
 
 ### Bug fixes
 
-- Annotation values of fields of record type descriptors that are not defined with a type definition are now accessible at runtime
+- Annotation values of fields of record type descriptors that are not defined with a type definition are now accessible at runtime.
 
-To view bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.4.0+is%3Aclosed+label%3AType%2FBug).
+- To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.4.0+is%3Aclosed+label%3AType%2FBug).
 
 ## Runtime updates
 
@@ -69,83 +62,80 @@ To view bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https://git
 
 #### Get the strand dump during `bal test`
 
-When running the tests in a Ballerina package or a file using the `bal test` command, the strand dump can be obtained by sending the `SIGTRAP` signal to that process.
+- When running the tests in a Ballerina package or a file using the `bal test` command, the strand dump can be obtained by sending the `SIGTRAP` signal to that process.
 
 ### Improvements
 
-#### Improvements in runtime Java APIs
+#### Get the user-defined type name on Singleton types
 
-##### Get the user-defined type name on Singleton types
+- Calling `getName()` on the runtime class `FiniteType` will return the user-defined type name if it is available.
 
-Calling `getName()` on the runtime class `FiniteType` will return the user-defined type name if it is available.
+  For example, if a constant is defined in the following way, the `getName()` method on the `FiniteType` will return the string `"OPEN"`.
 
-For example, if a constant is defined in the following way, the `getName()` method on the `FiniteType` will return the string `"OPEN"`.
+  ```ballerina
+  const OPEN = "open";
+  ```
 
-```ballerina
-const OPEN = "open";
-```
+#### Type-reference type support in runtime Java APIs
 
-##### Type-reference type support in runtime Java APIs
+- The following runtime APIs are now modified to return the type-reference type instances according to the type definitions.
 
-The following runtime APIs are now modified to return the type-reference type instances according to the type definitions.
+  | **Runtime API**                                                          | **Java class**                                     |
+  |--------------------------------------------------------------------------|----------------------------------------------------|
+  | `getElementType`                                                         | `io.ballerina.runtime.api.types.ArrayType`         |
+  | `getDetailType`                                                          | `io.ballerina.runtime.api.types.ErrorType`         |
+  | `getFieldType`                                                           | `io.ballerina.runtime.api.types.Field`             |
+  | `getParameterTypes`                                                      | `io.ballerina.runtime.api.types.FunctionType`      |
+  | `getReturnType`                                                          | `io.ballerina.runtime.api.types.FunctionType`      |
+  | `getReturnParameterType`                                                 | `io.ballerina.runtime.api.types.FunctionType`      |
+  | `getRestType`                                                            | `io.ballerina.runtime.api.types.FunctionType`      |
+  | `getParameters` (The `Parameter.type` field can be a type-reference type.) | `io.ballerina.runtime.api.types.FunctionType`      |
+  | `getConstituentTypes`                                                    | `io.ballerina.runtime.api.types.IntersectionType`  |
+  | `getEffectiveType`                                                       | `io.ballerina.runtime.api.types.IntersectionType`  |
+  | `getConstrainedType`                                                     | `io.ballerina.runtime.api.types.MapType`           |
+  | `getParamValueType`                                                      | `io.ballerina.runtime.api.types.ParameterizedType` |
+  | `getRestFieldType`                                                       | `io.ballerina.runtime.api.types.RecordType`        |
+  | `getReferredType`                                                        | `io.ballerina.runtime.api.types.ReferenceType`     |
+  | `getConstrainedType`                                                     | `io.ballerina.runtime.api.types.StreamType`        |
+  | `getCompletionType`                                                      | `io.ballerina.runtime.api.types.StreamType`        |
+  | `getConstrainedType`                                                     | `io.ballerina.runtime.api.types.TableType`         |
+  | `getTupleTypes`                                                          | `io.ballerina.runtime.api.types.TupleType`         |
+  | `getRestType`                                                            | `io.ballerina.runtime.api.types.TupleType`         |
+  | `getConstraint`                                                          | `io.ballerina.runtime.api.types.TypedescType`      |
+  | `getMemberTypes`                                                         | `io.ballerina.runtime.api.types.UnionType`         |
+  | `getOriginalMemberTypes`                                                 | `io.ballerina.runtime.api.types.UnionType`         |
+  | `getElementType`                                                         | `io.ballerina.runtime.api.values.BArray`           |
+  | `getConstraintType`                                                      | `io.ballerina.runtime.api.values.BStream`          |
+  | `getCompletionType`                                                      | `io.ballerina.runtime.api.values.BStream`          |
+  | `getKeyType`                                                             | `io.ballerina.runtime.api.values.BTable`           |
+  | `getDescribingType`                                                      | `io.ballerina.runtime.api.values.BTypedesc`        |
+  | `getType`                                                                | `io.ballerina.runtime.api.values.BValue`           |
+  | `getType`                                                                | `io.ballerina.runtime.api.utils.TypeUtils`         |
 
+  For example, if the type-reference types are defined in the following way,
 
-| **Runtime API**                                                          | **Java class**                                     |
-|--------------------------------------------------------------------------|----------------------------------------------------|
-| `getElementType`                                                         | `io.ballerina.runtime.api.types.ArrayType`         |
-| `getDetailType`                                                          | `io.ballerina.runtime.api.types.ErrorType`         |
-| `getFieldType`                                                           | `io.ballerina.runtime.api.types.Field`             |
-| `getParameterTypes`                                                      | `io.ballerina.runtime.api.types.FunctionType`      |
-| `getReturnType`                                                          | `io.ballerina.runtime.api.types.FunctionType`      |
-| `getReturnParameterType`                                                 | `io.ballerina.runtime.api.types.FunctionType`      |
-| `getRestType`                                                            | `io.ballerina.runtime.api.types.FunctionType`      |
-| `getParameters` The `Parameter.type` field can be a type-reference type. | `io.ballerina.runtime.api.types.FunctionType`      |
-| `getConstituentTypes`                                                    | `io.ballerina.runtime.api.types.IntersectionType`  |
-| `getEffectiveType`                                                       | `io.ballerina.runtime.api.types.IntersectionType`  |
-| `getConstrainedType`                                                     | `io.ballerina.runtime.api.types.MapType`           |
-| `getParamValueType`                                                      | `io.ballerina.runtime.api.types.ParameterizedType` |
-| `getRestFieldType`                                                       | `io.ballerina.runtime.api.types.RecordType`        |
-| `getReferredType`                                                        | `io.ballerina.runtime.api.types.ReferenceType`     |
-| `getConstrainedType`                                                     | `io.ballerina.runtime.api.types.StreamType`        |
-| `getCompletionType`                                                      | `io.ballerina.runtime.api.types.StreamType`        |
-| `getConstrainedType`                                                     | `io.ballerina.runtime.api.types.TableType`         |
-| `getTupleTypes`                                                          | `io.ballerina.runtime.api.types.TupleType`         |
-| `getRestType`                                                            | `io.ballerina.runtime.api.types.TupleType`         |
-| `getConstraint`                                                          | `io.ballerina.runtime.api.types.TypedescType`      |
-| `getMemberTypes`                                                         | `io.ballerina.runtime.api.types.UnionType`         |
-| `getOriginalMemberTypes`                                                 | `io.ballerina.runtime.api.types.UnionType`         |
-| `getElementType`                                                         | `io.ballerina.runtime.api.values.BArray`           |
-| `getConstraintType`                                                      | `io.ballerina.runtime.api.values.BStream`          |
-| `getCompletionType`                                                      | `io.ballerina.runtime.api.values.BStream`          |
-| `getKeyType`                                                             | `io.ballerina.runtime.api.values.BTable`           |
-| `getDescribingType`                                                      | `io.ballerina.runtime.api.values.BTypedesc`        |
-| `getType`                                                                | `io.ballerina.runtime.api.values.BValue`           |
-| `getType`                                                                | `io.ballerina.runtime.api.utils.TypeUtils`         |
+  ```ballerina
+  type Integer int;
 
-For example, if the type-reference types are defined in the following way,
+  type IntegerArray Integer[];
 
-```ballerina
-type Integer int;
+  IntegerArray arr = [1, 2, 3, 4];
+  ```
+  the results of the runtime API calls will be as follows.
 
-type IntegerArray Integer[];
+  | **Runtime API call**                            | **Result**                                                       |
+  |-------------------------------------------------|------------------------------------------------------------------|
+  | `arr.getType()`                                 | This will return a `ReferenceType` with the name `IntegerArray`. |
+  | `getReferredType()` on `IntegerArray`           | This will return an `ArrayType` with name `IntegerArray`.        |
+  | `getElementType()` on `IntegerArray` array type | This will return a `ReferenceType` with the name `Integer`.      |
 
-IntegerArray arr = [1, 2, 3, 4];
-```
-the results of the runtime API calls will be as follows.
+  <br>
 
-| **Runtime API call**                            | **Result**                                                       |
-|-------------------------------------------------|------------------------------------------------------------------|
-| `arr.getType()`                                 | This will return a `ReferenceType` with the name `IntegerArray`. |
-| `getReferredType()` on `IntegerArray`           | This will return an `ArrayType` with name `IntegerArray`.        |
-| `getElementType()` on `IntegerArray` array type | This will return a `ReferenceType` with the name `Integer`.      |
-
-<br>
-
-> **Note:**
-> The definition of the `getType` API in the `BObject` runtime class is now modified to the following.
-> ```java
->  Type getType();
-> ```
+  > **Note:**
+  > The definition of the `getType` API in the `BObject` runtime class is now modified to the following.
+  > ```java
+  >  Type getType();
+  > ```
 
 ### Bug fixes
 
@@ -155,44 +145,44 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 ### New features
 
-##### `constraint` package
+#### `constraint` package
 
-- Introduced the `@pattern` constraint on string types
-- Added constraint validation support for `readonly` types
+- Introduced the `@pattern` constraint on string types.
+- Added constraint validation support for `readonly` types.
 
-##### `oauth2` package
+#### `oauth2` package
 
-- Allow the use of inferred values for refreshing tokens through the password grant type
-- Allow the use of string values for the `scopes` field in the client grant configuration 
+- Allow the use of inferred values for refreshing tokens through the password grant type.
+- Allow the use of string values for the `scopes` field in the client grant configuration. 
 
-##### `graphql` package
+#### `graphql` package
 
-- Added support for multiplexing in GraphQL subscriptions
-- Added support to access the GraphQL field information from resolvers
+- Added support for multiplexing in GraphQL subscriptions.
+- Added support to access the GraphQL field information from resolvers.
 
-##### `nats` package
+#### `nats` package
 
-- Added support for the new NATS JetStream client with publishing and subscribing functionalities
+- Added support for the new NATS JetStream client with publishing and subscribing functionalities.
 
-##### `persist` package
+#### `persist` package
 
-- Added support for Ballerina Persistent Layer. This functionality is provided with the newly introduced `persist` package. 
+- Added support for Ballerina Persistent Layer. This functionality is provided with the newly introduced `persist` package.
 
   The Ballerina persistent layer provides the functionality of storing and querying data conveniently.
-  >**Info:** This is an experimental feature; APIs might change in future releases.
+  >**Info:** This is an experimental feature. APIs might change in future releases.
 
 ### Improvements
 
-##### `graphql` package
+#### `graphql` package
 
-- Removed the limitation on the GraphQL `context` object parameter order
+- Removed the limitation on the GraphQL `context` object parameter order.
 
 ### Backward-incompatible changes
 
-##### `io` package
+#### `io` package
 
-- To ensure the order of fields while mapping CSV files to records, the column headers have been made mandatory in CSV files. This is only applicable for the case where the expected type is `record[]`.
-- To ensure the order of fields while writing a `record[]` to a CSV, the column headers are automatically written to the CSV file.
+- Made the column headers mandatory in CSV files to ensure the order of fields while mapping CSV files to records. This is only applicable for the case where the expected type is `record[]`.
+- Made the column headers automatically be written to the CSV file to ensure the order of fields while writing a `record[]` to a CSV.
 
 ### Bug fixes
 
@@ -201,10 +191,10 @@ To view bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https://git
 ### Code to Cloud updates
 
 ### New features
-- Added the ability to disable the thin JAR files generation by setting `settings.thinJar = false` in `Cloud.toml`
+- Added the ability to disable the thin JAR file generation by setting `settings.thinJar = false` in `Cloud.toml`.
 
 ### Improvements
-- Improved the main class name generation in `CMD` to support complex package names
+- Improved the main class name generation in `CMD` to support complex package names.
 
 ### Bug fixes
 
@@ -216,33 +206,39 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 #### Test Framework
 
-- Added support for executing tests using a GraalVM native image (experimental)
+- Added support for executing tests using a GraalVM native image (experimental).
   
-  Introduced the `--native` flag to `bal test` command, which executes tests using a GraalVM native executable.
+  >**Info:** Introduced the `--native` flag to `bal test` command, which executes tests using a GraalVM native executable.
 
 #### Language Server
 
-* Added the `Create variable with Type` code action
-* Added rename popup support for `Extract to constant`, `Extract to local variable` , and `Extract to function` code actions. This feature will be available from the [Ballerina VSCode plugin](https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina) version `4.0.0`.
-* Added quick pick support for selecting expressions in the `Extract to constant` code action
+* Added the `Create variable with Type` code action.
+* Added rename popup support for `Extract to constant`, `Extract to local variable` , and `Extract to function` code actions.
+ >**Info:** This feature will be available from the [Ballerina VSCode plugin](https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina) version `4.0.0`.
+* Added quick pick support for selecting expressions in the `Extract to constant` code action.
 
 #### GraphQL Tool
 
-- Added support for GraphQL SDL schema file generation
+- Added support for GraphQL SDL schema file generation.
 
 #### OpenAPI Tool
-Added support to generate Ballerina client and service declarations from Swagger 2.0(i.e. OpenAPI 2.0) definitions
+
+- Added support to generate Ballerina client and service declarations from Swagger 2.0 (i.e., OpenAPI 2.0) definitions.
 
 #### Persist Tool
+
 - Added a new `persist` command for users to enable the Ballerina persistence layer in a Ballerina project conveniently.
 
   With this support, users can define an entity data model, validate the model, and generate `persist` clients. This provides convenient APIs to store and query data in a data store.
+
   >**Info:** This is an experimental feature; the commands associated with the tool might change in future releases.
 
 ### Improvements
 
 #### CLI
+
 - Improved the `bal format` CLI command by introducing new command options to selectively format modules or single files with a provided Ballerina package. The updated format of the `bal format` command is shown below.
+
     ```bash
     bal format [OPTIONS] [<package>|<module>|<source-file>]
     ```
@@ -260,38 +256,40 @@ Added support to generate Ballerina client and service declarations from Swagger
     ```
 
 #### JSON-to-record converter
+
 - Improved the JSON-to-record converter tool to be more context-aware and generate records with non-conflicting names.
 
 #### Language Server
 
-* Improved the completion and code action support for pulled modules
-* Improved sorting of module-level completion items
-* Used the code action resolve request for compiler plugin code actions
+- Improved the completion and code action support for pulled modules.
+- Improved sorting of module-level completion items.
+- Used the code action resolve request for compiler plugin code actions.
 
 #### OpenAPI Tool
+
 - Added support for the `additionalProperties` attribute in OpenAPI object schemas. With this support, the generated Ballerina records can be either open or closed records, based on the `additionalProperties` details.
->**Info:** Thereby, some of your already generated open records may change into closed records, when re-generating using 2201.4.0 (and above) versions.
+  >**Info:** Thereby, some of your already generated open records may change into closed records, when re-generating using 2201.4.0 (and above) versions.
 - Improved support for `nullable:true` property OpenAPI schema, to generate record fields with default values (e.g. `string? name = ();`), instead of making the field both nilable and optional (e.g. `string? name?;`).
 - Changed the default request and response types of the generated Ballerina resource/remote methods from `json` to `http:Request` and `http:Response`, respectively.
 
 
-## Breaking changes
-- New improvements that were added to the `bal format` command to address some of the existing [limitations](https://github.com/ballerina-platform/ballerina-lang/issues/37868) may break the CLI usages of the `bal format <module-name>` option. 
-In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.
+### Breaking changes
 
-### Bug Fixes
+- New improvements that were added to the `bal format` command to address some of the existing [limitations](https://github.com/ballerina-platform/ballerina-lang/issues/37868) may break the CLI usages of the `bal format <module-name>` option. 
+
+  >**Info:** In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.
+
+### Bug fixes
 
 To view bug fixes, see the GitHub milestone for Swan Lake 2201.4.0 of the repositories below.
 
-- [Project API](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FProjectAPI+is%3Aclosed+milestone%3A2201.4.0+label%3AType%2FBug).
+- [Project API](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FProjectAPI+is%3Aclosed+milestone%3A2201.4.0+label%3AType%2FBug)
 - [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.4.0+is%3Aclosed)
 - [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.4.0+is%3Aclosed+label%3AArea%2FDebugger)
 - [OpenAPI Tool](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aclosed+milestone%3A%22Swan+Lake+2201.4.0+%22+label%3AType%2FBug)
 
 ## Ballerina packages updates
 
-### New Features
-- Added support for maintaining generated code in a Ballerina package
+### New features
 
-## Breaking changes
-
+- Added support for maintaining generated code in a Ballerina package.

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -14,7 +14,7 @@ redirect_from:
 
 ## Overview of Ballerina Swan Lake 2201.4.0
 
-<em>2201.4.0 (Swan Lake) is the fourth major release of 2022, and it includes a new set of features and significant improvements to the compiler, runtime, standard library, and developer tooling. It is based on the 2022R5 version of the Language Specification.</em> 
+<em>2201.4.0 (Swan Lake) is the fourth major release of 2022, and it includes a new set of features and significant improvements to the compiler, runtime, standard library, and developer tooling. It is based on the 2022R4 version of the Language Specification.</em> 
 
 ## Update Ballerina
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -50,13 +50,7 @@ type T [int, @annot string];
 
 Annotations are not allowed on the tuple rest descriptor. 
 
-### Bug fixes
-
-Annotation values of fields of record type descriptors that are not defined with a type definition are now accessible at runtime.
-
-To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.4.0+is%3Aclosed+label%3AType%2FBug).
-
-#### Backward incompatible changes
+### Backward-incompatible changes
 
 - Fixed a bug that incorrectly resolved the result type of a query action that would complete normally to `error?` instead of `()`. Now, the result type includes `error` only in instances where an error can be generated during the execution of the query pipeline (`from` clause/`join` clause).
 
@@ -104,6 +98,12 @@ public function main() {
    resultInt += 1; // error: resultInt may not have been initialized
 }
 ```
+
+### Bug fixes
+
+Annotation values of fields of record type descriptors that are not defined with a type definition are now accessible at runtime.
+
+To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.4.0+is%3Aclosed+label%3AType%2FBug).
 
 ## Runtime updates
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -55,7 +55,7 @@ Annotations are now supported on tuple members. Tuple members can be annotated u
 
 - Annotation values of fields of record type descriptors that are not defined with a type definition are now accessible at runtime.
 
-- To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.4.0+is%3Aclosed+label%3AType%2FBug).
+To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.4.0+is%3Aclosed+label%3AType%2FBug).
 
 ## Runtime updates
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -209,12 +209,12 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 - Added support for executing tests using a GraalVM native image (experimental).
   
-  >**Info:** Introduced the `--native` flag to `bal test` command, which executes tests using a GraalVM native executable.
+  >**Info:** Introduced the `--native` flag to the `bal test` command, which executes tests using a GraalVM native executable.
 
 #### Language Server
 
 - Added the `Create variable with Type` code action.
-- Added rename popup support for `Extract to constant`, `Extract to local variable` , and `Extract to function` code actions.
+- Added rename popup support to the `Extract to constant`, `Extract to local variable` , and `Extract to function` code actions.
  >**Info:** This feature will be available from the [Ballerina VS Code extension](https://wso2.com/ballerina/vscode/docs/edit-the-code/code-actions/) version `4.0.0`.
 - Added quick pick support for selecting expressions in the `Extract to constant` code action.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -285,8 +285,8 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 To view bug fixes, see the GitHub milestone for Swan Lake 2201.4.0 of the repositories below.
 
-- [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.4.0+is%3Aclosed)
-- [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.4.0+is%3Aclosed+label%3AArea%2FDebugger)
+- [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.4.0+is%3Aclosed+label%3AType%2FBug)
+- [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.4.0+is%3Aclosed+label%3AArea%2FDebugger+label%3AType%2FBug)
 - [OpenAPI Tool](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aclosed+milestone%3A%22Swan+Lake+2201.4.0+%22+label%3AType%2FBug)
 
 ## Ballerina packages updates

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -2,7 +2,7 @@
 layout: ballerina-left-nav-release-notes
 title: 2201.4.0 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.4.0/
-active: 2201.2.2
+active: 2201.4.0
 redirect_from: 
     - /downloads/swan-lake-release-notes/2201.4.0
     - /downloads/swan-lake-release-notes/2201.4.0/

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -69,9 +69,9 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
 
 #### Get the user-defined type name on Singleton types
 
-- Calling `getName()` on the runtime class `FiniteType` will return the user-defined type name if it is available.
+- Calling `getName()` on the `FiniteType` runtime class will return the user-defined type name if it is available.
 
-  For example, if a constant is defined in the following way, the `getName()` method on the `FiniteType` will return the string `"OPEN"`.
+  For example, if a constant is defined in the following way, the `getName()` method on the `FiniteType` will return the `"OPEN"` string.
 
   ```ballerina
   const OPEN = "open";
@@ -126,9 +126,9 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
 
   | **Runtime API call**                            | **Result**                                                       |
   |-------------------------------------------------|------------------------------------------------------------------|
-  | `arr.getType()`                                 | This will return a `ReferenceType` with the name `IntegerArray`. |
-  | `getReferredType()` on `IntegerArray`           | This will return an `ArrayType` with name `IntegerArray`.        |
-  | `getElementType()` on `IntegerArray` array type | This will return a `ReferenceType` with the name `Integer`.      |
+  | `arr.getType()`                                 | This will return a `ReferenceType` with the `IntegerArray` name. |
+  | `getReferredType()` on `IntegerArray`           | This will return an `ArrayType` with the `IntegerArray` name.        |
+  | `getElementType()` on `IntegerArray` array type | This will return a `ReferenceType` with the `Integer` name.      |
 
   <br>
 
@@ -153,8 +153,8 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 #### `oauth2` package
 
-- Allow the use of inferred values for refreshing tokens through the password grant type.
-- Allow the use of string values for the `scopes` field in the client grant configuration. 
+- Allowed the use of inferred values for refreshing tokens through the password grant type.
+- Allowed the use of string values for the `scopes` field in the client grant configuration. 
 
 #### `graphql` package
 
@@ -167,7 +167,7 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 #### `persist` package
 
-- Added support for Ballerina Persistent Layer. This functionality is provided with the newly introduced `persist` package.
+- Added support for the Ballerina persistent layer. This functionality is provided with the newly introduced `persist` package.
 
   The Ballerina persistent layer provides the functionality of storing and querying data conveniently.
   >**Info:** This is an experimental feature. APIs might change in future releases.
@@ -176,7 +176,7 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 #### `graphql` package
 
-- Removed the limitation on the GraphQL `context` object parameter order.
+- Removed the limitation on the parameter order of the GraphQL `context` object.
 
 ### Backward-incompatible changes
 
@@ -232,13 +232,13 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
   With this support, users can define an entity data model, validate the model, and generate `persist` clients. This provides convenient APIs to store and query data in a data store.
 
-  >**Info:** This is an experimental feature; the commands associated with the tool might change in future releases.
+  >**Info:** This is an experimental feature. The commands associated with the tool might change in future releases.
 
 ### Improvements
 
 #### CLI
 
-- Improved the `bal format` CLI command by introducing new command options to selectively format modules or single files with a provided Ballerina package. The updated format of the `bal format` command is shown below.
+- Improved the `bal format` CLI command by introducing new command options to format modules or single files selectively with a provided Ballerina package. The updated format of the `bal format` command is shown below.
 
     ```bash
     bal format [OPTIONS] [<package>|<module>|<source-file>]
@@ -269,10 +269,10 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 #### OpenAPI Tool
 
-- Added support for the `additionalProperties` attribute in OpenAPI object schemas. With this support, the generated Ballerina records can be either open or closed records, based on the `additionalProperties` details.
-  >**Info:** Thereby, some of your already generated open records may change into closed records, when re-generating using 2201.4.0 (and above) versions.
-- Improved support for `nullable:true` property OpenAPI schema, to generate record fields with default values (e.g. `string? name = ();`), instead of making the field both nilable and optional (e.g. `string? name?;`).
-- Changed the default request and response types of the generated Ballerina resource/remote methods from `json` to `http:Request` and `http:Response`, respectively.
+- Added support for the `additionalProperties` attribute in OpenAPI object schemas. With this support, the generated Ballerina records can be either open or closed records based on the `additionalProperties` details.
+  >**Info:** Thereby, some of your already generated open records may change into closed records when re-generating using 2201.4.0 (and above) versions.
+- Improved the support for the `nullable:true` property OpenAPI schema to generate record fields with default values (e.g., `string? name = ();`) instead of making the field both nilable and optional (e.g., `string? name?;`).
+- Changed the default request and response types of the generated Ballerina resource/remote methods from `json` to `http:Request` and `http:Response` respectively.
 
 
 ### Breaking changes

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -215,7 +215,7 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 - Added the `Create variable with Type` code action.
 - Added rename popup support for `Extract to constant`, `Extract to local variable` , and `Extract to function` code actions.
- >**Info:** This feature will be available from the [Ballerina VSCode plugin](https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina) version `4.0.0`.
+ >**Info:** This feature will be available from the [Ballerina VS Code extension](https://wso2.com/ballerina/vscode/docs/edit-the-code/code-actions/) version `4.0.0`.
 - Added quick pick support for selecting expressions in the `Extract to constant` code action.
 
 #### GraphQL Tool

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -67,7 +67,7 @@ To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https
 
 ### Improvements
 
-#### Get the user-defined type name on Singleton types
+#### Get the user-defined type name on singleton types
 
 - Calling `getName()` on the `FiniteType` runtime class will return the user-defined type name if it is available.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -14,7 +14,7 @@ redirect_from:
 
 ## Overview of Ballerina Swan Lake 2201.4.0
 
-<em>2201.4.0 (Swan Lake) is the fourth major release of 2022, and it includes a new set of features and significant improvements to the compiler, runtime, standard library, and developer tooling. It is based on the 2022R4 version of the Language Specification.</em> 
+<em>2201.4.0 (Swan Lake Update 4) is the fourth major release of Ballerina Swan Lake, and it includes a new set of features and significant improvements to the compiler, runtime, standard library, and developer tooling. It is based on the 2022R4 version of the Language Specification.</em> 
 
 ## Update Ballerina
 
@@ -53,7 +53,7 @@ Annotations are now supported on tuple members. Tuple members can be annotated u
 
 ### Bug fixes
 
-- Annotation values of fields of record type descriptors that are not defined with a type definition are now accessible at runtime.
+Annotation values of fields of record type descriptors that are not defined with a type definition are now accessible at runtime.
 
 To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.4.0+is%3Aclosed+label%3AType%2FBug).
 
@@ -63,23 +63,23 @@ To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https
 
 #### Get the strand dump during `bal test`
 
-- When running the tests in a Ballerina package or a file using the `bal test` command, the strand dump can be obtained by sending the `SIGTRAP` signal to that process.
+When running the tests in a Ballerina package or a file using the `bal test` command, the strand dump can be obtained by sending the `SIGTRAP` signal to that process.
 
 ### Improvements
 
 #### Get the user-defined type name on singleton types
 
-- Calling `getName()` on the `FiniteType` runtime class will return the user-defined type name if it is available.
+Calling `getName()` on the `FiniteType` runtime class will return the user-defined type name if it is available.
 
-  For example, if a constant is defined in the following way, the `getName()` method on the `FiniteType` will return the `"OPEN"` string.
+For example, if a constant is defined in the following way, the `getName()` method on the `FiniteType` will return the `"OPEN"` string.
 
-  ```ballerina
-  const OPEN = "open";
-  ```
+```ballerina
+const OPEN = "open";
+```
 
 #### Type-reference type support in runtime Java APIs
 
-- The following runtime APIs are now modified to return the type-reference type instances according to the type definitions.
+The following runtime APIs are now modified to return the type-reference type instances according to the type definitions.
 
   | **Runtime API**                                                          | **Java class**                                     |
   |--------------------------------------------------------------------------|----------------------------------------------------|
@@ -113,16 +113,16 @@ To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https
   | `getType`                                                                | `io.ballerina.runtime.api.values.BValue`           |
   | `getType`                                                                | `io.ballerina.runtime.api.utils.TypeUtils`         |
 
-  For example, if the type-reference types are defined in the following way,
+For example, if the type-reference types are defined in the following way,
 
-  ```ballerina
-  type Integer int;
+```ballerina
+type Integer int;
 
-  type IntegerArray Integer[];
+type IntegerArray Integer[];
 
-  IntegerArray arr = [1, 2, 3, 4];
-  ```
-  the results of the runtime API calls will be as follows.
+IntegerArray arr = [1, 2, 3, 4];
+```
+the results of the runtime API calls will be as follows.
 
   | **Runtime API call**                            | **Result**                                                       |
   |-------------------------------------------------|------------------------------------------------------------------|
@@ -132,11 +132,11 @@ To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https
 
   <br>
 
-  > **Note:**
-  > The definition of the `getType` API in the `BObject` runtime class is now modified to the following.
-  > ```java
-  >  Type getType();
-  > ```
+> **Note:**
+> The definition of the `getType` API in the `BObject` runtime class is now modified to the following.
+> ```java
+>  Type getType();
+> ```
 
 ### Bug fixes
 
@@ -276,9 +276,9 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 ### Breaking changes
 
-- New improvements that were added to the `bal format` command to address some of the existing [limitations](https://github.com/ballerina-platform/ballerina-lang/issues/37868) may break the CLI usages of the `bal format <module-name>` option. 
+New improvements that were added to the `bal format` command to address some of the existing [limitations](https://github.com/ballerina-platform/ballerina-lang/issues/37868) may break the CLI usages of the `bal format <module-name>` option. 
 
-  >**Info:** In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.
+>**Info:** In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.
 
 ### Bug fixes
 
@@ -293,4 +293,4 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.4.0 of the reposi
 
 ### New features
 
-- Added support for maintaining generated code in a Ballerina package.
+Added support for maintaining generated code in a Ballerina package.

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -42,14 +42,13 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
 
 Annotations are now supported on tuple members. Tuple members can be annotated using annotations declared with the `field` attachment point.
 
-  ```ballerina
-  annotation annot on field;
+```ballerina
+annotation annot on field;
 
-  type T [int, @annot
-      string ];
-  ```
+type T [int, @annot string];
+```
 
-  Annotations are not allowed on the tuple rest descriptor. 
+Annotations are not allowed on the tuple rest descriptor. 
 
 ### Bug fixes
 
@@ -135,7 +134,7 @@ the results of the runtime API calls will be as follows.
 > **Note:**
 > The definition of the `getType` API in the `BObject` runtime class is now modified to the following.
 > ```java
->  Type getType();
+> Type getType();
 > ```
 
 ### Bug fixes

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -40,7 +40,7 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
 
 #### Support for annotations on tuple members
 
-- Annotations are now supported on tuple members. Tuple members can be annotated using annotations declared with the `field` attachment point.
+Annotations are now supported on tuple members. Tuple members can be annotated using annotations declared with the `field` attachment point.
 
   ```ballerina
   annotation annot on field;

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -14,7 +14,7 @@ redirect_from:
 
 ## Overview of Ballerina Swan Lake 2201.4.0
 
-<em>2201.4.0 (Swan Lake Update 4) is the fourth major release of Ballerina Swan Lake, and it includes a new set of features and significant improvements to the compiler, runtime, standard library, and developer tooling. It is based on the 2022R4 version of the Language Specification.</em> 
+<em>2201.4.0 (Swan Lake Update 4) is the fourth update release of Ballerina Swan Lake, and it includes a new set of features and significant improvements to the compiler, runtime, standard library, and developer tooling. It is based on the 2022R4 version of the Language Specification.</em> 
 
 ## Update Ballerina
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -285,6 +285,7 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 To view bug fixes, see the GitHub milestone for Swan Lake 2201.4.0 of the repositories below.
 
+- [Project API](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+label%3AType%2FBug+milestone%3A2201.4.0+label%3AArea%2FProjectAPI)
 - [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.4.0+is%3Aclosed+label%3AType%2FBug)
 - [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.4.0+is%3Aclosed+label%3AArea%2FDebugger+label%3AType%2FBug)
 - [OpenAPI Tool](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aclosed+milestone%3A%22Swan+Lake+2201.4.0+%22+label%3AType%2FBug)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -32,7 +32,7 @@ However, if you are using a version below 2201.0.0 (Swan Lake) and if you alread
 
 ## Install Ballerina
 
-If you have not installed Ballerina, then download the [installers](/downloads/#swanlake) to install.
+If you have not installed Ballerina, download the [installers](/downloads/#swanlake) to install.
 
 ## Language updates
 
@@ -45,7 +45,8 @@ If you have not installed Ballerina, then download the [installers](/downloads/#
   ```ballerina
   annotation annot on field;
 
-  type T [int, @annot string];
+  type T [int, @annot
+      string ];
   ```
 
   Annotations are not allowed on the tuple rest descriptor. 
@@ -212,10 +213,10 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 #### Language Server
 
-* Added the `Create variable with Type` code action.
-* Added rename popup support for `Extract to constant`, `Extract to local variable` , and `Extract to function` code actions.
+- Added the `Create variable with Type` code action.
+- Added rename popup support for `Extract to constant`, `Extract to local variable` , and `Extract to function` code actions.
  >**Info:** This feature will be available from the [Ballerina VSCode plugin](https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina) version `4.0.0`.
-* Added quick pick support for selecting expressions in the `Extract to constant` code action.
+- Added quick pick support for selecting expressions in the `Extract to constant` code action.
 
 #### GraphQL Tool
 
@@ -242,6 +243,7 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
     ```bash
     bal format [OPTIONS] [<package>|<module>|<source-file>]
     ```
+
     ```
     OPTIONS
         --module <module-name>
@@ -283,7 +285,6 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 To view bug fixes, see the GitHub milestone for Swan Lake 2201.4.0 of the repositories below.
 
-- [Project API](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AArea%2FProjectAPI+is%3Aclosed+milestone%3A2201.4.0+label%3AType%2FBug)
 - [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.4.0+is%3Aclosed)
 - [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.4.0+is%3Aclosed+label%3AArea%2FDebugger)
 - [OpenAPI Tool](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aclosed+milestone%3A%22Swan+Lake+2201.4.0+%22+label%3AType%2FBug)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -271,7 +271,7 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 - Added support for the `additionalProperties` attribute in OpenAPI object schemas. With this support, the generated Ballerina records can be either open or closed records based on the `additionalProperties` details.
   >**Info:** Thereby, some of your already generated open records may change into closed records when re-generating using 2201.4.0 (and above) versions.
-- Improved the support for the `nullable:true` property OpenAPI schema to generate record fields with default values (e.g., `string? name = ();`) instead of making the field both nilable and optional (e.g., `string? name?;`).
+- Improved the behaviour for the `nullable:true` property in OpenAPI schemas, to generate record fields with default values (e.g., `string? name = ();`), instead of making the field both nilable and optional (e.g., `string? name?;`).
 - Changed the default request and response types of the generated Ballerina resource/remote methods from `json` to `http:Request` and `http:Response` respectively.
 
 

--- a/utils/archived-lm.json
+++ b/utils/archived-lm.json
@@ -23,6 +23,14 @@
                     "id": "swan-lake-api-docs"
                 },
                 {
+                    "dirName": "2201.3.2",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "#2201.3.2",
+                    "id": "2201.3.2v"
+                },
+                {
                     "dirName": "2201.3.1",
                     "level": 2,
                     "position": 1,


### PR DESCRIPTION
## Purpose
Update the 2201.4.0 release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
