### PR TITLE
Add ls changes to 2201.6.0 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
@@ -98,7 +98,7 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.6.0 of the reposi
 #### Language Server
 
 - Removed service template initialization from the lightweight mode.
-- Improved completions in the client resource access action node context.
+- Improved the completion support and signature help for client resource access actions.
 - Improved the main function completion item.
 - improved completions in the named argument context.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
@@ -88,7 +88,19 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.6.0 of the reposi
 
 ### New features
 
+#### Language Server
+
+- Added completions for the `group by` clause.
+- Added inlay hint support for function call expressions and method call expressions to provide information about parameters.
+
 ### Improvements
+
+#### Language Server
+
+- Removed service template initialization from the lightweight mode.
+- Improved completions in the client resource access action node context.
+- Improved the main function completion item.
+- improved completions in the named argument context.
 
 ### Bug fixes
 


### PR DESCRIPTION
## Purpose
Add LS release note for the 2201.6.0 release.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
