### PR TITLE
Redesign learn the language section

### DIFF
--- a/components/learn/language/Language.js
+++ b/components/learn/language/Language.js
@@ -47,41 +47,48 @@ export default function Language(props) {
       </Row>
 
       <Row className="pageContentRow llanding">
-        <Col xs={12} lg={6}>
+        <Col xs={12} lg={2} className={styles.newBox,styles.newBoxBorder} >
           <div className={styles.langRow}>
             <a href={`${prefix}/learn/language-basics`} className={styles.linkText}>Language basics</a>
           </div>
-
+        </Col>
+        <Col xs={12}  lg={2} className={styles.newBox,styles.newBoxBorder}>
           <div className={styles.langRow}>
             <a href={`${prefix}/learn/distinctive-language-features/network-interaction`} className={styles.linkText}>Network interaction</a>
           </div>
+        </Col>
+          <Col xs={12} lg={2} className={styles.newBox,styles.newBoxBorder}>
 
           <div className={styles.langRow}>
             <a href={`${prefix}/learn/distinctive-language-features/data`} className={styles.linkText}>Data</a>
           </div>
-
+        </Col>
+          <Col xs={12} lg={2} className={styles.newBox,styles.newBoxBorder}>
           <div className={styles.langRow}>
             <a href={`${prefix}/learn/distinctive-language-features/concurrency`} className={styles.linkText}>Concurrency</a>
           </div>
-
+        </Col>
+          <Col xs={12} lg={2} className={styles.newBox}>
           <div className={styles.langRow}>
             <a href={`${prefix}/learn/distinctive-language-features/advanced-general-purpose-language-features`} className={styles.linkText}>Advanced general purpose language features</a>
           </div>
-
-
-          {/* <div className={styles.langRow}>
-          <a href={`${prefix}/learn/#`} className={styles.linkBtn}>Complete language guide slides</a>
-          <a href="https://www.youtube.com/watch?list=PL7JOecNWBb0KX8RGAjF-oRknb_YIYN-dR&v=My_uqtHvXV8" className={styles.linkBtn}>Watch video</a>
-          </div> */}
         </Col>
 
-        <Col xs={12} lg={6} className={styles.btnCol}>
+       
+      </Row>
+      <Row className="pageContentRow llanding">
+
+
+        <Col xs={12} lg={8} className={styles.cHighlightedText}>
           <div className={styles.btnWrapper}>
-          <a href={`${prefix}/learn/language-walkthrough/#watch-the-videos`} className={styles.linkBtn}>Watch videos</a>
-          <a href={`${prefix}/learn/language-walkthrough/#view-the-slides`} className={styles.linkBtn}>View slides</a>
+          <div className={styles.btnWrapper}>
+          Explore more on the above topics via the concise video and slide resources. &nbsp; <a href={`${prefix}/learn/language-walkthrough/#watch-the-videos`} className={styles.linkText}>Watch videos</a> &nbsp;&nbsp;<span className={styles.linkTextSpan}>|</span>&nbsp;&nbsp; <a href={`${prefix}/learn/language-walkthrough/#view-the-slides`} className={styles.linkText}>View slides</a>
+       </div>
           </div>
         </Col>
       </Row>
     </>
   );
 }
+
+

--- a/components/learn/language/Language.module.css
+++ b/components/learn/language/Language.module.css
@@ -4,6 +4,7 @@
     display: flex;
     justify-content: space-between;
     flex-direction: column;
+    text-align: center;
     /* align-items: center; */
 }
 
@@ -16,6 +17,10 @@
 .linkText:hover {
     color: #57595d;
 }
