### PR TITLE
Add Vs Code ext to the Learn block

### DIFF
--- a/components/learn/intro/Intro.js
+++ b/components/learn/intro/Intro.js
@@ -27,8 +27,7 @@ export default function Intro() {
     return (
         <>
             <Container>
-
-                <Row className='pageContentRow llanding'>
+            <Row className='pageContentRow llanding justify-content-center'>
                     <Col xs={12} md={3} lg={3} className={styles.introCard}>
                         <a href={`${prefix}/learn/get-started`} className={`${styles.cardWrapper} ${styles.secondary}`}>
                             <div>
@@ -50,6 +49,21 @@ export default function Intro() {
                             </div>
                         </a>
                     </Col>
+                    <Col xs={12} md={3} lg={3} className={styles.introCard}>
+                        <a href={`${prefix}/learn/by-example`} className={`${styles.cardWrapper} ${styles.secondary}`}>
+                            <div>
+                                <h3>VS Code extension</h3>
+                                <div className={styles.cardDescription}>
+                                    <p>Design and develop Ballerina code via its graphical representation.</p>
+                                </div>
+                            </div>
+                        </a>
+                    </Col>
+    
+                </Row>
+
+                <Row className='pageContentRow llanding justify-content-center'>
+     
                     <Col xs={12} md={3} lg={3} className={styles.introCard}>
                         <a href={`https://lib.ballerina.io/`} target='_blank' rel="noreferrer" className={`${styles.cardWrapper} ${styles.secondary}`}>
                             <div>


### PR DESCRIPTION
## Purpose
Add Vs Code ext to the Learn block as shown below.

<img width="1728" alt="Screenshot 2023-05-23 at 11 05 36" src="https://github.com/ballerina-platform/ballerina-dev-website/assets/11707273/fcc8deaa-42d3-4f10-b6ae-94d596b4f4ab">

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
