### PR TITLE
removed the stray indent code block

### DIFF
--- a/swan-lake/development-tutorials/test-document-the-code/generate-code-documentation.md
+++ b/swan-lake/development-tutorials/test-document-the-code/generate-code-documentation.md
@@ -90,9 +90,7 @@ type Record record {|
 # interactions with the endpoint.
 #
 # Example:
-# ```ballerina
 # HttpFuture future = myMsg.submit("GET", "/test", req);
-# ```
 #
 # + httpVerb - The HTTP verb value
 # + path - The resource path
@@ -162,9 +160,7 @@ Now, let's add a function to the `math` module to be documented. Copy and paste 
 
 ```ballerina
 # Calculates the value of the 'a' raised to the power of 'b'.
-# ```ballerina
 # float aPowerB = math:pow(3.2, 2.4);
-# ```
 # 
 # + a - Base value
 # + b - Exponential value


### PR DESCRIPTION
## Purpose
This PR fixes the code block indent for the docs by removing the stray indent code block. This Pr solves the issue #6656 .
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
