### PR TITLE
Fix a minor typo in the RESTful get started guide

### DIFF
--- a/swan-lake/featured-scenarios/write-a-restful-api-with-ballerina.md
+++ b/swan-lake/featured-scenarios/write-a-restful-api-with-ballerina.md
@@ -127,7 +127,7 @@ service /covid/status on new http:Listener(9000) {
 In this code:
 
 - Unlike normal functions, resource methods can have accessors. In this case, the accessor is set to `get`, which means only HTTP `GET` requests could hit this resource. Ballerina automatically serializes Ballerina records as JSON and sends them over the wire. 
-- The default HTTP response status code for a resource method other than `post` is `200 OK`. For an HTTP `POST` resource, the default HTTP response status code is `201 Creted`. 
+- The default HTTP response status code for a resource method other than `post` is `200 OK`. For an HTTP `POST` resource, the default HTTP response status code is `201 Created`. 
 
 ### Create the second resource to add data
 


### PR DESCRIPTION
## Purpose
Fix a minor typo in the RESTful get started guide.
> Fixes #6838 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
