### PR TITLE
Remove user forms from the Community page

### DIFF
--- a/components/community/get-involved/GetInvolved.js
+++ b/components/community/get-involved/GetInvolved.js
@@ -79,15 +79,6 @@ export default function GetInvolved() {
             <p>Want to talk about Ballerina at your local tech meetup? Reach us at <a className={styles.getStartLinks} href="mailto:contact@ballerina.io">contact@ballerina.io</a>.</p>
           </Col>
           
-
-          <Modal show={show} onHide={handleClose} id="submitUseCaseForm" className={styles.customModal}>
-            <Modal.Header closeButton>
-              <Modal.Title>Submit a use case</Modal.Title>
-            </Modal.Header>
-            <Modal.Body className={styles.customModalBody}>
-              <iframe src="https://resources.wso2.com/l/142131/2022-01-05/b3x743" frameBorder="0" className={styles.formEmbedded} />
-            </Modal.Body>
-          </Modal>
         </Row>
       </Container>
     </Col>

--- a/components/community/get-involved/GetInvolved.js
+++ b/components/community/get-involved/GetInvolved.js
@@ -23,11 +23,6 @@ import styles from './GetInvolved.module.css';
 
 export default function GetInvolved() {
 
-  const [show, setShow] = React.useState(false);
-
-  const handleClose = () => setShow(false);
-  const handleShow = () => setShow(true);
-
   return (
     <Col xs={12}>
       <Container>

--- a/components/community/get-involved/GetInvolved.js
+++ b/components/community/get-involved/GetInvolved.js
@@ -50,7 +50,7 @@ export default function GetInvolved() {
             <h4 id="contribute-to-the-source-code-title">
               Contribute to the source code
             </h4>
-            <p>Make Ballerina better by contributing to its source code. Read the <a className={styles.getStartLinks} target="_blank" rel="noreferrer" href="https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md" >contribution guide</a> and  get started. Happy contributing!</p>
+            <p>Make Ballerina better by contributing to its source code. Read the <a className={styles.getStartLinks} target="_blank" rel="noreferrer" href="https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md" >contribution guide</a> and  get started.</p>
           </Col>
           <Col xs={12} md={4} lg={4} className={styles.card}>
             <span className="bookMarkOnPage" id="contribute-to-ballerina-central"></span>
@@ -58,7 +58,7 @@ export default function GetInvolved() {
               Contribute to Ballerina Central
             </h4>
             <p>Let the whole community benefit from your work by <a className={styles.getStartLinks} target="_blank" rel="noreferrer" href="/learn/publish-packages-to-ballerina-central/" >
-              creating and publishing</a> your own module to <a className={styles.getStartLinks} target="_blank" rel="noreferrer" href="https://central.ballerina.io/" >Ballerina Central</a>. </p>
+              creating and publishing</a> your module to <a className={styles.getStartLinks} target="_blank" rel="noreferrer" href="https://central.ballerina.io/" >Ballerina Central</a>. </p>
           </Col>
         </Row>
 
@@ -72,18 +72,11 @@ export default function GetInvolved() {
             <p>Want to find out the active proposals proposed by the Ballerina community? Check out the <a className={styles.getStartLinks} rel="noreferrer" target="_blank" href="/community/active-proposals">active proposals list</a>.</p>
           </Col>
           <Col xs={12} md={4} lg={4} className={styles.card}>
-            <span className="bookMarkOnPage" id="submit-a-use-case"></span>
-            <h4 id="submit-a-use-case-title">
-              Submit a use case
-            </h4>
-            <p><a id="submitUseCase" className={styles.getStartLinks} onClick={handleShow}>Tell us</a> how you&apos;re using Ballerina in your project and be a part of our community stories. </p>
-          </Col>
-          <Col xs={12} md={4} lg={4} className={styles.card}>
             <span className="bookMarkOnPage" id="host-a-ballerina-event"></span>
             <h4 id="host-a-ballerina-event-title">
               Host a Ballerina event
             </h4>
-            <p>Want to talk about Ballerina at your local tech meetup? Reach us at <a className={styles.getStartLinks} href="mailto:contact@ballerina.io">contact@ballerina.io</a>, and we will help you with any presentation content.</p>
+            <p>Want to talk about Ballerina at your local tech meetup? Reach us at <a className={styles.getStartLinks} href="mailto:contact@ballerina.io">contact@ballerina.io</a>.</p>
           </Col>
           
 

--- a/components/community/tech-talk/TechTalk.js
+++ b/components/community/tech-talk/TechTalk.js
@@ -75,15 +75,6 @@ export default function TechTalk() {
           </Col>
         </Row>
 
-
-        <Modal show={show} onHide={handleClose} id="techTalkForm" className={styles.customModal}>
-          <Modal.Header closeButton>
-            <Modal.Title>Suggest topics or give feedback</Modal.Title>
-          </Modal.Header>
-          <Modal.Body className={styles.customModalBody}>
-            <iframe src="https://resources.wso2.com/l/142131/2022-01-05/b3x767" frameBorder="0" className={styles.formEmbedded} />
-          </Modal.Body>
-        </Modal>
       </Container>
     </Col>
   );

--- a/components/community/tech-talk/TechTalk.js
+++ b/components/community/tech-talk/TechTalk.js
@@ -25,10 +25,6 @@ import { prefix } from '../../../utils/prefix';
 export default function TechTalk() {
 
   const [hoverBtn, setHoverBtn] = React.useState(false);
-  const [show, setShow] = React.useState(false);
-
-  const handleClose = () => setShow(false);
-  const handleShow = () => setShow(true);
 
   let linkArrowPath = prefix + '/images/toc-bg.svg';
   let linkArrowHoverPath = prefix + '/images/toc-bg-hover.svg';

--- a/components/community/tech-talk/TechTalk.js
+++ b/components/community/tech-talk/TechTalk.js
@@ -57,10 +57,6 @@ export default function TechTalk() {
             <p>
               We host a public tech talk, where our engineers discuss different technical topics, show you how Ballerina can be leveraged to implement related use cases, present upcoming features, and answer all your questions live.
             </p>
-
-            <p>
-              If you would like to suggest a topic for our next talk or give feedback on tech talks, please fill this <a id="techTalkFormButton" className={styles.formLink} onClick={handleShow}>form</a>.
-            </p>
           </Col>
 
           <Col sm={12} md={6} lg={6}>


### PR DESCRIPTION
## Purpose
Remove user forms from the Community page.
> Fixes #6785

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
