### PR TITLE
[2201.7.0] - Add installer verification section to Update 7 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.0/RELEASE_NOTE.md
@@ -26,6 +26,11 @@ Update your current Ballerina installation directly to 2201.7.0 using the [Balle
 
 If you have not installed Ballerina, download the [installers](/downloads/#swanlake) to install.
 
+### Ballerina artifacts verification
+
+From this release onwards, you can verify Ballerina artifacts using the Cosign CLI and Rekor APIs. For more information, see [Verify Ballerina artifacts](/downloads/verify-ballerina-artifacts).
+
+
 ## Backward-incompatible changes
 
 - A bug that allowed using a function reference of a non-`isolated` function type in a function or method call expression within an `isolated` function or method has been fixed.
@@ -85,10 +90,6 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
 ### Official support for generating GraalVM native executables
 
 Ballerina now officially supports generating GraalVM native executables and the language and the standard libraries are compatible with the GraalVM native executable generation. In addition to that, GraalVM incompatibility warnings will be printed for any incompatible modules in the application. To explore more on this support, see [Build a GraalVM executable](/learn/graalvm-executable-overview/).
-
-### Ballerina artifacts verification
-
-From this release onwards, you can verify Ballerina artifacts using the Cosign CLI and Rekor APIs. For more information, see [Verify Ballerina artifacts](/downloads/verify-ballerina-artifacts).
 
 ## Language updates
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.0/RELEASE_NOTE.md
@@ -26,10 +26,7 @@ Update your current Ballerina installation directly to 2201.7.0 using the [Balle
 
 If you have not installed Ballerina, download the [installers](/downloads/#swanlake) to install.
 
-### Ballerina artifacts verification
-
-From this release onwards, you can verify Ballerina artifacts using the Cosign CLI and Rekor APIs. For more information, see [Verify Ballerina artifacts](/downloads/verify-ballerina-artifacts).
-
+>**Info:** From this release onwards, you can verify Ballerina artifacts using the Cosign CLI and Rekor APIs. For more information, see [Verify Ballerina artifacts](/downloads/verify-ballerina-artifacts).
 
 ## Backward-incompatible changes
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.0/RELEASE_NOTE.md
@@ -50,7 +50,7 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
   
 - A bug that caused the broader type to be used instead of the singleton type when a constant is used as a type descriptor has been fixed.
 
-  For example, the code below may result in a compilation error now since `num`, which is of type `CONST` can only be integer `8`.
+  This may result in a compilation error now since `num`, which is of type `CONST` can only be integer `8`.
 
     ```ballerina
     const int CONST = 1 + 7;
@@ -100,7 +100,7 @@ The language now supports the `group by` and `collect` clauses to perform aggreg
 
 ##### The `group by` clause
 
-The `group by` clause is used to group a collection based on a `grouping-key` as shown in the example below. The `grouping-key` will be unique to each group.
+The `group by` clause is used to group a collection based on a grouping-key as shown in the example below. The grouping-key will be unique to each group.
 
 ```ballerina
 import ballerina/io;

--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.0/RELEASE_NOTE.md
@@ -86,6 +86,10 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
 
 Ballerina now officially supports generating GraalVM native executables and the language and the standard libraries are compatible with the GraalVM native executable generation. In addition to that, GraalVM incompatibility warnings will be printed for any incompatible modules in the application. To explore more on this support, see [Build a GraalVM executable](/learn/graalvm-executable-overview/).
 
+### Ballerina artifacts verification
+
+From this release onwards, you can verify Ballerina artifacts using the Cosign CLI and Rekor APIs. For more information, see [Verify Ballerina artifacts](/downloads/verify-ballerina-artifacts).
+
 ## Language updates
 
 ### New features


### PR DESCRIPTION
## Purpose
Add installer verification section to Update 7 release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
