### PR TITLE
Fix more tool page links after learn revamp

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.1.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.1.0/RELEASE_NOTE.md
@@ -632,7 +632,7 @@ To view bug fixes, see the [GitHub milestone for Ballerina 2201.1.0 (Swan Lake U
 
 #### AsyncAPI tool
 
-Introduced the AsyncAPI tool, which will make it easy for you to start the development of an event API documented in an AsyncAPI contract in Ballerina by generating Ballerina service and listener skeletons. Ballerina Swan Lake supports the [AsyncAPI Specification version 2.x](https://www.asyncapi.com/docs/specifications/v2.0.0). For more information, see [Ballerina AsyncAPI support](/learn/asyncapi-tool/) and [AsyncAPI CLI documentation](/learn/asyncapi/#asyncapi-to-ballerina).
+Introduced the AsyncAPI tool, which will make it easy for you to start the development of an event API documented in an AsyncAPI contract in Ballerina by generating Ballerina service and listener skeletons. Ballerina Swan Lake supports the [AsyncAPI Specification version 2.x](https://www.asyncapi.com/docs/specifications/v2.0.0). For more information, see [Ballerina AsyncAPI support](/learn/asyncapi-tool/) and [AsyncAPI CLI documentation](/learn/asyncapi-tool).
 
 #### GraphQL tool
 

--- a/swan-lake/development-tutorials/build-and-run/cli-commands.md
+++ b/swan-lake/development-tutorials/build-and-run/cli-commands.md
@@ -210,7 +210,7 @@ These powerful supporting tools extend Ballerina to various ecosystem technologi
 </tr>
 <tr>
 <td class="cCommand">grpc</td>
-<td class="cDescription">This is the gRPC stub/skeleton generation tool. For more information, see <a href="/learn/grpc">gRPC/Protocol Buffers</a>.</td>
+<td class="cDescription">This is the gRPC stub/skeleton generation tool. For more information, see <a href="/learn/grpc-tool">gRPC tool</a>.</td>
 </tr>
 <tr>
 <td class="cCommand">graphql</td>

--- a/swan-lake/integration-tools/graphql-tool.md
+++ b/swan-lake/integration-tools/graphql-tool.md
@@ -138,7 +138,7 @@ In general you can use the command format given below.
 $ bal graphql [-i | --input] <graphql-configuration-file-path> [-o | --output] <output-location> 
 ```
 
-This generates a Ballerina client with remote operations corresponding to each GraphQL query/mutation in the GraphQL document (`.graphql document`). The generated sources gets written into the same directory from which the command is executed (i.e., the Ballerina package root directory). For more information, see [GraphQL to Ballerina](/learn/graphql/#graphql-to-ballerina).
+This generates a Ballerina client with remote operations corresponding to each GraphQL query/mutation in the GraphQL document (`.graphql document`). The generated sources gets written into the same directory from which the command is executed (i.e., the Ballerina package root directory). For more information, see [GraphQL to Ballerina](/learn/graphql-tool).
 
 The above command can be run from anywhere on the execution path. It is not mandatory to run it from within a Ballerina package.
 

--- a/swan-lake/integration-tools/graphql-tool.md
+++ b/swan-lake/integration-tools/graphql-tool.md
@@ -138,7 +138,7 @@ In general you can use the command format given below.
 $ bal graphql [-i | --input] <graphql-configuration-file-path> [-o | --output] <output-location> 
 ```
 
-This generates a Ballerina client with remote operations corresponding to each GraphQL query/mutation in the GraphQL document (`.graphql document`). The generated sources gets written into the same directory from which the command is executed (i.e., the Ballerina package root directory). For more information, see [GraphQL to Ballerina](/learn/graphql-tool).
+This generates a Ballerina client with remote operations corresponding to each GraphQL query/mutation in the GraphQL document (`.graphql document`). The generated sources gets written into the same directory from which the command is executed (i.e., the Ballerina package root directory).
 
 The above command can be run from anywhere on the execution path. It is not mandatory to run it from within a Ballerina package.
 

--- a/swan-lake/integration-tools/openapi-tool.md
+++ b/swan-lake/integration-tools/openapi-tool.md
@@ -59,7 +59,7 @@ $ bal openapi -i hello.yaml --tags "pets", "list"
 
 Once you execute the command, only the operations related to the given tags get included in the generated service file.
 
->**Info:** For more information on the command options, see [OpenAPI to Ballerina](/learn/openapi/#openapi-to-ballerina).
+>**Info:** For more information on the command options, see [OpenAPI to Ballerina](/learn/openapi-tool).
 
 ## Export OpenAPI contracts from Ballerina services
 

--- a/swan-lake/integration-tools/openapi-tool.md
+++ b/swan-lake/integration-tools/openapi-tool.md
@@ -59,8 +59,6 @@ $ bal openapi -i hello.yaml --tags "pets", "list"
 
 Once you execute the command, only the operations related to the given tags get included in the generated service file.
 
->**Info:** For more information on the command options, see [OpenAPI to Ballerina](/learn/openapi-tool).
-
 ## Export OpenAPI contracts from Ballerina services
 
 If you prefer to follow the **code-first approach**, you can convert your Ballerina service APIs into human-readable or machine-readable documents such as OpenAPI documents by using the Ballerina to OpenAPI CLI Tool as follows.

--- a/swan-lake/resources/featured-scenarios/write-a-grpc-service-with-ballerina.md
+++ b/swan-lake/resources/featured-scenarios/write-a-grpc-service-with-ballerina.md
@@ -274,5 +274,5 @@ Response : Hello Ballerina
 
 To learn more about gRPC support in Ballerina, see the following:
 - [`grpc` module documentation](https://lib.ballerina.io/ballerina/grpc/latest)
-- [gRPC CLI tooling guide](/learn/grpc/)
+- [gRPC CLI tooling guide](/learn/grpc-tool/)
 - [Simple RPC](/learn/by-example/grpc-service-simple/)


### PR DESCRIPTION
## Purpose
Fix more tool page links after learn revamp.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
