### PR TITLE
Update the tooling link in the 2201.7.2 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.2/RELEASE_NOTE.md
@@ -35,7 +35,7 @@ To view bug fixes, see the [GitHub milestone for 2201.7.2 (Swan Lake)](https://g
 
 ### Bug fixes
 
-To view bug fixes, see the [GitHub milestone for 2201.7.2 (Swan Lake)](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aissue+label%3AType%2FBug+is%3Aclosed+milestone%3A2201.7.2).
+To view bug fixes, see the [GitHub milestone for 2201.7.2 (Swan Lake)](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+label%3AType%2FBug+is%3Aclosed+milestone%3A%22Swan+Lake+2201.7.2%22).
 
 ## Developer tools updates
 


### PR DESCRIPTION

## Purpose
Update the tooling link in the 2201.7.2 release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
