### PR TITLE
Update C2C learn page path

### DIFF
--- a/components/learn/platform/Platform.js
+++ b/components/learn/platform/Platform.js
@@ -125,7 +125,7 @@ export default function Platform(props) {
 
             <div className={styles.content}>
               <p className={styles.title}>
-                <a href={`${prefix}/learn/run-in-the-cloud/code-to-cloud-deployment`} className={styles.titleLink}>
+                <a href={`${prefix}/learn/run-in-the-cloud/code-to-cloud/code-to-cloud-deployment`} className={styles.titleLink}>
                   Code to cloud deployment
                 </a>
               </p>

--- a/utils/learn-lm.json
+++ b/utils/learn-lm.json
@@ -523,7 +523,7 @@
                             "level": 3,
                             "position": 1,
                             "isDir": false,
-                            "url": "/learn/run-in-the-cloud/code-to-cloud-deployment",
+                            "url": "/learn/run-in-the-cloud/code-to-cloud/code-to-cloud-deployment",
                             "id": "code-to-cloud-deployment"
             
                         },


### PR DESCRIPTION
## Purpose
Update C2C learn page path.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
