### PR TITLE
Remove archived DZone article

### DIFF
--- a/components/community/resources/articles/Articles.js
+++ b/components/community/resources/articles/Articles.js
@@ -147,12 +147,6 @@ export default function Articles() {
             </div>
 
             <div className={styles.articleInfo}>
-              <a target="_blank" rel="noreferrer" href="https://dzone.com/articles/utilising-binding-patterns-in-ballerina"><h4>Using Binding Patterns in Ballerina</h4></a>
-              <p> By Suleka Helmini</p>
-              <p> 20 Oct 2021</p>
-            </div>
-
-            <div className={styles.articleInfo}>
               <a target="_blank" rel="noreferrer" href="https://dzone.com/articles/binding-patterns-in-ballerina"><h4>Binding Patterns in Ballerina</h4></a>
               <p> By Suleka Helmini</p>
               <p> 19 Oct 2021</p>


### PR DESCRIPTION
## Purpose
Remove archived DZone article.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
