### PR TITLE
Fix GraphQL broken link

### DIFF
--- a/swan-lake/development-tutorials/run-in-the-cloud/aws-lambda.md
+++ b/swan-lake/development-tutorials/run-in-the-cloud/aws-lambda.md
@@ -96,6 +96,6 @@ To deploy the function, execute the command, which you get in the CLI output log
 
 In a more practical scenario, the AWS Lambda functions will be used by associating them with an external event source such as Amazon DynamoDB or Amazon SQS. For more information on this, go to <a href="https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventsourcemapping.html" target="_blank">AWS Lambda event source mapping documentation</a>.
 
-For examples of the usage of AWS Lambda functions, see [AWS Lambda](learn/by-example/#aws-lambda).
+For examples of the usage of AWS Lambda functions, see [AWS Lambda](/learn/by-example/#aws-lambda).
 
 <style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/swan-lake/resources/featured-scenarios/write-a-graphql-api-with-ballerina.md
+++ b/swan-lake/resources/featured-scenarios/write-a-graphql-api-with-ballerina.md
@@ -459,5 +459,4 @@ To learn more about GraphQL services in Ballerina, see the following.
 
 - [`graphql` module documentation](https://lib.ballerina.io/ballerina/graphql/latest)
 - [GraphQL Hello World](/learn/by-example/graphql-hello-world)
-- [GraphQL to Ballerina](/learn/graphql/#graphql-to-ballerina)
 - [GraphQL tool](/learn/graphql-tool/)


### PR DESCRIPTION
## Purpose
Fix GraphQL broken link.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
