### PR TITLE
Fix code snippets in CLI commands page

### DIFF
--- a/swan-lake/development-tutorials/build-and-run/cli-commands.md
+++ b/swan-lake/development-tutorials/build-and-run/cli-commands.md
@@ -16,6 +16,7 @@ It also enables you to easily install, update, and switch among Ballerina distri
 
 In the CLI, execute the `bal help` command to view all the actions you can perform with the Ballerina Tool as shown below.
 
+```
 $ bal help
 NAME
        The build system and package manager of Ballerina
@@ -85,6 +86,7 @@ $ bal <COMMAND> <ARGUMENTS>
 
 > **Tip:** You can view details of the commands by executing the `bal help <COMMAND>`. For example, the following is the output of the `bal help pull` command.
 
+```
 $ bal help pull
 NAME
        ballerina-pull - Fetch packages from Ballerina Central


### PR DESCRIPTION
## Purpose
Fix code snippets in CLI commands page.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
