### PR TITLE
Fix learn run in cloud pages

### DIFF
--- a/components/learn/boxes/Boxes.js
+++ b/components/learn/boxes/Boxes.js
@@ -322,7 +322,7 @@ export default function Boxes(props) {
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/bal-persist-overview`} className={styles.titleLink}>
-                            Overview
+                          Bal persist overview
                           </a>
                         </p>
                         <p className={styles.description}>How to simplify data persistence with <code>bal persist</code>.</p>
@@ -370,7 +370,7 @@ export default function Boxes(props) {
                     <div className={styles.cardDescription}>
                       <div className={styles.content}>
                         <p className={styles.title}>
-                          <a href={`${prefix}/learn/run-in-the-cloud/code-to-cloud-deployment`} className={styles.titleLink}>
+                          <a href={`${prefix}/learn/code-to-cloud-deployment`} className={styles.titleLink}>
                             Code to cloud deployment
                           </a>
                         </p>
@@ -378,7 +378,7 @@ export default function Boxes(props) {
                       </div>
                       <div className={styles.content}>
                         <p className={styles.title}>
-                          <a href={`${prefix}/learn/run-in-the-cloud/azure-functions/`} className={styles.titleLink}>
+                          <a href={`${prefix}/learn/azure-functions/`} className={styles.titleLink}>
                             Azure Function
                           </a>
                         </p>
@@ -387,7 +387,7 @@ export default function Boxes(props) {
 
                       <div className={styles.content}>
                         <p className={styles.title}>
-                          <a href={`${prefix}/learn/run-in-the-cloud/aws-lambda/`} className={styles.titleLink}>
+                          <a href={`${prefix}/learn/aws-lambda/`} className={styles.titleLink}>
                             AWS Lambda
                           </a>
                         </p>

--- a/components/learn/platform/Platform.js
+++ b/components/learn/platform/Platform.js
@@ -125,7 +125,7 @@ export default function Platform(props) {
 
             <div className={styles.content}>
               <p className={styles.title}>
-                <a href={`${prefix}/learn/run-in-the-cloud/code-to-cloud-deployment`} className={styles.titleLink}>
+                <a href={`${prefix}/learn/code-to-cloud-deployment`} className={styles.titleLink}>
                   Code to cloud deployment
                 </a>
               </p>
@@ -134,7 +134,7 @@ export default function Platform(props) {
 
             <div className={styles.content}>
               <p className={styles.title}>
-                <a href={`${prefix}/learn/run-in-the-cloud/aws-lambda/`} className={styles.titleLink}>
+                <a href={`${prefix}/learn/aws-lambda/`} className={styles.titleLink}>
                   Functions as a service
                 </a>
               </p>

--- a/downloads/1.2.x-release-notes/1.2.8.md
+++ b/downloads/1.2.x-release-notes/1.2.8.md
@@ -33,8 +33,8 @@ If you have not installed jBallerina, then download the [installers](/downloads/
 
 ##### Azure Functions
 
-The fix for [Pure HTTP Functions Not Working](https://github.com/ballerina-platform/module-ballerinax-azure.functions/issues/33). For more information, see [Azure Functions](/learn/run-in-the-cloud/azure-functions/).
+The fix for [Pure HTTP Functions Not Working](https://github.com/ballerina-platform/module-ballerinax-azure.functions/issues/33). For more information, see [Azure Functions](/learn/azure-functions/).
 
 ##### AWS Lambda
 
-Added the support for domain-specific event types. For more information, see [AWS Lambda](/learn/run-in-the-cloud/aws-lambda/).
+Added the support for domain-specific event types. For more information, see [AWS Lambda](/learn/aws-lambda/).

--- a/downloads/swan-lake-release-notes/swan-lake-preview3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview3/RELEASE_NOTE.md
@@ -332,4 +332,4 @@ public function fromHttpToQueue(af:Context ctx,
 }
 ```
 
-For more information, see [Azure Functions](https://ballerina.io/learn/run-in-the-cloud/azure-functions/).
+For more information, see [Azure Functions](https://ballerina.io/learn/azure-functions/).

--- a/next.config.js
+++ b/next.config.js
@@ -217,8 +217,16 @@ const nextConfig = {
         destination: `/${redirectBase}learn/development-tutorials/ballerina-central/publish-packages-to-ballerina-central`,
       },
       {
-        source: `/${redirectBase}learn/run-in-the-cloud/:slug`,
-        destination: `/${redirectBase}learn/development-tutorials/run-in-the-cloud/:slug`,
+        source: `/${redirectBase}learn/code-to-cloud-deployment`,
+        destination: `/${redirectBase}learn/development-tutorials/run-in-the-cloud/code-to-cloud-deployment`,
+      },
+      {
+        source: `/${redirectBase}learn/azure-functions`,
+        destination: `/${redirectBase}learn/development-tutorials/run-in-the-cloud/azure-functions`,
+      },
+      {
+        source: `/${redirectBase}learn/aws-lambda`,
+        destination: `/${redirectBase}learn/development-tutorials/run-in-the-cloud/aws-lambda`,
       },
       {
         source: `/${redirectBase}learn/test-ballerina-code/:slug`,

--- a/swan-lake/by-example/aws-lambda-deployment/content.jsx
+++ b/swan-lake/by-example/aws-lambda-deployment/content.jsx
@@ -66,7 +66,7 @@ export function AwsLambdaDeployment({ codeSnippets }) {
 
       <p>
         For more information, see the{" "}
-        <a href="/learn/run-in-the-cloud/aws-lambda/">
+        <a href="/learn/aws-lambda/">
           AWS Lambda Deployment Guide
         </a>
         .
@@ -304,7 +304,7 @@ export function AwsLambdaDeployment({ codeSnippets }) {
       <p>
         For instructions on getting the value for the
         <code>$LAMBDA_ROLE_ARN</code>, see{" "}
-        <a href="/learn/run-in-the-cloud/aws-lambda/">
+        <a href="/learn/aws-lambda/">
           AWS Lambda deployment
         </a>
         .
@@ -455,7 +455,7 @@ export function AwsLambdaDeployment({ codeSnippets }) {
 
       <p>
         For registration and execution details, see{" "}
-        <a href="/learn/run-in-the-cloud/aws-lambda/">
+        <a href="/learn/aws-lambda/">
           AWS Lambda deployment
         </a>
         .

--- a/swan-lake/by-example/azure-functions-deployment/content.jsx
+++ b/swan-lake/by-example/azure-functions-deployment/content.jsx
@@ -54,7 +54,7 @@ export function AzureFunctionsDeployment({ codeSnippets }) {
 
       <p>
         For more information, see the{" "}
-        <a href="/learn/run-in-the-cloud/azure-functions/">
+        <a href="/learn/azure-functions/">
           Azure deployment guide
         </a>
         .
@@ -433,7 +433,7 @@ export function AzureFunctionsDeployment({ codeSnippets }) {
         The <code>timer</code> function is triggered by the Azure Functions app
         from a timer. You can check the queue storage to see the output. For
         more information on the infrastructure, see{" "}
-        <a href="/learn/run-in-the-cloud/azure-functions/">
+        <a href="/learn/azure-functions/">
           Azure Functions deployment
         </a>
         .

--- a/swan-lake/by-example/c2c-docker-deployment/content.jsx
+++ b/swan-lake/by-example/c2c-docker-deployment/content.jsx
@@ -53,7 +53,7 @@ export function C2cDockerDeployment({ codeSnippets }) {
 
       <p>
         For more information, see{" "}
-        <a href="/learn/run-in-the-cloud/code-to-cloud/code-to-cloud-deployment/">
+        <a href="/learn/code-to-cloud/code-to-cloud-deployment/">
           Code to Cloud Deployment
         </a>
         .

--- a/swan-lake/by-example/c2c-k8s-deployment/content.jsx
+++ b/swan-lake/by-example/c2c-k8s-deployment/content.jsx
@@ -61,7 +61,7 @@ export function C2cK8sDeployment({ codeSnippets }) {
 
       <p>
         For more information, see{" "}
-        <a href="/learn/run-in-the-cloud/code-to-cloud/code-to-cloud-deployment/">
+        <a href="/learn/code-to-cloud/code-to-cloud-deployment/">
           Code to Cloud Deployment
         </a>
         .

--- a/swan-lake/resources/featured-scenarios/deploy-ballerina-on-kubernetes.md
+++ b/swan-lake/resources/featured-scenarios/deploy-ballerina-on-kubernetes.md
@@ -155,5 +155,5 @@ horizontalpodautoscaler.autoscaling/greeter-hpa created
 
 ## Learn more
 
-For in-depth information about executing these deployed applications and the supported customizations in code to cloud, see [Code to Cloud deployment](/learn/run-in-the-cloud/code-to-cloud-deployment).
+For in-depth information about executing these deployed applications and the supported customizations in code to cloud, see [Code to Cloud deployment](/learn/code-to-cloud-deployment).
  

--- a/utils/learn-lm.json
+++ b/utils/learn-lm.json
@@ -561,7 +561,7 @@
                             "level": 3,
                             "position": 1,
                             "isDir": false,
-                            "url": "/learn/run-in-the-cloud/code-to-cloud-deployment",
+                            "url": "/learn/code-to-cloud-deployment",
                             "id": "code-to-cloud-deployment"
                         },
                         {
@@ -569,7 +569,7 @@
                             "level": 3,
                             "position": 1,
                             "isDir": false,
-                            "url": "/learn/run-in-the-cloud/azure-functions",
+                            "url": "/learn/azure-functions",
                             "id": "azure-functions"
                         },
                         {
@@ -577,7 +577,7 @@
                             "level": 3,
                             "position": 2,
                             "isDir": false,
-                            "url": "/learn/run-in-the-cloud//aws-lambda",
+                            "url": "/learn/aws-lambda",
                             "id": "aws-lambda"
                         }
                     ]


### PR DESCRIPTION
## Purpose
>$subject
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
