### PR TITLE
Sync persist docs to up6

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
@@ -26,9 +26,123 @@ Update your currrent Ballerina installation directly to 2201.6.0 by using the [B
 
 If you have not installed Ballerina, download the [installers](/downloads/#swanlake) to install.
 
-## Language updates
+## Backward-incompatible changes
 
-### New features
+- `self` of an object is now implicitly final and cannot be assigned to.
+
+    ```ballerina
+    class Counter {
+        private int i = 0;
+
+        function updateSelf() {
+            self = new; // Compilation error now.
+        }
+
+        function increment() {
+            lock {
+                self.i += 1;
+            }
+        }
+    }    
+    ```
+
+  This also allows using `self` of an object that is a subtype of `readonly` or `isolated object {}` as a captured variable within an `isolated` anonymous function.
+
+    ```ballerina
+    isolated class Filter {
+        final string[] & readonly words;
+        private int length;
+
+        isolated function init(string[] & readonly words, int length) {
+            self.words = words;
+            self.length = length;
+        }
+
+        isolated function setLength(int length) {
+            lock {
+                self.length = length;
+            }
+        }
+
+        isolated function getCount() returns int =>
+            self.words.filter(
+                // Allowed now.
+                word => word.length() == self.length).length();
+    }
+    ```
+
+- A bug that allowed assigning nil to a record field with member access expressions when there are no fields of optional types has been fixed. This previously resulted in a runtime panic if the value was nil.
+
+    ```ballerina
+    type Employee record {|
+        string id;
+        string name;
+    |};
+
+    public function main() {
+        Employee employee = {
+            name: "Jo",
+            id: "E12321"
+        };
+
+        string key = "name";
+        employee[key] = (); // Compilation error now.
+
+        map<string> data = {
+            name: "Jo Doe",
+            dept: "IT"
+        };
+
+        foreach string mkey in employee.keys() {
+            // `data[key]` will be nil if the key is not present in `data`.
+            // E.g., `data[key]` is nil when `key` is `name`.
+            employee[mkey] = data[mkey]; // Compilation error now.
+        }
+    }
+    ```
+    
+- Fixed a bug with the XML parser error messages that showed dependency information. The error message prefix `failed to create xml` is now changed to `failed to parse xml` to have a single prefix for all the XML-parsing error messages.
+
+    For example, consider the content below of the `invalid_xml.txt` file.
+
+    ```
+    <!-- comments cannot have -- in it -->
+    ```
+
+    When the following Ballerina code is run,
+
+    ```ballerina
+    import ballerina/io;
+
+    public function main() returns error? {
+        xml readResult = check io:fileReadXml("invalid_xml.txt");
+    }
+    ```
+
+    it gives the error below.
+
+    ```
+    error: failed to parse xml: String '--' not allowed in comment (missing '>'?)
+     at [row,col {unknown-source}]: [1,4]
+    ```
+
+- The `Environment`, `Future`, and `Runtime` classes in the `io.ballerina.runtime.api` package are refactored to abstract classes. Creating an instance of those classes is incorrect.
+
+- A typedesc value (returned by evaluating the `typeof` expression on a result of the `value:cloneWithType` and `value:fromJsonWithType` functions) is changed to give the correct type-reference type.
+
+    ```ballerina
+    import ballerina/io;
+
+    type IntArray int[];
+
+    public function main() returns error? {
+        float[] arr = [1.0, 2.0];
+        IntArray result = check arr.cloneWithType();
+        io:println(typeof result); // Prints 'typedesc IntArray'.
+    }
+    ```
+
+## Language updates
 
 ### Bug fixes
 
@@ -38,7 +152,36 @@ To view other bug fixes, see the [GitHub milestone for Swan Lake 2201.6.0](https
 
 ### New features
 
+#### New Runtime Java APIs
+
+Introduced the `getInitMethod()` API in the `io.ballerina.runtime.api.types.ObjectType` class to get the method type of the initializer method of Ballerina objects.
+
+```java
+MethodType getInitMethod();
+```
+
 ### Improvements
+
+#### Improvements in Runtime Java APIs
+
+The following APIs in the `io.ballerina.runtime.api` package are deprecated and marked for removal in a future release.
+
+  | **Runtime API**                                  | **Java class**                                     |
+  |--------------------------------------------------|----------------------------------------------------|
+  | `getCurrentRuntime()`                            | `io.ballerina.runtime.api.Runtime`                 |
+  | `createDecimalValue(String, DecimalValueKind)`   | `io.ballerina.runtime.api.creators.ValueCreator`   |
+  | `createStreamingJsonValue(JsonDataSource)`       | `io.ballerina.runtime.api.creators.ValueCreator`   |
+  | `convertToJson(Object, List<TypeValuePair>)`     | `io.ballerina.runtime.api.utils.JsonUtils`         |
+  | `getStringValue(Object, BLink)`                  | `io.ballerina.runtime.api.utils.StringUtils`       |
+  | `getExpressionStringValue(Object, BLink)`        | `io.ballerina.runtime.api.utils.StringUtils`       |
+  | `parseExpressionStringValue(String, BLink)`      | `io.ballerina.runtime.api.utils.StringUtils`       |
+  | `getValueKind()`                                 | `io.ballerina.runtime.api.values.BDecimal`         |
+  | `getStrand()`                                    | `io.ballerina.runtime.api.values.BFuture`          |
+  | `call(Strand, String, Object...)`                | `io.ballerina.runtime.api.values.BObject`          |
+  | `start(Strand, String, Object...)`               | `io.ballerina.runtime.api.values.BObject`          |
+  | `getRegExpDisjunction()`                         | `io.ballerina.runtime.api.values.BRegexpValue`     |
+  | `instantiate(Strand)`                            | `io.ballerina.runtime.api.values.BTypedesc`        |
+  | `instantiate(Strand, BInitialValueEntry[])`      | `io.ballerina.runtime.api.values.BTypedesc`        |
 
 ### Bug fixes
 
@@ -48,27 +191,131 @@ To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://g
 
 ### New features
 
+#### `constraint` package
+
+- Introduced the `@constriant:Date` annotation to validate date record structures.
+- Allowed constraint annotations on subtypes.
+
+#### `http` package
+
+- Added constraint validation support for `query`, `path`, and `header` parameters.
+- Exposed the `http:Request` object in the response interceptors as a remote method parameter.
+- Added finite type support for `query`, `path`, and `header` parameters.
+
+#### `graphql` package
+
+- Added support for GraphQL field interceptors.
+- Added support for GraphQL interceptor configurations.
+- Added support to access subfields of a GraphQL field from the `graphql:Field` object.
+
+#### `persist` package
+
+- Added support for the `in-memory` data store.
+- Added support for the `google-sheets` data store. This is currently an experimental feature and its behavior may be subject to change in future releases.
+- Added support for defining enums and adding `enum` fields to the data model.
+
+#### `toml` package
+
+- Introduced the `toml` module to convert a TOML configuration file to `map<json>` and vice-versa.
+
+#### `yaml` package
+
+- Introduced the `yaml` module to convert a YAML configuration file to JSON and vice-versa.
+
 ### Improvements
+
+#### `persist` package
+
+- Renamed the error types to the following:
+    - `InvalidKeyError` to `NotFoundError`
+    - `DuplicateKeyError` to `AlreadyExistsError`
+    - `ForeignKeyConstraintViolationError` to `ForeignKeyViolationError`
+- Removed the `FieldDoesNotExistError` error type as the `NotFoundError` error type can be used instead.
+- Marked the generated client object as `isolated`.
+- Added support for transactions in the `mysql` data store.
+
+#### `http` package
+
+- Allowed a single interceptor service object to be configured as the interceptor pipeline.
+- Allowed the subtypes of one of `string`, `int`, `float`, `boolean`, or `decimal` as path parameters.
+- Added support for `http:InterceptableService` to enable engaging service-level interceptors and deprecated the usage of interceptors in the `http:HttpServiceConfig`.
+
+    For example, consider the following implementation of the `http:InterceptableService`.
+    ```ballerina
+    import ballerina/http;
+    
+    service http:InterceptableService / on new http:Listener(9090) {
+
+        public function createInterceptors() returns RequestInterceptor {
+            return new RequestInterceptor();
+        }
+
+        resource function get user() returns string {
+            return "John, Doe";
+        }
+    }
+    ```
 
 ### Bug fixes
 
 To view bug fixes, see the [GitHub milestone for Swan Lake 2201.6.0](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aclosed+is%3Aissue+milestone%3A%222201.6.0%22+label%3AType%2FBug).
 
-## Code to Cloud updates
-
-### New features
-
-### Improvements
-
-### Bug fixes
-
-To view bug fixes, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://github.com/ballerina-platform/module-ballerina-c2c/issues?q=is%3Aissue+is%3Aclosed+milestone%3A%22Ballerina+2201.6.0%22+label%3AType%2FBug).
-
 ## Developer tools updates
 
 ### New features
 
+#### Persist Tool
+
+- Added support for the `in-memory` data store. This is set as the default data store.
+- Added support for the `google-sheets` data store. This is currently an experimental feature and its behavior may be subject to change in future releases.
+- Added the `persist migrate` command to generate migration scripts for data model changes in the `mysql` data store. The support for migrations is currently an experimental feature and its behavior may be subject to change in future releases.
+
+#### Language Server
+
+- Added inlay hint support for function call expressions and method call expressions to provide information about parameters.
+
 ### Improvements
+
+#### Persist Tool
+
+- Added support for additional DB configurations in the generated client objects for the `mysql` data store.
+- Changed the Ballerina `byte[]` type mapping to `LONGBLOB` in the generated SQL script file.
+
+#### Language Server
+
+- Removed service template initialization from the lightweight mode.
+- Improved the completion support and signature help for client resource access actions.
+- Improved the main function completion item.
+- Improved completions in the named argument context.
+- Added support to rename parameter documentation for record fields and required parameters.
+
+#### Ballerina Update Tool
+
+- Improved the `bal dist update` command to update the active distribution to the latest patch version (of the active Swan Lake version). 
+- Improved the `bal dist pull latest` command to update the active distribution to the latest Swan Lake version.
+
+#### OpenAPI Tool
+
+- Added support for OpenAPI regular expression templates (the pattern property) defined on the `string` type in Ballerina client and service generation.
+  With this support, the aforementioned Regex templates will be represented as `ballerina/constraint` module annotations in the generated code. This support applies to Regex patterns that satisfy [the Ballerina regular expression grammar](https://ballerina.io/spec/lang/2022R4/#section_10.1).
+- Added support for OpenAPI enums in the client and service generation. 
+- Added support for query parameters with referenced schema in the Ballerina service generation. 
+- Added support for header parameters with referenced schema in the Ballerina service generation. 
+- Added support for `integer`, `float`, `decimal`, and `boolean` header parameter types in the Ballerina service generation.
+
+#### Architecture model generator
+
+To view improvements of the architecture model generator, see the [GitHub milestone for 2201.6.0 (Swan Lake)](https://github.com/ballerina-platform/ballerina-dev-tools/pulls?q=is%3Apr+is%3Aclosed+label%3AArea%2FArchitectureModelGenerator+label%3AType%2FImprovement+milestone%3A2201.6.0).
+
+#### CLI commands
+
+##### Support for providing paths with `bal new`
+
+Added support to provide a directory path with the `bal new` command to create a package in a specific directory (e.g., `bal new <package-path>`). 
+
+##### Deprecation of `bal init`
+
+The `bal init` coomand is deprecated and will be removed in a future version. `bal new .` can be used instead.
 
 ### Bug fixes
 
@@ -76,13 +323,10 @@ To view bug fixes, see the GitHub milestone for Swan Lake 2201.6.0 of the reposi
 
 - [Test Framework](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+is%3Aclosed+label%3AType%2FBug+label%3AArea%2FTestFramework+milestone%3A2201.6.0)
 - [Language Server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.6.0+is%3Aclosed+label%3AType%2FBug)
-- [OpenAPI](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aclosed+milestone%3A%22Swan+Lake+2201.6.0%22+label%3AType%2FBug)
+- [OpenAPI](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+milestone%3A%22Swan+Lake+2201.6.0+%22+label%3AType%2FBug+is%3Aclosed)
+- [Architecture model generator](https://github.com/ballerina-platform/ballerina-dev-tools/issues?q=is%3Aissue+milestone%3A2201.6.0+is%3Aclosed+label%3AArea%2FArchitectureModelGenerator+label%3AType%2FBug)
 
 ## Ballerina packages updates
-
-### New features
-
-### Improvements
 
 ### Bug fixes
 

--- a/pages/downloads/0.9.x-release-notes/[...slug].js
+++ b/pages/downloads/0.9.x-release-notes/[...slug].js
@@ -463,6 +463,9 @@ export default function PostPage({ frontmatter, content, id }) {
                           {children}
                         </code>
                       </pre>
+                },
+                table({node, className, children, ...props}) { 
+                  return <div className='mdTable'><table {...props}>{children}</table></div>
                 }
               }}
               remarkPlugins={[remarkGfm]}

--- a/pages/downloads/1.0.x-release-notes/[...slug].js
+++ b/pages/downloads/1.0.x-release-notes/[...slug].js
@@ -463,6 +463,9 @@ export default function PostPage({ frontmatter, content, id }) {
                           {children}
                         </code>
                       </pre>
+                },
+                table({node, className, children, ...props}) { 
+                  return <div className='mdTable'><table {...props}>{children}</table></div>
                 }
               }}
               remarkPlugins={[remarkGfm]}

--- a/pages/downloads/1.1.x-release-notes/[...slug].js
+++ b/pages/downloads/1.1.x-release-notes/[...slug].js
@@ -463,6 +463,9 @@ export default function PostPage({ frontmatter, content, id }) {
                           {children}
                         </code>
                       </pre>
+                },
+                table({node, className, children, ...props}) { 
+                  return <div className='mdTable'><table {...props}>{children}</table></div>
                 }
               }}
               remarkPlugins={[remarkGfm]}

