### PR TITLE
Update the GraphQL Tool Guide with Ballerina GraphQL service generation

### DIFF
--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/cli-commands.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/cli-commands.md
@@ -62,8 +62,8 @@ COMMANDS
         grpc            Generate the Ballerina sources for a given Protocol
                         Buffer definition
         graphql         Generate the Ballerina client sources for a given GraphQL config
-                        file and generate the GraphQL schema for a given Ballerina
-                        GraphQL service.
+                        file, generate the GraphQL schema for a given Ballerina
+                        GraphQL service, and generate the Ballerina service sources for a given GraphQL schema file.
         openapi         Generate the Ballerina sources for a given OpenAPI
                         definition and vice versa
         asyncapi        Generate the Ballerina sources for a given AsyncAPI definition
@@ -219,7 +219,7 @@ These powerful supporting tools extend Ballerina to various ecosystem technologi
 </tr>
 <tr>
 <td class="cCommand">graphql</td>
-<td class="cDescription">This is the GraphQL client/schema generation tool. For more information, see <a href="/learn/graphql-tool/">Ballerina GraphQL tool support</a>.</td>
+<td class="cDescription">This is the GraphQL client/schema/service generation tool. For more information, see <a href="/learn/graphql-tool/">Ballerina GraphQL tool support</a>.</td>
 </tr>
 <tr>
 <td class="cCommand">openapi</td>

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/graphql.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/graphql.md
@@ -12,6 +12,7 @@ intro: The sections below include information about the usages of the Ballerina 
 
 The GraphQL to Ballerina command supports several usages in the Ballerina GraphQL tool as follows.
 
