### PR TITLE
[Update 8] - Remove `soap` package from the release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.0/RELEASE_NOTE.md
@@ -337,9 +337,6 @@ To view bug fixes, see the [GitHub milestone for 2201.8.0 (Swan Lake)](https://g
 
 ### New features
 
-#### `soap` package
-- Introduced the `soap` standard library package, which provides a client API to connect to SOAP endpoints.
-
 #### `mqtt` package
 - Introduced the `mqtt` standard library package, which provides an implementation to interact with message brokers using the MQTT protocol.
 


### PR DESCRIPTION
## Purpose
$subject