### PR TITLE
Fix the `Get started` section broken links 

### DIFF
--- a/pages/downloads/index.js
+++ b/pages/downloads/index.js
@@ -83,21 +83,21 @@ export default function Downloads() {
                            <tr> </tr>
                            <tr>
                               <td>Install via Homebrew (for macOS)
-                                 <a href={`${prefix}/learn/install-ballerina/installation-options/#install-using-homebrew`} className={styles.cDownloadLinkIcon}>
+                                 <a href={`${prefix}/downloads/installation-options/#install-using-homebrew`} className={styles.cDownloadLinkIcon}>
                                     <Image src={`${prefix}/images/right-bg-green-fill.svg`} width={13} height={13} alt="Install via Homebrew (for macOS)"/>
                                  </a>
                               </td>
                            </tr>
                            <tr>
                               <td>Install via the ZIP archive
-                                 <a href={`${prefix}/learn/install-ballerina/installation-options/#install-via-the-ballerina-language-zip-file`} className={styles.cDownloadLinkIcon}>
+                                 <a href={`${prefix}/downloads/installation-options/#install-via-the-ballerina-language-zip-file`} className={styles.cDownloadLinkIcon}>
                                     <Image src={`${prefix}/images/right-bg-green-fill.svg`} width={13} height={13} alt="Install via the ZIP archive"/>
                                  </a>
                               </td>
                            </tr>
                            <tr>
                               <td>Install from source
-                                 <a href={`${prefix}/learn/install-ballerina/installation-options/#build-from-source`} className={styles.cDownloadLinkIcon}>
+                                 <a href={`${prefix}/downloads/installation-options/#build-from-source`} className={styles.cDownloadLinkIcon}>
                                     <Image src={`${prefix}/images/right-bg-green-fill.svg`} width={13} height={13} alt="Install from source"/>
                                  </a>
                               </td>
@@ -111,7 +111,7 @@ export default function Downloads() {
             <Row className={`${styles.donwloadVersion} pageContentRow`}>
                <Col xs={12}>
                   <p>
-                     To <a href={`${prefix}/learn/install-ballerina/installation-options/#verify-the-installation`} className={styles.instructions}>verify that Ballerina was successfully installed</a>, execute 
+                     To <a href={`${prefix}/downloads/installation-options/#verify-the-installation`} className={styles.instructions}>verify that Ballerina was successfully installed</a>, execute 
                      the <code className="highlighter-rouge language-plaintext">bal version<span aria-hidden="true" className="line-numbers-rows"><span></span></span></code> command 
                      in the Terminal/Shell. For more information on installing Ballerina, see <a href={`${prefix}/downloads/installation-options/`} className={styles.instructions}>Installation options</a>.
                   </p>
@@ -143,7 +143,7 @@ export default function Downloads() {
 
             <Row className={`${styles.downloadsVSCode} pageContentRow`}>
                <Col xs={12} sm={12} md={12} lg={4}>
-                  <p>Now, you are all set to <a href={`${prefix}/learn/get-started-with-ballerina/`}>get started with Ballerina.</a></p>
+                  <p>Now, you are all set to <a href={`${prefix}/learn/get-started/`}>get started with Ballerina.</a></p>
                </Col>
             </Row>
          </Col>

--- a/swan-lake/featured-scenarios/build-a-data-service-in-ballerina.md
+++ b/swan-lake/featured-scenarios/build-a-data-service-in-ballerina.md
@@ -12,7 +12,7 @@ intro: This guide helps you understand the basics of Ballerina constructs, which
 
 To complete this tutorial, you need:
 
-1. [Ballerina 2201.0.0 (Swan Lake)](/learn/install-ballerina/set-up-ballerina/) or greater
+1. [Ballerina 2201.0.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
   >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the 
   <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.

--- a/swan-lake/featured-scenarios/deploy-ballerina-on-kubernetes.md
+++ b/swan-lake/featured-scenarios/deploy-ballerina-on-kubernetes.md
@@ -14,7 +14,7 @@ Code to Cloud is a compiler extension, which is packed with Ballerina. It eases 
 
 To complete this tutorial, you need:
 
-1. [Ballerina 2201.0.0 (Swan Lake)](/learn/install-ballerina/set-up-ballerina/) or greater
+1. [Ballerina 2201.0.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
     >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal

--- a/swan-lake/featured-scenarios/work-with-data-using-queries-in-ballerina.md
+++ b/swan-lake/featured-scenarios/work-with-data-using-queries-in-ballerina.md
@@ -14,7 +14,7 @@ Ballerina has first-class support for writing SQL-like queries to process data. 
 
 To run this guide, you need the following prerequisites:
 
-1. [Ballerina 2201.0.0 (Swan Lake)](/learn/install-ballerina/set-up-ballerina/) or greater
+1. [Ballerina 2201.0.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
     >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal

--- a/swan-lake/featured-scenarios/write-a-graphql-api-with-ballerina.md
+++ b/swan-lake/featured-scenarios/write-a-graphql-api-with-ballerina.md
@@ -14,7 +14,7 @@ intro: This guide walks you through writing a simple GraphQL service to serve a 
 
 To complete this tutorial, you need:
 
-1. [Ballerina 2201.0.0 (Swan Lake) ](/learn/install-ballerina/set-up-ballerina/) or greater
+1. [Ballerina 2201.0.0 (Swan Lake) ](/downloads/) or greater
 2. A text editor
     >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal

--- a/swan-lake/featured-scenarios/write-a-grpc-service-with-ballerina.md
+++ b/swan-lake/featured-scenarios/write-a-grpc-service-with-ballerina.md
@@ -12,7 +12,7 @@ intro: This guide walks you through writing a simple Ballerina gRPC service and 
 
 To complete this tutorial, you need:
 
-1. [Ballerina 2201.0.0 (Swan Lake)](/learn/install-ballerina/set-up-ballerina/) or greater
+1. [Ballerina 2201.0.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
   >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal

--- a/swan-lake/featured-scenarios/write-a-restful-api-with-ballerina.md
+++ b/swan-lake/featured-scenarios/write-a-restful-api-with-ballerina.md
@@ -12,7 +12,7 @@ intro: This guide helps you understand the basics of Ballerina constructs, which
 
 To complete this tutorial, you need:
 
-1. [Ballerina 2201.0.0 (Swan Lake)](/learn/install-ballerina/set-up-ballerina/) or greater
+1. [Ballerina 2201.0.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
     >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the  <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal

--- a/swan-lake/get-started/get-started.md
+++ b/swan-lake/get-started/get-started.md
@@ -12,6 +12,8 @@ intro: Let’s set up a Ballerina development environment and write a simple Bal
 
 [Download](/downloads/) Ballerina based on the operating system you are using and install it.
 
+>**Tip:** For more information on installing Ballerina, see [Installation options](/downloads/installation-options/).
+
 ## Set up the editor
 
 Set up a text editor to write Ballerina code.

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/cli-commands.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/cli-commands.md
@@ -122,12 +122,12 @@ These everyday commands are your best friends! They address the very basics of p
 <table class="cComandTable">
 <tr>
 <td class="cCommand">build</td>
-<td class="cDescription">Compile a standalone <code>.bal</code> file, or an entire package into an executable JAR file. For more information, see <a href="/learn/get-started-with-ballerina/">Getting started with Ballerina</a>.
+<td class="cDescription">Compile a standalone <code>.bal</code> file, or an entire package into an executable JAR file. For more information, see <a href="/learn/get-started/">Getting started with Ballerina</a>.
 </td>
 </tr>
 <tr>
 <td class="cCommand">run</td>
-<td class="cDescription">Build and run a standalone <code>.bal</code> file, an entire package, or a previously-built program. For more information, see <a href="/learn/get-started-with-ballerina/">Getting started with Ballerina</a>.
+<td class="cDescription">Build and run a standalone <code>.bal</code> file, an entire package, or a previously-built program. For more information, see <a href="/learn/get-started/">Getting started with Ballerina</a>.
 </td>
 </tr>
 <tr>
@@ -154,7 +154,7 @@ Ballerina packages are the way to organize real-world Ballerina development task
 <table class="cComandTable">
 <tr>
 <td class="cCommand">new</td>
-<td class="cDescription">Create a Ballerina package. For more information, see <a href="/learn/get-started-with-ballerina/#create-a-new-package">Create a new package</a>.
+<td class="cDescription">Create a Ballerina package. For more information, see <a href="/learn/get-started/#create-a-new-package">Create a new package</a>.
 </td>
 </tr>
 <tr>

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/update-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/update-tool.md
@@ -30,7 +30,7 @@ Patch releases of Ballerina distributions contain bug fixes and fixes for critic
 
 ## Use the update tool
 
-If you haven’t installed Ballerina yet, see [Install Ballerina](/learn/install-ballerina/set-up-ballerina) for the instructions.
+If you haven’t installed Ballerina yet, [install it](/downloads/).
 
 Once the installation is complete, you would see the following directory structure inside the installation directory.
 


### PR DESCRIPTION
## Purpose
Fix the `Get started` section broken links.
> Fixes #6837 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
