### PR TITLE
Fix VS Code links in more pages

### DIFF
--- a/components/integration/ballerina-vs-apollo-for-graphql/code/apollo-graphql-bbe/designer-tool.md
+++ b/components/integration/ballerina-vs-apollo-for-graphql/code/apollo-graphql-bbe/designer-tool.md
@@ -2,5 +2,5 @@
 title: "Built-in designer tool for GraphQL"
 description: "Explore the boundless possibilities with the in-built GraphQL API designer, a visual tool in the Ballerina VS Code plugin. Effortlessly design and prototype GraphQL APIs, unlocking a seamless and intuitive development experience. Empower your GraphQL services with this exceptional visual designer tool."
 image: "images/usecases/integration/apollo-graphql/graphql-diagram-editor.png"
-url: "https://wso2.com/ballerina/vscode/docs/visual-programming/graphql-designer/"
+url: "https://wso2.com/ballerina/vscode/docs/design-the-services/graphql-api-designer/"
 ---

--- a/downloads/swan-lake-release-notes/swan-lake-preview3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview3/RELEASE_NOTE.md
@@ -212,7 +212,7 @@ Furthermore, the line with the error would be replaced with a function call as s
 Grade grades = mapNameAndGradeToGrade(student);
 ```
 
-For more information, see [Code Actions](https://wso2.com/ballerina/vscode/docs/edit-the-code/code-actions/).
+For more information, see [Code actions](https://wso2.com/ballerina/vscode/docs/write-the-code/code-actions/).
 
 ##### Test framework
 

--- a/swan-lake/featured-scenarios/build-a-data-service-in-ballerina.md
+++ b/swan-lake/featured-scenarios/build-a-data-service-in-ballerina.md
@@ -15,7 +15,7 @@ To complete this tutorial, you need:
 1. [Ballerina 2201.0.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
   >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the 
-  <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+  <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal
 
 ## Understand the implementation

--- a/swan-lake/featured-scenarios/deploy-ballerina-on-kubernetes.md
+++ b/swan-lake/featured-scenarios/deploy-ballerina-on-kubernetes.md
@@ -16,7 +16,7 @@ To complete this tutorial, you need:
 
 1. [Ballerina 2201.0.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
-    >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+    >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal
 4. [Docker](https://www.docker.com/) installed and configured in your machine
 5. A [Docker Hub](https://hub.docker.com/) account

--- a/swan-lake/featured-scenarios/manage-data-persistence-with-bal-persist.md
+++ b/swan-lake/featured-scenarios/manage-data-persistence-with-bal-persist.md
@@ -21,7 +21,7 @@ To complete this tutorial, you need:
 1. [Ballerina 2201.6.0 (Swan Lake)](/learn/get-started/) or greater
 2. A text editor
 >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the
-<a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+<a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal
 
 ## Understand the implementation

--- a/swan-lake/featured-scenarios/work-with-data-using-queries-in-ballerina.md
+++ b/swan-lake/featured-scenarios/work-with-data-using-queries-in-ballerina.md
@@ -16,7 +16,7 @@ To run this guide, you need the following prerequisites:
 
 1. [Ballerina 2201.0.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
-    >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+    >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal
 
 ## Create the Ballerina package

--- a/swan-lake/featured-scenarios/write-a-graphql-api-with-ballerina.md
+++ b/swan-lake/featured-scenarios/write-a-graphql-api-with-ballerina.md
@@ -16,7 +16,7 @@ To complete this tutorial, you need:
 
 1. [Ballerina 2201.0.0 (Swan Lake) ](/downloads/) or greater
 2. A text editor
-    >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+    >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal
 
 ## Design the GraphQL endpoint

--- a/swan-lake/featured-scenarios/write-a-grpc-service-with-ballerina.md
+++ b/swan-lake/featured-scenarios/write-a-grpc-service-with-ballerina.md
@@ -14,7 +14,7 @@ To complete this tutorial, you need:
 
 1. [Ballerina 2201.0.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
-  >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+  >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal
 
 ## Understand the implementation

--- a/swan-lake/featured-scenarios/write-a-restful-api-with-ballerina.md
+++ b/swan-lake/featured-scenarios/write-a-restful-api-with-ballerina.md
@@ -14,7 +14,7 @@ To complete this tutorial, you need:
 
 1. [Ballerina 2201.0.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
-    >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the  <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+    >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the  <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina extension</a> installed.
 3. A command terminal
 
 ## Understand the implementation

--- a/swan-lake/learn-the-platform/ballerina-tooling/asyncapi-tool.md
+++ b/swan-lake/learn-the-platform/ballerina-tooling/asyncapi-tool.md
@@ -17,7 +17,7 @@ To run this tutorial, you need the following prerequisites:
 1. [Ballerina 2202.1.0 (Swan Lake)](/downloads/) or greater
 2. A text editor
   >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the 
-  <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+  <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina extension</a> installed.
 
 ## Prepare the AsyncAPI contract
 

--- a/swan-lake/learn-the-platform/native-support/build-a-native-executable.md
+++ b/swan-lake/learn-the-platform/native-support/build-a-native-executable.md
@@ -181,7 +181,7 @@ Now, you have built and tested a native executable locally for a simple Ballerin
 To complete this part of the guide, you need:
 1. [Ballerina 2201.3.0 (Swan Lake)](/learn/install-ballerina/set-up-ballerina/) or greater
 2. A text editor
-   >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the  <a href="https://wso2.com/ballerina/vscode/docs/get-started/install-the-extension/" target="_blank">Ballerina extension</a> installed.
+   >**Tip:** Preferably, <a href="https://code.visualstudio.com/" target="_blank">Visual Studio Code</a> with the  <a href="https://wso2.com/ballerina/vscode/docs/" target="_blank">Ballerina extension</a> installed.
 3. [Docker](https://www.docker.com) installed and configured in your machine
    >**Tip:** Since the GraalVM native build consumes a significant amount of memory, it is recommended to increase the memory allocated to Docker to at least 8GB and potentially add more CPUs as well. For more details, see [How to assign more memory to Docker container](https://stackoverflow.com/questions/44533319/how-to-assign-more-memory-to-docker-container/44533437#44533437).
 4. A command terminal


### PR DESCRIPTION
## Purpose
Fix VS Code links in more pages.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
