### PR TITLE
Remove redirections from learn pages

### DIFF
--- a/swan-lake/featured-use-cases/build-a-data-service-in-ballerina.md
+++ b/swan-lake/featured-use-cases/build-a-data-service-in-ballerina.md
@@ -6,13 +6,6 @@ keywords: ballerina, data service, mysql, database, REST, API
 permalink: /learn/build-a-data-service-in-ballerina/
 active: build-a-data-service
 intro: This guide helps you understand the basics of Ballerina constructs, which allow you to work with data services.
-
-redirect_from:
- - /learn/building-a-data-service-in-ballerina
- - /learn/building-a-data-service-in-ballerina/
- - /learn/build-a-data-service-in-ballerina
- - /learn/getting-started/building-a-data-service-in-ballerina/
- - /learn/getting-started/building-a-data-service-in-ballerina
 ---
 
 ## Set up the prerequisites

--- a/swan-lake/featured-use-cases/deploy-ballerina-on-kubernetes.md
+++ b/swan-lake/featured-use-cases/deploy-ballerina-on-kubernetes.md
@@ -6,12 +6,6 @@ keywords: ballerina, programming language, cloud, kubernetes, docker, cloud-nati
 permalink: /learn/deploy-ballerina-on-kubernetes/
 active: deploy-ballerina-on-kubernetes
 intro: This guide walks you through writing a simple Ballerina service, building it, and deploying it on Kubernetes.
-redirect_from:
-    - /learn/deploying-ballerina-on-kubernetes
-    - /learn/deploying-ballerina-on-kubernetes/
-    - /learn/deploy-ballerina-on-kubernetes
-    - /learn/getting-started/deploying-ballerina-on-kubernetes/
-    - /learn/getting-started/deploying-ballerina-on-kubernetes
 ---
 
 Code to Cloud is a compiler extension, which is packed with Ballerina. It eases generating the artifacts required for the cloud from your Ballerina code. Currently, you could generate Docker and Kubernetes artifacts from the Ballerina code. This process encourages you to write cloud-ready code from day one without any additional effort. 

--- a/swan-lake/featured-use-cases/work-with-data-using-queries-in-ballerina.md
+++ b/swan-lake/featured-use-cases/work-with-data-using-queries-in-ballerina.md
@@ -6,14 +6,6 @@ keywords: query expressions, language integrated queries, programming language, 
 description: Learn how to use Ballerina query expressions to filter, sort, and join different iterable collections.
 active: work-with-data-using-queries-in-ballerina
 intro: This guide walks you through using query expressions (a.k.a. language integrated queries) on data to filter, sort, and join with different data sets to produce new data.
-redirect_from:
-  - /learn/working-with-data-in-ballerina
-  - /learn/working-with-data-in-ballerina/
-  - /learn/work-with-data-in-ballerina
-  - /learn/work-with-data-in-ballerina/
-  - /learn/getting-started/working-with-data-in-ballerina/
-  - /learn/getting-started/working-with-data-in-ballerina
-  - /learn/work-with-data-using-queries-in-ballerina
 ---
 
 Ballerina has first-class support for writing SQL-like queries to process data. Language-integrated queries can process any Ballerina iterable.

--- a/swan-lake/featured-use-cases/write-a-graphql-api-with-ballerina.md
+++ b/swan-lake/featured-use-cases/write-a-graphql-api-with-ballerina.md
@@ -6,12 +6,6 @@ keywords: ballerina, graphql, ballerina packages, language-guide, standard libra
 permalink: /learn/write-a-graphql-api-with-ballerina/
 active: write-a-graphql-api-with-ballerina
 intro: This guide walks you through writing a simple GraphQL service to serve a dummy dataset related to COVID-19.
-redirect_from:
-    - /learn/writing-a-graphql-api-with-ballerina/
-    - /learn/writing-a-graphql-api-with-ballerina
-    - /learn/write-a-graphql-api-with-ballerina
-    - /learn/getting-started/writing-a-graphql-api-with-ballerina/
-    - /learn/getting-started/writing-a-graphql-api-with-ballerina
 ---
 
 >**Info:** Due to the batteries included nature of the Ballerina language, there is no need to add any third-party libraries to implement the GraphQL API. The Ballerina standard library itself is adequate. 

--- a/swan-lake/featured-use-cases/write-a-grpc-service-with-ballerina.md
+++ b/swan-lake/featured-use-cases/write-a-grpc-service-with-ballerina.md
@@ -6,16 +6,6 @@ keywords: ballerina, grpc, protocol buffers, protobuf, ballerina packages, langu
 permalink: /learn/write-a-grpc-service-with-ballerina/
 active: write-a-grpc-service-with-ballerina
 intro: This guide walks you through writing a simple Ballerina gRPC service and invoking the service through a Ballerina gRPC client application.
-redirect_from:
-- /learn/getting-started/writing-a-grpc-service-with-ballerina
-- /learn/getting-started/writing-a-grpc-service-with-ballerina/
-- /learn/user-guide/getting-started/writing-a-grpc-service-with-ballerina
-- /learn/user-guide/getting-started/writing-a-grpc-service-with-ballerina/
-- /learn/writing-a-grpc-service-with-ballerina/
-- /learn/writing-a-grpc-service-with-ballerina
-- /learn/write-a-grpc-service-with-ballerina
-- /learn/getting-started/writing-a-grpc-service-with-ballerina/
-- /learn/getting-started/writing-a-grpc-service-with-ballerina
 ---
 
 ## Set up the prerequisites

--- a/swan-lake/featured-use-cases/write-a-restful-api-with-ballerina.md
+++ b/swan-lake/featured-use-cases/write-a-restful-api-with-ballerina.md
@@ -6,12 +6,6 @@ description: This guide helps you understand the basics of Ballerina constructs,
 keywords: ballerina, programming language, restful-api, ballerina packages, language-guide
 active: write-a-restful-api-with-ballerina
 intro: This guide helps you understand the basics of Ballerina constructs, which allow you to write RESTful APIs.
-redirect_from:
-  - /learn/writing-a-restful-api-with-ballerina
-  - /learn/writing-a-restful-api-with-ballerina/
-  - /learn/write-a-restful-api-with-ballerina
-  - /learn/getting-started/writing-a-restful-api-with-ballerina/
-  - /learn/getting-started/writing-a-restful-api-with-ballerina
 ---
 
 ## Set up the prerequisites

--- a/swan-lake/get-started/get-started-with-ballerina.md
+++ b/swan-lake/get-started/get-started-with-ballerina.md
@@ -6,16 +6,6 @@ keywords: ballerina, programming language, ballerina packages, getting started
 permalink: /learn/get-started-with-ballerina/
 active: get-started-with-ballerina
 intro: Let’s set up a Ballerina development environment and write a simple Ballerina program.
-redirect_from:
-- /learn/getting-started-with-ballerina/
-- /learn/getting-started-with-ballerina
-- /learn/getting-started/hello-world/creating-your-first-ballerina-package
-- /learn/getting-started/hello-world/creating-your-first-ballerina-package/
-- /learn/getting-started/hello-world/writing-your-first-ballerina-program
-- /learn/getting-started/hello-world/writing-your-first-ballerina-program/
-- /learn/get-started-with-ballerina
-- /learn/getting-started/getting-started-with-ballerina/
-- /learn/getting-started/getting-started-with-ballerina
 ---
 
 ## Set up the prerequisites

--- a/swan-lake/get-started/install-ballerina/installation-options.md
+++ b/swan-lake/get-started/install-ballerina/installation-options.md
@@ -6,28 +6,6 @@ keywords: ballerina, installing ballerina, programming language, ballerina insta
 permalink: /learn/install-ballerina/installation-options/
 active: installation-options
 intro: The sections below include information about installing Ballerina.
-redirect_from:
-  - /learn/install-ballerina/
-  - /learn/install-ballerina
-  - /learn/installing-ballerina
-  - /learn/installing-ballerina/
-  - /learn/installing-ballerina/#installing-from-source
-  - /learn/installing-ballerina/#installing-from-source/
-  - /swan-lake/learn/getting-started/installing-ballerina/
-  - /swan-lake/learn/getting-started/installing-ballerina
-  - /learn/getting-started/installing-ballerina/
-  - /learn/getting-started/installing-ballerina
-  - /learn/user-guide/getting-started/setting-up-ballerina/installation-options
-  - /learn/user-guide/getting-started/setting-up-ballerina/installation-options/
-  - /learn/user-guide/getting-started/installation-options
-  - /learn/user-guide/getting-started/installation-options/
-  - /learn/getting-started/installing-ballerina/installation-options
-  - /learn/getting-started/installing-ballerina/installation-options/
-  - /learn/installing-ballerina/installation-options
-  - /learn/installing-ballerina/installation-options/
-  - /learn/instal-ballerina/installation-options
-  - /learn/get-started/install-ballerina/Installation-options/
-  - /learn/get-started/install-ballerina/Installation-options
 ---
 
 ## Install Ballerina via installers

--- a/swan-lake/get-started/install-ballerina/set-up-ballerina.md
+++ b/swan-lake/get-started/install-ballerina/set-up-ballerina.md
@@ -6,33 +6,6 @@ keywords: ballerina, quick tour, programming language, http service
 permalink: /learn/install-ballerina/set-up-ballerina/
 active: set-up-ballerina
 intro: Let's get started.
-redirect_from:
-  - /learn/quick-tour
-  - /learn/quick-tour/
-  - /swan-lake/learn/getting-started/quick-tour/
-  - /swan-lake/learn/getting-started/quick-tour
-  - /learn/getting-started/quick-tour/
-  - /learn/getting-started/quick-tour
-  - /learn/getting-started/
-  - /learn/getting-started
-  - /learn/user-guide/getting-started
-  - /learn/user-guide/getting-started/
-  - /learn/user-guide/getting-started/setting-up-ballerina
-  - /learn/user-guide/
-  - /learn/user-guide
-  - /learn/user-guide/getting-started/setting-up-ballerina
-  - /learn/user-guide/getting-started/setting-up-ballerina/
-  - /learn/getting-started/installing-ballerina/setting-up-ballerina
-  - /learn/getting-started/installing-ballerina/setting-up-ballerina/
-  - /learn/installing-ballerina/setting-up-ballerina
-  - /learn/installing-ballerina/setting-up-ballerina/
-  - /learn/installing-ballerina/
-  - /learn/installing-ballerina
-  - /learn/install-ballerina/set-up-ballerina
-  - /learn/install-ballerina/
-  - /learn/install-ballerina
-  - /learn/get-started/install-ballerina/set-up-ballerina/
-  - /learn/get-started/install-ballerina/set-up-ballerina
 ---
 
 ## Download Ballerina

--- a/swan-lake/learn-the-language/distinctive-language-features/advanced-general-purpose-language-features.md
+++ b/swan-lake/learn-the-language/distinctive-language-features/advanced-general-purpose-language-features.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages,language-guide
 permalink: /learn/distinctive-language-features/advanced-general-purpose-language-features/
 active: advanced-general-purpose-language-features
 intro: Let's now look at the other features of the Ballerina language. These are a mixed bag of additional options to the language, making everything fit together to build a Ballerina application.
-redirect_from:
-- /learn/distinctive-language-features/advanced-general-purpose-language-features
 ---
 
 ## Default values for function parameters

--- a/swan-lake/learn-the-language/distinctive-language-features/concurrency.md
+++ b/swan-lake/learn-the-language/distinctive-language-features/concurrency.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages,language-guide
 permalink: /learn/distinctive-language-features/concurrency/
 active: concurrency
 intro: Let’s now look at how concurrency and transactions are handled in Ballerina. 
-redirect_from:
-- /learn/distinctive-language-features/concurrency
 ---
 
 ## Sequence diagram-based concurrency

--- a/swan-lake/learn-the-language/distinctive-language-features/data.md
+++ b/swan-lake/learn-the-language/distinctive-language-features/data.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages,language-guide
 permalink: /learn/distinctive-language-features/data/
 active: data
 intro: In this part, you will learn about some of the plain data supported by Ballerina that we have not covered in the last part, specifically, tables and XML types.
-redirect_from:
-- /learn/distinctive-language-features/data
 ---
 
 ## Plain data

--- a/swan-lake/learn-the-language/distinctive-language-features/network-interaction.md
+++ b/swan-lake/learn-the-language/distinctive-language-features/network-interaction.md
@@ -6,12 +6,6 @@ keywords: ballerina, programming language, ballerina packages,language-guide
 permalink: /learn/distinctive-language-features/network-interaction/
 active: network-interaction
 intro: In this part, you will learn about the features of the Ballerina programming language that are distinctive. These features revolve around key design considerations that make Ballerina suitable for cloud application programming using small and medium-sized programs.
-redirect_from:
-- /learn/distinctive-language-features/what-makes-ballerina-distinctive
-- /learn/distinctive-language-features/what-makes-ballerina-distinctive/
-- /learn/distinctive-language-features/
-- /learn/distinctive-language-features
-- /learn/distinctive-language-features/network-interaction
 ---
 
 Ballerina aims to be as pragmatic as possible by taking cues from existing patterns used in programming. It models cloud-era applications that make heavy use of network interaction, network data, and concurrency. In addition, Ballerina focuses on providing integration that acts like glue for orchestrating other programs and ensures reliability and maintainability while also assuring moderate cognitive load on programmers.

--- a/swan-lake/learn-the-language/language-basics.md
+++ b/swan-lake/learn-the-language/language-basics.md
@@ -6,10 +6,6 @@ keywords: ballerina, programming language, ballerina packages,language-guide
 permalink: /learn/language-basics/
 active: language-basics
 intro: This guide introduces the Ballerina language to help you get started with basics that are common to all C-Family programming languages.
-redirect_from:
-- /learn/language-basics
-- /learn/getting-started/language-basics/
-- /learn/getting-started/language-basics
 ---
 
 ## Familiar subset of Ballerina

--- a/swan-lake/learn-the-language/language-walkthrough.md
+++ b/swan-lake/learn-the-language/language-walkthrough.md
@@ -4,13 +4,6 @@ title: Language walkthrough
 description: Explores the language concepts of the Ballerina programming language.
 keywords: ballerina, programming language, language walkthrough, specification
 permalink: /learn/language-walkthrough/
