### PR TITLE
Update spacing in learn page

### DIFF
--- a/components/learn/intro/Intro.js
+++ b/components/learn/intro/Intro.js
@@ -26,7 +26,7 @@ export default function Intro() {
 
     return (
         <>
-            <Row className="pageContentRow justify-content-md-center llanding">
+            <Row className=" justify-content-md-center llanding">
                 <Col xs={12} lg={4} className={styles.introCard}>
                     <a href={`${prefix}/learn/install-ballerina/set-up-ballerina`} className={styles.cardLink}>
                         <div className={`${styles.cardContent} ${styles.primary}`}>
@@ -46,7 +46,7 @@ export default function Intro() {
                 </Col>
             </Row>
 
-            <Row className="pageContentRow justify-content-md-center llanding">
+            <Row className="cardBottomExtraMargin justify-content-md-center llanding">
                 <Col xs={12} lg={4} className={styles.introCard}>
                     <a href={`${prefix}/learn/by-example/`} className={styles.cardLink}>
                         <div className={`${styles.cardContent} ${styles.secondary}`}>

--- a/components/learn/intro/Intro.module.css
+++ b/components/learn/intro/Intro.module.css
@@ -1,6 +1,6 @@
 .introCard {
     text-align: center;
-    margin-bottom: 10px;
+    margin-bottom: 30px;
 }
   
 .cardContent {
@@ -50,6 +50,7 @@
     color: #fff;
     height: 120px;
 }
+
 
 @media (min-width: 576px) {
     .secondary {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -461,7 +461,7 @@ a.cGreenLinkArrow:hover {
 }
 
 .pageContentRow {
-  margin-bottom: 20px;
+  margin-bottom: 35px;
 }
 
 .pageContentRow h2 {
@@ -688,9 +688,10 @@ ul.eventsTabs {
 
 .learnRow {
   margin-top: 20px;
-  padding-top: 20px;
+  padding-top: 30px;
   border-top: #a7a8ab solid 0.3px;
 }
+.cardBottomExtraMargin{margin-bottom: 5px;}
 
 .useRow {
   margin-bottom: 15px;


### PR DESCRIPTION
## Purpose
> Increase spacing in learn landing page
<img width="1495" alt="image" src="https://user-images.githubusercontent.com/73055030/219276701-4697afe5-65d0-44d5-8b9b-60bb41a62ec2.png">

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
