### PR TITLE
Fix a typo in the GraalVM section

### DIFF
--- a/swan-lake/development-tutorials/build-a-graalvm-executable/build-the-executable-locally.md
+++ b/swan-lake/development-tutorials/build-a-graalvm-executable/build-the-executable-locally.md
@@ -224,7 +224,7 @@ file under the section '[platform.<java*>]' with the attribute
 **********************************************************************************
 ```
 
-In that scenario, the package owner should evaluate the GraalVM-compatibility with `bal test --graalvm`. If the package has sufficient test cases to verify the compatibility, the package can be marked as GraalVM-compatible by adding the following to the Ballerin.toml file.
+In that scenario, the package owner should evaluate the GraalVM-compatibility with `bal test --graalvm`. If the package has sufficient test cases to verify the compatibility, the package can be marked as GraalVM-compatible by adding the following to the Ballerina.toml file.
 ```toml
 [platform.java17]
 graalvmCompatible = true


### PR DESCRIPTION
## Purpose
Fix a typo in the GraalVM section.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