+.newBox{width:20% ;float:left;padding: 0 15px; text-align: center;}
+.newBoxBorder{border-right: 1px solid #d7d7d7;width:20% ;float:left;}
+.cHighlightedText{background-color: #F8F8F8; padding: 25px ;}
+.linkTextSpan{color: #b3b3b3;}
 
 /* .linkVideo {
     padding: 5px 15px;
@@ -89,12 +94,23 @@
     .langRow {
         display: flex;
         justify-content: space-between;
-        flex-direction: row;
-        align-items: center;
+
+        
     }
 
     .linkBtn:not(:last-of-type) {
         margin-right: 10px;
     }
+    
+}
+@media (max-width: 820px) {
+    .newBoxBorder{width:100% ;float:left;padding: 0 15px; text-align: center;text-align: left;border: none !important;}
+    .newBox{width: 100%;text-align: left;}
+
+    .linkBtn:not(:last-of-type) {
+        margin-right: 10px;
+    }
+    .langRow{text-align: left;}
+    
 }
 

--- a/components/learn/platform/Platform.js
+++ b/components/learn/platform/Platform.js
@@ -119,10 +119,6 @@ export default function Platform(props) {
               <p className={styles.description}>Generate documentation for the code.</p>
             </div>
           </div>
-
-
-        </Col>
-        <Col xs={12} lg={4} className={styles.contentCol}>
           <div className={styles.pGroup}>
             <h3>Run in the cloud</h3>
 
@@ -146,6 +142,79 @@ export default function Platform(props) {
           </div>
 
 
+        </Col>
+        <Col xs={12} lg={4} className={styles.contentCol}>
+
+          <div className={styles.pGroup}>
+            <h3>Configure and observe</h3>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/configure-ballerina-programs/configure-a-sample-ballerina-service`} className={styles.titleLink}>
+                  Configure Ballerina programs
+                </a>
+              </p>
+              <p className={styles.description}>The language support for configurability.</p>
+            </div>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/observe-ballerina-programs`} className={styles.titleLink}>
+                  Observe Ballerina programs</a>
+              </p>
+              <p className={styles.description}>Basics of the observability functionalities that are provided for Ballerina programs.</p>
+            </div>
+          </div>
+          <div className={styles.pGroup}>
+            <h3>Java interoperability</h3>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/call-java-code-from-ballerina`} className={styles.titleLink}>
+                  Call Java code from Ballerina
+                </a>
+              </p>
+              <p className={styles.description}>Calling Java code from Ballerina.</p>
+            </div>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/java-interoperability-guide/java-interoperability`} className={styles.titleLink}>
+                  Java interoperability guide
+                </a>
+              </p>
+              <p className={styles.description}>Instructions on the supoorted Java interoperability.</p>
+            </div>
+          </div>
+
+          <div className={styles.pGroup}>
+            <h3>Native support</h3>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/build-a-native-executable`} className={styles.titleLink}>
+                  [Experimental] Build a native executable
+                </a>
+              </p>
+              <p className={styles.description}>Building a GraalVM native executable from Ballerina.</p>
+            </div>
+          </div>
+          <div className={styles.pGroup}>
+            <h3>Ballerina Central</h3>
+
+            <div className={styles.content}>
+              <p className={styles.title}>
+                <a href={`${prefix}/learn/publish-packages-to-ballerina-central`} className={styles.titleLink}>
+                  Publish packages to Ballerina Central
+                </a>
+              </p>
+              <p className={styles.description}>Details of publishing your library package to Ballerina Central.</p>
+            </div>
+          </div>
+
+          
+        </Col>
+        <Col xs={12} lg={4} className={styles.contentCol}>
           <div className={styles.pGroup}>
             <h3>Ballerina tooling</h3>
 
@@ -214,77 +283,7 @@ export default function Platform(props) {
 
 
         </Col>
-        <Col xs={12} lg={4} className={styles.contentCol}>
-
-          <div className={styles.pGroup}>
-            <h3>Configure and observe</h3>
-
-            <div className={styles.content}>
-              <p className={styles.title}>
-                <a href={`${prefix}/learn/configure-ballerina-programs/configure-a-sample-ballerina-service`} className={styles.titleLink}>
-                  Configure Ballerina programs
-                </a>
-              </p>
-              <p className={styles.description}>The language support for configurability.</p>
-            </div>
-
-            <div className={styles.content}>
-              <p className={styles.title}>
-                <a href={`${prefix}/learn/observe-ballerina-programs`} className={styles.titleLink}>
-                  Observe Ballerina programs</a>
-              </p>
-              <p className={styles.description}>Basics of the observability functionalities that are provided for Ballerina programs.</p>
-            </div>
-          </div>
-
-          <div className={styles.pGroup}>
-            <h3>Ballerina Central</h3>
-
-            <div className={styles.content}>
-              <p className={styles.title}>
-                <a href={`${prefix}/learn/publish-packages-to-ballerina-central`} className={styles.titleLink}>
-                  Publish packages to Ballerina Central
-                </a>
-              </p>
-              <p className={styles.description}>Details of publishing your library package to Ballerina Central.</p>
-            </div>
-          </div>
-
-          <div className={styles.pGroup}>
-            <h3>Java interoperability</h3>
-
-            <div className={styles.content}>
-              <p className={styles.title}>
-                <a href={`${prefix}/learn/call-java-code-from-ballerina`} className={styles.titleLink}>
-                  Call Java code from Ballerina
-                </a>
-              </p>
-              <p className={styles.description}>Calling Java code from Ballerina.</p>
-            </div>
-
-            <div className={styles.content}>
-              <p className={styles.title}>
-                <a href={`${prefix}/learn/java-interoperability-guide/java-interoperability`} className={styles.titleLink}>
-                  Java interoperability guide
-                </a>
-              </p>
-              <p className={styles.description}>Instructions on the supoorted Java interoperability.</p>
-            </div>
-          </div>
-
-          <div className={styles.pGroup}>
-            <h3>Native support</h3>
-
-            <div className={styles.content}>
-              <p className={styles.title}>
-                <a href={`${prefix}/learn/build-a-native-executable`} className={styles.titleLink}>
-                  [Experimental] Build a native executable
-                </a>
-              </p>
-              <p className={styles.description}>Building a GraalVM native executable from Ballerina.</p>
-            </div>
-          </div>
-        </Col>
+        
       </Row>
     </>
   );

--- a/components/learn/platform/Platform.module.css
+++ b/components/learn/platform/Platform.module.css
@@ -4,9 +4,9 @@
   
 .pGroup {
     border: #a7a8ab solid 0.3px;
-    padding: 15px;
+    padding: 25px;
     /* height: 120px; */
-    margin-bottom: 10px;
+    margin-bottom: 30px;
 }
 
 .pGroup h3 {
@@ -40,7 +40,7 @@
 }
 
 .contentCol {
-    display: flex;
+    /* display: flex; */
     flex-direction: column;
     justify-content: space-between;
 }


### PR DESCRIPTION
## Purpose
>Redesign the Learn the language section
<img width="1413" alt="image" src="https://user-images.githubusercontent.com/73055030/218954486-649b6c57-63b3-4d8d-8712-2579bf91905b.png">

and rearreange and increase padding spacing in Learn the platform
<img width="1245" alt="image" src="https://user-images.githubusercontent.com/73055030/218954903-c97c8d68-761b-4be7-a324-559d6165ca3c.png">


> Fixes #6268

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
