### PR TITLE
Fix the order in learn left nav

### DIFF
--- a/utils/learn-lm.json
+++ b/utils/learn-lm.json
@@ -601,7 +601,7 @@
         {
             "dirName": "Learn the language",
             "level": 1,
-            "position": 4,
+            "position": 3,
             "isDir": true,
             "url": "swan-lake/learn-the-language",
             "id": "learn-the-language",


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
