### PR TITLE
Add the 2201.6.0 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
@@ -144,8 +144,6 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
 
 ## Language updates
 
-### New features
-
 ### Bug fixes
 
 To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.6.0](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.6.0+is%3Aclosed+label%3AType%2FBug).
@@ -256,10 +254,6 @@ To view bug fixes, see the [GitHub milestone for Swan Lake 2201.6.0](https://git
 
 ## Code to Cloud updates
 
-### New features
-
-### Improvements
-
 ### Bug fixes
 
 To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://github.com/ballerina-platform/module-ballerina-c2c/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22Ballerina+2201.6.0%22+label%3AType%2FBug).
@@ -274,11 +268,24 @@ To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://g
 - Added support for the `google-sheets` data store. This is currently an experimental feature, and its behavior may be subject to change in future releases.
 - Added `persist migrate` command to generate migration scripts for data model changes in the `mysql` data store. The support for migrations is currently an experimental feature, and its behavior may be subject to change in future releases.
 
+#### Language Server
+
+- Added inlay hint support for function call expressions and method call expressions to provide information about parameters.
+
 ### Improvements
 
 #### Persist Tool
+
 - Added support for additional DB configurations in the generated client objects for `mysql` data store.
 - Changed the Ballerina `byte[]` type mapping to `LONGBLOB` in the generated SQL script file.
+
+#### Language Server
+
+- Removed service template initialization from the lightweight mode.
+- Improved the completion support and signature help for client resource access actions.
+- Improved the main function completion item.
+- Improved completions in the named argument context.
+- Added support to rename parameter documentation for record fields and required parameters.
 
 #### Ballerina Update Tool
 
@@ -293,7 +300,7 @@ Added support to provide a directory path with `bal new` to create a package in 
 
 `bal init` is deprecated and will be removed in a future version. `bal new .` can be used instead.
 
-#### Architecture Model Generator
+#### Architecture model generator
 
 To view improvements, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://github.com/ballerina-platform/ballerina-dev-tools/pulls?q=is%3Apr+is%3Aclosed+label%3AArea%2FArchitectureModelGenerator+label%3AType%2FImprovement+milestone%3A2201.6.0).
 
@@ -313,25 +320,17 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.6.0 of the reposi
 - [Test Framework](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+label%3AType%2FBug+label%3AArea%2FTestFramework+milestone%3A2201.6.0)
 - [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.6.0+is%3Aclosed+label%3AType%2FBug)
 - [OpenAPI](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+milestone%3A%22Swan+Lake+2201.6.0+%22+label%3AType%2FBug+is%3Aclosed)
-- [Architecture Model Generator](https://github.com/ballerina-platform/ballerina-dev-tools/issues?q=is%3Aissue+milestone%3A2201.6.0+is%3Aclosed+label%3AArea%2FArchitectureModelGenerator+label%3AType%2FBug)
+- [Architecture model generator](https://github.com/ballerina-platform/ballerina-dev-tools/issues?q=is%3Aissue+milestone%3A2201.6.0+is%3Aclosed+label%3AArea%2FArchitectureModelGenerator+label%3AType%2FBug)
 
 ## Ballerina packages updates
 
 ### New features
 
-#### Language Server
 
-- Added inlay hint support for function call expressions and method call expressions to provide information about parameters.
 
 ### Improvements
 
-#### Language Server
 
-- Removed service template initialization from the lightweight mode.
-- Improved the completion support and signature help for client resource access actions.
-- Improved the main function completion item.
-- improved completions in the named argument context.
-- Added support to rename parameter documentation for record fields and required parameters.
 
 ### Bug fixes
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
@@ -214,6 +214,14 @@ To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://g
 - Added support for the `google-sheets` data store. This is currently an experimental feature and its behavior may be subject to change in future releases.
 - Added support for defining enums and adding `enum` fields to the data model.
 
+#### `toml` package
+
+- Introduced the `toml` module to convert a TOML configuration file to `map<json>` and vice-versa.
+
+#### `yaml` package
+
+- Introduced the `yaml` module to convert a YAML configuration file to JSON and vice-versa.
+
 ### Improvements
 
 #### `persist` package
@@ -323,14 +331,6 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.6.0 of the reposi
 - [Architecture model generator](https://github.com/ballerina-platform/ballerina-dev-tools/issues?q=is%3Aissue+milestone%3A2201.6.0+is%3Aclosed+label%3AArea%2FArchitectureModelGenerator+label%3AType%2FBug)
 
 ## Ballerina packages updates
-
-### New features
-
-
-
-### Improvements
-
-
 
 ### Bug fixes
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
@@ -101,7 +101,7 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
     }
     ```
     
-- Fixed a bug with the XML parser error messages that showed dependency information. The error message prefix `failed to create xml` is now changed to `failed to parse xml`, to have a single prefix for all the XML-parsing error messages.
+- Fixed a bug with the XML parser error messages that showed dependency information. The error message prefix `failed to create xml` is now changed to `failed to parse xml` to have a single prefix for all the XML-parsing error messages.
 
     For example, consider the content below of the `invalid_xml.txt` file.
 
@@ -198,9 +198,9 @@ To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://g
 
 #### `http` package
 
-- Added constraint validation support for query, path, and header parameters.
+- Added constraint validation support for `query`, `path`, and `header` parameters.
 - Exposed the `http:Request` object in the response interceptors as a remote method parameter.
-- Added finite type support for query, path, and header parameters.
+- Added finite type support for `query`, `path`, and `header` parameters.
 
 #### `graphql` package
 
@@ -238,9 +238,9 @@ To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://g
 
 - Allowed a single interceptor service object to be configured as the interceptor pipeline.
 - Allowed the subtypes of one of `string`, `int`, `float`, `boolean`, or `decimal` as path parameters.
-- Added support for `http:InterceptableService` to enable engaging service level interceptors and deprecated the usage of interceptors in `http:HttpServiceConfig`.
+- Added support for `http:InterceptableService` to enable engaging service-level interceptors and deprecated the usage of interceptors in the `http:HttpServiceConfig`.
 
-    For a example, consider the following implementation of the `http:InterceptableService`.
+    For example, consider the following implementation of the `http:InterceptableService`.
     ```ballerina
     import ballerina/http;
     
@@ -260,12 +260,6 @@ To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://g
 
 To view bug fixes, see the [GitHub milestone for Swan Lake 2201.6.0](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aclosed+is%3Aissue+milestone%3A%222201.6.0%22+label%3AType%2FBug).
 
-## Code to Cloud updates
-
-### Bug fixes
-
-To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://github.com/ballerina-platform/module-ballerina-c2c/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22Ballerina+2201.6.0%22+label%3AType%2FBug).
-
 ## Developer tools updates
 
 ### New features
@@ -273,8 +267,8 @@ To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://g
 #### Persist Tool
 
 - Added support for the `in-memory` data store. This is set as the default data store.
-- Added support for the `google-sheets` data store. This is currently an experimental feature, and its behavior may be subject to change in future releases.
-- Added `persist migrate` command to generate migration scripts for data model changes in the `mysql` data store. The support for migrations is currently an experimental feature, and its behavior may be subject to change in future releases.
+- Added support for the `google-sheets` data store. This is currently an experimental feature and its behavior may be subject to change in future releases.
+- Added the `persist migrate` command to generate migration scripts for data model changes in the `mysql` data store. The support for migrations is currently an experimental feature and its behavior may be subject to change in future releases.
 
 #### Language Server
 
@@ -284,7 +278,7 @@ To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://g
 
 #### Persist Tool
 
-- Added support for additional DB configurations in the generated client objects for `mysql` data store.
+- Added support for additional DB configurations in the generated client objects for the `mysql` data store.
 - Changed the Ballerina `byte[]` type mapping to `LONGBLOB` in the generated SQL script file.
 
 #### Language Server
@@ -300,26 +294,28 @@ To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://g
 - Improved the `bal dist update` command to update the active distribution to the latest patch version (of the active Swan Lake version). 
 - Improved the `bal dist pull latest` command to update the active distribution to the latest Swan Lake version.
 
-#### Support for providing paths with `bal new`
+#### OpenAPI Tool
 
-Added support to provide a directory path with `bal new` to create a package in a specific directory. E.g., `bal new <package-path>`. 
-
-#### Deprecation of the `bal init` command 
-
-`bal init` is deprecated and will be removed in a future version. `bal new .` can be used instead.
+- Added support for OpenAPI regular expression templates (the pattern property) defined on the `string` type in Ballerina client and service generation.
+  With this support, the aforementioned Regex templates will be represented as `ballerina/constraint` module annotations in the generated code. This support applies to Regex patterns that satisfy [the Ballerina regular expression grammar](https://ballerina.io/spec/lang/2022R4/#section_10.1).
+- Added support for OpenAPI enums in the client and service generation. 
+- Added support for query parameters with referenced schema in the Ballerina service generation. 
+- Added support for header parameters with referenced schema in the Ballerina service generation. 
+- Added support for `integer`, `float`, `decimal`, and `boolean` header parameter types in the Ballerina service generation.
 
 #### Architecture model generator
 
-To view improvements, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://github.com/ballerina-platform/ballerina-dev-tools/pulls?q=is%3Apr+is%3Aclosed+label%3AArea%2FArchitectureModelGenerator+label%3AType%2FImprovement+milestone%3A2201.6.0).
+To view improvements of the architecture model generator, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://github.com/ballerina-platform/ballerina-dev-tools/pulls?q=is%3Apr+is%3Aclosed+label%3AArea%2FArchitectureModelGenerator+label%3AType%2FImprovement+milestone%3A2201.6.0).
 
-#### OpenAPI Tool
+#### CLI commands
 
-- Added support for openAPI regular expression templates (pattern property) defined on `string` type in Ballerina client and service generation.
-  With this support, the aforementioned regex templates will be represented as `ballerina/constraint` module annotations in the generated code. This support applies to regex patterns that satisfy [the Ballerina regular expression grammar](https://ballerina.io/spec/lang/2022R4/#section_10.1).
-- Added support for the openAPI enums in client and service generation. 
-- Added support for query parameters with referenced schema in Ballerina service generation. 
-- Added support for header parameters with referenced schema in Ballerina service generation. 
-- Added support for integer, float, decimal, and boolean header parameter types in Ballerina service generation.
+##### Support for providing paths with `bal new`
+
+Added support to provide a directory path with the `bal new` command to create a package in a specific directory (e.g., `bal new <package-path>`). 
+
+##### Deprecation of `bal init`
+
+The `bal init` coomand is deprecated and will be removed in a future version. `bal new .` can be used instead.
 
 ### Bug fixes
 


### PR DESCRIPTION
## Purpose
Add the 2201.6.0 release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