-redirect_from:
-  - /learn/language-concepts
-  - /learn/language-walkthrough/Ballerina_Language_Presentation-2021-03-08.pdf
-  - /learn/language-walkthrough/Ballerina_Language_Presentation-2021-01-29.pdf
-  - /learn/language-concepts/
-  - /learn/language-concepts
-  - /learn/language-walkthrough
 ---
 
 <style>

--- a/swan-lake/learn-the-platform/ballerina-central/publish-packages-to-ballerina-central.md
+++ b/swan-lake/learn-the-platform/ballerina-central/publish-packages-to-ballerina-central.md
@@ -6,16 +6,6 @@ keywords: ballerina, programming language, ballerina packages, libraries, publis
 permalink: /learn/publish-packages-to-ballerina-central/
 active: publish-packages-to-ballerina-central
 intro: A package uses Ballerina library packages as dependencies. The sections below include information about working with library packages.
-redirect_from:
- - /learn/user-guide/ballerina-packages/sharing-a-library-package
- - /learn/user-guide/ballerina-packages/sharing-a-library-package/
- - /learn/publishing-packages-to-ballerina-central
- - /learn/publishing-packages-to-ballerina-central/
- - /learn/user-guide/publishing-packages-to-ballerina-central
- - /learn/user-guide/publishing-packages-to-ballerina-central/
- - /learn/publish-packages-to-ballerina-central
- - /learn/guides/publishing-packages-to-ballerina-central/
- - /learn/guides/publishing-packages-to-ballerina-central
 ---
 
 ## Create a library package

--- a/swan-lake/learn-the-platform/ballerina-tooling/asyncapi-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/asyncapi-tool.md
@@ -6,10 +6,6 @@ keywords: ballerina, programming language, asyncapi, contract
 permalink: /learn/asyncapi-tool/
 active: asyncapi-tool
 intro: AsyncAPI is a specification, which is used to describe and document message-driven APIs in a machine-readable format for easy development, discovery, and integration. Ballerina Swan Lake supports the AsyncAPI Specification version 2.x.
-redirect_from:
-  - /learn/ballerina-asyncapi-support
-  - /learn/ballerina-asyncapi-support/
-  - /learn/asyncapi-tool
 ---
 
 The Ballerina AsyncAPI tool makes it easy for you to start the development of an event API documented in an AsyncAPI contract in Ballerina by generating a Ballerina service and listener skeletons.

--- a/swan-lake/learn-the-platform/ballerina-tooling/ballerina-shell.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/ballerina-shell.md
@@ -6,10 +6,6 @@ description: The Ballerina Shell is a Read-Evaluate-Print Loop (REPL) for Baller
 keywords: ballerina shell, REPL, ballerina, programming language
 active: ballerina-shell
 intro: The Ballerina Shell is a Read-Evaluate-Print Loop (REPL) for Ballerina.
-redirect_from:
-  - /learn/tooling-guide/ballerina-shell
-  - /learn/tooling-guide/ballerina-shell/
-  - /learn/ballerina-shell
 ---
 
 The Ballerina shell allows you to evaluate code snippets, eliminating the need to write complete programs.

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/asyncapi.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/asyncapi.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages, package structure
 permalink: /learn/cli-documentation/asyncapi/
 active: asyncapi
 intro: The sections below include information about the usages of the Ballerina AsyncAPI tool.
-redirect_from:
-  - /learn/cli-documentation/asyncapi
 ---
 
 ## AsyncAPI to Ballerina 

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/cli-commands.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/cli-commands.md
@@ -6,20 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/cli-documentation/cli-commands/
 active: cli-commands
 intro: The Ballerina Tool is your one-stop-shop for all the things you do in Ballerina. 
-redirect_from:
-  - /learn/cli-commands
-  - /learn/cli-commands/
-  - /learn/using-the-cli-tools/
-  - /learn/using-the-cli-tools
-  - /swan-lake/learn/using-the-cli-tools/
-  - /swan-lake/learn/using-the-cli-tools
-  - /learn/tooling-guide/cli-tools/cli-commands
-  - /learn/tooling-guide/cli-tools/
-  - /learn/tooling-guide/cli-tools
-  - /learn/tooling-guide/cli-tools/cli-commands/
-  - /learn/cli-documentation/cli-commands
-  - /learn/cli-documentation
-  - /learn/cli-documentation/
 ---
 
 ## Use the Ballerina tool

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/graphql.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/graphql.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages, package structure
 permalink: /learn/cli-documentation/graphql/
 active: graphql
 intro: The sections below include information about the usages of the Ballerina GraphQL tool.
-redirect_from:
-  - /learn/cli-documentation/graphql
 ---
 
 ## GraphQL to Ballerina 

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/grpc.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/grpc.md
@@ -6,15 +6,6 @@ keywords: ballerina, protocol buffers, programming language
 permalink: /learn/cli-documentation/grpc/
 active: grpc
 intro: Protocol Buffers is an open-source cross-platform data format used to serialize structured data. gRPC uses Protocol Buffers as Interface Definition Language to create service contracts, detailing all of its remote methods and message formats. The `Protocol Buffers to Ballerina` tooling makes it easy for users to develop a service documented in a Protocol Buffers by generating Ballerina service/client stub files and skeletons.
-redirect_from:
-  - /learn/how-to-generate-code-for-protocol-buffers
-  - /learn/how-to-generate-code-for-protocol-buffers/
-  - /learn/generating-ballerina-code-for-protocol-buffer-definitions
-  - /swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions/
-  - /swan-lake/learn/generating-ballerina-code-for-protocol-buffer-definitions
-  - /learn/tooling-guide/cli-tools/grpc
-  - /learn/tooling-guide/cli-tools/grpc/
-  - /learn/cli-documentation/grpc
 ---
 
 ## Usage of the tool

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/openapi.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/openapi.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages, package structure
 permalink: /learn/cli-documentation/openapi/
 active: openapi
 intro: The sections below include information about the usages of the Ballerina OpenAPI tool.
-redirect_from:
-  - /learn/cli-documentation/openapi
 ---
 
 ## OpenAPI to Ballerina 

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/update-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/update-tool.md
@@ -6,16 +6,6 @@ keywords: ballerina, programming language, release, update
 permalink: /learn/cli-documentation/update-tool/
 active: update-tool
 intro: This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases.
-redirect_from:
-  - /learn/how-to-keep-ballerina-up-to-date
-  - /learn/how-to-keep-ballerina-up-to-date/
-  - /learn/keeping-ballerina-up-to-date/
-  - /learn/keeping-ballerina-up-to-date
-  - /swan-lake/learn/keeping-ballerina-up-to-date/
-  - /swan-lake/learn/keeping-ballerina-up-to-date
-  - /learn/tooling-guide/cli-tools/update-tool
-  - /learn/tooling-guide/cli-tools/update-tool/
-  - /learn/cli-documentation/update-tool
 ---
 
 ## Understand Ballerina distributions 

--- a/swan-lake/learn-the-platform/ballerina-tooling/graphql-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/graphql-tool.md
@@ -6,11 +6,6 @@ keywords: ballerina, programming language, graphql, sdl, schema definition langu
 permalink: /learn/graphql-tool/
 active: graphql-tool
 intro: The Ballerina GraphQL tool makes it easy to start the development of a GraphQL client. It generates the client skeletons in Ballerina for a given GraphQL schema and a GraphQL document. In addition, the GraphQL tool supports generating the GraphQL schema for a given Ballerina GraphQL service and writing it to a file in GraphQL schema definition language (SDL).
-redirect_from:
-  - /learn/ballerina-graphql-support
-  - /learn/ballerina-graphql-support/
-  - /learn/graphql-tool
-  - /learn/graphql-tool/
 --- 
 
 The Ballerina GraphQL tooling support provides the following capabilities.

--- a/swan-lake/learn-the-platform/ballerina-tooling/openapi-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/openapi-tool.md
@@ -6,21 +6,6 @@ keywords: ballerina, programming language, openapi, open api, restful api
 permalink: /learn/openapi-tool/
 active: openapi-tool
 intro: OpenAPI Specification is a specification that creates a RESTFUL contract for APIs by detailing all of its resources and operations in a human and machine-readable format for easy development, discovery, and integration. Ballerina Swan Lake supports the OpenAPI Specification version 3.0.0 onwards.
-redirect_from:
-  - /learn/how-to-use-openapi-tools/
-  - /learn/how-to-use-openapi-tools
-  - /learn/using-the-openapi-tools/
-  - /learn/using-the-openapi-tools
-  - /swan-lake/learn/using-the-openapi-tools/
-  - /swan-lake/learn/using-the-openapi-tools
-  - /learn/tooling-guide/cli-tools/openapi
-  - /learn/tooling-guide/cli-tools/openapi/
-  - /learn/cli-documentation/openapi/#using-the-capabilities-of-the-openapi-tools/
-  - /learn/cli-documentation/openapi/#using-the-capabilities-of-the-openapi-tools
-  - /learn/cli-documentation/openapi/#openapi-validator-compiler-plugin/
-  - /learn/cli-documentation/openapi/#openapi-validator-compiler-plugin
-  - /learn/ballerina-openapi-support
-  - /learn/ballerina-openapi-support/
 --- 
 
 Ballerina OpenAPI tool makes it easy for you to start the development of a service documented in an OpenAPI contract in Ballerina by generating a Ballerina service and client skeletons. It enables you to take the code-first API design approach by generating an OpenAPI contract for the given service implementation.

--- a/swan-lake/learn-the-platform/ballerina-tooling/strand-dump-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/strand-dump-tool.md
@@ -4,8 +4,6 @@ description: Check out how you can dump and inspect the currently available stra
 keywords: ballerina runtime, troubleshoot, strand dump, thread dump
 permalink: /learn/strand-dump-tool/
 active: strand-dump-tool
-redirect_from:
-  - /learn/strand-dump-tool
 ---
 
 The Ballerina runtime can have unexpected behaviors due to user code errors, bugs, or issues with the running environment. 

--- a/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/configure-a-sample-ballerina-service.md
+++ b/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/configure-a-sample-ballerina-service.md
@@ -6,32 +6,6 @@ keywords: ballerina, programming language, configurable, variables
 permalink: /learn/configure-ballerina-programs/configure-a-sample-ballerina-service/
 active: configure-a-sample-ballerina-service/
 intro: Configurability enables users to modify the system behavior through external user inputs. Ballerina Language provides an in-built functionality to configure values at runtime through configurable  module-level variables.
-redirect_from:
-- /learn/user-guide/configurability/defining-configurable-variables
-- /learn/user-guide/configurability/defining-configurable-variables/
-- /learn/user-guide/configurability/
-- /learn/user-guide/configurability
-- /learn/making-ballerina-programs-configurable/
-- /learn/making-ballerina-programs-configurable
-- /learn/making-ballerina-programs-configurable/defining-configurable-variables
-- /learn/user-guide/configurability/trying-it-out
-- /learn/user-guide/configurability/trying-it-out/
-- /learn/making-ballerina-programs-configurable/trying-it-out
-- /learn/making-ballerina-programs-configurable/trying-it-out/
-- /learn/making-ballerina-programs-configurable/trying-out-configurability
-- /learn/configuring-ballerina-programs
-- /learn/configuring-ballerina-programs/
-- /learn/configure-ballerina-programs/
-- /learn/configure-ballerina-programs
-- /learn/configuring-ballerina-programs/quick-start-on-configurable-variables
-- /learn/configuring-ballerina-programs/quick-start-on-configurable-variables/
-- /learn/making-ballerina-programs-configurable/defining-configurable-variables/
-- /learn/making-ballerina-programs-configurable/defining-configurable-variables
-- /learn/configure-ballerina-programs/quick-start-on-configurable-variables/ 
-- /learn/configure-ballerina-programs/quick-start-on-configurable-variables
-- /learn/guides/configuring-ballerina-programs/quick-start-on-configurable-variables/
-- /learn/guides/configuring-ballerina-programs/quick-start-on-configurable-variables
-- /learn/configure-ballerina-programs/configure-a-sample-ballerina-service
 ---
 
 Consider the following step-by-step guide to configuring a Ballerina package that contains an HTTP service.

--- a/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/configure-values.md
+++ b/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/configure-values.md
@@ -6,16 +6,6 @@ intro: Below are a few advanced usecases in which you configure values using con
 keywords: ballerina, programming language, configurable, variables, kubernetes, pod
 permalink: /learn/configure-ballerina-programs/configure-values/
 active: configure-values
-redirect_from:
-    - /learn/making-ballerina-programs-configurable/configuring-values-in-kubernetes-environment
-    - /learn/configuring-ballerina-programs/configuring-values-in-kubernetes-environment
-    - /learn/configuring-ballerina-programs/configuring-values-in-kubernetes-environment/
-    - /learn/configure-ballerina-programs/configure-values-in-kubernetes-environment
-    - /learn/guides/configuring-ballerina-programs/configuring-values-in-kubernetes-environment/
-    - /learn/guides/configuring-ballerina-programs/configuring-values-in-kubernetes-environment
-    - /learn/configure-ballerina-programs/configure-values
-    - /learn/configure-ballerina-programs/provide-values-to-configurable-variables/#providing-module-information-of-the-configurable-variable/
-    - /learn/configure-ballerina-programs/provide-values-to-configurable-variables/#providing-module-information-of-the-configurable-variable
 ---
 
 ## Configure in multiple modules

--- a/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/provide-values-to-configurable-variables.md
+++ b/swan-lake/learn-the-platform/configure-observe/configure-ballerina-programs/provide-values-to-configurable-variables.md
@@ -5,16 +5,6 @@ description: You can supply values to configurable variables using the methods b
 keywords: ballerina, programming language, configurable, variables, values, toml
 permalink: /learn/configure-ballerina-programs/provide-values-to-configurable-variables/
 active: provide-values-to-configurable-variables
