### PR TITLE
Remove the horizontal bar on Learn page

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -689,7 +689,6 @@ ul.eventsTabs {
 .learnRow {
   margin-top: 20px;
   padding-top: 30px;
-  border-top: #a7a8ab solid 0.3px;
 }
 .cardBottomExtraMargin{margin-bottom: 5px;}
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -461,7 +461,7 @@ a.cGreenLinkArrow:hover {
 }
 
 .pageContentRow {
-  margin-bottom: 35px;
+  margin-bottom: 45px;
 }
 
 .pageContentRow h2 {


### PR DESCRIPTION
## Purpose
Remove the horizontal bar on Learn page as shown below to be consistent with the other Community and Home page designs.

![screenbud-a9e75563-b673-4eec-9c6c-b78cb23cb81d](https://user-images.githubusercontent.com/11707273/219653435-dfd5d148-8482-4e28-b0a3-50b80f2715bc.png)

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
