### PR TITLE
Fix typo in 1.2.36.md

### DIFF
--- a/downloads/1.2.x-release-notes/1.2.36.md
+++ b/downloads/1.2.x-release-notes/1.2.36.md
@@ -9,7 +9,7 @@ redirect_from:
 
 ### Overview of jBallerina 1.2.36
 
-The jBallerina 1.2.36 patch release improves upon the 1.2.27 release by addressing an [issue](https://github.com/ballerina-platform/ballerina-standard-library/issues/4083).
+The jBallerina 1.2.36 patch release improves upon the 1.2.35 release by addressing an [issue](https://github.com/ballerina-platform/ballerina-standard-library/issues/4083).
 
 You can use the update tool to update to jBallerina 1.2.36 as follows.
 


### PR DESCRIPTION
## Purpose
Fix typo in 1.2.36.md.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
