### PR TITLE
Remove standard library bug fixes from 2201.5.1

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.1/RELEASE_NOTE.md
@@ -12,7 +12,7 @@ redirect_from:
 
 ## Overview of Ballerina Swan Lake 2201.5.1
 
-<em>Swan Lake 2201.5.1 is the first patch release of Ballerina 2201.5.0 (Swan Lake Update 5) and it includes a new set of bug fixes to the language, tooling, and standard library.</em>
+<em>Swan Lake 2201.5.1 is the first patch release of Ballerina 2201.5.0 (Swan Lake Update 5) and it includes a new set of bug fixes to the language and tooling.</em>
 
 ## Update Ballerina
 
@@ -30,12 +30,6 @@ If you have not installed Ballerina, then, download the [installers](/downloads/
 ### Bug fixes
 
 To view bug fixes, see the [GitHub milestone for 2201.5.1 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.5.1+label%3AType%2FBug+is%3Aclosed).
-
-## Standard library updates
-
-### Bug fixes
-
-To view bug fixes, see the [GitHub milestone for 2201.5.1 (Swan Lake)](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aissue+milestone%3A2201.5.1+label%3AType%2FBug+is%3Aclosed+).
 
 ## Developer tools updates
 


### PR DESCRIPTION
## Purpose
Remove standard library bug fixes from the 2201.5.1 release note as we do not have any.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
