### PR TITLE
Add VS Code ext docs in B.io

### DIFF
--- a/pages/downloads/index.js
+++ b/pages/downloads/index.js
@@ -126,7 +126,7 @@ export default function Downloads() {
 
             <Row className={`${styles.downloadsVSCode} pageContentRow`}>
                <Col xs={12}>
-                  <p>Next, install the Ballerina Visual Studio Code extension from the VS Code marketplace.</p>
+                  <p>Next, install the Ballerina Visual Studio Code extension from the VS Code marketplace. For detailed information of the functionalities of this extension, go to the <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina VS Code Extension Documentation</a>.</p>
                </Col>
             </Row>
 

--- a/swan-lake/get-started/get-started.md
+++ b/swan-lake/get-started/get-started.md
@@ -18,7 +18,7 @@ intro: Let’s set up a Ballerina development environment and write a simple Bal
 
 Set up a text editor to write Ballerina code.
 
->**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+>**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina VS Code extension</a> installed. For detailed information of the functionalities of this extension, go to the <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina VS Code Extension Documentation</a>.
 
 ## Meet `bal`
 


### PR DESCRIPTION
## Purpose
Add VS Code ext docs in B.io.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