+### Client generation
 ```
 $ bal graphql [-i | --input] <graphql-configuration-file-path>
             [-o | --output] <output-location>
@@ -23,6 +24,22 @@ The command-line arguments below can be used with the command for each particula
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `-i, --input`  | The `input` parameter specifies the path of the GraphQL config file (e.g., `graphql.config.yaml`) configured with GraphQL schemas specified by the Schema Definition Language and GraphQL documents. This parameter is mandatory.                             |
 | `-o, --output` | The `output` parameter specifies the path of the output location of the generated files. This parameter is optional. If this parameter is not specified, the Ballerina files will be generated at the same location in which the GraphQL command is executed. |
+
+### Service generation 
+```
+$ bal graphql [-i | --input] <graphql-schema-file-path>
+            [-o | --output] <output-location>
+            [-m | --mode] <operation-mode>
+            [-r | --use-records-for-objects]
+```
+The command-line arguments below can be used with the command for each particular purpose as described below.
+
+| Argument       | Description                                                                                                                                                                                                                                                   |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `-i, --input`  | The `input` parameter specifies the path of the GraphQL schema file (e.g., `schema.graphql`) specified in Schema Definition Language. This parameter is mandatory.                             |
+| `-o, --output` | The `output` parameter specifies the path of the output location of the generated files. This parameter is optional. If this parameter is not specified, the Ballerina files will be generated at the same location where the GraphQL command is executed. |
+| `-m, --mode`  | The `mode` parameter specifies the operation mode. It indicates the way to process the schema file. This parameter is mandatory for GraphQL service generation. |
+| `-r, --use-records-for-objects`  | The `use-records-for-objects` parameter specifies to generate record types for GraphQL object types whenever it is possible. This parameter is optional. If this parameter is not specified, service class types will be generated for GraphQL object types. |
 
 ## Ballerina to GraphQL
 

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/graphql.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/graphql.md
@@ -38,7 +38,7 @@ The command-line arguments below can be used with the command for each particula
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `-i, --input`  | The `input` parameter specifies the path of the GraphQL schema file (e.g., `schema.graphql`) specified in Schema Definition Language. This parameter is mandatory.                             |
 | `-o, --output` | The `output` parameter specifies the path of the output location of the generated files. This parameter is optional. If this parameter is not specified, the Ballerina files will be generated at the same location where the GraphQL command is executed. |
-| `-m, --mode`  | The `mode` parameter specifies the operation mode. It indicates the way to process the schema file. This parameter is mandatory for GraphQL service generation. |
+| `-m, --mode`  | The `mode` parameter specifies the operation mode. It indicates the way to process the schema file. If the `mode` flag is not specified, the `graphql` tool will infer the mode from the `input` file extension. |
 | `-r, --use-records-for-objects`  | The `use-records-for-objects` parameter specifies to generate record types for GraphQL object types whenever it is possible. This parameter is optional. If this parameter is not specified, service class types will be generated for GraphQL object types. |
 
 ## Ballerina to GraphQL

--- a/swan-lake/learn-the-platform/ballerina-tooling/graphql-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/graphql-tool.md
@@ -301,41 +301,41 @@ The `service` parameter specifies the base path of the Ballerina GraphQL service
 
 ## Service generation
 
-The GraphQL tool supports generating a Ballerina GraphQL service from a given GraphQL schema. Successfull execution will generate two files. One contains the service, and other contains the types needed. You can export the generated files into a given location. The tool can be used in the following ways to generate a Ballerina GraphQL service.
+The GraphQL tool supports generating a Ballerina GraphQL service from a given GraphQL schema. Successful execution will generate two files. One contains the service and the other contains the types needed. You can export the generated files to a given location. The tool can be used in the following ways to generate a Ballerina GraphQL service.
 
 ### Generate a service with GraphQL object types represented in service class types 
 
-If you want to generate service class types for GraphQL object types in the GraphQL schema, use the following command to generate the service.
+Execute the command below to generate service class types for GraphQL object types in the GraphQL schema.
 
 ```
 $ bal graphql [-i | --input] <graphql-schema-file-path> [-m | --mode] <operation-mode> [-o | --output <output-location>] 
 ```
 
-For example,
+For example, see the command below.
 
 ```
 $ bal graphql -i schema.graphql -m service -o ./service
 ```
 
-Output flag is optional. If it is omitted, the generated files will be written to the current directory. 
+The output flag is optional. If it is omitted, the generated files will be written to the current directory. 
 
 >**Info:** For more information on the command, see [Ballerina to GraphQL](/learn/cli-documentation/graphql/#ballerina-to-graphql).
 
 ### Generate a service with GraphQL object types represented in record types
 
-If you want to generate record types for GraphQL object types in the GraphQL schema, use the following command to generate the service. 
+Execute the command below to generate record types for GraphQL object types in the GraphQL schema. 
 
 ```
 $ bal graphql [-i | --input] <graphql-schema-file-path> [-m | --mode] <operation-mode> [-o | --output <output-location>] [-r | --use-records-for-objects]
 ```
 
-For example, 
+For example, see the command below.
    
 ```
 $ bal graphql -i schema.graphql -m service -o ./service -r
 ```
 
-Even if the `[-r | --use-records-for-objects]` flag is used, the following object types will be generated using service types because these types cannot be represented by Ballerina record types.
+Even if the `[-r | --use-records-for-objects]` flag is used, the following object types will be generated using the service types because these types cannot be represented by Ballerina record types.
 - types having a field with input arguments 
 - types being a subtype of a union type 
 - types implementing an interface 

--- a/swan-lake/learn-the-platform/ballerina-tooling/graphql-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/graphql-tool.md
@@ -1,11 +1,11 @@
 ---
 layout: ballerina-graphql-support-left-nav-pages-swanlake
 title: GraphQL tool
-description: Check out how the Ballerina GraphQL tool makes it easy to generate a client in Ballerina using a given GraphQL config file and generate a GraphQL schema using a given Ballerina GraphQL service.
+description: Check out how the Ballerina GraphQL tool makes it easy to generate a client in Ballerina using a given GraphQL config file, generate a GraphQL schema using a given Ballerina GraphQL service, and generate a service in Ballerina using a given GraphQL schema file.
 keywords: ballerina, programming language, graphql, sdl, schema definition language
 permalink: /learn/graphql-tool/
 active: graphql-tool
-intro: The Ballerina GraphQL tool makes it easy to start the development of a GraphQL client. It generates the client skeletons in Ballerina for a given GraphQL schema and a GraphQL document. In addition, the GraphQL tool supports generating the GraphQL schema for a given Ballerina GraphQL service and writing it to a file in GraphQL schema definition language (SDL).
+intro: The Ballerina GraphQL tool makes it easy to start the development of a GraphQL client. It generates the client skeletons in Ballerina for a given GraphQL schema and a GraphQL document. In addition, the GraphQL tool supports generating the GraphQL schema for a given Ballerina GraphQL service and writing it to a file in GraphQL schema definition language (SDL). Also the GraphQL tool makes it easy to start the development of a GraphQL service. It generates the service skeletons in Ballerina for a given GraphQL schema.
 --- 
 
 The Ballerina GraphQL tooling support provides the following capabilities.
@@ -15,6 +15,8 @@ The Ballerina GraphQL tooling support provides the following capabilities.
 2. Generating multiple Ballerina modules from a given GraphQL config file configured with multiple GraphQL projects.
 
 3. Generate the GraphQL schema for a given Ballerina GraphQL service(s) and write the schema(s) to a file/files using the GraphQL schema definition language.
+
+4. Generating a Ballerina service from a given GraphQL schema which is specified by the GraphQL schema definition language. 
 
 > **Prerequisites:** Install the latest <a href="https://ballerina.io/downloads/" target="_blank">Ballerina Swan Lake distribution</a>.
 
@@ -294,5 +296,48 @@ $ bal graphql -i service.bal -o ./schema -s /starwars
 ```
 
 The `service` parameter specifies the base path of the Ballerina GraphQL service of which the schema needs to be generated. This generates the GraphQL schema for the Ballerina GraphQL service in the `service.bal` file of which the `service-base-path` is `/starwars`.
