### PR TITLE
Fix VS Code links after revamp

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -258,7 +258,7 @@ To view bug fixes, see the [GitHub milestone for 2201.4.0 (Swan Lake)](https://g
 
 - Added the `Create variable with Type` code action.
 - Added rename popup support to the `Extract to constant`, `Extract to local variable` , and `Extract to function` code actions.
- >**Info:** This feature will be available from the [Ballerina VS Code extension](https://wso2.com/ballerina/vscode/docs/edit-the-code/code-actions/) version `4.0.0`.
+ >**Info:** This feature will be available from the [Ballerina VS Code extension](https://wso2.com/ballerina/vscode/docs/write-the-code/code-actions/) version `4.0.0`.
 - Added quick pick support for selecting expressions in the `Extract to constant` code action.
 
 #### GraphQL Tool

--- a/downloads/vs-code-release-notes/3.3.0.md
+++ b/downloads/vs-code-release-notes/3.3.0.md
@@ -6,7 +6,7 @@ We are happy to announce the Ballerina VSCode plugin 3.3.0 release, which has so
 - [Improved record editor](#record-editor) - Provides a better editing experience with suggestions 
 - [Project Design View](#record-editor) - Facilitates visualizing service interactions in your project
 
-If you are new to Ballerina, you can download the [installers](/downloads/#swanlake) to install it and install the [Ballerina VS Code extension](https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/). 
+If you are new to Ballerina, you can download the [installers](/downloads/#swanlake) to install it and install the [Ballerina VS Code extension](https://wso2.com/ballerina/vscode/docs/). 
 
 ## Data Mapper
 ![data-mapper](./../../resources/release-notes/3.3.0/data-mapper.gif)

--- a/swan-lake/get-started/get-started.md
+++ b/swan-lake/get-started/get-started.md
@@ -18,7 +18,7 @@ intro: Let’s set up a Ballerina development environment and write a simple Bal
 
 Set up a text editor to write Ballerina code.
 
->**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina VS Code extension</a> installed. For detailed information of the functionalities of this extension, go to the <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina VS Code extension documentation</a>.
+>**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the Ballerina VS Code extension installed. For detailed information of the functionalities of this extension, go to the <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina VS Code extension documentation</a>.
 
 ## Meet `bal`
 

--- a/swan-lake/learn-the-platform/native-support/build-a-native-executable.md
+++ b/swan-lake/learn-the-platform/native-support/build-a-native-executable.md
@@ -59,9 +59,9 @@ From Ballerina 2201.3.0 (SwanLake) onwards, Ballerina supports GraalVM AOT compi
 ### Set up the prerequisites
 
 To complete this part of the guide, you need:
-1. [Ballerina 2201.3.0 (Swan Lake)](/learn/install-ballerina/set-up-ballerina/) or greater
+1. [Ballerina 2201.3.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
-   >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the  <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+   >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the  <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina extension</a> installed.
 3. GraalVM installed and configured appropriately
 4. A command terminal
 

--- a/swan-lake/learn-the-platform/test-document-the-code/debug-ballerina-programs.md
+++ b/swan-lake/learn-the-platform/test-document-the-code/debug-ballerina-programs.md
@@ -9,20 +9,20 @@ active: debug-ballerina-programs
 
 The Ballerina compiler comes in handy to detect syntax and semantic issues that occur in your code when developing large-scale applications with complex logic. However, it is difficult for the compiler to detect runtime errors like logical errors because they occur during the program execution after a successful compilation. This is where the dedicated debugging tooling support of Ballerina becomes important.
 
-## Debugging overview
+## Debugging sessions
 
 The Ballerina VS Code extension offers three types of debugging sessions (i.e., program debugging, test debugging, and remote debugging). Debugging sessions can be initiated using CodeLens or configurations in a `launch.json file`. It also provides a **Debug Console** to view the output and perform various debugging scenarios.
 
->**Info:** For more information on the debugging sessions and methods, go to <a href="https://wso2.com/ballerina/vscode/docs/debug-the-code/debugging-overview/" target="_blank">Debug sessions</a>.
-
-## Debugging configurations
-
-The Ballerina debugger allows you to create a `launch.json` file with default configurations for debugging Ballerina programs. You can generate the file by following a few steps and then, modify the configurations to suit your needs. These configurations have specific attributes that can be edited to customize the debugging process so that you can set program arguments, command options, environment variables, run in a separate terminal, etc. Additionally, you can configure remote debugging by specifying the host address and port number. These configurations provide flexibility and control when debugging Ballerina code in VS Code.
-
->**Info:** For more information on the debugging configurations, go to <a href="https://wso2.com/ballerina/vscode/docs/debug-the-code/debugging-configurations/" target="_blank">Debug methods</a>.
+>**Info:** For more information on the debugging sessions and methods, go to <a href="https://wso2.com/ballerina/vscode/docs/debug-the-code/debug-sessions/" target="_blank">Debugging sessions</a>.
 
 ## Debugging features
 
 The Ballerina VS Code extension provides a range of powerful debugging features. You can set breakpoints with conditions and logpoints, pause and continue program execution for precise inspection, evaluate expressions at runtime, and view call stacks and strands. These features enhance the debugging experience, enabling effective troubleshooting and analysis of Ballerina code.
 
->**Info:** For detailed information on the feature-rich debugging experience for troubleshooting Ballerina applications provided via the Ballerina VS Code extension, go to <a href="https://wso2.com/ballerina/vscode/docs/debug-the-code/debugging-features/" target="_blank">Debugging features</a>.
+>**Info:** For detailed information on the feature-rich debugging experience for troubleshooting Ballerina applications provided via the Ballerina VS Code extension, go to <a href="https://wso2.com/ballerina/vscode/docs/debug-the-code/debug-features/" target="_blank">Debugging features</a>.
+
+## Debugging configurations
+
+The Ballerina debugger allows you to create a `launch.json` file with default configurations for debugging Ballerina programs. You can generate the file by following a few steps and then, modify the configurations to suit your needs. These configurations have specific attributes that can be edited to customize the debugging process so that you can set program arguments, command options, environment variables, run in a separate terminal, etc. Additionally, you can configure remote debugging by specifying the host address and port number. These configurations provide flexibility and control when debugging Ballerina code in VS Code.
+
+>**Info:** For more information on the debugging configurations, go to <a href="https://wso2.com/ballerina/vscode/docs/debug-the-code/debug-configurations/" target="_blank">Debugging configurations</a>.

--- a/swan-lake/why-ballerina/graphical.md
+++ b/swan-lake/why-ballerina/graphical.md
@@ -25,7 +25,7 @@ One of the key benefits of the diagram is that it acts as a documentation of the
 
 ### Get started
 
-The <a href="https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina" target="_blank">Ballerina extension for Visual Studio Code</a> can generate a sequence diagram dynamically from the source code. To start generating a sequence diagram from your Ballerina code, <a href="https://wso2.com/ballerina/vscode/docs/visual-programming/sequence-diagram-view/" target="_blank">download</a> the VS Code extension and launch the graphical viewer.
+The <a href="https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina" target="_blank">Ballerina extension for Visual Studio Code</a> can generate a sequence diagram dynamically from the source code. To start generating a sequence diagram from your Ballerina code, <a href="https://wso2.com/ballerina/vscode/docs/implement-the-code/sequence-diagram-view/" target="_blank">download</a> the VS Code extension and launch the graphical viewer.
 
 
 ## Graphical representation


### PR DESCRIPTION
## Purpose
Fix VS Code links after revamp.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
