### PR TITLE
Update missing Up6 changes

### DIFF
--- a/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/cli-commands.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/cli-documentation/cli-commands.md
@@ -46,7 +46,6 @@ COMMANDS
 
    Package Commands:
         new             Create a new Ballerina package
-        init            Create a new Ballerina package in an existing directory
         add             Add a new Ballerina module to the current package
         pull            Pull a package from Ballerina Central
         push            Publish a package to Ballerina Central
@@ -156,11 +155,6 @@ Ballerina packages are the way to organize real-world Ballerina development task
 <tr>
 <td class="cCommand">new</td>
 <td class="cDescription">Create a Ballerina package. For more information, see <a href="/learn/get-started/#create-a-new-package">Create a new package</a>.
-</td>
-</tr>
-<tr>
-<td class="cCommand">init</td>
-<td class="cDescription">Create a new Ballerina package in the current directory.
 </td>
 </tr>
 <tr>

--- a/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/configure-tests.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/test-ballerina-code/configure-tests.md
@@ -277,6 +277,14 @@ Configurations for testing can be provided using configurable variables. The val
 provided in a file named `Config.toml` located in the `tests` directory, which will only be initialized when the tests
 are run. 
 
+Configurable variables can also be provided as command line arguments when running the tests. The configurable values can be passed with `bal test` in the format `-Ckey=value` where `key` is the configurable variable name and `value` is the value to be assigned to the configurable variable.
+
+***Example:***
+
+```
+$ bal test -Cval1=add -Cval2=10 -Cval3=5
+```
+
 Configurable variables are useful when you require separate configurations that cannot be feasibly used outside of 
 testing. This is particularly useful when testing services and clients where you may need different host values when you
 are trying to test the service or client.


### PR DESCRIPTION
## Purpose
Update missing Up6 changes.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
