### PR TITLE
Fix GraphiQL word in Update 8 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.0/RELEASE_NOTE.md
@@ -289,7 +289,7 @@ To view bug fixes, see the [GitHub milestone for Swan Lake Update 8 (2201.8.0)](
 #### `graphql` package
 
 - Added support for the `@deprecated` directive in output objects defined using record types.
-- Added support for printing the GraphQL URL to `stdout`.
+- Added support for printing the GraphiQL URL to `stdout`.
 - Added support for generating a subgraph SDL schema at compile time.
 
 #### `log` package


### PR DESCRIPTION
## Purpose
Fix GraphiQL word in Update 8 release note.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
