### PR TITLE
Improve the privacy and cookie policy pages

### DIFF
--- a/policy/cookie-policy.md
+++ b/policy/cookie-policy.md
@@ -11,7 +11,7 @@ Below is information about how the <a target="_blank" href="https://ballerina.io
 
 The Site stores and retrieves information on your browser using cookies. This information is used to make the Site work as you expect it to. It is not personally identifiable to you, but it can be used to give you a more personalized web experience.
 
-This cookie policy is part of our [Privacy policy](/privacy-policy/). It explains the following:
+This cookie policy is part of our <a target="_blank" href="/privacy-policy/">privacy policy</a>. It explains the following:
 
 ## What are cookies?
 
@@ -161,7 +161,7 @@ These cookies allow us to count visits and traffic sources so we can measure and
     </tr>
     <tr>
       <td><a class="in-cell-link" href="http://central.ballerina.io" target="_blank">central.ballerina.io</a></td>
-      <td>route</td>
+      <td><code>route</code></td>
     </tr>
     <tr>
       <td><a class="in-cell-link" href="http://api.central.ballerina.io" target="_blank">api.central.ballerina.io</a></td>
@@ -169,7 +169,7 @@ These cookies allow us to count visits and traffic sources so we can measure and
     </tr>
     <tr>
       <td><a class="in-cell-link" href="http://lib.ballerina.io" target="_blank">lib.ballerina.io</a></td>
-      <td>route</td>
+      <td><code>route</code></td>
     </tr>
     <tr>
       <td rowspan="3" colspan="1">Third party</td>
@@ -238,7 +238,7 @@ These cookies allow us to count visits and traffic sources so we can measure and
       <td>729</td>
     </tr>
     <tr>
-      <td>VISITOR_INFO1_LIVE</td>
+      <td><code>VISITOR_INFO1_LIVE</code></td>
       <td rowspan="2" colspan="1">179</td>
     </tr>
     <tr>

--- a/policy/privacy-policy.md
+++ b/policy/privacy-policy.md
@@ -24,7 +24,7 @@ California residents may view WSO2's California-specific privacy policy at <a ta
 
 2. **Information collected automatically from your devices**
 
-    We also collect certain standard information that Your browser sends to every website you visit, such as your IP address, browser type, and language, access times, and referring website addresses. Our website may also place certain cookies to help you access our sites and to track and analyze Your actions on our website such as navigation, number of visits, downloads, and search items to gain a better understanding of our visitors and their movements through the site. Please see our <a target="_blank" href="https://ballerina.io/cookie-policy/">Cookie policy</a> on how we use and store cookies. 
+    We also collect certain standard information that Your browser sends to every website you visit, such as your IP address, browser type, and language, access times, and referring website addresses. Our website may also place certain cookies to help you access our sites, and to track and analyze Your actions on our website such as navigation, number of visits, downloads, and search items to gain a better understanding of our visitors and their movements through the site. Please see our <a target="_blank" href="https://ballerina.io/cookie-policy/">cookie policy</a> on how we use and store cookies. 
 
 4. **Information received from third parties**
 
@@ -52,7 +52,7 @@ We will only collect and process personal data about You where we have lawful ba
 - The processing is necessary for us to comply with a relevant legal obligation; or
 - The processing is in our legitimate commercial interests and necessary for us to administer our business, subject to Your interests and fundamental rights.
 
-Where we rely on Your consent to process personal data, You have the right to withdraw or decline Your consent at any time, and where we rely on legitimate interests, You have the right to object. If You have any questions about the lawful bases upon which we collect and use Your personal data or wish to withdraw consent or object, You can submit a request via <a target="_blank" href="mailto:dpo@wso2.com">dpo@wso2.com</a> or through the details listed in the [How to contact us](#information-about-data-controllers-processors-and-how-to-contact-us) section below.
+Where we rely on Your consent to process personal data, You have the right to withdraw or decline Your consent at any time, and where we rely on legitimate interests, You have the right to object. If You have any questions about the lawful bases upon which we collect and use Your personal data or wish to withdraw consent or object, You can submit a request via <a target="_blank" href="mailto:dpo@wso2.com">dpo@wso2.com</a> or through the details listed in the [Information about data controllers, processors, and how to contact us](#information-about-data-controllers-processors-and-how-to-contact-us) section below.
 
 
 ## Who is your information shared with?
@@ -77,7 +77,7 @@ We may also release your information when we believe release is necessary to com
 
 ### Dispute resolution
 
-In compliance with the Data Privacy Framework Principles, we commit to resolving complaints about our collection or use of your personal information. EU/EEA or UK individuals with inquiries or complaints regarding our DPF policy should first reach out to us using the information in the [How to contact us](#information-about-data-controllers-processors-and-how-to-contact-us) section below.
+In compliance with the Data Privacy Framework Principles, we commit to resolving complaints about our collection or use of your personal information. EU/EEA or UK individuals with inquiries or complaints regarding our DPF policy should first reach out to us using the information in the [Information about data controllers, processors, and how to contact us](#information-about-data-controllers-processors-and-how-to-contact-us) section below.
 
 WSO2 has committed to refer unresolved DTF complaints to JAMS, an alternative dispute resolution provider located in the United States. If you do not receive timely acknowledgment of your complaint from us, or if we have not addressed your complaint to your satisfaction, please contact or visit <a target="_blank" href="https://www.jamsadr.com/eu-us-data-privacy-framework">EU-US Data Privacy Framework | JAMS Mediation, Arbitration, ADR Services</a> for more information or to file a complaint. The services of JAMS are provided at no cost to you. Under certain conditions, more fully described on the DTF website, you may invoke binding arbitration when other dispute resolution procedures have been exhausted.
 
@@ -107,7 +107,7 @@ At our discretion, we may include or offer third-party products or services on o
 
 ## Information about our website
 
-This privacy policy applies only to information collected through the Sites and not to information collected offline. Please also visit our <a target="_blank" href="https://ballerina.io/terms-of-service/">Terms of service</a> section relating to use, disclaimers, indemnities, and limitations of liability governing the use of our site and services.
+This privacy policy applies only to information collected through the Sites and not to information collected offline. Please also visit our <a target="_blank" href="https://ballerina.io/terms-of-service/">terms of service</a> relating to use, disclaimers, indemnities, and limitations of liability governing the use of our site and services.
 
 ## Information about data controllers, processors, and how to contact us
 


### PR DESCRIPTION
## Purpose
Improve the privacy and cookie policy pages.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
