### PR TITLE
Fix the broken links of the GraphQL tool page

### DIFF
--- a/components/learn/platform/Platform.js
+++ b/components/learn/platform/Platform.js
@@ -245,11 +245,11 @@ export default function Platform(props) {
 
             <div className={styles.content}>
               <p className={styles.title}>
-                <a href={`${prefix}/learn/graphql-client-tool`} className={styles.titleLink}>
-                  GraphQL client tool
+                <a href={`${prefix}/learn/graphql-tool`} className={styles.titleLink}>
+                  GraphQL tool
                 </a>
               </p>
-              <p className={styles.description}>Details of the Ballerina GraphQL client tool.</p>
+              <p className={styles.description}>Details of the Ballerina GraphQL tool.</p>
             </div>
 
             <div className={styles.content}>

--- a/next.config.js
+++ b/next.config.js
@@ -98,8 +98,8 @@ const nextConfig = {
         destination: `/${redirectBase}learn/learn-the-platform/ballerina-tooling/openapi-tool`,
       },
       {
-        source: `/${redirectBase}learn/graphql-client-tool`,
-        destination: `/${redirectBase}learn/learn-the-platform/ballerina-tooling/graphql-client-tool`,
+        source: `/${redirectBase}learn/graphql-tool`,
+        destination: `/${redirectBase}learn/learn-the-platform/ballerina-tooling/graphql-tool`,
       },
       {
         source: `/${redirectBase}learn/asyncapi-tool`,

--- a/utils/learn-lm.json
+++ b/utils/learn-lm.json
@@ -253,12 +253,12 @@
                             ]
                         },
                         {
-                            "dirName": "GraphQL client tool",
+                            "dirName": "GraphQL tool",
                             "level": 3,
                             "position": 3,
                             "isDir": false,
-                            "url": "/learn/graphql-client-tool",
-                            "id": "graphql-client-tool"
+                            "url": "/learn/graphql-tool",
+                            "id": "graphql-tool"
                         },
                         {
                             "dirName": "AsyncAPI tool",


### PR DESCRIPTION
## Purpose
Fix the broken links of the GraphQL tool page.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
