### PR TITLE
Fix broken links after FaaS doc changes

### DIFF
--- a/swan-lake/featured-scenarios/deploy-ballerina-on-kubernetes.md
+++ b/swan-lake/featured-scenarios/deploy-ballerina-on-kubernetes.md
@@ -155,5 +155,5 @@ horizontalpodautoscaler.autoscaling/greeter-hpa created
 
 ## Learn more
 
-For in-depth information about executing these deployed applications and the supported customizations in code to cloud, see [Code to Cloud deployment](/learn/run-in-the-cloud/code-to-cloud/code-to-cloud-deployment/).
+For in-depth information about executing these deployed applications and the supported customizations in code to cloud, see [Code to Cloud deployment](/learn/run-in-the-cloud/code-to-cloud-deployment).
  

--- a/swan-lake/learn-the-platform/run-in-the-cloud/function-as-a-service/aws-lambda.md
+++ b/swan-lake/learn-the-platform/run-in-the-cloud/function-as-a-service/aws-lambda.md
@@ -93,11 +93,6 @@ To deploy the function, execute the command, which you get in the CLI output log
 
 In a more practical scenario, the AWS Lambda functions will be used by associating them with an external event source such as Amazon DynamoDB or Amazon SQS. For more information on this, go to <a href="https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html" target="_blank">AWS Lambda event source mapping documentation</a>.
 
-For examples of the usage of AWS Lambda functions, see the below.
-
-- [Hello world](/learn/by-example/aws-lambda-hello-world/)
-- [Execution context](/learn/by-example/aws-lambda-execution-context/)
-- [S3 trigger](/learn/by-example/aws-lambda-s3-trigger/)
-- [DynamoDB trigger](/learn/by-example/aws-lambda-dynamodb-trigger/)
+For an example of the usage of AWS Lambda functions, see [AWS Lambda](/learn/by-example/aws-lambda-deployment/).
 
 <style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/swan-lake/learn-the-platform/run-in-the-cloud/function-as-a-service/azure-functions.md
+++ b/swan-lake/learn-the-platform/run-in-the-cloud/function-as-a-service/azure-functions.md
@@ -142,9 +142,4 @@ $ func azure functionapp publish <function_app_name> --script-root target/azure_
 
 ## Examples
 
-For examples of the usage of Azure Functions, see the below.
-
-- [Hello world](/learn/by-example/azure-functions-hello-world/)
-- [HTTP trigger with queue](/learn/by-example/azure-functions-http-trigger-with-queue/)
-- [Timer trigger](/learn/by-example/azure-functions-timer-trigger/)
-- [Cosmos DB trigger](/learn/by-example/azure-functions-cosmosdb-trigger/)
+For an example of the usage of Azure Functions, see [Azure Functions](learn/by-example/azure-functions-deployment/).

--- a/swan-lake/why-ballerina/graphical.md
+++ b/swan-lake/why-ballerina/graphical.md
@@ -8,7 +8,7 @@ permalink: /why-ballerina/graphical/
 active: graphical
 ---
 
-In today’s cloud era, you need technologies that can model distributed systems in a more developer-friendly way. The feature-rich development experience of the [Ballerina Visual Studio code extension](/vscode/) brings in graphical representations for designing the architecture of your applications, designing and editing your services, modeling how concurrent execution flows and how multiple actors interact with each other, and mapping the data conversions within your applications.
+In today’s cloud era, you need technologies that can model distributed systems in a more developer-friendly way. The feature-rich development experience of the [Ballerina Visual Studio code extension](https://marketplace.visualstudio.com/items?itemName=WSO2.ballerina) brings in graphical representations for designing the architecture of your applications, designing and editing your services, modeling how concurrent execution flows and how multiple actors interact with each other, and mapping the data conversions within your applications.
 
 Ballerina provides the flexibility of a general-purpose language with the capabilities to model and visualize solutions based on higher-level abstractions derived from the graphical representations provided by its developer tooling features as described below.
 


### PR DESCRIPTION
## Purpose
Fix broken links after FaaS doc changes.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