-redirect_from:
-- /learn/user-guide/configurability/providing-values-to-configurable-variables
-- /learn/user-guide/configurability/providing-values-to-configurable-variables/
-- /learn/making-ballerina-programs-configurable/providing-values-to-configurable-variables
-- /learn/making-ballerina-programs-configurable/providing-values-to-configurable-variables/
-- /learn/configuring-ballerina-programs/providing-values-to-configurable-variables
-- /learn/configuring-ballerina-programs/providing-values-to-configurable-variables/
-- /learn/configure-ballerina-programs/provide-values-to-configurable-variables
-- /learn/guides/configuring-ballerina-programs/providing-values-to-configurable-variables/
-- /learn/guides/configuring-ballerina-programs/providing-values-to-configurable-variables
 ---
 
 The values for configurable variables can be provided through configuration files, command-line arguments, and

--- a/swan-lake/learn-the-platform/configure-observe/observe-ballerina-programs.md
+++ b/swan-lake/learn-the-platform/configure-observe/observe-ballerina-programs.md
@@ -6,31 +6,6 @@ keywords: ballerina, observability, metrics, tracing, logs, prometheus, grafana,
 permalink: /learn/observe-ballerina-programs/
 active: observe-ballerina-programs
 intro: Observability is a measure of how well the internal states of a system can be inferred from the knowledge of its external outputs.
-redirect_from:
-  - /learn/how-to-observe-ballerina-code
-  - /learn/how-to-observe-ballerina-code/
-  - /learn/how-to-observe-ballerina-services/
-  - /learn/how-to-observe-ballerina-services
-  - /learn/observing-ballerina-code
-  - /swan-lake/learn/observing-ballerina-code/
-  - /swan-lake/learn/observing-ballerina-code
-  - /learn/observing-ballerina-code/
-  - /learn/observing-ballerina-code
-  - /learn/user-guide/observing-ballerina-code
-  - /learn/user-guide/observing-ballerina-code/
-  - /learn/user-guide/observability/
-  - /learn/user-guide/observability
-  - /learn/user-guide/observability/observing-ballerina-code/
-  - /learn/user-guide/observability/observing-ballerina-code
-  - /learn/observing-ballerina-programs/observing-your-application-with-prometheus-grafana-and-jaeger/
-  - /learn/observing-ballerina-programs/observing-your-application-with-prometheus-grafana-and-jaeger
-  - /learn/observing-ballerina-programs/observing-your-application-with-prometheus-grafana-jaeger-and-the-elastic-stack
-  - /learn/observing-ballerina-programs/observing-your-application-with-prometheus-grafana-jaeger-and-the-elastic-stack/
-  - /learn/observing-ballerina-programs/
-  - /learn/observing-ballerina-programs
-  - /learn/observe-ballerina-programs
-  - /learn/guides/observing-your-application-with-prometheus-grafana-jaeger-and-elastic-the-stack/
-  - /learn/guides/observing-your-application-with-prometheus-grafana-jaeger-and-elastic-the-stack
 ---
 
 It consists of the three major pillars below.

--- a/swan-lake/learn-the-platform/java-interoperability/call-java-code-from-ballerina.md
+++ b/swan-lake/learn-the-platform/java-interoperability/call-java-code-from-ballerina.md
@@ -6,26 +6,6 @@ keywords: ballerina, programming language, java api, interoperability
 permalink: /learn/call-java-code-from-ballerina/
 active: call-java-code-from-ballerina
 intro: Ballerina offers a straightforward way to call existing Java code from Ballerina. Although Ballerina is not designed to be a JVM language, the current implementation, which targets the JVM, aka jBallerina, provides Java interoperability by adhering to the Ballerina language semantics.
-redirect_from:
-  - /learn/how-to-use-java-interoperability
-  - /learn/how-to-use-java-interoperability/
-  - /learn/how-to-call-java-code-from-ballerina
-  - /learn/how-to-call-java-code-from-ballerina/
-  - /learn/calling-java-code-from-ballerina
-  - /learn/calling-java-code-from-ballerina/
-  - /swan-lake/learn/calling-java-code-from-ballerina
-  - /swan-lake/learn/calling-java-code-from-ballerina/
-  - /learn/user-guide/calling-java-code-from-ballerina
-  - /learn/user-guide/calling-java-code-from-ballerina/
-  - /learn/user-guide/interoperability/calling-java-code-from-ballerina
-  - /learn/user-guide/interoperability/calling-java-code-from-ballerina/
-  - /learn/user-guide/interoperability/
-  - /learn/user-guide/interoperability
-  - /learn/calling-java-code-from-ballerina-and-vice-versa
-  - /learn/calling-java-code-from-ballerina-and-vice-versa/
-  - /learn/call-java-code-from-ballerina
-  - /learn/guides/calling-java-code-from-ballerina/
-  - /learn/guides/calling-java-code-from-ballerina
 ---
 
 ## Write Ballerina bindings

--- a/swan-lake/learn-the-platform/java-interoperability/java-interoperability-guide/ballerina-ffi.md
+++ b/swan-lake/learn-the-platform/java-interoperability/java-interoperability-guide/ballerina-ffi.md
@@ -6,13 +6,6 @@ keywords: ballerina, programming language, ffi, foreign function invocation
 permalink: /learn/java-interoperability/ballerina-ffi/
 active: ballerina-ffi
 intro: The reference guide on the list of language features that enable Ballerina developers to call foreign code written in other programming languages.
-redirect_from:
-  - /learn/tooling-guide/cli-tools/ballerina-ffi/
-  - /learn/tooling-guide/cli-tools/ballerina-ffi
-  - /learn/cli-documentation/ballerina-ffi/
-  - /learn/cli-documentation/ballerina-ffi
-  - /learn/cli-documentation/ballerina-ffi/
-  - /learn/cli-documentation/ballerina-ffi
 ---
 
 Let's look at the list of language features that enable Ballerina developers to call foreign code written in other programming languages. E.g., while the jBallerina compiler allows you to call any `Java` code, the nBallerina compiler allows you to call any `C` Code.

--- a/swan-lake/learn-the-platform/java-interoperability/java-interoperability-guide/java-interoperability.md
+++ b/swan-lake/learn-the-platform/java-interoperability/java-interoperability-guide/java-interoperability.md
@@ -6,10 +6,6 @@ keywords: ballerina, programming language, java api, interoperability
 permalink: /learn/java-interoperability/
 active: java-interoperability
 intro: Ballerina offers a straightforward way to call the existing Java code from Ballerina. Although Ballerina is not designed to be a JVM language, the current implementation, which targets the JVM, aka jBallerina, provides Java interoperability by adhering to the Ballerina language semantics.
-redirect_from:
-  - /learn/java-interoperability
-  - /swan-lake/learn/java-interoperability/
-  - /swan-lake/learn/java-interoperability
 ---
 
 ## Ballerina bindings to Java code

--- a/swan-lake/learn-the-platform/java-interoperability/java-interoperability-guide/the-bindgen-tool.md
+++ b/swan-lake/learn-the-platform/java-interoperability/java-interoperability-guide/the-bindgen-tool.md
@@ -6,13 +6,6 @@ keywords: ballerina, programming language, java, interoperability, bindgen
 permalink: /learn/java-interoperability/the-bindgen-tool/
 active: the-bindgen-tool
 intro: The Bindgen Tool is a CLI tool that generates Ballerina bindings for Java classes.
-redirect_from:
-  - /learn/tooling-guide/cli-tools/bindgen-tool/
-  - /learn/tooling-guide/cli-tools/bindgen-tool
-  - /learn/cli-documentation/bindgen-tool/
-  - /learn/cli-documentation/bindgen-tool
-  - /learn/cli-documentation/the-bindgen-tool/
-  - /learn/cli-documentation/the-bindgen-tool
 ---
 
 The following sections explain how the Bindgen Tool works.

--- a/swan-lake/learn-the-platform/run-in-the-cloud/code-to-cloud/code-to-cloud-deployment.md
+++ b/swan-lake/learn-the-platform/run-in-the-cloud/code-to-cloud/code-to-cloud-deployment.md
@@ -6,33 +6,6 @@ keywords: ballerina, programming language, services, cloud, kubernetes, docker
 permalink: /learn/run-ballerina-programs-in-the-cloud/code-to-cloud-deployment/
 active: code-to-cloud-deployment
 intro: Ballerina Code to Cloud is designed to allow developers to write code without thinking about the deployment platform. 
-redirect_from:
-  - /learn/deployment/code-to-cloud
-  - /swan-lake/learn/deployment/code-to-cloud/
-  - /swan-lake/learn/deployment/code-to-cloud
-  - /learn/deployment/code-to-cloud/
-  - /learn/deployment/code-to-cloud
-  - /learn/deployment/docker/
-  - /learn/deployment/docker
-  - /learn/user-guide/deployment/code-to-cloud
-  - /learn/user-guide/deployment/
-  - /learn/user-guide/deployment
-  - /learn/user-guide/deployment/docker/
-  - /learn/user-guide/deployment/docker
-  - /learn/user-guide/deployment/code-to-cloud/
-  - /learn/running-ballerina-programs-in-the-cloud/code-to-cloud
-  - /learn/running-ballerina-programs-in-the-cloud/code-to-cloud/
-  - /learn/running-ballerina-programs-in-the-cloud/
-  - /learn/running-ballerina-programs-in-the-cloud
-  - /learn/running-ballerina-programs-in-the-cloud/code-to-cloud/code-to-cloud-deployment
-  - /learn/running-ballerina-programs-in-the-cloud/code-to-cloud/code-to-cloud-deployment/
-  - /learn/running-ballerina-programs-in-the-cloud/code-to-cloud-deployment/
-  - /learn/running-ballerina-programs-in-the-cloud/code-to-cloud-deployment
-  - /learn/run-ballerina-programs-in-the-cloud/code-to-cloud-deployment
-  - /learn/run-ballerina-programs-in-the-cloud/
-  - /learn/run-ballerina-programs-in-the-cloud
-  - /learn/guides/running-ballerina-programs-in-the-cloud/code-to-cloud/code-to-cloud-deployment/
-  - /learn/guides/running-ballerina-programs-in-the-cloud/code-to-cloud/code-to-cloud-deployment
 ---
 
 This greatly simplifies the experience of developing and deploying Ballerina code in the cloud. It also enables using cloud-native technologies easily without in-depth knowledge.

--- a/swan-lake/learn-the-platform/run-in-the-cloud/function-as-a-service/aws-lambda.md
+++ b/swan-lake/learn-the-platform/run-in-the-cloud/function-as-a-service/aws-lambda.md
@@ -6,23 +6,6 @@ keywords: ballerina, programming language, serverless, cloud, aws, lambda, cloud
 permalink: /learn/run-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda/
 active: aws-lambda
 intro: The AWS Lambda extension provides the functionality to expose a Ballerina function as an AWS Lambda function.
-redirect_from:
-  - /learn/deployment/aws-lambda
-  - /swan-lake/learn/deployment/aws-lambda/
-  - /swan-lake/learn/deployment/aws-lambda
-  - /learn/deployment/aws-lambda/
-  - /learn/deployment/aws-lambda
-  - /learn/user-guide/deployment/aws-lambda
-  - /learn/user-guide/deployment/aws-lambda/
-  - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/
-  - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina
-  - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda/
-  - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda
-  - /learn/run-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda
-  - /learn/guides/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda/
-  - /learn/guides/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/aws-lambda
-  - /learn/run-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/
-  - /learn/run-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina
 ---
 
 ## Prerequisites

--- a/swan-lake/learn-the-platform/run-in-the-cloud/function-as-a-service/azure-functions.md
+++ b/swan-lake/learn-the-platform/run-in-the-cloud/function-as-a-service/azure-functions.md
@@ -6,19 +6,6 @@ keywords: ballerina, programming language, serverless, cloud, azure, functions, 
 permalink: /learn/run-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/azure-functions/
 active: azure-functions
 intro: The Azure Functions extension provides the functionality to expose a Ballerina function as a serverless function in the Azure Functions platform.
-redirect_from:
-  - /learn/deployment/azure-functions
-  - /swan-lake/learn/deployment/azure-functions/
-  - /swan-lake/learn/deployment/azure-functions
-  - /learn/deployment/azure-functions/
-  - /learn/deployment/azure-functions
-  - /learn/user-guide/deployment/azure-functions
-  - /learn/user-guide/deployment/azure-functions/
-  - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/azure-functions
-  - /learn/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/azure-functions/
-  - /learn/run-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/azure-functions
-  - /learn/guides/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/azure-functions/
-  - /learn/guides/running-ballerina-programs-in-the-cloud/function-as-a-service-with-ballerina/azure-functions
 ---
 
 ## Prerequisites

--- a/swan-lake/learn-the-platform/source-code-dependencies/manage-dependencies.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/manage-dependencies.md
@@ -6,14 +6,6 @@ keywords: ballerina, programming language, ballerina packages, dependencies, imp
 permalink: /learn/manage-dependencies/
 active: manage-dependencies
 intro: The sections below include information about dependencies, imports, and how they can be used in your package.
-redirect_from:
-- /learn/user-guide/ballerina-packages/dependencies
-- /learn/user-guide/ballerina-packages/dependencies/
-- /learn/managing-dependencies
-- /learn/managing-dependencies/
-- /learn/manage-dependencies
-- /learn/guides/managing-dependencies/
-- /learn/guides/managing-dependencies
 ---
 
 ## Specify dependencies

--- a/swan-lake/learn-the-platform/source-code-dependencies/organize-ballerina-code.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/organize-ballerina-code.md
@@ -6,18 +6,6 @@ keywords: ballerina, programming language, ballerina packages, dependencies, imp
 permalink: /learn/organize-ballerina-code/
 active: organize-ballerina-code
 intro: The sections below include information about packages and how you can manage the growth of your source code.
-redirect_from:
-- /learn/user-guide/ballerina-packages/organizing-ballerina-code
-- /learn/user-guide/ballerina-packages/organizing-ballerina-code/
-- /learn/organizing-ballerina-code
-- /learn/organizing-ballerina-code/
-- /learn/user-guide/structuring-ballerina-code/
-- /learn/user-guide/structuring-ballerina-code
-- /learn/user-guide/ballerina-packages/
-- /learn/user-guide/ballerina-packages
-- /learn/organize-ballerina-code
-- /learn/guides/organizing-ballerina-code/
-- /learn/guides/organizing-ballerina-code
 ---
 
 ## Package structure

