### PR TITLE
Add runtime changes to `2201.5.0` release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
@@ -87,7 +87,7 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
     }
     ```
 
-- Fixed a bug that resulted in inconsistent error messages with `cloneWithType` operation.
+- Fixed a bug that resulted in inconsistent error messages with the `cloneWithType` operation.
     
     ```ballerina
     type OpenRecord record {
@@ -206,6 +206,7 @@ public static void getResource(BObject client, BArray path, BString str) {
 
 - The `getType` runtime API, which returns an `ObjectType` in the `io.ballerina.runtime.api.values.BObject` class is now deprecated. A new `getOriginalType` API, which returns the `Type` is introduced to return both the `ObjectType` and the type-reference type.
 - The `XMLNS` Java constant in the `io.ballerina.runtime.api.values.BXmlItem` runtime class is now deprecated. Instead, the `javax.xml.XMLConstants.XMLNS_ATTRIBUTE` constant needs to be used.
+
 ### Bug fixes
 
 To view bug fixes, see the [GitHub milestone for 2201.5.0 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.5.0+label%3ATeam%2FjBallerina+label%3AType%2FBug+is%3Aclosed).

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
@@ -134,7 +134,7 @@ bal run -- 1 b 33
 When a structural value is provided for a configurable variable of a union type that includes more than one type descriptor, the inherent type used will be the first (leftmost) type descriptor, from which the value can be constructed.
 
 For example, given the following Ballerina code
-```bal
+```ballerina
 type Person record {|
     string name;
     string city;

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
@@ -126,33 +126,33 @@ To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.5.0](https
 
 #### New Runtime Java APIs
 
-- To clone an `anydata` value with another subtype of `anydata` type, the following API is introduced in the `io.ballerina.runtime.api.utils.ValueUtils` class.
+- Introduced the following API in the `io.ballerina.runtime.api.utils.ValueUtils` class to clone an `anydata` value with another subtype of the `anydata` type.
     ```java
     public static Object convert(Object value, Type targetType);
     ```
-- `getFunctionName()` and `getPathParameters()` APIs are introduced in the runtime `io.ballerina.runtime.api.Environment` class. They provide the Ballerina function name and path parameters associated with an external Java method, respectively.
+- Introduced the `getFunctionName()` and `getPathParameters()` APIs in the runtime `io.ballerina.runtime.api.Environment` class. They provide the Ballerina function name and path parameters associated with an external Java method respectively.
 
 ### Improvements
 
-#### Support for command line arguments of built-in subtypes
+#### Support for command-line arguments of built-in subtypes
 
-The command-line arguments of Ballerina built-in subtypes are now supported to be parsed as operands.
+The command-line arguments of the Ballerina built-in subtypes are now supported to be parsed as operands.
 
 For the following `main` function,
 ```ballerina
 public function main(byte byteVal, string:Char charVal, int:Signed8 int8Val) {
 }
 ```
-the values can be passed through the command line arguments as follows.
+the values can be passed through command-line arguments as follows.
 ```
 bal run -- 1 b 33
 ```
 
 #### Support ambiguous union type configurable variables
 
-When a structural value is provided for a configurable variable of a union type that includes more than one type descriptor, the inherent type used will be the first (leftmost) type descriptor, from which the value can be constructed.
+When a structural value is provided for a configurable variable of a union type that includes more than one type descriptor, the inherent type used will be the first (leftmost) type descriptor from which the value can be constructed.
 
-For example, given the following Ballerina code
+For example, in the following Ballerina code,
 ```ballerina
 type Person record {|
     string name;
@@ -161,15 +161,15 @@ type Person record {|
 
 configurable map<string>|Person configVar = ?;
 ```
-and the `Config.toml` file contents as follows,
+and when the `Config.toml` file contents are as follows,
 ```toml
 configVar = {name = "Jack", city = "Colombo"}
 ```
-`configVar` is instantiated with the inherent type `map<string>`.
+`configVar` is instantiated with the `map<string>` inherent type.
 
 #### Support binding of resource functions to a generic native method
 
-A new way has been introduced to support the binding of any resource function to a generic native method, regardless of the resource path parameters. The generic native method should be defined with a `BArray` parameter, which represents all path parameters. To avoid errors due to overloaded methods, it is recommended to define parameter type constraints as well.
+A new way has been introduced to support the binding of any resource function to a generic native method regardless of the resource path parameters. The generic native method should be defined with a `BArray` parameter, which represents all the path parameters. To avoid errors due to overloaded methods, it is recommended to define the parameter type constraints as well.
 
 For example, the following Ballerina resource function
 ```ballerina
@@ -187,8 +187,7 @@ public static void getResource(BObject client, BArray path, BString str) {
 
 #### Improvements in Runtime Java APIs
 
-- The `getType` runtime API which returns an `ObjectType` in `io.ballerina.runtime.api.values.BObject` class is now deprecated. A new API `getOriginalType` which returns the `Type` is introduced to return both the `ObjectType` and the type-reference type. We need to modify the previous `getType` API to return the `Type` after fixing the caching issue [#39850](https://github.com/ballerina-platform/ballerina-lang/issues/39850).
-
+- The `getType` runtime API, which returns an `ObjectType` in the `io.ballerina.runtime.api.values.BObject` class is now deprecated. A new `getOriginalType` API, which returns the `Type` is introduced to return both the `ObjectType` and the type-reference type.
 - The java constant `XMLNS` in `io.ballerina.runtime.api.values.BXmlItem` runtime class is now deprecated. The constant `javax.xml.XMLConstants.XMLNS_ATTRIBUTE` needs to be used instead.
 
 ### Bug fixes

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
@@ -118,14 +118,11 @@ To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.5.0](https
 The command-line arguments of Ballerina built-in subtypes are now supported to be parsed as operands.
 
 For the following `main` function,
-
 ```ballerina
 public function main(byte byteVal, string:Char charVal, int:Signed8 int8Val) {
 }
 ```
-
 the values can be passed through the command line arguments as follows.
-
 ```
 bal run -- 1 b 33
 ```
@@ -160,9 +157,7 @@ isolated resource function get abc/[int p1]/[string p2]/[string p3]/[int ...p4] 
         paramTypes: ["io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BString"]
     } external;
 ```
-
 can be bound to the following Java method.
-
 ```java
 public static void getResource(BObject client, BArray path, BString str) {
 }

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
@@ -98,6 +98,12 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
         json jsonVal = checkpanic tupleVal.cloneWithType();
     }
     ```
+    now gives
+    ```
+    error: {ballerina/lang.value}ConversionError {"message":"'[OpenRecord...]' value cannot be converted to 'json'"}
+        at ballerina.lang.value.0:cloneWithType(value.bal:114)
+           sample:main(sample.bal:6)
+    ```
 
 - Improved the error message given in a failure of `fromJsonWithType` or `cloneWithType` operations, when the target type is a union type.
     
@@ -106,6 +112,17 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
         json j = [1, 1.2, "hello"];
         int[]|float[] val = checkpanic j.fromJsonWithType();
     }
+    ```
+    now gives
+    ```
+    error: {ballerina/lang.value}ConversionError {"message":"'json[]' value cannot be converted to '(int[]|float[])': 
+                {
+                  array element '[2]' should be of type 'int', found '"hello"'
+                or
+                  array element '[2]' should be of type 'float', found '"hello"'
+                }"}
+        at ballerina.lang.value.0:fromJsonWithType(value.bal:370)
+           sample:main(sample.bal:3)
     ```
 
 - Due to an internal API change, the GraphQL `1.7.0` package is not compatible with older Ballerina versions and older GraphQL versions are not compatible with Ballerina `2201.5.0`. When migrating to Ballerina `2201.5.0` from previous Ballerina distributions, the GraphQL version should be updated to `1.7.0` with this release.

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
@@ -103,7 +103,76 @@ To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.5.0](https
 
 ### New features
 
+#### New Runtime Java APIs
+
+- To clone an `anydata` value with another subtype of `anydata` type, the following API is introduced in the `io.ballerina.runtime.api.utils.ValueUtils` class.
+    ```java
+    public static Object convert(Object value, Type targetType);
+    ```
+- `getFunctionName()` and `getPathParameters()` APIs are introduced in the runtime `io.ballerina.runtime.api.Environment` class. They provide the Ballerina function name and path parameters associated with Java interop methods, respectively.
+
 ### Improvements
+
+#### Support for command line arguments of built-in subtypes
+
+The command-line arguments of Ballerina built-in subtypes are now supported to be parsed as operands.
+
+For the following `main` function,
+
+```ballerina
+public function main(byte byteVal, string:Char charVal, int:Signed8 int8Val) {
+}
+```
+
+the values can be passed through the command line arguments as follows.
+
+```
+bal run -- 1 b 33
+```
+#### Support ambiguous union type configurable variables
+
+When a structural value is provided for a configurable variable of a union type that includes more than one type descriptor, the inherent type used will be the first (leftmost) type descriptor, from which the value can be constructed.
+
+For example, given the following Ballerina code
+```bal
+type Person record {|
+    string name;
+    string city;
+|};
+
+configurable map<string>|Person configVar = ?;
+```
+and the `Config.toml` file contains the following,
+```toml
+configVar = {name = "Jack", city = "Colombo"}
+```
+`configVar` is instantiated with the inherent type `map<string>`.
+
+#### Support binding of resource functions to a generic native method
+
+A new way has been introduced to support the binding of any resource function to a generic native method, regardless of the resource path parameters. The generic native method should be defined with a `BArray` parameter, which represents all path parameters. To avoid errors due to overloaded methods, it is recommended to define parameter type constraints as well.
+
+For example, the following Ballerina resource function
+```ballerina
+isolated resource function get abc/[int p1]/[string p2]/[string p3]/[int ...p4] (string s) = @java:Method {
+        'class: "javalibs.app.App",
+        name: "getResource",
+        paramTypes: ["io.ballerina.runtime.api.values.BObject", "io.ballerina.runtime.api.values.BArray", "io.ballerina.runtime.api.values.BString"]
+    } external;
+```
+
+can be bound to the following Java method.
+
+```java
+public static void getResource(BObject client, BArray path, BString str) {
+}
+```
+
+#### Improvements in Runtime Java APIs
+
+- The `getType` runtime API which returns an `ObjectType` in `io.ballerina.runtime.api.values.BObject` class is now deprecated. A new API `getOriginalType` which returns the Type is introduced to return both the `ObjectType` and the type-reference type. We need to modify the previous `getType` API to return the Type after fixing the caching issue [#39850](https://github.com/ballerina-platform/ballerina-lang/issues/39850).
+
+- The java constant `XMLNS` in `io.ballerina.runtime.api.values.BXmlItem` runtime class is now deprecated. The constant `javax.xml.XMLConstants.XMLNS_ATTRIBUTE` needs to be used instead.
 
 ### Bug fixes
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
@@ -109,7 +109,7 @@ To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.5.0](https
     ```java
     public static Object convert(Object value, Type targetType);
     ```
-- `getFunctionName()` and `getPathParameters()` APIs are introduced in the runtime `io.ballerina.runtime.api.Environment` class. They provide the Ballerina function name and path parameters associated with Java interop methods, respectively.
+- `getFunctionName()` and `getPathParameters()` APIs are introduced in the runtime `io.ballerina.runtime.api.Environment` class. They provide the Ballerina function name and path parameters associated with an external Java method, respectively.
 
 ### Improvements
 
@@ -126,6 +126,7 @@ the values can be passed through the command line arguments as follows.
 ```
 bal run -- 1 b 33
 ```
+
 #### Support ambiguous union type configurable variables
 
 When a structural value is provided for a configurable variable of a union type that includes more than one type descriptor, the inherent type used will be the first (leftmost) type descriptor, from which the value can be constructed.
@@ -139,7 +140,7 @@ type Person record {|
 
 configurable map<string>|Person configVar = ?;
 ```
-and the `Config.toml` file contains the following,
+and the `Config.toml` file contents as follows,
 ```toml
 configVar = {name = "Jack", city = "Colombo"}
 ```
@@ -165,7 +166,7 @@ public static void getResource(BObject client, BArray path, BString str) {
 
 #### Improvements in Runtime Java APIs
 
-- The `getType` runtime API which returns an `ObjectType` in `io.ballerina.runtime.api.values.BObject` class is now deprecated. A new API `getOriginalType` which returns the Type is introduced to return both the `ObjectType` and the type-reference type. We need to modify the previous `getType` API to return the Type after fixing the caching issue [#39850](https://github.com/ballerina-platform/ballerina-lang/issues/39850).
+- The `getType` runtime API which returns an `ObjectType` in `io.ballerina.runtime.api.values.BObject` class is now deprecated. A new API `getOriginalType` which returns the `Type` is introduced to return both the `ObjectType` and the type-reference type. We need to modify the previous `getType` API to return the `Type` after fixing the caching issue [#39850](https://github.com/ballerina-platform/ballerina-lang/issues/39850).
 
 - The java constant `XMLNS` in `io.ballerina.runtime.api.values.BXmlItem` runtime class is now deprecated. The constant `javax.xml.XMLConstants.XMLNS_ATTRIBUTE` needs to be used instead.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
@@ -89,6 +89,27 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
 
 - Due to an internal API change, the GraphQL `1.7.0` package is not compatible with older Ballerina versions and older GraphQL versions are not compatible with Ballerina `2201.5.0`. When migrating to Ballerina `2201.5.0` from previous Ballerina distributions, the GraphQL version should be updated to `1.7.0` with this release.
 
+- Fixed a bug that resulted in inconsistent error messages with `cloneWithType` operation.
+    
+    ```ballerina
+    type OpenRecord record {
+    };
+
+    public function main() {
+        [OpenRecord...] tupleVal = [{"nonJson": xml `<a>abc</a>`}];
+        json jsonVal = checkpanic tupleVal.cloneWithType();
+    }
+    ```
+
+- Improved the error message given in a failure of `fromJsonWithType` or `cloneWithType` operations, when the target type is a union type.
+    
+    ```ballerina
+    public function main() {
+        json j = [1, 1.2, "hello"];
+        int[]|float[] val = checkpanic j.fromJsonWithType();
+    }
+    ```
+
 ## Language updates
 
 ### New features

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0 /RELEASE_NOTE.md
@@ -188,8 +188,7 @@ public static void getResource(BObject client, BArray path, BString str) {
 #### Improvements in Runtime Java APIs
 
 - The `getType` runtime API, which returns an `ObjectType` in the `io.ballerina.runtime.api.values.BObject` class is now deprecated. A new `getOriginalType` API, which returns the `Type` is introduced to return both the `ObjectType` and the type-reference type.
-- The java constant `XMLNS` in `io.ballerina.runtime.api.values.BXmlItem` runtime class is now deprecated. The constant `javax.xml.XMLConstants.XMLNS_ATTRIBUTE` needs to be used instead.
-
+- The `XMLNS` Java constant in the `io.ballerina.runtime.api.values.BXmlItem` runtime class is now deprecated. Instead, the `javax.xml.XMLConstants.XMLNS_ATTRIBUTE` constant needs to be used.
 ### Bug fixes
 
 To view bug fixes, see the [GitHub milestone for 2201.5.0 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.5.0+label%3ATeam%2FjBallerina+label%3AType%2FBug+is%3Aclosed).


### PR DESCRIPTION
## Purpose
Add runtime release notes for the `2201.5.0` release.

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
