### PR TITLE
Add breaking changes section in 2201.4.0 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.3.4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.3.4/RELEASE_NOTE.md
@@ -12,7 +12,7 @@ redirect_from:
 
 ## Overview of Ballerina Swan Lake 2201.3.4
 
-<em>Swan Lake 2201.3.4 is the fourth patch release of Ballerina 2201.3.0 (Swan Lake Update 3) and it includes a new set of bug fixes to the debugger and xml components.</em>
+<em>Swan Lake 2201.3.4 is the fourth patch release of Ballerina 2201.3.0 (Swan Lake Update 3) and it includes a new set of bug fixes to the language and tooling.</em>
 
 ## Update Ballerina
 
@@ -36,5 +36,5 @@ If you have not installed Ballerina, then, download the [installers](/downloads/
 
 ### Bug fixes
 
-To view bug fixes, see the [GitHub milestone for 2201.3.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.3.4+is%3Aclosed).
+To view bug fixes, see the [GitHub milestone for 2201.3.4 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.3.4+is%3Aclosed+label%3AType%2FBug).
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -129,14 +129,6 @@ the results of the runtime API calls will be as follows.
   | `getReferredType()` on `IntegerArray`           | This will return an `ArrayType` with the `IntegerArray` name.        |
   | `getElementType()` on `IntegerArray` array type | This will return a `ReferenceType` with the `Integer` name.      |
 
-  <br>
-
-> **Note:**
-> The definition of the `getType` API in the `BObject` runtime class is now modified to the following.
-> ```java
-> Type getType();
-> ```
-
 ### Bug fixes
 
 To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.4.0+label%3ATeam%2FjBallerina+label%3AType%2FBug+is%3Aclosed).
@@ -282,8 +274,6 @@ Added support for maintaining generated code in a Ballerina package.
 
 ## Backward-incompatible changes
 
-### Language updates
-
 - Fixed a bug that incorrectly resolved the result type of a query action that would complete normally to `error?` instead of `()`. Now, the result type includes `error` only in instances where an error can be generated during the execution of the query pipeline (`from` clause/`join` clause).
 
 ```ballerina
@@ -330,17 +320,20 @@ public function main() {
    resultInt += 1; // error: resultInt may not have been initialized
 }
 ```
-### Standard library updates
-
-#### `io` package
 
 - Made the column headers mandatory in CSV files to ensure the order of fields while mapping CSV files to records. This is only applicable for the case where the expected type is `record[]`.
+
 - Made the column headers automatically be written to the CSV file to ensure the order of fields while writing a `record[]` to a CSV.
 
