### PR TITLE
Update 2201.6.1 release note tooling bug fixes link

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.1/RELEASE_NOTE.md
@@ -48,4 +48,4 @@ To view bug fixes, see the [GitHub milestone for 2201.6.1 (Swan Lake)](https://g
 
 ### Bug fixes
 
-To view bug fixes, see the [GitHub milestone for 2201.6.1 (Swan Lake)][OpenAPI Tool](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+milestone%3A%22Swan+Lake+2201.6.1%22+label%3AType%2FBug+is%3Aclosed+).
+To view bug fixes, see the [GitHub milestone for 2201.6.1 (Swan Lake)](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+milestone%3A%22Swan+Lake+2201.6.1%22+label%3AType%2FBug+is%3Aclosed+).


### PR DESCRIPTION
## Purpose
Update 2201.6.1 release note tooling bug fixes link.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
