### PR TITLE
Revert the Learn page

### DIFF
--- a/components/learn/boxes/Boxes.js
+++ b/components/learn/boxes/Boxes.js
@@ -15,15 +15,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 import * as React from 'react';
 import { Row, Col, Container } from 'react-bootstrap';
-
 import styles from './Boxes.module.css';
 import { prefix } from '../../../utils/prefix';
-
 export default function Boxes(props) {
-
   return (
     <>
       {/* <Container> */}
@@ -46,7 +42,6 @@ export default function Boxes(props) {
           </h2>
         </Col>
       </Row> */}
-
       {/* <Container className=" text-center">
   <Row className="gy-5 gx-5">
     <Col xs={6} style={{border:"1px solid #000000"}}>
@@ -63,8 +58,6 @@ export default function Boxes(props) {
     </Col>
   </Row>
 </Container> */}
-
-
       <Row className="pageContentRow llanding" >
         <Col xs={12}>
           <Container>
@@ -72,7 +65,7 @@ export default function Boxes(props) {
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
-                    <h3>Integration</h3>
+                    <h3>Integrations</h3>
                     <div className={styles.cardDescription}>
                       <div className={styles.content}>
                         <p className={styles.title}>
@@ -80,7 +73,7 @@ export default function Boxes(props) {
                             Integration examples
                           </a>
                         </p>
-                        <p className={styles.description}>Explore and try out a series of guided integration examples.</p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
 
                       <div className={styles.content}>
@@ -89,7 +82,7 @@ export default function Boxes(props) {
                             Enterprise Integration Patterns (EIP)
                           </a>
                         </p>
-                        <p className={styles.description}>Learn how common EIPs can be implemented using Ballerina.</p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
 
                       <div className={styles.content}>
@@ -98,38 +91,36 @@ export default function Boxes(props) {
                             Integration tutorials
                           </a>
                         </p>
-                        <p className={styles.description}>Explore and try out a series of guided integration tutorials.</p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
 
                       <div className={styles.content}>
                         <p className={styles.title}>
-                          <a href={`${prefix}/learn/supported-network-protocols`} className={styles.titleLink}>
+                          <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
                             Supported network integration protocols
                           </a>
                         </p>
-                        <p className={styles.description}>Details of the list of network integration protocols supported by Ballerina.</p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
 
                       <div className={styles.content}>
                         <p className={styles.title}>
-                          <a href={`${prefix}/learn/supported-data-formats`} className={styles.titleLink}>
+                          <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
                             Supported data formats
                           </a>
                         </p>
-                        <p className={styles.description}>Details of the list of data formats supported by Ballerina.</p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
 
                     </div>
                   </div>
                 </div>
               </Col>
-
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
                     <h3>Integration technology tools</h3>
                     <div className={styles.cardDescription}>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/openapi-tool`} className={styles.titleLink}>
@@ -137,7 +128,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details of the Ballerina OpenAPI tool.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/graphql-tool`} className={styles.titleLink}>
@@ -146,7 +136,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details of the Ballerina GraphQL tool.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/asyncapi-tool`} className={styles.titleLink}>
@@ -155,7 +144,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details of the Ballerina AsyncAPI tool.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/asyncapi-tool`} className={styles.titleLink}>
@@ -167,28 +155,17 @@ export default function Boxes(props) {
 
                       <div className={styles.content}>
                         <p className={styles.title}>
-                          <a href={`${prefix}/learn/health-tool`} className={styles.titleLink}>
-                            Health tool (FHIR/HL7)
+                          <a href={`${prefix}/learn/asyncapi-tool`} className={styles.titleLink}>
+                            FHIR tool
                           </a>
                         </p>
                         <p className={styles.description}>Details of the Ballerina FHIR profile to client and stub generation tool.</p>
-                      </div>
-
-
-                      <div className={styles.content}>
-                        <p className={styles.title}>
-                          <a href={`${prefix}/learn/edi-tool`} className={styles.titleLink}>
-                            EDI tool 
-                          </a>
-                        </p>
-                        <p className={styles.description}>The set of command line tools provided to work with EDI files in Ballerina.</p>
                       </div>
 
                     </div>
                   </div>
                 </div>
               </Col>
-
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
@@ -197,7 +174,7 @@ export default function Boxes(props) {
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/get-started`} className={styles.titleLink}>
-                            Get started
+                            Get started with Ballerina
                           </a>
                         </p>
                         <p className={styles.description}>Install Ballerina, set it all up, and take it for a spin.</p>
@@ -218,7 +195,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Refer Ballerina library (API) documentation.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/ballerina-specifications`} className={styles.titleLink}>
@@ -227,7 +203,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Refer language, library, and platform specifications.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a target='_blank' rel="noreferrer" href="https://wso2.com/ballerina/vscode/docs/" className={styles.titleLink}>
@@ -235,11 +210,20 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details of the Ballerina Visual Studio Code extension.</p>
                       </div>
+
+                      <div className={styles.content}>
+                        <p className={styles.title}>
+                          <a href={`${prefix}/learn/cli-documentation/cli-commands`} className={styles.titleLink}>
+                            CLI documentation
+                          </a>
+                        </p>
+                        <p className={styles.description}>Details of the CLI commands of the bal tool.</p>
+                      </div>
+
                     </div>
                   </div>
                 </div>
               </Col>
-
               {/* <Col xs={12} md={3} lg={3} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
@@ -253,7 +237,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -262,7 +245,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -271,7 +253,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -280,7 +261,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -289,7 +269,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -298,7 +277,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -307,7 +285,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -316,7 +293,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -325,7 +301,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -334,7 +309,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -343,7 +317,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -352,12 +325,10 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                     </div>
                   </div>
                 </div>
               </Col>
-
               <Col xs={12} md={3} lg={3} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
@@ -365,13 +336,12 @@ export default function Boxes(props) {
                     <div className={styles.cardDescription}>
                       <div className={styles.content}>
                         <p className={styles.title}>
-                          <a href={`${prefix}/learn/integration/supported-data-formats`} className={styles.titleLink}>
+                          <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
                             JSON
                           </a>
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -380,7 +350,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -389,7 +358,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -398,7 +366,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -407,7 +374,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -416,7 +382,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -425,7 +390,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -434,7 +398,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -443,7 +406,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
@@ -460,9 +422,6 @@ export default function Boxes(props) {
           </Container>
         </Col>
       </Row>
-
-
-
       <Row className="pageContentRow llanding" style={{ background: "#eeeeee" }}>
         <Col xs={12}>
           <Container>
@@ -479,21 +438,29 @@ export default function Boxes(props) {
                     <div className={styles.cardDescription}>
                       <div className={styles.content}>
                         <p className={styles.title}>
-                          <a href={`/learn/cli-documentation/cli-commands/`} className={styles.titleLink}>
+                          <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
+                            Quick run: via VSCode
+                          </a>
+                        </p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
+                      </div>
+
+                      <div className={styles.content}>
+                        <p className={styles.title}>
+                          <a href={`${prefix}/learn2/#`} className={styles.titleLink}>
                             Bal command
                           </a>
                         </p>
-                        <p className={styles.description}>Details of the CLI commands of the bal tool.</p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
                     </div>
                   </div>
                 </div>
               </Col>
-
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
-                    <h3>Organize source code and dependencies</h3>
+                    <h3>Organize source code &amp; dependencies</h3>
                     <div className={styles.cardDescription}>
                       <div className={styles.content}>
                         <p className={styles.title}>
@@ -503,7 +470,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Basics of projects, packages, and modules.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/package-references`} className={styles.titleLink}>
@@ -512,7 +478,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>References related to Ballerina Packages.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/manage-dependencies`} className={styles.titleLink}>
@@ -521,7 +486,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details of declaring and managing dependencies and using the local repository.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/style-guide/coding-conventions`} className={styles.titleLink}>
@@ -530,16 +494,14 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Best practices to follow when formatting Ballerina code.</p>
                       </div>
-
                     </div>
                   </div>
                 </div>
               </Col>
-
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
-                    <h3>Test, debug, and document the code</h3>
+                    <h3>Test, debug and document the code</h3>
                     <div className={styles.cardDescription}>
                       <div className={styles.content}>
                         <p className={styles.title}>
@@ -549,7 +511,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details of writing automated tests using the built-in test framework.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/debug-ballerina-programs`} className={styles.titleLink}>
@@ -558,7 +519,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details of tooling support for troubleshooting Ballerina applications.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/strand-dump-tool`} className={styles.titleLink}>
@@ -567,7 +527,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details of the Ballerina strand dump tool.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/generate-code-documentation`} className={styles.titleLink}>
@@ -580,10 +539,7 @@ export default function Boxes(props) {
                   </div>
                 </div>
               </Col>
-
             </Row>
-
-
             <Row>
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
@@ -598,7 +554,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details on how to simplify data persistence with <code>bal persist</code>.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/persist-model`} className={styles.titleLink}>
@@ -607,7 +562,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details on how to model and define data structures for efficient data persistence.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/persist-cli-tool`} className={styles.titleLink}>
@@ -616,7 +570,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details on how to use the tool for generating client code and types for the data model.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/persist-client-api`} className={styles.titleLink}>
@@ -625,7 +578,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Details on generated client, types, and their usages for managing data persistence.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/supported-data-stores`} className={styles.titleLink}>
@@ -638,7 +590,6 @@ export default function Boxes(props) {
                   </div>
                 </div>
               </Col>
-
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
@@ -652,14 +603,13 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Generating cloud deployment artifacts.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/run-in-the-cloud/function-as-a-service/azure-functions/`} className={styles.titleLink}>
-                            Azure Functions
+                            Azure Function
                           </a>
                         </p>
-                        <p className={styles.description}>Details of Azure Functions related functionalities.</p>
+                        <p className={styles.description}>Details of Azure Function.</p>
                       </div>
 
                       <div className={styles.content}>
@@ -668,18 +618,17 @@ export default function Boxes(props) {
                             AWS Lambda
                           </a>
                         </p>
-                        <p className={styles.description}>Details of AWS Lambda related functionalities.</p>
+                        <p className={styles.description}>Details of AWS Lambda.</p>
                       </div>
 
                     </div>
                   </div>
                 </div>
               </Col>
-
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
-                    <h3>Configurability</h3>
+                    <h3>Configure and observe</h3>
                     <div className={styles.cardDescription}>
                       <div className={styles.content}>
                         <p className={styles.title}>
@@ -689,15 +638,7 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>The language support for configurability.</p>
                       </div>
-                    </div>
-                  </div>
-                </div>
-              </Col>
-              <Col xs={12} md={4} lg={4} className={styles.boxCol}>
-                <div className={styles.cardWrapper}>
-                  <div>
-                    <h3>Observability</h3>
-                    <div className={styles.cardDescription}>
+
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/observe-ballerina-programs`} className={styles.titleLink}>
@@ -705,33 +646,11 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Basics of the observability functionalities that are provided for Ballerina programs.</p>
                       </div>
-                      <div className={styles.content}>
-                        <p className={styles.title}>
-                          <a href={`${prefix}/learn/observe-ballerina-programs`} className={styles.titleLink}>
-                            Observe logs</a>
-                        </p>
-                        <p className={styles.description}>Details of how Ballerina supports observing logs of external systems.</p>
-                      </div>
-                      <div className={styles.content}>
-                        <p className={styles.title}>
-                          <a href={`${prefix}/learn/observe-ballerina-programs`} className={styles.titleLink}>
-                            Observe metrics</a>
-                        </p>
-                        <p className={styles.description}>Details of how Ballerina supports observing metrics of external systems.</p>
-                      </div>
-                      <div className={styles.content}>
-                        <p className={styles.title}>
-                          <a href={`${prefix}/learn/observe-ballerina-programs`} className={styles.titleLink}>
-                            Observe tracing</a>
-                        </p>
-                        <p className={styles.description}>Details of how Ballerina supports observing tracing of external systems.</p>
-                      </div>
                     </div>
                   </div>
                 </div>
               </Col>
             </Row>
-
             <Row>
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
@@ -741,12 +660,11 @@ export default function Boxes(props) {
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/call-java-code-from-ballerina`} className={styles.titleLink}>
-                            Details of how to call Java code from Ballerina.
+                            Call Java code from Ballerina
                           </a>
                         </p>
                         <p className={styles.description}>Calling Java code from Ballerina.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/java-interoperability-guide/java-interoperability`} className={styles.titleLink}>
@@ -759,7 +677,6 @@ export default function Boxes(props) {
                   </div>
                 </div>
               </Col>
-
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
@@ -773,7 +690,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>The overview of GraalVM and the native executable.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/build-the-executable-in-a-container`} className={styles.titleLink}>
@@ -782,7 +698,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Building and packing the GraalVM executable in a container.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/build-the-executable-locally`} className={styles.titleLink}>
@@ -791,12 +706,10 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Building the GraalVM executable locally from Ballerina.</p>
                       </div>
-
                     </div>
                   </div>
                 </div>
               </Col>
-
               <Col xs={12} md={4} lg={4} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
@@ -818,24 +731,15 @@ export default function Boxes(props) {
           </Container>
         </Col>
       </Row>
-
-
-
-
-
       <Row className="pageContentRow llanding" >
         <Col xs={12}>
           <Container>
-
             <Row>
               <Col xs={12}>
                 <h2>Resources</h2>
               </Col>
             </Row>
-
-
             <Row>
-
               <Col xs={12} md={6} lg={6} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
@@ -849,7 +753,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Use Ballerina constructs to create RESTful APIs.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/write-a-grpc-service-with-ballerina/`} className={styles.titleLink}>
@@ -858,7 +761,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Write and invoke a simple Ballerina gRPC service.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/manage-data-persistence-with-bal-persist/`} className={styles.titleLink}>
@@ -867,7 +769,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Use <code>bal persist</code> to simplify data persistence management.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/write-a-graphql-api-with-ballerina/`} className={styles.titleLink}>
@@ -876,7 +777,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Write and invoke a simple Ballerina GraphQL service.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/work-with-data-using-queries-in-ballerina/`} className={styles.titleLink}>
@@ -885,7 +785,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Use query expressions to work with data.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/build-a-data-service-in-ballerina/`} className={styles.titleLink}>
@@ -894,7 +793,6 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Use Ballerina constructs to work with data services.</p>
                       </div>
-
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/deploy-ballerina-on-kubernetes/`} className={styles.titleLink}>
@@ -903,12 +801,10 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Write, build, and deploy a Ballerina service on Kubernetes.</p>
                       </div>
-
                     </div>
                   </div>
                 </div>
               </Col>
-
               <Col xs={12} md={6} lg={6} className={styles.boxCol}>
                 <div className={styles.cardWrapper}>
                   <div>
@@ -920,32 +816,51 @@ export default function Boxes(props) {
                           Language basics
                           </a>
                         </p>
-                        <p className={styles.description}>Get started with basics that are common to all C-Family programming languages.</p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
+                      </div>
+
+                      <div className={styles.content}>
+                        <h4>
+                          Distinctive language features
+                        </h4>
+                      </div>
+
+                      <div className={`${styles.content} ${styles.sub}`}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/distinctive-language-features/network-interaction`} className={styles.titleLink}>
                           Network interaction
                           </a>
                         </p>
-                        <p className={styles.description}>The features of the Ballerina programming language that are distinctive. </p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
+                      </div>
+
+                      <div className={`${styles.content} ${styles.sub}`}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/distinctive-language-features/data`} className={styles.titleLink}>
                             Data
                           </a>
                         </p>
-                        <p className={styles.description}>Some of the plain data supported by Ballerina that we have not covered in the last part, specifically, tables and XML types.</p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
+                      </div>
+
+                      <div className={`${styles.content} ${styles.sub}`}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/distinctive-language-features/concurrency`} className={styles.titleLink}>
                           Concurrency
                           </a>
                         </p>
-                        <p className={styles.description}>How concurrency and transactions are handled in Ballerina.</p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
+                      </div>
+
+                      <div className={`${styles.content} ${styles.sub}`}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/distinctive-language-features/advanced-general-purpose-language-features`} className={styles.titleLink}>
                           Advanced general purpose language features
                           </a>
                         </p>
-                        <p className={styles.description}>Advanced features which are a mixed bag of additional options to the language.</p>
+                        <p className={styles.description}>Lorem Ipsum is simply dummy text of the printing and typesetting industry.</p>
                       </div>
+
                     </div>
                   </div>
                 </div>
@@ -954,6 +869,9 @@ export default function Boxes(props) {
           </Container>
         </Col>
       </Row>
+
+
+
       {/* </Container> */}
 
     </>


### PR DESCRIPTION
## Purpose
Revert the Learn page.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