--- a/swan-lake/learn-the-platform/source-code-dependencies/package-references.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/package-references.md
@@ -6,12 +6,6 @@ keywords: ballerina, programming language, ballerina packages, package structure
 permalink: /learn/organize-ballerina-code/package-references/
 active: package-references
 intro: The sections below include information about the structure of a package directory. It explains the purpose of each file in a package.
-redirect_from:
-  - /learn/package-layout
-  - /learn/package-layout/
-  - /learn/package-references/
-  - /learn/package-references/
-  - /learn/organize-ballerina-code/package-references
 ---
 
 ## Package layout

--- a/swan-lake/learn-the-platform/source-code-dependencies/style-guide/annotations-documentation-and-comments.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/style-guide/annotations-documentation-and-comments.md
@@ -6,19 +6,6 @@ keywords: ballerina, programming language, ballerina style guide, annotations, c
 permalink: /learn/style-guide/annotations-documentation-and-comments/
 active: annotations-documentation-and-comments
 intro: The sections below include the coding conventions with respect to annotations, documentation, and comments.
-redirect_from:
-  - /learn/style-guide/annotations_documentation_and_comments
-  - /learn/coding-conventions/annotations_documentation_and_comments
-  - /swan-lake/learn/coding-conventions/annotations_documentation_and_comments/
-  - /swan-lake/learn/coding-conventions/annotations_documentation_and_comments
-  - /learn/coding-conventions/annotations_documentation_and_comments/
-  - /learn/coding-conventions/annotations_documentation_and_comments
-  - /learn/user-guide/coding-conventions/annotations_documentation_and_comments
-  - /learn/user-guide/coding-conventions/annotations_documentation_and_comments/
-  - /learn/user-guide/code-organization/coding-conventions/annotations_documentation_and_comments/
-  - /learn/user-guide/code-organization/coding-conventions/annotations_documentation_and_comments
-  - /learn/user-guide/style-guide/coding-conventions/annotations-documentation-and-comments
-  - /learn/user-guide/style-guide/coding-conventions/annotations-documentation-and-comments/
 ---
 
 ## Annotations

--- a/swan-lake/learn-the-platform/source-code-dependencies/style-guide/coding-conventions.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/style-guide/coding-conventions.md
@@ -6,22 +6,6 @@ keywords: ballerina, programming language, ballerina style guide
 permalink: /learn/style-guide/coding-conventions/
 active: coding-conventions
 intro: This Ballerina Style Guide aims at maintaining a standard coding style among the Ballerina community. Therefore, the Ballerina code formatting tools are based on this guide.
-redirect_from:
-  - /learn/style-guide/
-  - /learn/style-guide
-  - /swan-lake/learn/coding-conventions/
-  - /swan-lake/learn/coding-conventions
-  - /learn/coding-conventions/
-  - /learn/coding-conventions
-  - /learn/user-guide/coding-conventions
-  - /learn/user-guide/coding-conventions/
-  - /learn/user-guide/code-organization/coding-conventions
-  - /learn/user-guide/code-organization/coding-conventions/
-  - /learn/user-guide/style-guide/coding-conventions
-  - /learn/user-guide/style-guide/coding-conventions/
-  - /learn/user-guide/style-guide/
-  - /learn/user-guide/style-guide
-  - /learn/style-guide/coding-conventions
 ---
 
 ## Indentation and line length

--- a/swan-lake/learn-the-platform/source-code-dependencies/style-guide/expressions.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/style-guide/expressions.md
@@ -6,19 +6,6 @@ keywords: ballerina, programming language, ballerina style guide, expressions
 active: expressions
 permalink: /learn/style-guide/expressions/
 intro: The sections below include the coding conventions with respect to expressions.
-redirect_from:
-  - /learn/style-guide/expressions
-  - /learn/coding-conventions/expressions
-  - /swan-lake/learn/coding-conventions/expressions/
-  - /swan-lake/learn/coding-conventions/expressions
-  - /learn/coding-conventions/expressions/
-  - /learn/coding-conventions/expressions
-  - /learn/user-guide/coding-conventions/expressions
-  - /learn/user-guide/coding-conventions/expressions/
-  - /learn/user-guide/code-organization/coding-conventions/expressions/
-  - /learn/user-guide/code-organization/coding-conventions/expressions
-  - /learn/user-guide/style-guide/coding-conventions/expressions
-  - /learn/user-guide/style-guide/coding-conventions/expressions/
 ---
 
 ## Function invocation

--- a/swan-lake/learn-the-platform/source-code-dependencies/style-guide/operators-keywords-and-types.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/style-guide/operators-keywords-and-types.md
@@ -6,19 +6,6 @@ keywords: ballerina, programming language, ballerina style guide, operators, key
 active: operators-keywords-and-types
 permalink: /learn/style-guide/operators-keywords-and-types/
 intro: The sections below include the coding conventions with respect to operators, keywords, and types.
-redirect_from:
-  - /learn/style-guide/operators_keywords_and_types
-  - /learn/coding-conventions/operators_keywords_and_types
-  - /swan-lake/learn/coding-conventions/operators_keywords_and_types/
-  - /swan-lake/learn/coding-conventions/operators_keywords_and_types
-  - /learn/coding-conventions/operators_keywords_and_types/
-  - /learn/coding-conventions/operators_keywords_and_types
-  - /learn/user-guide/coding-conventions/operators_keywords_and_types
-  - /learn/user-guide/coding-conventions/operators_keywords_and_types/
-  - /learn/user-guide/code-organization/coding-conventions/operators_keywords_and_types/
-  - /learn/user-guide/code-organization/coding-conventions/operators_keywords_and_types
-  - /learn/user-guide/style-guide/coding-conventions/operators-keywords-and-types
-  - /learn/user-guide/style-guide/coding-conventions/operators-keywords-and-types/
 ---
 
 ## Keywords and Types

--- a/swan-lake/learn-the-platform/source-code-dependencies/style-guide/statements.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/style-guide/statements.md
@@ -6,20 +6,6 @@ keywords: ballerina, programming language, ballerina style guide, statements
 active: statements
 permalink: /learn/style-guide/statements/
 intro: The sections below include the coding conventions with respect to statements.
-redirect_from:
-  - /learn/style-guide/statements
-  - /learn/coding-conventions/statements
-  - /swan-lake/learn/coding-conventions/statements/
-  - /swan-lake/learn/coding-conventions/statements
-  - /learn/coding-conventions/statements/
-  - /learn/coding-conventions/statements
-  - /learn/user-guide/coding-conventions/statements
-  - /learn/user-guide/coding-conventions/statements/
-  - /learn/user-guide/code-organization/coding-conventions/statements/
-  - /learn/user-guide/code-organization/coding-conventions/statements
-  - /learn/user-guide/style-guide/coding-conventions/statements
-  - /learn/user-guide/style-guide/coding-conventions/statements/
-
 ---
 
 ## If statement

--- a/swan-lake/learn-the-platform/source-code-dependencies/style-guide/top-level-definitions.md
+++ b/swan-lake/learn-the-platform/source-code-dependencies/style-guide/top-level-definitions.md
@@ -4,21 +4,6 @@ title: Top-level definitions
 active: top-level-definitions
 permalink: /learn/style-guide/top-level-definitions/
 intro: The sections below include the coding conventions with respect to top-level definitions.
-redirect_from:
-  - /learn/style-guide/definitions
-  - /learn/coding-conventions/definitions
-  - /learn/coding-conventions/top-level-definitions
-  - /swan-lake/learn/coding-conventions/top-level-definitions/
-  - /swan-lake/learn/coding-conventions/top-level-definitions
-  - /learn/coding-conventions/top-level-definitions/
-  - /learn/coding-conventions/top-level-definitions
-  - /learn/user-guide/coding-conventions/top-level-definitions
-  - /learn/user-guide/coding-conventions/top-level-definitions/
-  - /learn/user-guide/code-organization/coding-conventions/top-level-definitions/
-  - /learn/user-guide/code-organization/coding-conventions/top-level-definitions
-  - /learn/user-guide/style-guide/coding-conventions/top-level-definitions
-  - /learn/user-guide/style-guide/coding-conventions/top-level-definitions/
-  - /learn/style-guide/top-level-definitions
 ---
 
 ## General practices

--- a/swan-lake/learn-the-platform/test-document-the-code/debug-ballerina-programs.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/debug-ballerina-programs.md
@@ -5,35 +5,6 @@ description: Describes debugging functionalities provided by Ballerina in Visual
 keywords: ballerina debugging, ballerina debug, ballerina debugger, ballerina vscode
 permalink: /learn/debug-ballerina-programs/
 active: debug-ballerina-programs
-redirect_from:
-  - /learn/tools-ides/vscode-plugin/run-and-debug
-  - /learn/tools-ides/vscode-plugin/run-and-debug/
-  - /learn/vscode-plugin/run-and-debug/
-  - /learn/vscode-plugin/run-and-debug
-  - /learn/tools-ides/setting-up-visual-studio-code/run-and-debug
-  - /learn/tools-ides/setting-up-visual-studio-code/run-and-debug/
-  - /learn/setting-up-visual-studio-code/run-and-debug
-  - /learn/setting-up-visual-studio-code/run-and-debug/
-  - /learn/run-and-debug
-  - /learn/run-and-debug/
-  - /swan-lake/learn/getting-started/setting-up-visual-studio-code/run-and-debug/
-  - /swan-lake/learn/getting-started/setting-up-visual-studio-code/run-and-debug
-  - /learn/tooling-guide/vs-code-extension/run-and-debug
-  - /learn/tooling-guide/vs-code-extension/run-and-debug/
-  - /learn/tooling-guide/visual-studio-code-extension/debugging
-  - /learn/tooling-guide/visual-studio-code-extension/debugging/
-  - /learn/tooling-guide/visual-studio-code-extension/debugging
-  - /learn/getting-started/visual-studio-code-extension/debugging
-  - /learn/getting-started/visual-studio-code-extension/debugging/
-  - /learn/visual-studio-code-extension
-  - /learn/visual-studio-code-extension/
-  - /learn/visual-studio-code-extension/debugging
-  - /learn/visual-studio-code-extension/debugging/
-  - /learn/debugging-ballerina-programs
-  - /learn/debugging-ballerina-programs/
-  - /learn/debug-ballerina-programs
-  - /learn/guides/debugging-ballerina-programs/
-  - /learn/guides/debugging-ballerina-programs
 ---
 
 When writing large-scale applications with complex logic, it is quite possible to have syntax, semantic, 

--- a/swan-lake/learn-the-platform/test-document-the-code/generate-code-documentation.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/generate-code-documentation.md
@@ -6,25 +6,6 @@ keywords: ballerina, programming language, api documentation, api docs
 permalink: /learn/generate-code-documentation/
 active: generate-code-documentation
 intro: Ballerina has a built-in Ballerina Flavored Markdown (BFM) documentation framework named Docerina. The documentation framework allows you to write unstructured documents with a bit of structure to generate HTML content as API documentation.
-redirect_from:
-  - /learn/how-to-document-ballerina-code
-  - /learn/how-to-document-ballerina-code/
-  - /learn/documenting-ballerina-code
-  - /swan-lake/learn/documenting-ballerina-code/
-  - /swan-lake/learn/documenting-ballerina-code
-  - /learn/documenting-ballerina-code/
-  - /learn/documenting-ballerina-code
-  - /learn/user-guide/documenting-ballerina-code
-  - /learn/user-guide/code-organization/documenting-ballerina-code
-  - /learn/user-guide/code-organization/documenting-ballerina-code/
-  - /learn/user-guide/documenting-ballerina-code/
-  - /learn/user-guide/code-organization/
-  - /learn/user-guide/code-organization
-  - /learn/generating-code-documentation
-  - /learn/generating-code-documentation/
-  - /learn/generate-code-documentation
-  - /learn/guides/generating-code-documentation/
-  - /learn/guides/generating-code-documentation
 ---
 
 ## Generate documentation for modules

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/code-coverage-and-reporting.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/code-coverage-and-reporting.md
@@ -6,23 +6,6 @@ keywords: ballerina, programming language, testing, code coverage, test report
 permalink: /learn/test-ballerina-code/code-coverage-and-reporting/
 active: code-coverage-and-reporting
 intro: The Ballerina Test Framework allows you to generate test reports and code coverage reports for the executed tests.
-redirect_from:
-- /learn/testing-ballerina-code/
-- /learn/testing-ballerina-code
-- /learn/test-ballerina-code/
-- /learn/test-ballerina-code
-- /swan-lake/learn/testing-ballerina-code/code-coverage-and-reporting/
-- /swan-lake/learn/testing-ballerina-code/code-coverage-and-reporting
-- /learn/user-guide/testing-ballerina-code/code-coverage-and-reporting
-- /learn/user-guide/testing-ballerina-code/code-coverage-and-reporting/
-- /learn/user-guide/testing-ballerina-code/
-- /learn/user-guide/testing-ballerina-code
-- /learn/user-guide/testing-ballerina-code/code-coverage-and-reporting/
-- /learn/testing-ballerina-code/code-coverage-and-reporting
-- /learn/testing-ballerina-code/code-coverage-and-reporting/
-- /learn/test-ballerina-code/code-coverage-and-reporting
-- /learn/guides/testing-ballerina-code/code-coverage-and-reporting/
-- /learn/guides/testing-ballerina-code/code-coverage-and-reporting
 ---
 
 ## Generate a test report

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/configure-tests.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/configure-tests.md
@@ -6,23 +6,6 @@ keywords: ballerina, programming language, testing, test setup
 permalink: /learn/test-ballerina-code/configure-tests/
 active: configure-tests
 intro: The Ballerina Test framework has configurations at various levels to streamline the testing process and ensure that the tests are written with a comprehensible structure.