--- a/pages/downloads/1.2.x-release-notes/[...slug].js
+++ b/pages/downloads/1.2.x-release-notes/[...slug].js
@@ -430,6 +430,9 @@ export default function PostPage({ frontmatter, content, id, codeSnippets }) {
                           {children}
                         </code>
                       </pre>
+                },
+                table({node, className, children, ...props}) { 
+                  return <div className='mdTable'><table {...props}>{children}</table></div>
                 }
               }}
               remarkPlugins={[remarkGfm]}

--- a/pages/downloads/swan-lake-release-notes/[...slug].js
+++ b/pages/downloads/swan-lake-release-notes/[...slug].js
@@ -434,6 +434,9 @@ export default function PostPage({ frontmatter, content, id, codeSnippets }) {
                           {children}
                         </code>
                       </pre>
+                },
+                table({node, className, children, ...props}) { 
+                  return <div className='mdTable'><table {...props}>{children}</table></div>
                 }
               }}
               remarkPlugins={[remarkGfm]}

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/cli-commands.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/cli-commands.md
@@ -46,7 +46,6 @@ COMMANDS
 
    Package Commands:
         new             Create a new Ballerina package
-        init            Create a new Ballerina package in an existing directory
         add             Add a new Ballerina module to the current package
         pull            Pull a package from Ballerina Central
         push            Publish a package to Ballerina Central
