### PR TITLE
Add copyright statement to B.io footer

### DIFF
--- a/components/common/footer/Footer.js
+++ b/components/common/footer/Footer.js
@@ -102,6 +102,7 @@
  
            <Col xs={12} sm={12} md={6} lg={6} className={styles.inspire}>
              <p>In the creation of Ballerina, we were inspired by many technologies. Thank you to all that have come before us (and forgive us if we missed one): Java, Go, C, C++, D, Rust, Haskell, Kotlin, Dart, TypeScript, JavaScript, Python, Perl, Flow, Swift, Elm, RelaxNG, NPM, Crates, Maven, Gradle, Kubernetes, Docker, Envoy, Markdown, GitHub, and WSO2.</p>
+             <p>Copyright © WSO2 LLC (2018-2023)</p>
            </Col>
          </Row>
  

--- a/components/common/footer/Footer.js
+++ b/components/common/footer/Footer.js
@@ -102,7 +102,6 @@
  
            <Col xs={12} sm={12} md={6} lg={6} className={styles.inspire}>
              <p>In the creation of Ballerina, we were inspired by many technologies. Thank you to all that have come before us (and forgive us if we missed one): Java, Go, C, C++, D, Rust, Haskell, Kotlin, Dart, TypeScript, JavaScript, Python, Perl, Flow, Swift, Elm, RelaxNG, NPM, Crates, Maven, Gradle, Kubernetes, Docker, Envoy, Markdown, GitHub, and WSO2.</p>
-             <p>Copyright © WSO2 LLC (2018-2023)</p>
            </Col>
          </Row>
  
@@ -116,6 +115,7 @@
                <li><Link className="footerLink" href={`/cookie-policy`}>COOKIE POLICY</Link></li>
                <li><Link className="footerLink" href={`/security-policy`}>SECURITY POLICY</Link></li>
                <li><Link className="footerLink" href={`/trademark-usage-policy/`}>TRADEMARK USAGE POLICY</Link></li>
+               <li><span className="footerLink">© Copyright (2018-2023) WSO2 LLC</span></li>
              </ul>
            </Col>
          </Row>


### PR DESCRIPTION
## Purpose
Add a copyright statement to B.io footer.
> Fixes #6345 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