-redirect_from:
-- /learn/testing-ballerina-code/
-- /learn/testing-ballerina-code
-- /swan-lake/learn/testing-ballerina-code/configuring-tests/
-- /swan-lake/learn/testing-ballerina-code/configuring-tests
-- /learn/user-guide/testing-ballerina-code/configuring-tests
-- /learn/user-guide/testing-ballerina-code/configuring-tests/
-- /learn/user-guide/testing-ballerina-code/
-- /learn/user-guide/testing-ballerina-code
-- /learn/user-guide/testing-ballerina-code/configuring-tests/
-- /learn/testing-ballerina-code/configuring-tests/
-- /learn/testing-ballerina-code/configuring-tests
-- /learn/test-ballerina-code/configuring-tests
-- /learn/test-ballerina-code/configuring-test/
-- /learn/test-ballerina-code/configure-tests
-- /learn/guides/testing-ballerina-code/configuring-tests/
-- /learn/guides/testing-ballerina-code/configuring-tests
 ---
 
 ## Set up and tearing down

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/define-data-driven-tests.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/define-data-driven-tests.md
@@ -6,21 +6,6 @@ keywords: ballerina, programming language, testing, data-driven, data providers
 permalink: /learn/test-ballerina-code/define-data-driven-tests/
 active: define-data-driven-tests
 intro: The Ballerina Test Framework allows you to specify a function that returns a set of data values as a data-provider.
-redirect_from:
-- /swan-lake/learn/testing-ballerina-code/defining-data-driven-tests/
-- /swan-lake/learn/testing-ballerina-code/defining-data-driven-tests
-- /learn/user-guide/testing-ballerina-code/defining-data-driven-tests
-- /learn/user-guide/testing-ballerina-code/defining-data-driven-tests/
-- /learn/user-guide/testing-ballerina-code/
-- /learn/user-guide/testing-ballerina-code
-- /learn/user-guide/testing-ballerina-code/defining-data-driven-tests/
-- /learn/testing-ballerina-code/defining-data-driven-tests/
-- /learn/testing-ballerina-code/defining-data-driven-tests
-- /learn/testing-ballerina-code/define-data-driven-tests/
-- /learn/testing-ballerina-code/define-data-driven-tests
-- /learn/test-ballerina-code/define-data-driven-tests
-- /learn/guides/testing-ballerina-code/defining-data-driven-tests/
-- /learn/guides/testing-ballerina-code/defining-data-driven-tests
 ---
 
 ## Use data providers

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/define-test-groups.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/define-test-groups.md
@@ -6,23 +6,6 @@ keywords: ballerina, programming language, testing, test groups
 permalink: /learn/test-ballerina-code/define-test-groups/
 active: test-groups
 intro: The Ballerina test framework allows grouping of tests.
-redirect_from:
-- /learn/testing-ballerina-code/
-- /learn/testing-ballerina-code
-- /swan-lake/learn/testing-ballerina-code/defining-test-groups/
-- /swan-lake/learn/testing-ballerina-code/defining-test-groups
-- /learn/user-guide/testing-ballerina-code/defining-test-groups
-- /learn/user-guide/testing-ballerina-code/defining-test-groups/
-- /learn/user-guide/testing-ballerina-code/
-- /learn/user-guide/testing-ballerina-code
-- /learn/user-guide/testing-ballerina-code/defining-test-groups/
-- /learn/testing-ballerina-code/defining-test-groups/
-- /learn/testing-ballerina-code/defining-test-groups
-- /learn/testing-ballerina-code/define-test-groups/
-- /learn/testing-ballerina-code/define-test-groups
-- /learn/test-ballerina-code/define-test-groups
-- /learn/guides/testing-ballerina-code/defining-test-groups/
-- /learn/guides/testing-ballerina-code/defining-test-groups
 ---
 
 ## Group tests

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/execute-tests.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/execute-tests.md
@@ -6,18 +6,6 @@ keywords: ballerina, programming language, testing, test execution
 permalink: /learn/test-ballerina-code/execute-tests/
 active: execute-tests
 intro: The sections below include information about executing tests in Ballerina.
-redirect_from:
-  - /swan-lake/learn/testing-ballerina-code/executing-tests/
-  - /swan-lake/learn/testing-ballerina-code/executing-tests
-  - /learn/user-guide/testing-ballerina-code/executing-tests
-  - /learn/user-guide/testing-ballerina-code/executing-tests/
-  - /learn/testing-ballerina-code/executing-tests/
-  - /learn/testing-ballerina-code/executing-tests
-  - /learn/testing-ballerina-code/execute-tests/
-  - /learn/testing-ballerina-code/execute-tests
-  - /learn/test-ballerina-code/execute-tests
-  - /learn/guides/testing-ballerina-code/executing-tests/
-  - /learn/guides/testing-ballerina-code/executing-tests
 ---
 
 ## Understand the test execution behavior

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/mocking.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/mocking.md
@@ -7,16 +7,6 @@ keywords: ballerina, programming language, testing, mocking, object mocking
 permalink: /learn/test-ballerina-code/mocking/
 active: mocking
 intro: Mocking is useful to control the behavior of functions and objects to control the communication with other modules and external endpoints. A mock can be created by defining return values or replacing the entire object or function with a user-defined equivalent. This feature will help you to test the Ballerina code independently from other modules and external endpoints.
-redirect_from:
-  - /learn/testing-ballerina-code/mocking
-  - /learn/testing-ballerina-code/mocking/
-  - /swan-lake/learn/testing-ballerina-code/mocking/
-  - /swan-lake/learn/testing-ballerina-code/mocking
-  - /learn/user-guide/testing-ballerina-code/mocking
-  - /learn/user-guide/testing-ballerina-code/mocking/
-  - /learn/test-ballerina-code/mocking
-  - /learn/guides/testing-ballerina-code/mocking/
-  - /learn/guides/testing-ballerina-code/mocking
 ---
 
 ## Mock objects

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/structure-tests.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/structure-tests.md
@@ -6,23 +6,6 @@ keywords: ballerina, programming language, testing
 permalink: /learn/test-ballerina-code/structure-tests/
 active: structure-tests
 intro: The Ballerina Test Framework follows a general, organized structure that allows testing code under various conditions by making use of resources and configurations. 
-redirect_from:
-    - /swan-lake/learn/testing-ballerina-code/structuring-tests/
-    - /swan-lake/learn/testing-ballerina-code/structuring-tests
-    - /learn/user-guide/testing-ballerina-code/structuring-tests
-    - /learn/user-guide/testing-ballerina-code/structuring-tests/
-    - /learn/user-guide/testing-ballerina-code/
-    - /learn/user-guide/testing-ballerina-code
-    - /learn/user-guide/testing-ballerina-code/structuring-tests/
-    - /learn/testing-ballerina-code/structuring-tests/
-    - /learn/testing-ballerina-code/structuring-tests
-    - /learn/testing-ballerina-code/structure-tests/
-    - /learn/testing-ballerina-code/structure-tests
-    - /learn/testing-ballerina-code/structure-the-tests/
-    - /learn/testing-ballerina-code/structure-the-tests
-    - /learn/test-ballerina-code/structure-tests
-    - /learn/guides/testing-ballerina-code/structuring-the-tests/
-    - /learn/guides/testing-ballerina-code/structuring-the-tests
 ---
 
 ## Test source files

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/test-a-simple-function.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/test-a-simple-function.md
@@ -6,29 +6,6 @@ keywords: ballerina, programming language, testing
 permalink: /learn/test-ballerina-code/test-a-simple-function/
 active: test-a-simple-function
 intro: The Ballerina language has a built-in robust test framework, which allows you to achieve multiple levels of the test pyramid including, unit testing, integration testing, and end-to-end testing. It provides assertions, data providers, mocking, and code coverage features, which enable the programmers to write comprehensive tests.
-redirect_from:
-    - /learn/how-to-test-ballerina-code/
-    - /learn/how-to-test-ballerina-code
-    - /learn/testing-ballerina-code/testing-quick-start
-    - /learn/testing-ballerina-code/testing-quick-start/
-    - /swan-lake/learn/testing-ballerina-code/testing-quick-start/
-    - /swan-lake/learn/testing-ballerina-code/testing-quick-start
-    - /learn/user-guide/testing-ballerina-code/testing-quick-start
-    - /learn/user-guide/testing-ballerina-code/testing-quick-start/
-    - /learn/user-guide/testing-ballerina-code/
-    - /learn/user-guide/testing-ballerina-code
-    - /learn/user-guide/testing-ballerina-code/testing-quick-start/
-    - /learn/testing-ballerina-code/testing-a-simple-function
-    - /learn/testing-ballerina-code/testing-a-simple-function/
-    - /learn/testing-ballerina-code/test-a-simple-function/
-    - /learn/testing-ballerina-code/test-a-simple-function
-    - /learn/test-ballerina-code/test-a-simple-function
-    - /learn/testing-ballerina-code/
-    - /learn/testing-ballerina-code
-    - /learn/test-ballerina-code/
-    - /learn/test-ballerina-code
-    - /learn/guides/testing-ballerina-code/testing-a-simple-function
-    - /learn/guides/testing-ballerina-code/testing-a-simple-function
 ---
 
 To get started, let's set up the Ballerina package to run tests.

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/test-services-and-clients.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/test-services-and-clients.md
@@ -6,18 +6,6 @@ keywords: ballerina, programming language, testing
 permalink: /learn/test-ballerina-code/test-services-and-clients/
 active: testing-services-and-clients
 intro: Testing Ballerina services involves sending specific requests to the service using a client and verifying the responses using the assertion functions. The aim is to make sure that the service and client behave as expected when sending and recieving both expected requests and malformed ones.
-redirect_from:
-- /learn/testing-ballerina-code/testing-services-and-clients
-- /learn/testing-ballerina-code/testing-services-and-clients/
-- /swan-lake/learn/testing-ballerina-code/testing-services-and-clients/
-- /swan-lake/learn/testing-ballerina-code/testing-services-and-clients
-- /learn/user-guide/testing-ballerina-code/testing-services-and-clients
-- /learn/user-guide/testing-ballerina-code/testing-services-and-clients/
-- /learn/testing-ballerina-code/test-services-and-clients/
-- /learn/testing-ballerina-code/test-services-and-clients
-- /learn/test-ballerina-code/test-services-and-clients
-- /learn/guides/testing-ballerina-code/testing-services-and-clients/
-- /learn/guides/testing-ballerina-code/testing-services-and-clients
 ---
 
 ## Test services

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/write-tests.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/write-tests.md
@@ -6,18 +6,6 @@ keywords: ballerina, programming language, testing
 permalink: /learn/test-ballerina-code/write-tests/
 active: write-tests
 intro: The sections below include information about writing tests in Ballerina.
-redirect_from:
-  - /learn/testing-ballerina-code/writing-tests
-  - /learn/testing-ballerina-code/writing-tests/
-  - /swan-lake/learn/testing-ballerina-code/writing-tests/
-  - /swan-lake/learn/testing-ballerina-code/writing-tests
-  - /learn/user-guide/testing-ballerina-code/writing-tests
-  - /learn/user-guide/testing-ballerina-code/writing-tests/
-  - /learn/testing-ballerina-code/write-tests/
-  - /learn/testing-ballerina-code/write-tests
-  - /learn/test-ballerina-code/write-tests
-  - /learn/guides/testing-ballerina-code/writing-tests/
-  - /learn/guides/testing-ballerina-code/writing-tests
 ---
 
 ## Define a test

--- a/swan-lake/other/data-and-events-processing/use-language-integrated-queries.md
+++ b/swan-lake/other/data-and-events-processing/use-language-integrated-queries.md
@@ -6,19 +6,6 @@ keywords: ballerina, programming language, queries, query expression, query acti
 permalink: /learn/user-guide/data-and-events-processing/using-language-integrated-queries/
 active: using-language-integrated-queries
 intro: Language integrated queries specify the logic in SQL-like syntax to process data and events. They are easy to write and understand due to the simplicity of the syntax. The sections below will explore Ballerina’s first-class support for writing queries that process data with examples.
-redirect_from:
-  - /learn/data-and-events-processing/using-language-integrated-queries
-  - /learn/data-and-events-processing/
-  - /learn/data-and-events-processing
-  - /swan-lake/learn/data-and-events-processing/using-language-integrated-queries/
-  - /swan-lake/learn/data-and-events-processing/using-language-integrated-queries
-  - /learn/data-and-events-processing/using-language-integrated-queries/
-  - /learn/data-and-events-processing/using-language-integrated-queries
-  - /learn/user-guide/data-and-events-processing/using-language-integrated-queries
-  - /learn/user-guide/data-and-events-processing/
-  - /learn/user-guide/data-and-events-processing
-redirect_to:
-  - /learn/by-example/
 ---
 
 ## Using language-integrated queries

--- a/swan-lake/other/network-communication/GraphQL/graphql.md
+++ b/swan-lake/other/network-communication/GraphQL/graphql.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/graphql/
 active: graphql
 intro:  GraphQL has become a prominent technology for implementing data APIs because it provides a convenient and intuitive approach for querying data. It solves potential problems such as data over-fetching and high-latency that you may notice in traditional data services. This guide illustrates a sample GraphQL use case using Ballerina. 
-redirect_from:
-  - /learn/network-communication/graphql
-  - /swan-lake/learn/network-communication/graphql/
-  - /swan-lake/learn/network-communication/graphql
-  - /learn/network-communication/graphql/
-  - /learn/network-communication/graphql
-  - /learn/user-guide/network-communication/graphql
-redirect_to:
-  - https://lib.ballerina.io/ballerina/graphql/latest/
 ---
 
 ## Introducing the use case

--- a/swan-lake/other/network-communication/GraphQL/implement-graphql-services.md
+++ b/swan-lake/other/network-communication/GraphQL/implement-graphql-services.md
@@ -6,10 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/graphql/implementing-graphql-services/
 active: implementing-graphql-services
 intro:  In Ballerina, the GraphQL object structure is modeled using services. A Ballerina GraphQL service contains resource methods that map to the fields of the GraphQL objects and work as resolver functions to provide its data. The GraphQL schema is automatically derived from this service structure and its resources. 
