### PR TITLE
Make the button labels on learn and home pages consistent 

### DIFF
--- a/components/learn/intro/Intro.js
+++ b/components/learn/intro/Intro.js
@@ -34,7 +34,7 @@ export default function Intro() {
                             <div>
                                 <h3>Get started with Ballerina</h3>
                                 <div className={styles.cardDescription}>
-                                    <p>Write your first Ballerina program and create your first Ballerina package</p>
+                                    <p>Install Ballerina, set it all up, and take it for a spin. </p>
                                 </div>
                             </div>
                         </a>
@@ -55,7 +55,7 @@ export default function Intro() {
                             <div>
                                 <h3>Ballerina API Docs</h3>
                                 <div className={styles.cardDescription}>
-                                    <p>Library API documentation</p>
+                                    <p>Ballerina library (API) documentation</p>
                                 </div>
                             </div>
                         </a>


### PR DESCRIPTION
## Purpose
Make the button labels on learn and home pages consistent.
> Fixes #6887 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