-### Developer tools updates
+- Added new improvements to the `bal format` command to address some of the existing [limitations](https://github.com/ballerina-platform/ballerina-lang/issues/37868) may break the CLI usages of the `bal format <module-name>` option. 
 
-#### CLI
+ >**Info:** In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.
 
-New improvements that were added to the `bal format` command to address some of the existing [limitations](https://github.com/ballerina-platform/ballerina-lang/issues/37868) may break the CLI usages of the `bal format <module-name>` option. 
+- modified the definition of the `getType` API in the `BObject` runtime class to the following.
 
->**Info:** In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.
+  ```java
+  Type getType();
+  ```
+  
+  >**Note:** The modules that use this API that are compiled with older Ballerina versions will break now due to this modification. Deleting the `Dependencies.toml` file, clearing the internal cache, and republishing these modules will be required to resolve this.
+ 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -276,50 +276,50 @@ Added support for maintaining generated code in a Ballerina package.
 
 - Fixed a bug that incorrectly resolved the result type of a query action that would complete normally to `error?` instead of `()`. Now, the result type includes `error` only in instances where an error can be generated during the execution of the query pipeline (`from` clause/`join` clause).
 
-```ballerina
-public function main() returns error? {
-    from int i in 1 ... 3 // now valid
-    do {
-    };
-}
+  ```ballerina
+  public function main() returns error? {
+      from int i in 1 ... 3 // now valid
+      do {
+      };
+  }
 
-function iterateStream(stream<int, error?> numberStream) returns error? {
-    check from int num in numberStream
-        do {
-        };
-}
-```
+  function iterateStream(stream<int, error?> numberStream) returns error? {
+      check from int num in numberStream
+          do {
+          };
+  }
+  ```
 
 - Fixed a bug that incorrectly propagated errors returned in a `do` clause of a query action to the result of the query action. Now, if the execution of a statement within a `do` clause fails with an error, it will be propagated to the nearest enclosing failure-handling statement.
 
-```ballerina
-public function main() {
-    error? queryActResult = from int i in 1 ... 3
-        do {
-            check validateAndGetError(); // error: invalid usage of the 'check' expression operator; 
-                                         // no matching error return type(s) in the enclosing invokable
-        };
-}
+  ```ballerina
+  public function main() {
+      error? queryActResult = from int i in 1 ... 3
+          do {
+              check validateAndGetError(); // error: invalid usage of the 'check' expression operator; 
+                                          // no matching error return type(s) in the enclosing invokable
+          };
+  }
 
-function validateAndGetError() returns error? {
-    return error("Invalid error");
-}
-```
+  function validateAndGetError() returns error? {
+      return error("Invalid error");
+  }
+  ```
 
 - Fixed a bug that resulted in variables that may or may not be initialized in an `on fail` clause not being identified as potentially uninitialized variables.
 
-```ballerina
-public function main() {
-   int resultInt;
-   transaction {
-       resultInt = check maybeProvideInt(true);
-       check commit;
-   } on fail {
-       io:println("Failed to initialize resultInt");
-   }
-   resultInt += 1; // error: resultInt may not have been initialized
-}
-```
+  ```ballerina
+  public function main() {
+    int resultInt;
+    transaction {
+        resultInt = check maybeProvideInt(true);
+        check commit;
+    } on fail {
+        io:println("Failed to initialize resultInt");
+    }
+    resultInt += 1; // error: resultInt may not have been initialized
+  }
+  ```
 
 - Made the column headers mandatory in CSV files to ensure the order of fields while mapping CSV files to records. This is only applicable for the case where the expected type is `record[]`.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -50,55 +50,6 @@ type T [int, @annot string];
 
 Annotations are not allowed on the tuple rest descriptor. 
 
-### Backward-incompatible changes
-
-- Fixed a bug that incorrectly resolved the result type of a query action that would complete normally to `error?` instead of `()`. Now, the result type includes `error` only in instances where an error can be generated during the execution of the query pipeline (`from` clause/`join` clause).
-
-```ballerina
-public function main() returns error? {
-    from int i in 1 ... 3 // now valid
-    do {
-    };
-}
-
-function iterateStream(stream<int, error?> numberStream) returns error? {
-    check from int num in numberStream
-        do {
-        };
-}
-```
-
-- Fixed a bug that incorrectly propagated errors returned in a `do` clause of a query action to the result of the query action. Now, if the execution of a statement within a `do` clause fails with an error, it will be propagated to the nearest enclosing failure-handling statement.
-
-```ballerina
-public function main() {
-    error? queryActResult = from int i in 1 ... 3
-        do {
-            check validateAndGetError(); // error: invalid usage of the 'check' expression operator; 
-                                         // no matching error return type(s) in the enclosing invokable
-        };
-}
-
-function validateAndGetError() returns error? {
-    return error("Invalid error");
-}
-```
-
-- Fixed a bug that resulted in variables that may or may not be initialized in an `on fail` clause not being identified as potentially uninitialized variables.
-
-```ballerina
-public function main() {
-   int resultInt;
-   transaction {
-       resultInt = check maybeProvideInt(true);
-       check commit;
-   } on fail {
-       io:println("Failed to initialize resultInt");
-   }
-   resultInt += 1; // error: resultInt may not have been initialized
-}
-```
-
 ### Bug fixes
 
 Annotation values of fields of record type descriptors that are not defined with a type definition are now accessible at runtime.
@@ -225,13 +176,6 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 - Removed the limitation on the parameter order of the GraphQL `context` object.
 
-### Backward-incompatible changes
-
-#### `io` package
-
-- Made the column headers mandatory in CSV files to ensure the order of fields while mapping CSV files to records. This is only applicable for the case where the expected type is `record[]`.
-- Made the column headers automatically be written to the CSV file to ensure the order of fields while writing a `record[]` to a CSV.
-
 ### Bug fixes
 
 To view bug fixes, see the [GitHub milestone for Swan Lake 2201.4.0](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aclosed+is%3Aissue+milestone%3A%222201.4.0%22+label%3AType%2FBug).
@@ -321,12 +265,6 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 - Improved the behaviour for the `nullable:true` property in OpenAPI schemas, to generate record fields with default values (e.g., `string? name = ();`), instead of making the field both nilable and optional (e.g., `string? name?;`).
 - Changed the default request and response types of the generated Ballerina resource/remote methods from `json` to `http:Request` and `http:Response` respectively.
 
-### Backward-incompatible changes
-
-New improvements that were added to the `bal format` command to address some of the existing [limitations](https://github.com/ballerina-platform/ballerina-lang/issues/37868) may break the CLI usages of the `bal format <module-name>` option. 
-
->**Info:** In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.
-
 ### Bug fixes
 
 To view bug fixes, see the GitHub milestone for Swan Lake 2201.4.0 of the repositories below.
@@ -341,3 +279,68 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.4.0 of the reposi
 ### New features
 
 Added support for maintaining generated code in a Ballerina package.
+
+## Backward-incompatible changes
+
+### Language updates
+
+- Fixed a bug that incorrectly resolved the result type of a query action that would complete normally to `error?` instead of `()`. Now, the result type includes `error` only in instances where an error can be generated during the execution of the query pipeline (`from` clause/`join` clause).
+
+```ballerina
+public function main() returns error? {
+    from int i in 1 ... 3 // now valid
+    do {
+    };
+}
+
+function iterateStream(stream<int, error?> numberStream) returns error? {
+    check from int num in numberStream
+        do {
+        };
+}
+```
+
+- Fixed a bug that incorrectly propagated errors returned in a `do` clause of a query action to the result of the query action. Now, if the execution of a statement within a `do` clause fails with an error, it will be propagated to the nearest enclosing failure-handling statement.
+
+```ballerina
+public function main() {
+    error? queryActResult = from int i in 1 ... 3
+        do {
+            check validateAndGetError(); // error: invalid usage of the 'check' expression operator; 
+                                         // no matching error return type(s) in the enclosing invokable
+        };
+}
+
+function validateAndGetError() returns error? {
+    return error("Invalid error");
+}
+```
+
+- Fixed a bug that resulted in variables that may or may not be initialized in an `on fail` clause not being identified as potentially uninitialized variables.
+
+```ballerina
+public function main() {
+   int resultInt;
+   transaction {
+       resultInt = check maybeProvideInt(true);
+       check commit;
+   } on fail {
+       io:println("Failed to initialize resultInt");
+   }
+   resultInt += 1; // error: resultInt may not have been initialized
+}
+```
+### Standard library updates
+
+#### `io` package
+
+- Made the column headers mandatory in CSV files to ensure the order of fields while mapping CSV files to records. This is only applicable for the case where the expected type is `record[]`.
+- Made the column headers automatically be written to the CSV file to ensure the order of fields while writing a `record[]` to a CSV.
+
+### Developer tools updates
+
+#### CLI
+
+New improvements that were added to the `bal format` command to address some of the existing [limitations](https://github.com/ballerina-platform/ballerina-lang/issues/37868) may break the CLI usages of the `bal format <module-name>` option. 
+
+>**Info:** In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -329,7 +329,7 @@ public function main() {
 
  >**Info:** In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.
 
-- modified the definition of the `getType` API in the `BObject` runtime class to the following.
+- Modified the definition of the `getType` API in the `BObject` runtime class to the following.
 
   ```java
   Type getType();

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -274,6 +274,16 @@ Added support for maintaining generated code in a Ballerina package.
 
 ## Backward-incompatible changes
 
+- Modified the definitions of the `getType` API in the `BObject` runtime class to the following.
+
+  ```java
+  Type getType();
+  ```
+  
+  Also, modified the behavior of the [runtime Java APIs to support the type-reference type](/downloads/swan-lake-release-notes/swan-lake-2201.4.0#type-reference-type-support-in-runtime-java-apis).
+
+  >**Note:** The modules that use these APIs that are compiled with older Ballerina versions will break now due to these modifications. Deleting the `Dependencies.toml` file, clearing the internal cache, and republishing these modules will be required to resolve this.
+
 - Fixed a bug that incorrectly resolved the result type of a query action that would complete normally to `error?` instead of `()`. Now, the result type includes `error` only in instances where an error can be generated during the execution of the query pipeline (`from` clause/`join` clause).
 
   ```ballerina
@@ -328,14 +338,3 @@ Added support for maintaining generated code in a Ballerina package.
 - Added new improvements to the `bal format` command to address some of the existing [limitations](https://github.com/ballerina-platform/ballerina-lang/issues/37868) may break the CLI usages of the `bal format <module-name>` option. 
 
  >**Info:** In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.
-
-- Modified the definitions of the `getType` API in the `BObject` runtime class to the following.
-
-  ```java
-  Type getType();
-  ```
-  
-  Also, modified the behavior of the [runtime Java APIs to support the type-reference type](/downloads/swan-lake-release-notes/swan-lake-2201.4.0#type-reference-type-support-in-runtime-java-apis).
-
-  >**Note:** The modules that use these APIs that are compiled with older Ballerina versions will break now due to these modifications. Deleting the `Dependencies.toml` file, clearing the internal cache, and republishing these modules will be required to resolve this.
- 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -329,11 +329,13 @@ public function main() {
 
  >**Info:** In such instances, the `bal format <package-path> --module <module-name>` option can be used for the same purpose from the Swan Lake Update 4 release onwards.
 
-- Modified the definition of the `getType` API in the `BObject` runtime class to the following.
+- Modified the definitions of the `getType` API in the `BObject` runtime class to the following.
 
   ```java
   Type getType();
   ```
   
-  >**Note:** The modules that use this API that are compiled with older Ballerina versions will break now due to this modification. Deleting the `Dependencies.toml` file, clearing the internal cache, and republishing these modules will be required to resolve this.
+  Also, modified the behavior of the [runtime Java APIs to support the type-reference type](/downloads/swan-lake-release-notes/swan-lake-2201.4.0#type-reference-type-support-in-runtime-java-apis).
+
+  >**Note:** The modules that use these APIs that are compiled with older Ballerina versions will break now due to these modifications. Deleting the `Dependencies.toml` file, clearing the internal cache, and republishing these modules will be required to resolve this.
  


### PR DESCRIPTION
## Purpose
Add breaking changes section in 2201.4.0 release note.
> Fixes #6505 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
