### PR TITLE
Fix syntax highlighting in code snippets inside tables

### DIFF
--- a/spec/graphql/spec.md
+++ b/spec/graphql/spec.md
@@ -2823,17 +2823,16 @@ To fully define an entity within a Ballerina GraphQL subgraph, you must:
 ###### Example: Federated Entity Definition and Corresponding GraphQL Schema
 
 <table>
-    <tr>
-        <th>Example</th>
+  <tr>
+    <th>Example</th>
         <th>Ballerina definition</th>
         <th>GraphQL schema</th>
-    </tr>
-    <tr>
-        <td>
-            Simple key
-        </td>
-        <td>
-            <pre lang="ballerina">
+  </tr>
+  <tr>
+    <td>Simple key</td>
+    <td>
+    <pre lang='ballerina'>
+
 ```ballerina
 @subgraph:Entity {
     key: "id",
@@ -2845,10 +2844,11 @@ type Product record {
     int price;
 };
 ```
-            </pre>
-        </td>
-        <td>
-            <pre lang="graphql">
+</pre>
+    </td>
+    <td>
+<pre lang='graphql'>
+
 ```graphql
 type Product @key(fields: "id") {
     id: String!
@@ -2856,15 +2856,14 @@ type Product @key(fields: "id") {
     price: Int!
 }
 ```
-            </pre>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            Mutiple keys
-        </td>
-        <td>
-            <pre lang="ballerina">
+</pre>
+    </td>
+  </tr>
+  <tr>
+    <td>Mutiple keys</td>
+    <td>
+    <pre lang='ballerina'>
+
 ```ballerina
 @subgraph:Entity {
     key: ["id", "sku"],
@@ -2877,10 +2876,11 @@ type Product record {
     int price;
 };
 ```
-            </pre>
-        </td>
-        <td>
-            <pre lang="graphql">
+</pre>
+    </td>
+    <td>
+    <pre lang='graphql'>
+
 ```graphql
 type Product @key(fields: "id") @key(fields: "sku") {
     id: String!
@@ -2889,15 +2889,14 @@ type Product @key(fields: "id") @key(fields: "sku") {
     price: Int!
 }
 ```
-            </pre>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            Compound key
-        </td>
-        <td>
-            <pre lang="ballerina">
+</pre>
+    </td>
+  </tr>
+  <tr>
+    <td>Compound key</td>
+    <td>
+    <pre lang='ballerina'>
+
 ```ballerina
 @subgraph:Entity {
     key: "id organization { id }",
@@ -2908,25 +2907,25 @@ type User record {
     Organization organization;
 }
 ```
-            </pre>
-        </td>
-        <td>
-            <pre lang="graphql">
+</pre>
+    </td>
+    <td>
+    <pre lang='graphql'>
+
 ```graphql
 type User @key(fields: "id organization { id }") {
     id: String!
     organization: Organization!
 }
 ```
-            </pre>
-        </td>
-    </tr>
-      <tr>
-        <td>
-            Non resolvable
-        </td>
-        <td>
-            <pre lang="ballerina">
+</pre>
+    </td>
+  </tr>
+  <tr>
+    <td>Non resolvable</td>
+    <td>
+    <pre lang='ballerina'>
+
 ```ballerina
 @subgraph:Entity {
     key: "id"
@@ -2936,18 +2935,19 @@ type Product record {
   id: String!
 }
 ```
-            </pre>
-        </td>
-        <td>
-            <pre lang="graphql">
+</pre>
+    </td>
+    <td>
+    <pre lang='graphql'>
+
 ```graphql
 type Product @key(fields: "id", resolvable: false) {
     id: ID!
 }
 ```
-            </pre>
-        </td>
-    </tr>
+</pre>
+    </td>
+  </tr>
 </table>
 
 #### 13.1.3 The `subgraph:ReferenceResolver`


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
