### PR TITLE
Add the `noreferrer` class to fix Zapier demo build errors

### DIFF
--- a/components/vs-code-home-page/intro/Intro.js
+++ b/components/vs-code-home-page/intro/Intro.js
@@ -62,16 +62,16 @@ export default function Intro() {
                         <p className={styles.dVersion}>
                         <br/>
                         <a href={`https://ballerina.io/downloads/`}
-                            className={styles.cVideoBtn} target="_blank"> 
+                            className={styles.cVideoBtn} target="_blank" rel="noreferrer"> 
                             <Image src={`${prefix}/images/ballerina-get-started.svg`} width={20} height={20} alt="Try GraphQL services" />
                             Get Ballerina
                         </a>
                         <a href={`https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina`}
-                            className={styles.cDownload} target="_blank">
+                            className={styles.cDownload} target="_blank" rel="noreferrer">
                             Install the extension
                         </a>
                         <a href={`https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina`}
-                            className={styles.cDownloadOutlined} target="_blank">
+                            className={styles.cDownloadOutlined} target="_blank" rel="noreferrer">
                             See it in action
                         </a>
                     </p>


### PR DESCRIPTION
## Purpose
Add the `noreferrer` class to fix Zapier demo build errors.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