-redirect_from:
-  - /learn/user-guide/network-communication/graphql/implementing-graphql-services
-redirect_to:
-  - https://lib.ballerina.io/ballerina/graphql/latest/
 ---
 
 The topics below demonstrates how to implement an [order information query scenario](/learn/user-guide/network-communication/graphql#introducing-the-use-case) using a Ballerina service. 

--- a/swan-lake/other/network-communication/HTTP/http-clients/communication-resiliency.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/communication-resiliency.md
@@ -6,17 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-clients/communication-resiliency/
 active: communication-resiliency
 intro: The HTTP client supports multiple communication resiliency options out of the box.  
-redirect_from:
-  - /learn/network-communication/http/http-clients/communication-resiliency
-  - /swan-lake/learn/network-communication/http/http-clients/communication-resiliency/
-  - /swan-lake/learn/network-communication/http/http-clients/xscommunication-resiliency
-  - /learn/network-communication/http/http-clients/communication-resiliency/
-  - /learn/network-communication/http/http-clients/communication-resiliency
-  - /learn/user-guide/network-communication/http/http-clients/communication-resiliency
-  - /learn/network-communication/http/communication-resiliency/
-  - /learn/network-communication/http/communication-resiliency
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 These features allow you to handle and recover from unexpected communication scenarios gracefully. 

--- a/swan-lake/other/network-communication/HTTP/http-clients/data-binding.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/data-binding.md
@@ -6,17 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-clients/data-binding/
 active: data-binding
 intro: The sections below explain the how to perform data binding with HTTP clients.  
-redirect_from:
-  - /learn/network-communication/http/http-clients/data-binding
-  - /swan-lake/learn/network-communication/http/http-clients/data-binding/
-  - /swan-lake/learn/network-communication/http/http-clients/data-binding
-  - /learn/network-communication/http/http-clients/data-binding/
-  - /learn/network-communication/http/http-clients/data-binding
-  - /learn/user-guide/network-communication/http/http-clients/data-binding
-  - /learn/network-communication/http/data-binding/
-  - /learn/network-communication/http/data-binding
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 [`http:Client`](https://docs.central.ballerina.io/ballerina/http/latest/clients/HttpClient) data binding happens automatically based on the left hand side type. The left hand side type could be any type such as `string`, `json`, `xml`, `map<json>`, `byte[]`, custom record, and record array types. 

--- a/swan-lake/other/network-communication/HTTP/http-clients/data-streaming.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/data-streaming.md
@@ -6,17 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-clients/data-streaming/
 active: data-streaming
 intro: HTTP data streaming can be attained using chunked transfer encoding.  
-redirect_from:
-  - /learn/network-communication/http/http-clients/data-streaming
-  - /swan-lake/learn/network-communication/http/http-clients/data-streaming/
-  - /swan-lake/learn/network-communication/http/http-clients/data-streaming
-  - /learn/network-communication/http/http-clients/data-streaming/
-  - /learn/network-communication/http/http-clients/data-streaming
-  - /learn/user-guide/network-communication/http/http-clients/data-streaming
-  - /learn/network-communication/http/data-streaming/
-  - /learn/network-communication/http/data-streaming
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 ## Data streaming modes

--- a/swan-lake/other/network-communication/HTTP/http-clients/http-clients.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/http-clients.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-clients/
 active: http-clients
 intro: The topics below explain how to process HTTP requests and responses using Ballerina. It provides in-depth details on how HTTP clients are created and how their functionality can be used effectively.  
-redirect_from:
-  - /learn/network-communication/http/http-clients
-  - /swan-lake/learn/network-communication/http/http-clients/
-  - /swan-lake/learn/network-communication/http/http-clients
-  - /learn/network-communication/http/http-clients/
-  - /learn/network-communication/http/http-clients
-  - /learn/user-guide/network-communication/http/http-clients
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 ## Creating HTTP clients

--- a/swan-lake/other/network-communication/HTTP/http-clients/multipart-message-handling.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/multipart-message-handling.md
@@ -6,17 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-clients/multipart-message-handling/
 active: multipart-message-handling
 intro: HTTP multipart messages can be created by using the Multipurpose Internet Mail Extensions (MIME) standard.  
-redirect_from:
-  - /learn/network-communication/http/http-clients/multipart-message-handling
-  - /swan-lake/learn/network-communication/http/http-clients/multipart-message-handling/
-  - /swan-lake/learn/network-communication/http/http-clients/multipart-message-handling
-  - /learn/network-communication/http/http-clients/multipart-message-handling/
-  - /learn/network-communication/http/http-clients/multipart-message-handling
-  - /learn/user-guide/network-communication/http/http-clients/multipart-message-handling
-  - /learn/network-communication/http/multipart-message-handling/
-  - /learn/network-communication/http/multipart-message-handling
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 You can provide MIME entity values to create single or multi-part HTTP messages using the [`http:Request`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request) object.

--- a/swan-lake/other/network-communication/HTTP/http-clients/secure-communication.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/secure-communication.md
@@ -6,17 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-clients/secure-communication/
 active: secure-communication
 intro: The HTTP client supports numerous secure communication features such as Transport Level Security (TLS) and mutual authentication.   
-redirect_from:
-  - /learn/network-communication/http/http-clients/secure-communication
-  - /swan-lake/learn/network-communication/http/http-clients/secure-communication/
-  - /swan-lake/learn/network-communication/http/http-clients/secure-communication
-  - /learn/network-communication/http/http-clients/secure-communication/
-  - /learn/network-communication/http/http-clients/secure-communication
-  - /learn/user-guide/network-communication/http/http-clients/secure-communication
-  - /learn/network-communication/http/secure-communication/
-  - /learn/network-communication/http/secure-communication
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 ## Configuring secure communication

--- a/swan-lake/other/network-communication/HTTP/http-services/extended-request-response-access.md
+++ b/swan-lake/other/network-communication/HTTP/http-services/extended-request-response-access.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-services/extended-request-response-access/
 active: extended-request-response-access
 intro: The service resources have the functionality of handling request and response data manually  without binding them to resource parameters or the return value. 
-redirect_from:
-  - /learn/network-communication/http/http-services/extended-request-response-access
-  - /swan-lake/learn/network-communication/http/http-services/extended-request-response-access/
-  - /swan-lake/learn/network-communication/http/http-services/extended-request-response-access
-  - /learn/network-communication/http/http-services/extended-request-response-access/
-  - /learn/network-communication/http/http-services/extended-request-response-access
-  - /learn/user-guide/network-communication/http/http-services
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 ## Interacting with the remote client

--- a/swan-lake/other/network-communication/HTTP/http-services/http-services.md
+++ b/swan-lake/other/network-communication/HTTP/http-services/http-services.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-services/
 active: http-services
 intro: The topics below cover details on the HTTP services support in Ballerina. They explore the basics of creating an HTTP service and how Ballerina provides a convenient abstraction for defining complex operations. 
-redirect_from:
-  - /learn/network-communication/http/http-services
-  - /swan-lake/learn/network-communication/http/http-services/
-  - /swan-lake/learn/network-communication/http/http-services
-  - /learn/network-communication/http/http-services/
-  - /learn/network-communication/http/http-services
-  - /learn/user-guide/network-communication/http/http-services
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 ## Structuring an HTTP service

--- a/swan-lake/other/network-communication/HTTP/http-services/multipart-message-handling.md
+++ b/swan-lake/other/network-communication/HTTP/http-services/multipart-message-handling.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-services/multipart-message-handling/
 active: multipart-message-handling
 intro: You can carry out multipart message handling in Ballerina HTTP services.
-redirect_from:
-  - /learn/network-communication/http/http-services/multipart-message-handling
-  - /swan-lake/learn/network-communication/http/http-services/multipart-message-handling/
-  - /swan-lake/learn/network-communication/http/http-services/multipart-message-handling
-  - /learn/network-communication/http/http-services/multipart-message-handling/
-  - /learn/network-communication/http/http-services/multipart-message-handling
-  - /learn/user-guide/network-communication/http/http-services/multipart-message-handling
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 ## Using MIME entities

--- a/swan-lake/other/network-communication/HTTP/http-services/payload-data-binding.md
+++ b/swan-lake/other/network-communication/HTTP/http-services/payload-data-binding.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-services/payload-data-binding/
 active: payload-data-binding
 intro: The HTTP service resource payloads can be directly data bound to the resource method parameters.
-redirect_from:
-  - /learn/network-communication/http/http-services/payload-data-binding
-  - /swan-lake/learn/network-communication/http/http-services/payload-data-binding/
-  - /swan-lake/learn/network-communication/http/http-services/payload-data-binding
-  - /learn/network-communication/http/http-services/payload-data-binding/
-  - /learn/network-communication/http/http-services/payload-data-binding
-  - /learn/user-guide/network-communication/http/http-services/payload-data-binding
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 ## Using the annotation

--- a/swan-lake/other/network-communication/HTTP/http-services/secure-communication.md
+++ b/swan-lake/other/network-communication/HTTP/http-services/secure-communication.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/http-services/secure-communication/
 active: secure-communication
 intro: The HTTP listener can be configured to enable transport security to restrict to HTTPS clients for communication. 
-redirect_from:
-  - /learn/network-communication/http/http-services/secure-communication
-  - /swan-lake/learn/network-communication/http/http-services/secure-communication/
-  - /swan-lake/learn/network-communication/http/http-services/secure-communication
-  - /learn/network-communication/http/http-services/secure-communication/
-  - /learn/network-communication/http/http-services/secure-communication/
-  - /learn/user-guide/network-communication/http/http-services/secure-communication
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 ## Configuring secure communication

--- a/swan-lake/other/network-communication/HTTP/http.md
+++ b/swan-lake/other/network-communication/HTTP/http.md
@@ -6,19 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/http/
 active: http
 intro: The topics below explain how to process HTTP requests and responses using Ballerina. 
-redirect_from:
-  - /learn/network-communication/http
-  - /learn/network-communication/
-  - /learn/network-communication
-  - /swan-lake/learn/network-communication/http/
-  - /swan-lake/learn/network-communication/http
-  - /learn/network-communication/http/
-  - /learn/network-communication/http
-  - /learn/user-guide/network-communication/http
-  - /learn/user-guide/network-communication/
-  - /learn/user-guide/network-communication
-redirect_to:
-  - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 ## Working with HTTP clients

--- a/swan-lake/other/network-communication/WebSocket/secure-websocket-communication.md
+++ b/swan-lake/other/network-communication/WebSocket/secure-websocket-communication.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/websocket/securing-websocket-communication/
 active: securing-websocket-communication
 intro: Whenever possible, you should use WebSocket with TLS. This makes sure that your data communication is secure through the network. 
-redirect_from:
-  - /learn/network-communication/websocket/using-primary-events
-  - /swan-lake/learn/network-communication/websocket/securing-websocket-communication/
-  - /swan-lake/learn/network-communication/websocket/securing-websocket-communication
-  - /learn/network-communication/websocket/securing-websocket-communication/
-  - /learn/network-communication/websocket/securing-websocket-communication
-  - /learn/user-guide/network-communication/websocket/securing-websocket-communication
-redirect_to:
-  - https://lib.ballerina.io/ballerina/websocket/latest/
 ---
 
 ## Configuring a secure socket 

--- a/swan-lake/other/network-communication/WebSocket/websocket.md
+++ b/swan-lake/other/network-communication/WebSocket/websocket.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/websocket/
 active: websocket
 intro: WebSocket is a low-latency communication protocol used for efficient full-duplex communication between web browsers and servers over TCP. The topics below explain how to implement WebSocket-based services using Ballerina.  
-redirect_from:
-  - /learn/network-communication/websocket
-  - /swan-lake/learn/network-communication/websocket/
-  - /swan-lake/learn/network-communication/websocket
-  - /learn/network-communication/websocket/
-  - /learn/network-communication/websocket
-  - /learn/user-guide/network-communication/websocket
-redirect_to:
-  - https://lib.ballerina.io/ballerina/websocket/latest/
 ---
 
 ## Upgrading the WebSocket 

--- a/swan-lake/other/network-communication/gRPC/define-the-service-interface.md
+++ b/swan-lake/other/network-communication/gRPC/define-the-service-interface.md
@@ -6,17 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/grpc/defining-the-service-interface/ 
 active: defining-the-service-interface
 intro: gRPC is an open-source remote procedure call (RPC) technology, which uses HTTP/2 for transport and is based on Google’s Protocol Buffers. It promises high performance, efficient network communication, features such as schema evolution, blocking and non-blocking communication, and bidirectional streaming. The topics below explain how gRPC works and the tools and techniques that are required to implement it using Ballerina. 
-redirect_from:
-  - /learn/network-communication/grpc
-  - /swan-lake/learn/network-communication/grpc/
-  - /swan-lake/learn/network-communication/grpc
-  - /learn/network-communication/grpc/
-  - /learn/network-communication/grpc
-  - /learn/user-guide/network-communication/grpc
-  - /learn/user-guide/network-communication/grpc/
-  - /learn/user-guide/network-communication/grpc/defining-the-service-interface
-redirect_to:
-  - https://lib.ballerina.io/ballerina/grpc/latest/
 ---
 
 In an RPC service, the first step is to define the interface of the service. This is done using an IDL (Interface Definition Language) file. The IDL file of a gRPC service is provided using Protocol Buffers. Protobuf is a standard for serializing structured data. It provides the structures required for defining services, operations, and messages used in the service communication. 

--- a/swan-lake/other/network-communication/gRPC/implement-grpc-services-and-clients/implement-grpc-clients.md
+++ b/swan-lake/other/network-communication/gRPC/implement-grpc-services-and-clients/implement-grpc-clients.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/grpc/implementing-grpc-services-and-clients/implementing-grpc-clients/
 active: implementing-grpc-clients
 intro: The topics below explain how to implement a gRPC service and write a client to invoke it. 
-redirect_from:
-  - /learn/network-communication/grpc/implementing-grpc-services-and-clients
-  - /swan-lake/learn/network-communication/grpc/implementing-grpc-services-and-clients/
-  - /swan-lake/learn/network-communication/grpc/implementing-grpc-services-and-clients
-  - /learn/network-communication/grpc/implementing-grpc-services-and-clients/
-  - /learn/network-communication/grpc/implementing-grpc-services-and-clients
-  - /learn/user-guide/network-communication/grpc/implementing-grpc-services-and-clients
-redirect_to:
-  - https://lib.ballerina.io/ballerina/grpc/latest/
 ---
 
 After completing the [gRPC service implementation](/learn/user-guide/network-communication/grpc/implementing-grpc-services-and-clients/implementing-grpc-services/), you can call these service methods using a client as follows. 

--- a/swan-lake/other/network-communication/gRPC/implement-grpc-services-and-clients/implement-grpc-services.md
+++ b/swan-lake/other/network-communication/gRPC/implement-grpc-services-and-clients/implement-grpc-services.md
@@ -6,17 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/grpc/implementing-grpc-services-and-clients/implementing-grpc-services/
 active: implementing-grpc-services
 intro: The topics below explain how to implement a gRPC service and write a client to invoke it. 
-redirect_from:
-  - /learn/network-communication/grpc/implementing-grpc-services-and-clients
-  - /swan-lake/learn/network-communication/grpc/implementing-grpc-services-and-clients/
-  - /swan-lake/learn/network-communication/grpc/implementing-grpc-services-and-clients
-  - /learn/network-communication/grpc/implementing-grpc-services-and-clients/
-  - /learn/network-communication/grpc/implementing-grpc-services-and-clients
-  - /learn/user-guide/network-communication/grpc/implementing-grpc-services-and-clients
-  - /learn/user-guide/network-communication/grpc/implementing-grpc-services-and-clients/
-  - /learn/user-guide/network-communication/grpc/implementing-grpc-services-and-clients/implementing-grpc-services
-redirect_to:
-  - https://lib.ballerina.io/ballerina/grpc/latest/
 ---
 
 Execute the `bal new service` command to create a Ballerina package to implement the service. You view the output below.

--- a/swan-lake/other/network-communication/gRPC/perform-grpc-streaming.md
+++ b/swan-lake/other/network-communication/gRPC/perform-grpc-streaming.md
@@ -6,15 +6,6 @@ keywords: ballerina, cli, command-line interface, programming language
 permalink: /learn/user-guide/network-communication/grpc/performing-grpc-streaming/
 active: performing-grpc-streaming
 intro: The topics below demonstrates an example implementation of a gRPC client and bi-directional streaming using Ballerina.
-redirect_from:
-  - /learn/network-communication/grpc/performing-grpc-streaming
-  - /swan-lake/learn/network-communication/grpc/performing-grpc-streaming/
-  - /swan-lake/learn/network-communication/grpc/performing-grpc-streaming
-  - /learn/network-communication/grpc/performing-grpc-streaming/
-  - /learn/network-communication/grpc/performing-grpc-streaming
-  - /learn/user-guide/network-communication/grpc/performing-grpc-streaming
-redirect_to:
-  - https://lib.ballerina.io/ballerina/grpc/latest/
 ---
 
 >**Info:** gRPC supports both client and bi-directional streaming. In client streaming, the client writes a sequence of messages and sends them to the server via a stream. Once the client has finished writing the messages, it waits for the server to read them and return a response. In bi-directional streaming, the client and server each send a sequence of messages using read-write streams that operate independently allowing them to read and write in any order.

--- a/swan-lake/other/security/http-client-authentication.md
+++ b/swan-lake/other/security/http-client-authentication.md
@@ -6,10 +6,6 @@ keywords: ballerina, programming language, security, secure ballerina code, auth
 permalink: /learn/user-guide/security/http-client-authentication/
 active: http-client-authentication
 intro: Ballerina HTTP clients can be configured to enforce authentication.
-redirect_from:
-    - /learn/user-guide/security/http-client-authentication
-redirect_to:
-    - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 The Ballerina HTTP client can be configured to send authentication information to the endpoint being invoked. Ballerina has built-in support for the following client authentication mechanisms.

--- a/swan-lake/other/security/http-listener-authentication-and-authorization.md
+++ b/swan-lake/other/security/http-listener-authentication-and-authorization.md
@@ -6,34 +6,6 @@ keywords: ballerina, programming language, security, secure ballerina code, auth
 permalink: /learn/user-guide/security/http-listener-authentication-and-authorization/
 active: http-listener-authentication-and-authorization
 intro: Ballerina HTTP services/resources can be configured to enforce authentication and authorization.
-redirect_from:
-- /learn/authentication-and-authorization
-- /learn/authentication-and-authorization/
-- /swan-lake/learn/security/authentication-and-authorization/
-- /swan-lake/learn/security/authentication-and-authorization
-- /learn/security/authentication-and-authorization/
-- /learn/security/authentication-and-authorization
-- /learn/user-guide/security/authentication-and-authorization
-- /learn/user-guide/authentication-and-authorization/
-- /learn/user-guide/authentication-and-authorization
-- /learn/how-to-write-secure-ballerina-code
-- /learn/how-to-write-secure-ballerina-code/
-- /learn/writing-secure-ballerina-code/
-- /learn/writing-secure-ballerina-code
-- /learn/security/
-- /learn/security
-- /swan-lake/learn/security/writing-secure-ballerina-code/
-- /swan-lake/learn/security/writing-secure-ballerina-code
-- /learn/security/writing-secure-ballerina-code/
-- /learn/security/writing-secure-ballerina-code
-- /learn/user-guide/security/writing-secure-ballerina-code
-- /learn/user-guide/security/writing-secure-ballerina-code/
-- /learn/user-guide/security/
-- /learn/user-guide/security
-- /learn/user-guide/security/authentication-and-authorization/
-- /learn/user-guide/security/authentication-and-authorization
-redirect_to:
-    - https://lib.ballerina.io/ballerina/http/latest/
 ---
 
 The Ballerina HTTP services/resources can be configured to authenticate and authorize the inbound requests. Ballerina has built-in support for the following listener authentication mechanisms.

--- a/swan-lake/other/tooling-guide/intellij-idea-plugin/set-up-intellij-idea.md
+++ b/swan-lake/other/tooling-guide/intellij-idea-plugin/set-up-intellij-idea.md
@@ -4,19 +4,6 @@ title: Setting up IntelliJ IDEA
 permalink: /learn/setting-up-intellij-idea/
 active: setting-up-intellij-idea
 intro: The IntelliJ Ballerina plugin provides the Ballerina development capabilities in IntelliJ IDEA. The below sections include instructions on how to download, install, and use the features of the IntelliJ plugin.
-redirect_from:
-  - /learn/tools-ides/intellij-plugin
-  - /learn/tools-ides/intellij-plugin/
-  - /learn/intellij-plugin
-  - /learn/intellij-plugin/
-  - /learn/tools-ides/setting-up-intellij-idea
-  - /learn/tools-ides/setting-up-intellij-idea/
-  - /learn/setting-up-intellij-idea
-  - /learn/setting-up-intellij-idea/
-  - /swan-lake/learn/setting-up-intellij-idea/
-  - /swan-lake/learn/setting-up-intellij-idea
-redirect_to:
-  - /learn/
 ---
 
 ## Setting up the prerequisites

--- a/swan-lake/other/tooling-guide/intellij-idea-plugin/set-up-intellij-idea/use-intellij-plugin-features 2.md
+++ b/swan-lake/other/tooling-guide/intellij-idea-plugin/set-up-intellij-idea/use-intellij-plugin-features 2.md
@@ -4,18 +4,6 @@ title: Using the features of the IntelliJ plugin
 permalink: /learn/setting-up-intellij-idea/using-intellij-plugin-features/
 active: using-intellij-plugin-features
 intro: The sections below include information on the various capabilities that are facilitated by the IntelliJ Ballerina plugin for the development process.
-redirect_from:
-  - /learn/tools-ides/intellij-plugin/using-intellij-plugin-features
-  - /learn/tools-ides/intellij-plugin/using-intellij-plugin-features/
-  - /learn/intellij-plugin/using-intellij-plugin-features
-  - /learn/intellij-plugin/using-intellij-plugin-features/
-  - /learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features
-  - /learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features/
-  - /learn/setting-up-intellij-idea/using-intellij-plugin-features
-  - /learn/using-intellij-plugin-features
-  - /learn/using-intellij-plugin-features/
-  - /swan-lake//learn/setting-up-intellij-idea/using-intellij-plugin-features/
-  - /swan-lake//learn/setting-up-intellij-idea/using-intellij-plugin-features
 ---
 
 ## Running Ballerina programs

--- a/swan-lake/other/tooling-guide/intellij-idea-plugin/set-up-intellij-idea/use-intellij-plugin-features.md
+++ b/swan-lake/other/tooling-guide/intellij-idea-plugin/set-up-intellij-idea/use-intellij-plugin-features.md
@@ -4,20 +4,6 @@ title: Using the features of the IntelliJ plugin
 permalink: /learn/setting-up-intellij-idea/using-intellij-plugin-features/
 active: using-intellij-plugin-features
 intro: The sections below include information on the various capabilities that are facilitated by the IntelliJ Ballerina plugin for the development process.
-redirect_from:
-  - /learn/tools-ides/intellij-plugin/using-intellij-plugin-features
-  - /learn/tools-ides/intellij-plugin/using-intellij-plugin-features/
-  - /learn/intellij-plugin/using-intellij-plugin-features
-  - /learn/intellij-plugin/using-intellij-plugin-features/
-  - /learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features
-  - /learn/tools-ides/setting-up-intellij-idea/using-intellij-plugin-features/
-  - /learn/setting-up-intellij-idea/using-intellij-plugin-features
-  - /learn/using-intellij-plugin-features
-  - /learn/using-intellij-plugin-features/
-  - /swan-lake//learn/setting-up-intellij-idea/using-intellij-plugin-features/
-  - /swan-lake//learn/setting-up-intellij-idea/using-intellij-plugin-features
-redirect_to:
-  - /learn/
 ---
 
 ## Running Ballerina programs

--- a/swan-lake/other/tooling-guide/intellij-idea-plugin/set-up-intellij-idea/use-the-intellij-plugin 2.md
+++ b/swan-lake/other/tooling-guide/intellij-idea-plugin/set-up-intellij-idea/use-the-intellij-plugin 2.md
@@ -4,21 +4,6 @@ title: Using the IntelliJ Ballerina plugin
 permalink: /learn/setting-up-intellij-idea/using-the-intellij-plugin/
 active: using-the-intellij-plugin
 intro: The sections below include information to start using the IntelliJ Ballerina plugin after installing it.
-redirect_from:
-  - /learn/tools-ides/intellij-plugin/using-the-intellij-plugin
-  - /learn/tools-ides/intellij-plugin/using-the-intellij-plugin/
-  - /learn/intellij-plugin/using-the-intellij-plugin
-  - /learn/intellij-plugin/using-the-intellij-plugin/
-  - /learn/set-up-ballerina-sdk/
-  - /learn/set-up-ballerina-sdk
-  - /learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin
-  - /learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin/
-  - /learn/setting-up-intellij-idea/using-the-intellij-plugin
-  - /learn/setting-up-intellij-idea/using-the-intellij-plugin/
-  - /learn/using-the-intellij-plugin
-  - /learn/using-the-intellij-plugin/
-  - /swan-lake/learn/setting-up-intellij-idea/using-the-intellij-plugin/
-  - /swan-lake/learn/setting-up-intellij-idea/using-the-intellij-plugin
 ---
 
 ## Creating a new Ballerina project

--- a/swan-lake/other/tooling-guide/intellij-idea-plugin/set-up-intellij-idea/use-the-intellij-plugin.md
+++ b/swan-lake/other/tooling-guide/intellij-idea-plugin/set-up-intellij-idea/use-the-intellij-plugin.md
@@ -4,23 +4,6 @@ title: Using the IntelliJ Ballerina plugin
 permalink: /learn/setting-up-intellij-idea/using-the-intellij-plugin/
 active: using-the-intellij-plugin
 intro: The sections below include information to start using the IntelliJ Ballerina plugin after installing it.
-redirect_from:
-  - /learn/tools-ides/intellij-plugin/using-the-intellij-plugin
-  - /learn/tools-ides/intellij-plugin/using-the-intellij-plugin/
-  - /learn/intellij-plugin/using-the-intellij-plugin
-  - /learn/intellij-plugin/using-the-intellij-plugin/
-  - /learn/set-up-ballerina-sdk/
-  - /learn/set-up-ballerina-sdk
-  - /learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin
-  - /learn/tools-ides/setting-up-intellij-idea/using-the-intellij-plugin/
-  - /learn/setting-up-intellij-idea/using-the-intellij-plugin
-  - /learn/setting-up-intellij-idea/using-the-intellij-plugin/
-  - /learn/using-the-intellij-plugin
-  - /learn/using-the-intellij-plugin/
-  - /swan-lake/learn/setting-up-intellij-idea/using-the-intellij-plugin/
-  - /swan-lake/learn/setting-up-intellij-idea/using-the-intellij-plugin
-redirect_to:
-  - /learn/
 ---
 
 ## Creating a new Ballerina project

--- a/swan-lake/references/language-introduction/language-introduction.md
+++ b/swan-lake/references/language-introduction/language-introduction.md
@@ -2,8 +2,6 @@
 layout: ballerina-inner-page
 title: Language introduction
 permalink: /learn/language-introduction/
-redirect_from:
-- /learn/language-introduction
 ---
 
 The [slide deck](/learn/references/language-introduction/Ballerina_Swan_Lake_Presentation_Deck_V1.0.pdf) below introduces the fundamentals of the Ballerina language. 

--- a/swan-lake/references/style-guide/coding-conventions.md
+++ b/swan-lake/references/style-guide/coding-conventions.md
@@ -6,22 +6,6 @@ keywords: ballerina, programming language, ballerina style guide
 permalink: /learn/style-guide/coding-conventions/
 active: coding-conventions
 intro: This Ballerina Style Guide aims at maintaining a standard coding style among the Ballerina community. Therefore, the Ballerina code formatting tools are based on this guide.
-redirect_from:
-  - /learn/style-guide/
-  - /learn/style-guide
-  - /swan-lake/learn/coding-conventions/
-  - /swan-lake/learn/coding-conventions
-  - /learn/coding-conventions/
-  - /learn/coding-conventions
-  - /learn/user-guide/coding-conventions
-  - /learn/user-guide/coding-conventions/
-  - /learn/user-guide/code-organization/coding-conventions
-  - /learn/user-guide/code-organization/coding-conventions/
-  - /learn/user-guide/style-guide/coding-conventions
-  - /learn/user-guide/style-guide/coding-conventions/
-  - /learn/user-guide/style-guide/
-  - /learn/user-guide/style-guide
-  - /learn/style-guide/coding-conventions
 ---
 
 ## Indentation and line length

--- a/swan-lake/references/style-guide/coding-conventions/annotations-documentation-and-comments.md
+++ b/swan-lake/references/style-guide/coding-conventions/annotations-documentation-and-comments.md
@@ -6,19 +6,6 @@ keywords: ballerina, programming language, ballerina style guide, annotations, c
 permalink: /learn/style-guide/annotations-documentation-and-comments/
 active: annotations-documentation-and-comments
 intro: The sections below include the coding conventions with respect to annotations, documentation, and comments.
-redirect_from:
-  - /learn/style-guide/annotations_documentation_and_comments
-  - /learn/coding-conventions/annotations_documentation_and_comments
-  - /swan-lake/learn/coding-conventions/annotations_documentation_and_comments/
-  - /swan-lake/learn/coding-conventions/annotations_documentation_and_comments
-  - /learn/coding-conventions/annotations_documentation_and_comments/
-  - /learn/coding-conventions/annotations_documentation_and_comments
-  - /learn/user-guide/coding-conventions/annotations_documentation_and_comments
-  - /learn/user-guide/coding-conventions/annotations_documentation_and_comments/
-  - /learn/user-guide/code-organization/coding-conventions/annotations_documentation_and_comments/
-  - /learn/user-guide/code-organization/coding-conventions/annotations_documentation_and_comments
-  - /learn/user-guide/style-guide/coding-conventions/annotations-documentation-and-comments
-  - /learn/user-guide/style-guide/coding-conventions/annotations-documentation-and-comments/
 ---
 
 ## Annotations

--- a/swan-lake/references/style-guide/coding-conventions/expressions.md
+++ b/swan-lake/references/style-guide/coding-conventions/expressions.md
@@ -6,19 +6,6 @@ keywords: ballerina, programming language, ballerina style guide, expressions
 active: expressions
 permalink: /learn/style-guide/expressions/
 intro: The sections below include the coding conventions with respect to expressions.
-redirect_from:
-  - /learn/style-guide/expressions
-  - /learn/coding-conventions/expressions
-  - /swan-lake/learn/coding-conventions/expressions/
-  - /swan-lake/learn/coding-conventions/expressions
-  - /learn/coding-conventions/expressions/
-  - /learn/coding-conventions/expressions
-  - /learn/user-guide/coding-conventions/expressions
-  - /learn/user-guide/coding-conventions/expressions/
-  - /learn/user-guide/code-organization/coding-conventions/expressions/
-  - /learn/user-guide/code-organization/coding-conventions/expressions
-  - /learn/user-guide/style-guide/coding-conventions/expressions
-  - /learn/user-guide/style-guide/coding-conventions/expressions/
 ---
 
 ## Function invocation

--- a/swan-lake/references/style-guide/coding-conventions/operators-keywords-and-types.md
+++ b/swan-lake/references/style-guide/coding-conventions/operators-keywords-and-types.md
@@ -6,19 +6,6 @@ keywords: ballerina, programming language, ballerina style guide, operators, key
 active: operators-keywords-and-types
 permalink: /learn/style-guide/operators-keywords-and-types/
 intro: The sections below include the coding conventions with respect to operators, keywords, and types.
-redirect_from:
-  - /learn/style-guide/operators_keywords_and_types
-  - /learn/coding-conventions/operators_keywords_and_types
-  - /swan-lake/learn/coding-conventions/operators_keywords_and_types/
-  - /swan-lake/learn/coding-conventions/operators_keywords_and_types
-  - /learn/coding-conventions/operators_keywords_and_types/
-  - /learn/coding-conventions/operators_keywords_and_types
-  - /learn/user-guide/coding-conventions/operators_keywords_and_types
-  - /learn/user-guide/coding-conventions/operators_keywords_and_types/
-  - /learn/user-guide/code-organization/coding-conventions/operators_keywords_and_types/
-  - /learn/user-guide/code-organization/coding-conventions/operators_keywords_and_types
-  - /learn/user-guide/style-guide/coding-conventions/operators-keywords-and-types
-  - /learn/user-guide/style-guide/coding-conventions/operators-keywords-and-types/
 ---
 
 ## Keywords and Types

--- a/swan-lake/references/style-guide/coding-conventions/statements.md
+++ b/swan-lake/references/style-guide/coding-conventions/statements.md
@@ -6,20 +6,6 @@ keywords: ballerina, programming language, ballerina style guide, statements
 active: statements
 permalink: /learn/style-guide/statements/
 intro: The sections below include the coding conventions with respect to statements.
-redirect_from:
-  - /learn/style-guide/statements
-  - /learn/coding-conventions/statements
-  - /swan-lake/learn/coding-conventions/statements/
-  - /swan-lake/learn/coding-conventions/statements
-  - /learn/coding-conventions/statements/
-  - /learn/coding-conventions/statements
-  - /learn/user-guide/coding-conventions/statements
-  - /learn/user-guide/coding-conventions/statements/
-  - /learn/user-guide/code-organization/coding-conventions/statements/
-  - /learn/user-guide/code-organization/coding-conventions/statements
-  - /learn/user-guide/style-guide/coding-conventions/statements
-  - /learn/user-guide/style-guide/coding-conventions/statements/
-
 ---
 
 ## If statement

--- a/swan-lake/references/style-guide/coding-conventions/top-level-definitions.md
+++ b/swan-lake/references/style-guide/coding-conventions/top-level-definitions.md
@@ -4,21 +4,6 @@ title: Top-level definitions
 active: top-level-definitions
 permalink: /learn/style-guide/top-level-definitions/
 intro: The sections below include the coding conventions with respect to top-level definitions.
-redirect_from:
-  - /learn/style-guide/definitions
-  - /learn/coding-conventions/definitions
-  - /learn/coding-conventions/top-level-definitions
-  - /swan-lake/learn/coding-conventions/top-level-definitions/
-  - /swan-lake/learn/coding-conventions/top-level-definitions
-  - /learn/coding-conventions/top-level-definitions/
-  - /learn/coding-conventions/top-level-definitions
-  - /learn/user-guide/coding-conventions/top-level-definitions
-  - /learn/user-guide/coding-conventions/top-level-definitions/
-  - /learn/user-guide/code-organization/coding-conventions/top-level-definitions/
-  - /learn/user-guide/code-organization/coding-conventions/top-level-definitions
-  - /learn/user-guide/style-guide/coding-conventions/top-level-definitions
-  - /learn/user-guide/style-guide/coding-conventions/top-level-definitions/
-  - /learn/style-guide/top-level-definitions
 ---
 
 ## General practices

--- a/swan-lake/slides/language-walkthrough/language-walkthrough.md
+++ b/swan-lake/slides/language-walkthrough/language-walkthrough.md
@@ -4,13 +4,6 @@ title: Language walkthrough
 description: Explores the language concepts of the Ballerina programming language.
 keywords: ballerina, programming language, language walkthrough, specification
 permalink: /learn/language-walkthrough/
-redirect_from:
-  - /learn/language-concepts
-  - /learn/language-walkthrough/Ballerina_Language_Presentation-2021-03-08.pdf
-  - /learn/language-walkthrough/Ballerina_Language_Presentation-2021-01-29.pdf
-  - /learn/language-concepts/
-  - /learn/language-concepts
-  - /learn/language-walkthrough
 ---
 
 <style>

--- a/swan-lake/why-ballerina/cloud-native.md
+++ b/swan-lake/why-ballerina/cloud-native.md
@@ -6,26 +6,6 @@ keywords: ballerina, programming language, cloud, kubernetes, docker
 permalink: /why-ballerina/cloud-native/
 active: cloud-native
 intro: See how the Ballerina programming language has constructs that seamlessly map to network programming concepts such as services and network resources. It also comes with built-in language support to deploy Ballerina applications on the cloud using Docker and Kubernetes.
-redirect_from:
-  - /why/from-code-to-cloud/
-  - /why/from-code-to-cloud
-  - /why-ballerina/from-code-to-cloud/
-  - /why-ballerina/from-code-to-cloud
-  - /learn/user-guide/why-ballerina/from-code-to-cloud
-  - /learn/user-guide/why-ballerina/from-code-to-cloud/
-  - /learn/user-guide/why-ballerina/
-  - /learn/user-guide/why-ballerina
-  - /learn/user-guide/why-ballerina/cloud-native
-  - /learn/user-guide/why-ballerina/cloud-native/
-  - /learn/why-ballerina/
-  - /learn/why-ballerina
-  - /learn/why-ballerina/cloud-native/
-  - /learn/why-ballerina/cloud-native
-  - /why-ballerina/cloud-native
-  - /why-ballerina/
-  - /why-ballerina
-  - /why-ballerina/the-network-in-the-language/
-  - /why-ballerina/the-network-in-the-language
 ---
 
 In a microservice architecture, smaller services are developed, deployed, and scaled individually. These disaggregated services communicate with each other over the network forcing developers to deal with the 

--- a/swan-lake/why-ballerina/concurrent.md
+++ b/swan-lake/why-ballerina/concurrent.md
@@ -6,12 +6,6 @@ keywords: ballerina, ballerina platform, concurrency, workers, strands, threads,
 permalink: /why-ballerina/concurrent/
 active: concurrent
 intro: Concurrency in Ballerina is enabled by strands, which are lightweight threads.
-redirect_from:
-  - /learn/user-guide/why-ballerina/concurrent
-  - /learn/user-guide/why-ballerina/concurrent/
-  - /learn/why-ballerina/concurrent
-  - /learn/why-ballerina/concurrent/
-  - /why-ballerina/concurrent
 ---
 
 Ballerina's concurrency model supports both threads and coroutines and has been designed to have a close correspondence with sequence diagrams.

--- a/swan-lake/why-ballerina/data-oriented.md
+++ b/swan-lake/why-ballerina/data-oriented.md
@@ -6,12 +6,6 @@ keywords: ballerina, networking, microservices, programming language, distribute
 permalink: /why-ballerina/data-oriented/
 active: data-oriented
 intro: Language-integrated queries specify the logic in SQL-like syntax to process data and events. They are easy to write and understand due to the simplicity of the syntax. See how Ballerina provides first-class support for writing queries that process data.
-redirect_from:
-    - /learn/user-guide/why-ballerina/data-oriented/
-    - /learn/user-guide/why-ballerina/data-oriented
-    - /learn/why-ballerina/data-oriented
-    - /learn/why-ballerina/data-oriented/
-    - /why-ballerina/data-oriented
 ---
 
 As of now, language-integrated queries are supported for iterator implementations such as an array, map, stream, and table. There are two kinds of integrated queries that can be written in Ballerina:

--- a/swan-lake/why-ballerina/flexibly-typed.md
+++ b/swan-lake/why-ballerina/flexibly-typed.md
@@ -6,18 +6,6 @@ keywords: ballerina, programming lanaguage, type system, data binding
 permalink: /why-ballerina/flexibly-typed/
 active: flexibly-typed
 intro: See how the Ballerina programming language's flexible type system helps developers work with networked resources in their code.
-redirect_from:
-- /why/the-network-in-the-language/
-- /why/the-network-in-the-language
-- /learn/user-guide/why-ballerina/network-aware-type-system
-- /learn/user-guide/why-ballerina/network-aware-type-system/
-- /learn/user-guide/why-ballerina/flexibly-typed
-- /learn/user-guide/why-ballerina/flexibly-typed/
-- /learn/why-ballerina/flexibly-typed
-- /learn/why-ballerina/flexibly-typed/
-- /why-ballerina/flexibly-typed
-- /why-ballerina/network-aware-type-system/
-- /why-ballerina/network-aware-type-system
 ---
 
 In a programming language, the type system is the foundation for representing data and implementing logic. It provides the means of creating abstractions to the solutions that you provide. While some languages provide basic functionality, others strive to give in-built functionality for specialized domains.

--- a/swan-lake/why-ballerina/graphical.md
+++ b/swan-lake/why-ballerina/graphical.md
@@ -5,18 +5,6 @@ description: See why the support for a graphical model lays the foundation for d
 keywords: ballerina, programming language, sequence diagram, graphical, diagram editor, why ballerina
 permalink: /why-ballerina/graphical/
 active: graphical
-redirect_from:
-  - /why/sequence-diagrams-for-programming/
-  - /why/sequence-diagrams-for-programming
-  - /why-ballerina/sequence-diagrams-for-programming/
-  - /why-ballerina/sequence-diagrams-for-programming
-  - /learn/user-guide/why-ballerina/sequence-diagrams-for-programming
-  - /learn/user-guide/why-ballerina/sequence-diagrams-for-programming/
-  - /learn/user-guide/why-ballerina/graphical
-  - /learn/user-guide/why-ballerina/graphical/
-  - /learn/why-ballerina/graphical
-  - /learn/why-ballerina/graphical/
-  - /why-ballerina/graphical
 ---
 
 In today’s cloud-era, you need technologies that can model distributed systems in a more developer-friendly way. This means that for a single use case you need to model a flow that shows how multiple actors interact with each other, how concurrent execution flows, and what remote endpoints are involved. Sequence diagrams are known to be the best way to visually describe this.

--- a/swan-lake/why-ballerina/reliable-maintainable.md
+++ b/swan-lake/why-ballerina/reliable-maintainable.md
@@ -6,12 +6,6 @@ keywords: ballerina, ballerina platform, error handling, concurrency safety, rel
 permalink: /why-ballerina/reliable-maintainable/
 active: reliable-maintainable
 intro: The sections below explain how the explicit error handling, static types, and concurrency safety combined with a familiar, readable syntax make programs reliable and maintainable. 
-redirect_from:
-  - /learn/user-guide/why-ballerina/reliable-and-maintainable/
-  - /learn/user-guide/why-ballerina/reliable-maintainable
-  - /learn/why-ballerina/reliable-maintainable
-  - /learn/why-ballerina/reliable-maintainable/
-  - /why-ballerina/reliable-maintainable
 ---
 
 ## Explicit error handling  


### PR DESCRIPTION
## Purpose
Remove redirections from learn pages.
> Fixes #6069 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
