### PR TITLE
Add the 2201.5.0 (Swan Lake Update 5) release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
@@ -1,0 +1,118 @@
+---
+layout: ballerina-left-nav-release-notes
+title: 2201.5.0 (Swan Lake) 
+permalink: /downloads/swan-lake-release-notes/2201.5.0/
+active: 2201.5.0
+redirect_from: 
+    - /downloads/swan-lake-release-notes/2201.5.0
+    - /downloads/swan-lake-release-notes/2201.5.0/
+    - /downloads/swan-lake-release-notes/2201.5.0-swan-lake/
+    - /downloads/swan-lake-release-notes/2201.5.0-swan-lake
+    - /downloads/swan-lake-release-notes/
+    - /downloads/swan-lake-release-notes
+---
+
+## Overview of Ballerina Swan Lake 2201.5.0
+
+<em>2201.5.0 (Swan Lake Update 5) is the fourth update release of Ballerina Swan Lake, and it includes a new set of features and significant improvements to the compiler, runtime, standard library, and developer tooling. It is based on the 2022R4 version of the Language Specification.</em> 
+
+## Update Ballerina
+
+**If you are already using Ballerina 2201.0.0 (Swan Lake)**, run either of the commands below to directly update to 2201.5.0 using the [Ballerina Update Tool](/learn/cli-documentation/update-tool/).
+
+`bal dist update` (or `bal dist pull 2201.5.0`)
+
+**If you are using a version below 2201.0.0 (Swan Lake)**, run the commands below to update to 2201.5.0.
+
+1. Run `bal update` to get the latest version of the Update Tool.
+
+2. Run `bal dist update` ( or `bal dist pull 2201.5.0`) to update your Ballerina version to 2201.5.0.
+
+However, if you are using a version below 2201.0.0 (Swan Lake) and if you already ran `bal dist update` (or `bal dist pull 2201.5.0`) before `bal update`, see [Troubleshooting](/downloads/swan-lake-release-notes/swan-lake-2201.0.0#troubleshooting) to recover your installation.
+
+## Install Ballerina
+
+If you have not installed Ballerina, download the [installers](/downloads/#swanlake) to install.
+
+## Language updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.5.0](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.5.0+is%3Aclosed+label%3AType%2FBug).
+
+## Runtime updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for 2201.5.0 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.5.0+label%3ATeam%2FjBallerina+label%3AType%2FBug+is%3Aclosed).
+
+## Standard library updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for Swan Lake 2201.5.0](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aclosed+is%3Aissue+milestone%3A%222201.5.0%22+label%3AType%2FBug).
+
+### Code to Cloud updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for 2201.5.0 (Swan Lake)](https://github.com/ballerina-platform/module-ballerina-c2c/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22Ballerina+2201.5.0%22+label%3AType%2FBug).
+
+## Developer tools updates
+
+### New features
+
+#### Test Framework
+
+#### Language Server
+
+#### GraphQL Tool
+
+#### OpenAPI Tool
+
+#### Persist Tool
+
+### Improvements
+
+#### CLI
+
+#### JSON-to-record converter
+
+#### Language Server
+
+#### OpenAPI Tool
+
+### Bug fixes
+
+To view bug fixes, see the GitHub milestone for Swan Lake 2201.5.0 of the repositories below.
+
+- [Project API](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+label%3AType%2FBug+milestone%3A2201.5.0+label%3AArea%2FProjectAPI)
+- [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.5.0+is%3Aclosed+label%3AType%2FBug)
+- [Debugger](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.5.0+is%3Aclosed+label%3AArea%2FDebugger+label%3AType%2FBug)
+- [OpenAPI Tool](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aclosed+milestone%3A%22Swan+Lake+2201.5.0+%22+label%3AType%2FBug)
+
+## Ballerina packages updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+## Backward-incompatible changes

--- a/utils/archived-lm.json
+++ b/utils/archived-lm.json
@@ -23,6 +23,22 @@
                     "id": "swan-lake-api-docs"
                 },
                 {
+                    "dirName": "2201.4.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "#2201.4.1",
+                    "id": "2201.4.1v"
+                },
+                {
+                    "dirName": "2201.4.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "#2201.4.0",
+                    "id": "2201.4.0v"
+                },
+                {
                     "dirName": "2201.3.4",
                     "level": 2,
                     "position": 1,

--- a/utils/rl.json
+++ b/utils/rl.json
@@ -15,6 +15,22 @@
             "id": "swan-lake-release-notes",
             "subDirectories": [
                 {
+                    "dirName": "2201.5.0 (Swan Lake Update 5)",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.0",
+                    "id": "swan-lake-2201.5.0"
+                },
+                {
+                    "dirName": "2201.4.1 (Swan Lake Update 4)",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.1",
+                    "id": "swan-lake-2201.4.1"
+                },
+                {
                     "dirName": "2201.4.0 (Swan Lake Update 4)",
                     "level": 2,
                     "position": 1,


### PR DESCRIPTION
## Purpose
Add the 2201.5.0 (Swan Lake Update 5) release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
