### PR TITLE
Fix ls changes in 2201.6.0 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
@@ -98,7 +98,6 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.6.0 of the reposi
 
 #### Language Server
 
-- Added completions for the `group by` clause.
 - Added inlay hint support for function call expressions and method call expressions to provide information about parameters.
 
 ### Improvements
@@ -109,6 +108,7 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.6.0 of the reposi
 - Improved the completion support and signature help for client resource access actions.
 - Improved the main function completion item.
 - improved completions in the named argument context.
+- Added support to rename parameter documentation for record fields and required parameters.
 
 ### Bug fixes
 


### PR DESCRIPTION
## Purpose
Fix ls release note of update 6.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