@@ -156,11 +155,6 @@ Ballerina packages are the way to organize real-world Ballerina development task
 <tr>
 <td class="cCommand">new</td>
 <td class="cDescription">Create a Ballerina package. For more information, see <a href="/learn/get-started/#create-a-new-package">Create a new package</a>.
-</td>
-</tr>
-<tr>
-<td class="cCommand">init</td>
-<td class="cDescription">Create a new Ballerina package in the current directory.
 </td>
 </tr>
 <tr>

--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/update-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/update-tool.md
@@ -113,7 +113,7 @@ OPTIONS
 BALLERINA COMMANDS
        The below is a list of available subcommands:
 
-       update     Update to the latest patch version of the active distribution
+       update     Update to the latest Ballerina version
        pull       Fetch a distribution and set it as the active version
        use        Set a distribution as the active distribution
        list       List locally and remotely available distributions
@@ -140,7 +140,11 @@ The `bal dist list` command lists the installed distributions in your local envi
 
 ```bash
 $ bal dist list
+<<<<<<< HEAD
 ``` 
+=======
+```
+>>>>>>> 54995eb6128cbbca3e33f2edd9306aee5b314cf8
 
 You view the output below.
 

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/configure-tests.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/configure-tests.md
@@ -277,6 +277,14 @@ Configurations for testing can be provided using configurable variables. The val
 provided in a file named `Config.toml` located in the `tests` directory, which will only be initialized when the tests
 are run. 
 
+Configurable variables can also be provided as command-line arguments when running the tests. The configurable values can be passed with `bal test` in the format `-Ckey=value` where `key` is the configurable variable name and `value` is the value to be assigned to the configurable variable.
+
+***Example:***
+
+```
+$ bal test -Cval1=add -Cval2=10 -Cval3=5
+```
+
 Configurable variables are useful when you require separate configurations that cannot be feasibly used outside of 
 testing. This is particularly useful when testing services and clients where you may need different host values when you
 are trying to test the service or client.

--- a/swan-lake/why-ballerina/graphical.md
+++ b/swan-lake/why-ballerina/graphical.md
@@ -7,7 +7,7 @@ permalink: /why-ballerina/graphical/
 active: graphical
 ---
 
-In today’s cloud-era, you need technologies that can model distributed systems in a more developer-friendly way. This means that for a single use case you need to model a flow that shows how multiple actors interact with each other, how concurrent execution flows, and what remote endpoints are involved. Sequence diagrams are known to be the best way to visually describe this.
+In today’s cloud-era, you need technologies that can model distributed systems in a more developer-friendly way. This means that for a single use case, you need to model a flow that shows how multiple actors interact with each other, how concurrent execution flows, and what remote endpoints are involved. Sequence diagrams are known to be the best way to visually describe this.
 
 That’s why sequence diagrams are the foundation for designing the syntax and semantics of the Ballerina language. Ballerina provides the flexibility of a general-purpose language while having features to model and visualize solutions based on higher-level abstractions derived from sequence diagrams.
 


### PR DESCRIPTION
## Purpose
Sync persist docs to up6.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
