### PR TITLE
Fix mobile view intro button displaying

### DIFF
--- a/components/vs-code-home-page/code/Code.module.css
+++ b/components/vs-code-home-page/code/Code.module.css
@@ -87,7 +87,6 @@ a.cDownload span {
     height: auto;
     border-radius: 4px;
     margin-right: 20px;
-    margin-bottom: 20px;
 }
 
 .dVersions .dVersion a.cDownload {

--- a/components/vs-code-home-page/code/Code.module.css
+++ b/components/vs-code-home-page/code/Code.module.css
@@ -87,6 +87,7 @@ a.cDownload span {
     height: auto;
     border-radius: 4px;
     margin-right: 20px;
+    margin-bottom: 20px;
 }
 
 .dVersions .dVersion a.cDownload {

--- a/components/vs-code-home-page/intro/Intro.module.css
+++ b/components/vs-code-home-page/intro/Intro.module.css
@@ -63,6 +63,7 @@ a.cDownload {
     border-radius: 4px;
     background-size: 40px 30px;
     margin-right:20px;
+    margin-bottom:20px;
 }
 
 a.cDownloadOutlined {


### PR DESCRIPTION
Fix mobile view intro button displaying.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
