### PR TITLE
Add dev-tools changes to the 2201.8.1 release note

### DIFF
--- a/_data/swanlake_release_notes_versions.json
+++ b/_data/swanlake_release_notes_versions.json
@@ -969,5 +969,26 @@
    ],
    "api-docs":"ballerina-api-docs-2201.7.2.zip",
    "release-notes":"ballerina-release-notes-2201.7.2.md"
+},
+{
+	"version":"2201.8.0",
+	"short-version":"2201.8.0",
+	"display-version":"2201.8.0 (Swan Lake Update 8)",
+	"release-date":"2023-09-20",
+	"windows-installer":"ballerina-2201.8.0-swan-lake-windows-x64.msi",
+	"windows-installer-size":"173mb",
+	"linux-installer":"ballerina-2201.8.0-swan-lake-linux-x64.deb",
+	"linux-installer-size":"198mb",
+	"macos-installer":"ballerina-2201.8.0-swan-lake-macos-x64.pkg",
+	"macos-installer-size":"233mb",
+	"macos-arm-installer":"ballerina-2201.8.0-swan-lake-macos-arm-x64.pkg",
+	"macos-arm-installer-size":"231mb",
+	"rpm-installer":"ballerina-2201.8.0-swan-lake-linux-x64.rpm",
+	"rpm-installer-size":"235mb",
+	"other-artefacts":[
+		"ballerina-2201.8.0-swan-lake.zip"
+	],
+	"api-docs":"ballerina-api-docs-2201.8.0.zip",
+	"release-notes":"ballerina-release-notes-2201.8.0.md"
 }
 ]

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
@@ -28,35 +28,17 @@ If you have not installed Ballerina, download the [installers](/downloads/#swanl
 
 ## Language updates
 
-### New features
-
-### Improvements
-
 ### Bug fixes
 
 To view bug fixes, see the [GitHub milestone for 2201.8.1 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AType%2FBug+is%3Aclosed+milestone%3A2201.8.1).
 
-## Runtime updates
-
-### New features
-
-### Improvements
-
-### Bug fixes
-
 ## Ballerina library updates
-
-### New features
-
-### Improvements
 
 ### Bug fixes
 
 To view bug fixes, see the [GitHub milestone for 2201.8.1 (Swan Lake)](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aissue+label%3AType%2FBug+is%3Aclosed+milestone%3A2201.8.1).
 
 ## Developer tools updates
-
-### New features
 
 #### Ballerina Update Tool
 - Added distribution update support through a proxy server.

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
@@ -58,6 +58,10 @@ To view bug fixes, see the [GitHub milestone for 2201.8.1 (Swan Lake)](https://g
 
 ### New features
 
+#### Ballerina Update Tool
+- Added distribution update support through a proxy server.
+
+
 ### Improvements
 Added CodeLens support to visualize blocks with `regex` statements.
 ```ballerina

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
@@ -59,7 +59,7 @@ To view bug fixes, see the [GitHub milestone for 2201.8.1 (Swan Lake)](https://g
 ### New features
 
 ### Improvements
-Added code lens support to visualize blocks with `regex` statements.
+Added CodeLens support to visualize blocks with `regex` statements.
 ```ballerina
 var regexr = re `^test all\s*(?:resources?|endpoints?|paths?)?.?$`;
 ``` 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
@@ -59,6 +59,16 @@ To view bug fixes, see the [GitHub milestone for 2201.8.1 (Swan Lake)](https://g
 ### New features
 
 ### Improvements
+Added code lens support to visualize blocks with `regex` statements.
+```ballerina
+var regexr = re `^test all\s*(?:resources?|endpoints?|paths?)?.?$`;
+``` 
 
 ### Bug fixes
+Fixed visible endpoint generation for connector endpoints declared with access modifiers and display annotations.
+```ballerina
+import ballerinax/googleapis.sheets;
 
+@display {label: "Google Sheets API"}
+private sheets:Client sheetsEp;
+```

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
@@ -1,0 +1,64 @@
+---
+layout: ballerina-left-nav-release-notes
+title: 2201.8.1 (Swan Lake) 
+permalink: /downloads/swan-lake-release-notes/2201.8.1/
+active: 2201.8.1
+redirect_from: 
+    - /downloads/swan-lake-release-notes/2201.8.1
+    - /downloads/swan-lake-release-notes/2201.8.1-swan-lake/
+    - /downloads/swan-lake-release-notes/2201.8.1-swan-lake
+    - /downloads/swan-lake-release-notes/
+    - /downloads/swan-lake-release-notes
+---
+
+## Overview of Ballerina Swan Lake Update 8 (2201.8.1)
+
+<em>Swan Lake 2201.8.1 is the first patch release of Ballerina 2201.8.0 (Swan Lake Update 8) and it includes a new set of bug fixes to the language, standard library, and tooling.</em>
+
+## Update Ballerina
+
+Update your current Ballerina installation directly to 2201.8.1 using the [Ballerina Update Tool](/learn/update-tool/) as follows.
+
+1. Run `bal update` to get the latest version of the Update Tool.
+2. Run `bal dist update` to update to this latest distribution.
+
+## Install Ballerina
+
+If you have not installed Ballerina, download the [installers](/downloads/#swanlake) to install.
+
+## Language updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for 2201.8.1 (Swan Lake)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3AType%2FBug+is%3Aclosed+milestone%3A2201.8.1).
+
+## Runtime updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+## Ballerina library updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for 2201.8.1 (Swan Lake)](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aissue+label%3AType%2FBug+is%3Aclosed+milestone%3A2201.8.1).
+
+## Developer tools updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+

--- a/utils/archived-lm.json
+++ b/utils/archived-lm.json
@@ -23,6 +23,14 @@
                     "id": "swan-lake-api-docs"
                 },
                 {
+                    "dirName": "2201.8.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "#2201.8.0",
+                    "id": "2201.8.0v"
+                },
+                {
                     "dirName": "2201.7.2",
                     "level": 2,
                     "position": 1,

--- a/utils/rl.json
+++ b/utils/rl.json
@@ -15,6 +15,14 @@
             "id": "swan-lake-release-notes",
             "subDirectories": [
                 {
+                    "dirName": "2201.8.1 (Swan Lake Update 8)",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.1",
+                    "id": "swan-lake-2201.8.1"
+                },
+                {
                     "dirName": "2201.8.0 (Swan Lake Update 8)",
                     "level": 2,
                     "position": 1,


### PR DESCRIPTION
## Purpose
Add dev-tools changes to the 2201.8.1 release note.

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
