### PR TITLE
Remove Google Groups icon from footer

### DIFF
--- a/components/common/footer/Footer.js
+++ b/components/common/footer/Footer.js
@@ -47,11 +47,6 @@ export default function Footer() {
                         </a>
                       </li>
                       <li>
-                        <a className={styles.footerLinkSM} href="https://groups.google.com/g/ballerina-dev" target="_blank" rel="noreferrer" passHref title="Google Groups">
-                          <Image src={`${prefix}/images/google-group-grey.svg`} width={17} height={17} alt="Google Groups" />
-                        </a>
-                      </li>
-                      <li>
                         <a className={styles.footerLinkSM} href="https://discord.gg/ballerinalang" target="_blank" rel="noreferrer" passHref title="Discord">
                           <Image src={`${prefix}/images/discord-grey.svg`} width={17} height={17} alt="Discord" />
                         </a>


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #6885 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