+
+>**Info:** For more information on the command, see [Ballerina to GraphQL](/learn/cli-documentation/graphql/#ballerina-to-graphql).
+
+## Service generation
+
+The GraphQL tool supports generating a Ballerina GraphQL service from a given GraphQL schema. Successfull execution will generate two files. One contains the service, and other contains the types needed. You can export the generated files into a given location. The tool can be used in the following ways to generate a Ballerina GraphQL service.
+
+### Generate a service with GraphQL object types represented in service class types 
+
+If you want to generate service class types for GraphQL object types in the GraphQL schema, use the following command to generate the service.
+
+```
+$ bal graphql [-i | --input] <ballerina-service-file-path> [-m | --mode] <operation-mode> [-o | --output <output-location>] 
+```
+
+For example,
+
+```
+$ bal graphql -i schema.graphql -m service -o ./service
+```
+
+Output flag is optional. If it is omitted, the generated files will be written to the current directory. 
+
+>**Info:** For more information on the command, see [Ballerina to GraphQL](/learn/cli-documentation/graphql/#ballerina-to-graphql).
+
+### Generate a service with GraphQL object types represented in record types
+
+If you want to generate record types for GraphQL object types in the GraphQL schema, use the following command to generate the service. 
+
+```
+$ bal graphql [-i | --input] <ballerina-service-file-path> [-m | --mode] <operation-mode> [-o | --output <output-location>] [-r | --use-records-for-objects]
+```
+
+For example, 
+   
+```
+$ bal graphql -i schema.graphql -m service -o ./service -r
+```
+
+Some GraphQL object types can't be represented with record types. Those are identified as below.
+- types having a field with input arguments 
+- types being a subtype of a union type 
+- types implementing an interface 
 
 >**Info:** For more information on the command, see [Ballerina to GraphQL](/learn/cli-documentation/graphql/#ballerina-to-graphql).

--- a/swan-lake/learn-the-platform/ballerina-tooling/graphql-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/graphql-tool.md
@@ -1,11 +1,11 @@
 ---
 layout: ballerina-graphql-support-left-nav-pages-swanlake
 title: GraphQL tool
-description: Check out how the Ballerina GraphQL tool makes it easy to generate a client in Ballerina using a given GraphQL config file, generate a GraphQL schema using a given Ballerina GraphQL service, and generate a service in Ballerina using a given GraphQL schema file.
+description: Check out how the Ballerina GraphQL tool makes it easy to generate a client in Ballerina using a given GraphQL config file, generate a GraphQL schema using a given Ballerina GraphQL service, and generate a Ballerina service using a given GraphQL schema file.
 keywords: ballerina, programming language, graphql, sdl, schema definition language
 permalink: /learn/graphql-tool/
 active: graphql-tool
-intro: The Ballerina GraphQL tool makes it easy to start the development of a GraphQL client. It generates the client skeletons in Ballerina for a given GraphQL schema and a GraphQL document. In addition, the GraphQL tool supports generating the GraphQL schema for a given Ballerina GraphQL service and writing it to a file in GraphQL schema definition language (SDL). Also the GraphQL tool makes it easy to start the development of a GraphQL service. It generates the service skeletons in Ballerina for a given GraphQL schema.
+intro: The Ballerina GraphQL tool makes it easy to start the development of a GraphQL. It generates the client skeletons in Ballerina for a given GraphQL schema and a GraphQL document. In addition, the GraphQL tool supports generating the GraphQL schema for a given Ballerina GraphQL service and writing it to a file in GraphQL schema definition language (SDL). The GraphQL tool generates the Ballerina service skeletons for a given GraphQL schema.
 --- 
 
 The Ballerina GraphQL tooling support provides the following capabilities.
@@ -308,7 +308,7 @@ The GraphQL tool supports generating a Ballerina GraphQL service from a given Gr
 If you want to generate service class types for GraphQL object types in the GraphQL schema, use the following command to generate the service.
 
 ```
-$ bal graphql [-i | --input] <ballerina-service-file-path> [-m | --mode] <operation-mode> [-o | --output <output-location>] 
+$ bal graphql [-i | --input] <graphql-schema-file-path> [-m | --mode] <operation-mode> [-o | --output <output-location>] 
 ```
 
 For example,
@@ -326,7 +326,7 @@ Output flag is optional. If it is omitted, the generated files will be written t
 If you want to generate record types for GraphQL object types in the GraphQL schema, use the following command to generate the service. 
 
 ```
-$ bal graphql [-i | --input] <ballerina-service-file-path> [-m | --mode] <operation-mode> [-o | --output <output-location>] [-r | --use-records-for-objects]
+$ bal graphql [-i | --input] <graphql-schema-file-path> [-m | --mode] <operation-mode> [-o | --output <output-location>] [-r | --use-records-for-objects]
 ```
 
 For example, 
@@ -335,7 +335,7 @@ For example,
 $ bal graphql -i schema.graphql -m service -o ./service -r
 ```
 
-Some GraphQL object types can't be represented with record types. Those are identified as below.
+Even if the `[-r | --use-records-for-objects]` flag is used, the following object types will be generated using service types because these types cannot be represented by Ballerina record types.
 - types having a field with input arguments 
 - types being a subtype of a union type 
 - types implementing an interface 


### PR DESCRIPTION
## Purpose

The functionality to generate Ballerina GraphQL service sources for a given GraphQL schema is introduced to the GraphQL tool. The GraphQL tool guide is updated with the details of this functionality.

> Fixes [#4433](https://github.com/ballerina-platform/ballerina-standard-library/issues/4433)

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
