### PR TITLE
Re-organize learn intro boxes

### DIFF
--- a/components/learn/intro/Intro.js
+++ b/components/learn/intro/Intro.js
@@ -50,21 +50,6 @@ export default function Intro() {
                         </a>
                     </Col>
                     <Col xs={12} md={3} lg={3} className={styles.introCard}>
-                        <a href={`${prefix}/learn/by-example`} className={`${styles.cardWrapper} ${styles.secondary}`}>
-                            <div>
-                                <h3>VS Code extension</h3>
-                                <div className={styles.cardDescription}>
-                                    <p>Design and develop Ballerina code via its graphical representation.</p>
-                                </div>
-                            </div>
-                        </a>
-                    </Col>
-    
-                </Row>
-
-                <Row className='pageContentRow llanding justify-content-center'>
-     
-                    <Col xs={12} md={3} lg={3} className={styles.introCard}>
                         <a href={`https://lib.ballerina.io/`} target='_blank' rel="noreferrer" className={`${styles.cardWrapper} ${styles.secondary}`}>
                             <div>
                                 <h3>Ballerina API Docs</h3>
@@ -74,6 +59,11 @@ export default function Intro() {
                             </div>
                         </a>
                     </Col>
+  
+    
+                </Row>
+
+                <Row className='pageContentRow llanding justify-content-center'>
 
                     <Col xs={12} md={3} lg={3} className={styles.introCard}>
                         <a href={`${prefix}/learn/ballerina-specifications`} className={`${styles.cardWrapper} ${styles.secondary}`}>
@@ -81,6 +71,16 @@ export default function Intro() {
                                 <h3>Ballerina specifications</h3>
                                 <div className={styles.cardDescription}>
                                     <p>Refer language, library, and platform specifications.</p>
+                                </div>
+                            </div>
+                        </a>
+                    </Col>
+                    <Col xs={12} md={3} lg={3} className={styles.introCard}>
+                        <a href={`https://wso2.com/ballerina/vscode/docs/`} className={`${styles.cardWrapper} ${styles.secondary}`}>
+                            <div>
+                                <h3>VS Code extension</h3>
+                                <div className={styles.cardDescription}>
+                                    <p>Design and develop Ballerina code via its graphical representation.</p>
                                 </div>
                             </div>
                         </a>


### PR DESCRIPTION
## Purpose
Re-organize learn intro boxes as shown below.

<img width="1728" alt="Screenshot 2023-05-24 at 14 28 33" src="https://github.com/ballerina-platform/ballerina-dev-website/assets/11707273/e9ede2af-1b50-40d6-9447-df475b1707a7">

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
