### PR TITLE
Fix more `docs.central.ballerina.io` redirections

### DIFF
--- a/public/1.2/learn/deployment/aws-lambda/index.html
+++ b/public/1.2/learn/deployment/aws-lambda/index.html
@@ -697,7 +697,7 @@ public function apigwRequest(awslambda:Context ctx, awslambda:APIGatewayProxyReq
 }
 </code></pre>
 
-<p>The first parameter with the <a href="https://docs.central.ballerina.io/ballerinax/awslambda/1.0.0/classes/Context">awslambda:Context</a> object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time.</p>
+<p>The first parameter with the <a href="https://lib.ballerina.io/ballerinax/awslambda/1.0.0/classes/Context">awslambda:Context</a> object contains the information and operations related to the current function execution in AWS Lambda such as the request ID and the remaining execution time.</p>
 
 <p>The second parameter contains the input request data. This input value will vary depending on the source, which invoked the function (e.g., an AWS S3 bucket update event).</p>
 

--- a/swan-lake/api-docs/ballerina/index.html
+++ b/swan-lake/api-docs/ballerina/index.html
@@ -5,7 +5,7 @@
 <h1>Redirecting&hellip;</h1>
 <script>
     let loc = window.location.href;
-    let targetLoc = "https://docs.central.ballerina.io"
+    let targetLoc = "https://lib.ballerina.io"
     let regexExpr = /\/learn\/api-docs\/ballerina\/#((\/[^\/]*)(\/[^\/]*)?(\/[^\/]*)?(\/[^\/]*)?(\/[^\/]*)?(\/[^\/]*)?$)/;
     if (regexExpr.test(loc)) {
         const match = loc.match(regexExpr);

--- a/swan-lake/by-example/xslt-transformation/content.jsx
+++ b/swan-lake/by-example/xslt-transformation/content.jsx
@@ -90,7 +90,7 @@ export function XsltTransformation({ codeSnippets }) {
 
       <p>
         For more information on the underlying module, see the{" "}
-        <a href="https://docs.central.ballerina.io/ballerina/xslt/latest/">
+        <a href="https://lib.ballerina.io/ballerina/xslt/latest/">
           <code>xslt</code> module
         </a>
         .

--- a/swan-lake/other/network-communication/HTTP/http-clients/communication-resiliency.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/communication-resiliency.md
@@ -12,7 +12,7 @@ These features allow you to handle and recover from unexpected communication sce
 
 ## Retry
 
-The HTTP client can be configured with a retry configuration using the [`retryConfig`](https://docs.central.ballerina.io/ballerina/http/latest/records/RetryConfig) property in the [HTTP client configuration](https://docs.central.ballerina.io/ballerina/http/latest/records/ClientConfiguration) to retry sending the same request to the endpoint in the case of a failure. This follows an exponential backoff algorithm to execute the retry requests. 
+The HTTP client can be configured with a retry configuration using the [`retryConfig`](https://lib.ballerina.io/ballerina/http/latest/records/RetryConfig) property in the [HTTP client configuration](https://lib.ballerina.io/ballerina/http/latest/records/ClientConfiguration) to retry sending the same request to the endpoint in the case of a failure. This follows an exponential backoff algorithm to execute the retry requests. 
 
 The `retry_demo.bal` below shows an HTTP client configured with a retry configuration. 
 
@@ -64,7 +64,7 @@ If the requests sent to the backend service are successful in this state, it wil
 
 ### Circuit breaker client configuration
 
-The circuit breaker pattern can be used in Ballerina HTTP clients by using its [client configuration](https://docs.central.ballerina.io/ballerina/http/latest/records/CircuitBreakerConfig). This contains the configuration properties below. 
+The circuit breaker pattern can be used in Ballerina HTTP clients by using its [client configuration](https://lib.ballerina.io/ballerina/http/latest/records/CircuitBreakerConfig). This contains the configuration properties below. 
 
 - `rollingWindow`: A rolling window is used to calculate the statistics for backend service errors. 
 - `timeWindow`: The size of the rolling time window (in seconds).
@@ -107,7 +107,7 @@ Otherwise, in the case of 20% requests failure in the rolling window, the circui
 
 ## Load balancing and failover
 
-In the event of load balancing requests to multiple remote endpoints, Ballerina has the [`http:LoadBalanceClient`](https://docs.central.ballerina.io/ballerina/http/latest/clients/LoadBalanceClient) to provide a list of endpoints, and optionally an implementation of the algorithm to select the endpoint to distribute the traffic. The default load balancer rule is to use a round-robin strategy to distribute the load. 
+In the event of load balancing requests to multiple remote endpoints, Ballerina has the [`http:LoadBalanceClient`](https://lib.ballerina.io/ballerina/http/latest/clients/LoadBalanceClient) to provide a list of endpoints, and optionally an implementation of the algorithm to select the endpoint to distribute the traffic. The default load balancer rule is to use a round-robin strategy to distribute the load. 
 
 ### HTTP client-side load balancing
 
@@ -132,11 +132,11 @@ public function main() returns @tainted error? {
 
 In the above code, the three hosts configured using the `targets` property provide the list of base URLs used for the load balancing requests. 
 
-For more detailed configuration options, see the [`http:LoadBalanceClientConfiguration`](https://docs.central.ballerina.io/ballerina/http/latest/clients/LoadBalanceClient).
+For more detailed configuration options, see the [`http:LoadBalanceClientConfiguration`](https://lib.ballerina.io/ballerina/http/latest/clients/LoadBalanceClient).
 
 ## Handling failover scenarios
 
-Similarly, Ballerina supports fail-over scenarios using the [`http:FailoverClient`](https://docs.central.ballerina.io/ballerina/http/latest/clients/FailoverClient). In this, a list of target URLs can be provided to attempt requests in a sequence, in which, in the case of failure, it will move on to the next available URL in the list for retrying the request. 
+Similarly, Ballerina supports fail-over scenarios using the [`http:FailoverClient`](https://lib.ballerina.io/ballerina/http/latest/clients/FailoverClient). In this, a list of target URLs can be provided to attempt requests in a sequence, in which, in the case of failure, it will move on to the next available URL in the list for retrying the request. 
 
 The `fail_over_load-balancer_demo.bal` example below shows this in action. 
 
@@ -157,7 +157,7 @@ public function main() returns @tainted error? {
 }
 ```
 
-For more detailed configuration options of the failover client, see the [`http:FailoverClientConfiguration`](https://docs.central.ballerina.io/ballerina/http/latest/clients/FailoverClient). 
+For more detailed configuration options of the failover client, see the [`http:FailoverClientConfiguration`](https://lib.ballerina.io/ballerina/http/latest/clients/FailoverClient). 
 
 ## What's next?
 

--- a/swan-lake/other/network-communication/HTTP/http-clients/data-binding.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/data-binding.md
@@ -8,9 +8,9 @@ active: data-binding
 intro: The sections below explain the how to perform data binding with HTTP clients.  
 ---
 
-[`http:Client`](https://docs.central.ballerina.io/ballerina/http/latest/clients/HttpClient) data binding happens automatically based on the left hand side type. The left hand side type could be any type such as `string`, `json`, `xml`, `map<json>`, `byte[]`, custom record, and record array types. 
+[`http:Client`](https://lib.ballerina.io/ballerina/http/latest/clients/HttpClient) data binding happens automatically based on the left hand side type. The left hand side type could be any type such as `string`, `json`, `xml`, `map<json>`, `byte[]`, custom record, and record array types. 
 
-In the data binding, any HTTP response that returns the 4xx or 5xx status codes are considered as error situations. Therefore, the [`get`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#get) remote method will return the error value of the [`http:ClientError`](https://docs.central.ballerina.io/ballerina/http/latest/errors#ClientError) type. 
+In the data binding, any HTTP response that returns the 4xx or 5xx status codes are considered as error situations. Therefore, the [`get`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#get) remote method will return the error value of the [`http:ClientError`](https://lib.ballerina.io/ballerina/http/latest/errors#ClientError) type. 
 
 ## Using JSON and XML in data binding
 

--- a/swan-lake/other/network-communication/HTTP/http-clients/data-streaming.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/data-streaming.md
@@ -10,17 +10,17 @@ intro: HTTP data streaming can be attained using chunked transfer encoding.
 
 ## Data streaming modes
 
-In Ballerina, the clients automatically switch between the chunked or non-chunked modes based on the size of the content provided as the payload. This is controlled by the [`http:ClientConfiguration`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client) object’s [`http1Settings.chunking`](https://docs.central.ballerina.io/ballerina/http/latest/records/ClientHttp1Settings) property, which has a default value of [`AUTO`](https://docs.central.ballerina.io/ballerina/http/latest/constants#CHUNKING_AUTO). The fully supported modes are as follows.
+In Ballerina, the clients automatically switch between the chunked or non-chunked modes based on the size of the content provided as the payload. This is controlled by the [`http:ClientConfiguration`](https://lib.ballerina.io/ballerina/http/latest/clients/Client) object’s [`http1Settings.chunking`](https://lib.ballerina.io/ballerina/http/latest/records/ClientHttp1Settings) property, which has a default value of [`AUTO`](https://lib.ballerina.io/ballerina/http/latest/constants#CHUNKING_AUTO). The fully supported modes are as follows.
 
-- [`AUTO:`](https://docs.central.ballerina.io/ballerina/http/latest/constants#CHUNKING_AUTO): If the payload is less than 8KB, the client will not use chunking. It will load the full content to the memory, set the “Content-Length” header with the content size, and send out the request. Otherwise, it will use chunking to stream the data to the remote endpoint. 
-- [`ALWAYS:`](https://docs.central.ballerina.io/ballerina/http/latest/constants#CHUNKING_ALWAYS): The client will always use chunking to stream the payload to the remote endpoint. 
-- [`NEVER:`](https://docs.central.ballerina.io/ballerina/http/latest/constants#CHUNKING_NEVER): The client will never use chunking, and it will fully read in the payload to memory and send out the request. 
+- [`AUTO:`](https://lib.ballerina.io/ballerina/http/latest/constants#CHUNKING_AUTO): If the payload is less than 8KB, the client will not use chunking. It will load the full content to the memory, set the “Content-Length” header with the content size, and send out the request. Otherwise, it will use chunking to stream the data to the remote endpoint. 
+- [`ALWAYS:`](https://lib.ballerina.io/ballerina/http/latest/constants#CHUNKING_ALWAYS): The client will always use chunking to stream the payload to the remote endpoint. 
+- [`NEVER:`](https://lib.ballerina.io/ballerina/http/latest/constants#CHUNKING_NEVER): The client will never use chunking, and it will fully read in the payload to memory and send out the request. 
 
 ## Creating the input data stream
 
-To use the HTTP streaming feature effectively, you need to create an HTTP request with a stream of byte[]. For example, if you want to stream the content of a large file to a remote endpoint and read its content using a function such as [`io:fileReadBytes`](https://docs.central.ballerina.io/ballerina/io/latest/functions#fileReadBytes) to read in the full content as a byte array to memory, then you lose the benefit of streaming the data. 
+To use the HTTP streaming feature effectively, you need to create an HTTP request with a stream of byte[]. For example, if you want to stream the content of a large file to a remote endpoint and read its content using a function such as [`io:fileReadBytes`](https://lib.ballerina.io/ballerina/io/latest/functions#fileReadBytes) to read in the full content as a byte array to memory, then you lose the benefit of streaming the data. 
 
-Therefore, you should use a stream of byte[] by using an API such as the [`io:fileReadBlocksAsStream`](https://docs.central.ballerina.io/ballerina/io/latest/functions#fileReadBlocksAsStream), which returns a `stream<byte[], io:Error>`. This stream can be used in places that accept a stream of byte[] such as the [`http:Request`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request) object’s [`setByteStream`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request#setByteStream). 
+Therefore, you should use a stream of byte[] by using an API such as the [`io:fileReadBlocksAsStream`](https://lib.ballerina.io/ballerina/io/latest/functions#fileReadBlocksAsStream), which returns a `stream<byte[], io:Error>`. This stream can be used in places that accept a stream of byte[] such as the [`http:Request`](https://lib.ballerina.io/ballerina/http/latest/classes/Request) object’s [`setByteStream`](https://lib.ballerina.io/ballerina/http/latest/classes/Request#setByteStream). 
 
 The `data_streaming.bal` example below opens a file with a stream and uses it to create an HTTP request to stream its data to a remote endpoint.
 

--- a/swan-lake/other/network-communication/HTTP/http-clients/http-clients.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/http-clients.md
@@ -34,13 +34,13 @@ The code above creates a client by providing an explicit client configuration, w
 
 ## Basic HTTP requests
 
-After creating an HTTP client object, you can now execute HTTP requests through the [remote methods](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client). 
+After creating an HTTP client object, you can now execute HTTP requests through the [remote methods](https://lib.ballerina.io/ballerina/http/latest/clients/Client). 
 
 Below are some of the remote methods that are most often used in the HTTP client object. 
 
 ### GET
 
-An HTTP GET request is executed by using the [`get`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#get) remote method in the HTTP client. This remote method takes in the request path as the first parameter, and optionally a header map as the second parameter.
+An HTTP GET request is executed by using the [`get`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#get) remote method in the HTTP client. This remote method takes in the request path as the first parameter, and optionally a header map as the second parameter.
 
 The `client_demo_get.bal` below is an example of its usage.
 
@@ -62,11 +62,11 @@ Execute the `bal run client_demo_get.bal` command and the output will be as foll
 Payload: {"args":{},"headers":{"Host":"httpbin.org","User-Agent":"ballerina","X-Amzn-Trace-Id":"Root=1-5fd3b719-0d5a1625098ad73b53c0c094"},"origin":"45.30.94.9","url":"http://httpbin.org/get"}
 ```
 
-In case you want more information than the response payload, the [`http:Response`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response) object can be used to access information such as the client response payload, [content type](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response#getContentType), [headers](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response#getHeader), and [cookies](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response#getCookies).
+In case you want more information than the response payload, the [`http:Response`](https://lib.ballerina.io/ballerina/http/latest/classes/Response) object can be used to access information such as the client response payload, [content type](https://lib.ballerina.io/ballerina/http/latest/classes/Response#getContentType), [headers](https://lib.ballerina.io/ballerina/http/latest/classes/Response#getHeader), and [cookies](https://lib.ballerina.io/ballerina/http/latest/classes/Response#getCookies).
 
 ### POST
 
-An HTTP POST is executed using the [`post`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#post) remote method in the HTTP client. You can provide the request path as the first parameter. The second parameter is a value of the [`http:RequestMessage`](https://docs.central.ballerina.io/ballerina/http/latest/types#RequestMessage), which is a union type of the [`http:Request`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request) and other data-binding types such as XML, JSON, and other custom record types. Optionally as the third parameter you can send a header map.
+An HTTP POST is executed using the [`post`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#post) remote method in the HTTP client. You can provide the request path as the first parameter. The second parameter is a value of the [`http:RequestMessage`](https://lib.ballerina.io/ballerina/http/latest/types#RequestMessage), which is a union type of the [`http:Request`](https://lib.ballerina.io/ballerina/http/latest/classes/Request) and other data-binding types such as XML, JSON, and other custom record types. Optionally as the third parameter you can send a header map.
 
 The `client_demo_post.bal` below is an example of its usage.
 
@@ -90,7 +90,7 @@ Payload: {"args":{},"data":"Hello!","files":{},"form":{},"headers":{"Content-Len
 
 ### EXECUTE
 
-Similar to the [`get`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#get) and [`post`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#post) remote methods above, there are other methods such as [`put`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#put), [`delete`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#delete), [`patch`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#patch), [`head`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#head), and [`options`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#options) to represent the HTTP methods. There is also a generic [`execute`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client#execute) remote method for users to specify the HTTP verb and execute the HTTP action. 
+Similar to the [`get`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#get) and [`post`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#post) remote methods above, there are other methods such as [`put`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#put), [`delete`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#delete), [`patch`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#patch), [`head`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#head), and [`options`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#options) to represent the HTTP methods. There is also a generic [`execute`](https://lib.ballerina.io/ballerina/http/latest/clients/Client#execute) remote method for users to specify the HTTP verb and execute the HTTP action. 
 
 ## Multipart message handling
 

--- a/swan-lake/other/network-communication/HTTP/http-clients/multipart-message-handling.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/multipart-message-handling.md
@@ -8,9 +8,9 @@ active: multipart-message-handling
 intro: HTTP multipart messages can be created by using the Multipurpose Internet Mail Extensions (MIME) standard.  
 ---
 
-You can provide MIME entity values to create single or multi-part HTTP messages using the [`http:Request`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request) object.
+You can provide MIME entity values to create single or multi-part HTTP messages using the [`http:Request`](https://lib.ballerina.io/ballerina/http/latest/classes/Request) object.
 
-A MIME entity in Ballerina is represented using the [`mime:Entity`](https://docs.central.ballerina.io/ballerina/mime/latest/classes/Entity) object.
+A MIME entity in Ballerina is represented using the [`mime:Entity`](https://lib.ballerina.io/ballerina/mime/latest/classes/Entity) object.
 
 ## Setting a text payload
 
@@ -54,20 +54,20 @@ Execute the `bal run multipart_example_one.bal` command and the output will be a
 }
 ```
 
-The code above explicitly creates the MIME entity and sets it in the HTTP request. The same operation happens if you use the [`setTextPayload`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request#setTextPayload) method in the [`http:Request`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request) object. These functions are effectively helper functions to set the MIME entities in the HTTP request for often-used content types. 
+The code above explicitly creates the MIME entity and sets it in the HTTP request. The same operation happens if you use the [`setTextPayload`](https://lib.ballerina.io/ballerina/http/latest/classes/Request#setTextPayload) method in the [`http:Request`](https://lib.ballerina.io/ballerina/http/latest/classes/Request) object. These functions are effectively helper functions to set the MIME entities in the HTTP request for often-used content types. 
 
 ## Setting the body with other data types
 
-The [`mime:Entity`](https://docs.central.ballerina.io/ballerina/mime/latest/classes/Entity) object contains functions for setting the body with other data types such as [binary](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request#setTextPayload), [XML](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request#setXmlPayload), and [JSON](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request#setJsonPayload) as well.
+The [`mime:Entity`](https://lib.ballerina.io/ballerina/mime/latest/classes/Entity) object contains functions for setting the body with other data types such as [binary](https://lib.ballerina.io/ballerina/http/latest/classes/Request#setTextPayload), [XML](https://lib.ballerina.io/ballerina/http/latest/classes/Request#setXmlPayload), and [JSON](https://lib.ballerina.io/ballerina/http/latest/classes/Request#setJsonPayload) as well.
 
-A multipart message can be created by setting the body parts in the [`mime:Entity`](https://docs.central.ballerina.io/ballerina/mime/latest/classes/Entity) object using the [`setBodyParts`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request#setBodyParts) method. 
+A multipart message can be created by setting the body parts in the [`mime:Entity`](https://lib.ballerina.io/ballerina/mime/latest/classes/Entity) object using the [`setBodyParts`](https://lib.ballerina.io/ballerina/http/latest/classes/Request#setBodyParts) method. 
 
-This method takes in an array of [`mime:Entity`](https://docs.central.ballerina.io/ballerina/mime/latest/classes/Entity) objects, and also optionally, the content type of the enclosing entity, in which, the default is set to [`multipart/form-data`](https://docs.central.ballerina.io/ballerina/mime/latest/constants#MULTIPART_FORM_DATA). 
+This method takes in an array of [`mime:Entity`](https://lib.ballerina.io/ballerina/mime/latest/classes/Entity) objects, and also optionally, the content type of the enclosing entity, in which, the default is set to [`multipart/form-data`](https://lib.ballerina.io/ballerina/mime/latest/constants#MULTIPART_FORM_DATA). 
 
 
 ## Using other multipart values
 
-If required, you can override the default `multipart/form-data` with other multipart values such as [`multipart/mixed`](https://docs.central.ballerina.io/ballerina/mime/latest/constants#MULTIPART_MIXED), [`multipart/alternative`](https://docs.central.ballerina.io/ballerina/mime/latest/constants#MULTIPART_ALTERNATIVE), and [`multipart/related`](https://docs.central.ballerina.io/ballerina/mime/latest/constants#MULTIPART_RELATED). 
+If required, you can override the default `multipart/form-data` with other multipart values such as [`multipart/mixed`](https://lib.ballerina.io/ballerina/mime/latest/constants#MULTIPART_MIXED), [`multipart/alternative`](https://lib.ballerina.io/ballerina/mime/latest/constants#MULTIPART_ALTERNATIVE), and [`multipart/related`](https://lib.ballerina.io/ballerina/mime/latest/constants#MULTIPART_RELATED). 
 
 The `multipart_example_two.bal` below shows how a `multipart/mixed` message is created using plain text content and an image file as an attachment. 
 
@@ -96,11 +96,11 @@ public function main() returns @tainted error? {
   io:println(resp.getTextPayload());
 }
 ```
-In the above code, the [`setContentDisposition`](https://docs.central.ballerina.io/ballerina/mime/latest/classes/Entity#setContentDisposition) method in the [`mime:Entity'](https://docs.central.ballerina.io/ballerina/mime/latest/classes/Entity) object is used to set the content disposition of the entity. This provides information on how the recipient should handle the data. For example, if it should be displayed inline, treated as form data, or downloaded as an attachment.
+In the above code, the [`setContentDisposition`](https://lib.ballerina.io/ballerina/mime/latest/classes/Entity#setContentDisposition) method in the [`mime:Entity'](https://lib.ballerina.io/ballerina/mime/latest/classes/Entity) object is used to set the content disposition of the entity. This provides information on how the recipient should handle the data. For example, if it should be displayed inline, treated as form data, or downloaded as an attachment.
 
 ## Processing HTTP response entities
 
-Similar to how you work with MIME entities in HTTP requests, the HTTP response entities can also be processed using the [`getEntity`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response#getEntity) method in the [`http:Response`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response) object.
+Similar to how you work with MIME entities in HTTP requests, the HTTP response entities can also be processed using the [`getEntity`](https://lib.ballerina.io/ballerina/http/latest/classes/Response#getEntity) method in the [`http:Response`](https://lib.ballerina.io/ballerina/http/latest/classes/Response) object.
 
 The `multipart_example_three.bal` below is an example of its usage.
 

--- a/swan-lake/other/network-communication/HTTP/http-clients/secure-communication.md
+++ b/swan-lake/other/network-communication/HTTP/http-clients/secure-communication.md
@@ -10,7 +10,7 @@ intro: The HTTP client supports numerous secure communication features such as T
 
 ## Configuring secure communication
 
-The TLS features are used with the HTTP client by using the `https` protocol in the endpoint URL. Optionally, you can provide the information on the truststore or server public certificate location to use for validating the server certificates received when creating an HTTP connection over TLS. This is provided using the `secureSocket` property in the [HTTP client configuration](https://docs.central.ballerina.io/ballerina/http/latest/records/ClientConfiguration) instance when creating the [`http:Client`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client).
+The TLS features are used with the HTTP client by using the `https` protocol in the endpoint URL. Optionally, you can provide the information on the truststore or server public certificate location to use for validating the server certificates received when creating an HTTP connection over TLS. This is provided using the `secureSocket` property in the [HTTP client configuration](https://lib.ballerina.io/ballerina/http/latest/records/ClientConfiguration) instance when creating the [`http:Client`](https://lib.ballerina.io/ballerina/http/latest/clients/Client).
 
 ### Communicating with an HTTPS endpoint
 

--- a/swan-lake/other/network-communication/HTTP/http-services/extended-request-response-access.md
+++ b/swan-lake/other/network-communication/HTTP/http-services/extended-request-response-access.md
@@ -10,9 +10,9 @@ intro: The service resources have the functionality of handling request and resp
 
 ## Interacting with the remote client
 
-This is done by optionally taking in the [`http:Caller`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Caller) and [`http:Request`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request) typed parameters, which represent calling the remote client and the current request information respectively. 
+This is done by optionally taking in the [`http:Caller`](https://lib.ballerina.io/ballerina/http/latest/clients/Caller) and [`http:Request`](https://lib.ballerina.io/ballerina/http/latest/classes/Request) typed parameters, which represent calling the remote client and the current request information respectively. 
 
-The [`http:Caller`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Caller) contains functionality to interact with the remote client such as responding to the client using the [`respond`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Caller#respond) remote method. The [`http:Request`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request) object contains operations to look up information regarding the current incoming HTTP request such as the request payload, [query](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request#getQueryParams/[matrix](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request#getMatrixParams) parameters, [cookies](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request#getCookies), and [headers](https://docs.central.ballerina.io/ballerina/http/latest/classes/Request#getHeaders).
+The [`http:Caller`](https://lib.ballerina.io/ballerina/http/latest/clients/Caller) contains functionality to interact with the remote client such as responding to the client using the [`respond`](https://lib.ballerina.io/ballerina/http/latest/clients/Caller#respond) remote method. The [`http:Request`](https://lib.ballerina.io/ballerina/http/latest/classes/Request) object contains operations to look up information regarding the current incoming HTTP request such as the request payload, [query](https://lib.ballerina.io/ballerina/http/latest/classes/Request#getQueryParams/[matrix](https://lib.ballerina.io/ballerina/http/latest/classes/Request#getMatrixParams) parameters, [cookies](https://lib.ballerina.io/ballerina/http/latest/classes/Request#getCookies), and [headers](https://lib.ballerina.io/ballerina/http/latest/classes/Request#getHeaders).
 
 ## Example
 
@@ -49,7 +49,7 @@ Hello, Jack!
 
 Using this approach, you can also execute additional logic even after the response is sent back to the client. For example, in the case of a network issue when responding back to the client, you can do custom operations for failure-recovery or do extended logging operations. 
 
-The [`respond`](https://docs.central.ballerina.io/ballerina/http/latest/clients/Caller#respond) remote method also takes in an [`http:Response`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response) object if you need finer control in the response such as setting the status code or overriding the default [content type](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response#setContentType). 
+The [`respond`](https://lib.ballerina.io/ballerina/http/latest/clients/Caller#respond) remote method also takes in an [`http:Response`](https://lib.ballerina.io/ballerina/http/latest/classes/Response) object if you need finer control in the response such as setting the status code or overriding the default [content type](https://lib.ballerina.io/ballerina/http/latest/classes/Response#setContentType). 
 
 ### Example
 

--- a/swan-lake/other/network-communication/HTTP/http-services/http-services.md
+++ b/swan-lake/other/network-communication/HTTP/http-services/http-services.md
@@ -18,7 +18,7 @@ The elements of the service are as follows.
 
 - **Service name:** the service name represents the base path of the HTTP service. This is an optional value. If it’s kept empty, the base path defaults to the value “/”. 
 
-- **Listener object:** provides an instance of the [`http:Listener`](https://docs.central.ballerina.io/ballerina/http/latest/listeners/Listener) to bind to a specific host/port. 
+- **Listener object:** provides an instance of the [`http:Listener`](https://lib.ballerina.io/ballerina/http/latest/listeners/Listener) to bind to a specific host/port. 
 
 - **Resource:** a resource represents a specific subpath that can be accessed in relation to the service base path.
 

--- a/swan-lake/other/network-communication/HTTP/http-services/multipart-message-handling.md
+++ b/swan-lake/other/network-communication/HTTP/http-services/multipart-message-handling.md
@@ -10,15 +10,15 @@ intro: You can carry out multipart message handling in Ballerina HTTP services.
 
 ## Using MIME entities
 
-As used in the HTTP [client API](https://docs.central.ballerina.io/ballerina/http/latest/clients/Client), similarly, multipart messages can be created in service resources by using the Multipurpose Internet Mail Extensions (MIME) standard. You can provide MIME entity values to create single or multi-part HTTP messages using the [`http:Response`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response) object. 
+As used in the HTTP [client API](https://lib.ballerina.io/ballerina/http/latest/clients/Client), similarly, multipart messages can be created in service resources by using the Multipurpose Internet Mail Extensions (MIME) standard. You can provide MIME entity values to create single or multi-part HTTP messages using the [`http:Response`](https://lib.ballerina.io/ballerina/http/latest/classes/Response) object. 
 
-A MIME entity in Ballerina is represented using the [`mime:Entity`](https://docs.central.ballerina.io/ballerina/mime/latest/classes/Entity) object. 
+A MIME entity in Ballerina is represented using the [`mime:Entity`](https://lib.ballerina.io/ballerina/mime/latest/classes/Entity) object. 
 
 ## Example
 
 The example below shows how to set a text payload in the response using a MIME entity.
 
->**Info:** The code below explicitly creates the MIME entity and sets it in the HTTP response. The same operation happens if you use the [`setTextPayload`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response#setTextPayload) method in the [`http:Response`](https://docs.central.ballerina.io/ballerina/http/latest/classes/Response) object. These functions are effectively helper functions to set the MIME entities in the HTTP response for often-used content types. 
+>**Info:** The code below explicitly creates the MIME entity and sets it in the HTTP response. The same operation happens if you use the [`setTextPayload`](https://lib.ballerina.io/ballerina/http/latest/classes/Response#setTextPayload) method in the [`http:Response`](https://lib.ballerina.io/ballerina/http/latest/classes/Response) object. These functions are effectively helper functions to set the MIME entities in the HTTP response for often-used content types. 
 
 ```ballerina
 import ballerina/mime;

--- a/swan-lake/other/network-communication/HTTP/http-services/payload-data-binding.md
+++ b/swan-lake/other/network-communication/HTTP/http-services/payload-data-binding.md
@@ -10,7 +10,7 @@ intro: The HTTP service resource payloads can be directly data bound to the reso
 
 ## Using the annotation
 
-To distinguish between query parameters and resource payload parameters, the parameters that represent the resource payload are annotated with [`@http:Payload`](https://docs.central.ballerina.io/ballerina/http/latest/annotations#Payload). The supported parameter types are `string`, `json`, `xml`, `byte[]`, record types, and record array types. 
+To distinguish between query parameters and resource payload parameters, the parameters that represent the resource payload are annotated with [`@http:Payload`](https://lib.ballerina.io/ballerina/http/latest/annotations#Payload). The supported parameter types are `string`, `json`, `xml`, `byte[]`, record types, and record array types. 
 
 ## Example
 

--- a/swan-lake/other/network-communication/HTTP/http-services/secure-communication.md
+++ b/swan-lake/other/network-communication/HTTP/http-services/secure-communication.md
@@ -10,7 +10,7 @@ intro: The HTTP listener can be configured to enable transport security to restr
 
 ## Configuring secure communication
 
-This is done by providing the optional `secureSocket` property in the [HTTP Listener Configuration](https://docs.central.ballerina.io/ballerina/http/latest/records/ListenerConfiguration) instance when creating the [`http:Listener`](https://docs.central.ballerina.io/ballerina/http/latest/listeners/Listener).
+This is done by providing the optional `secureSocket` property in the [HTTP Listener Configuration](https://lib.ballerina.io/ballerina/http/latest/records/ListenerConfiguration) instance when creating the [`http:Listener`](https://lib.ballerina.io/ballerina/http/latest/listeners/Listener).
 
 ## Example of HTTPS endpoint configured public certificate and private key
 

--- a/swan-lake/other/network-communication/WebSocket/secure-websocket-communication.md
+++ b/swan-lake/other/network-communication/WebSocket/secure-websocket-communication.md
@@ -64,7 +64,7 @@ var ws = new WebSocket("wss://localhost:8443/ws");
     [ballerina/websocket] started WSS listener 0.0.0.0:9090
     ```
 
-    In the code above, you simply created a WebSocket listener by providing the [`websocket:ListenerConfiguration`](https://docs.central.ballerina.io/ballerina/http/latest/records/ListenerConfiguration), which contains the secure socket parameters. 
+    In the code above, you simply created a WebSocket listener by providing the [`websocket:ListenerConfiguration`](https://lib.ballerina.io/ballerina/http/latest/records/ListenerConfiguration), which contains the secure socket parameters. 
 
 
 3. Write a Ballerina WebSocket client (`wss_client.bal`) below to make a connection and send requests to the service above.
@@ -104,6 +104,6 @@ var ws = new WebSocket("wss://localhost:8443/ws");
     Response: Echo: Hello, World!
     ```
 
-    In the code above, you created a [`websocket:Client`](https://docs.central.ballerina.io/ballerina/websocket/latest/clients/Client) by providing the [`websocket:ClientConfiguration`](https://docs.central.ballerina.io/ballerina/websocket/latest/clients/Client) value containing the secure socket parameters. From here onwards, any communication done from the client to the WebSocket server will be done with TLS.
+    In the code above, you created a [`websocket:Client`](https://lib.ballerina.io/ballerina/websocket/latest/clients/Client) by providing the [`websocket:ClientConfiguration`](https://lib.ballerina.io/ballerina/websocket/latest/clients/Client) value containing the secure socket parameters. From here onwards, any communication done from the client to the WebSocket server will be done with TLS.
 
 <style> #tree-expand-all, #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/swan-lake/other/network-communication/WebSocket/websocket.md
+++ b/swan-lake/other/network-communication/WebSocket/websocket.md
@@ -133,7 +133,7 @@ Sub-protocols are given in the WebSocket constructor’s second parameter, which
 
 The server-side will be configured to handle zero or multiple sub-protocols. The server will check the client’s sub-protocol list in the priority order to see if it is supported in the given service. If it finds a match, it will return this single first-matched protocol to the client.
 
-The server-side configuration of sub-protocols is done using the [`websocket:ServiceConfig`](https://docs.central.ballerina.io/ballerina/websocket/latest/annotations#ServiceConfig) annotation using its `subProtocols` field.
+The server-side configuration of sub-protocols is done using the [`websocket:ServiceConfig`](https://lib.ballerina.io/ballerina/websocket/latest/annotations#ServiceConfig) annotation using its `subProtocols` field.
 
 #### Sub-protocol handling example
 


### PR DESCRIPTION
## Purpose
Fix more `docs.central.ballerina.io` redirections.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
