### PR TITLE
Update the VS Code home page in Learn

### DIFF
--- a/components/learn/intro/Intro.js
+++ b/components/learn/intro/Intro.js
@@ -76,7 +76,7 @@ export default function Intro() {
                         </a>
                     </Col>
                     <Col xs={12} md={3} lg={3} className={styles.introCard}>
-                        <a href={`https://wso2.com/ballerina/vscode/docs/`} className={`${styles.cardWrapper} ${styles.secondary}`} target='_blank' rel="noreferrer">
+                        <a href={`https://wso2.com/ballerina/vscode/`} className={`${styles.cardWrapper} ${styles.secondary}`} target='_blank' rel="noreferrer">
                             <div>
                                 <h3>VS Code extension</h3>
                                 <div className={styles.cardDescription}>


### PR DESCRIPTION
## Purpose
Update the VS Code home page in Learn.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
