### PR TITLE
fix: for missing page titles in library spec pages

### DIFF
--- a/pages/spec/[slug].js
+++ b/pages/spec/[slug].js
@@ -139,6 +139,7 @@ export default function PostPage({ frontmatter, content, codeSnippets }) {
         <meta property="og:description" content={frontmatter.description} />
 
         {/* <!--TWITTER--> */}
+        <meta name="twitter:title" content={`Ballerina - ${frontmatter.title || extractLibraryNameFromContent()}`} />
         <meta property="twitter:description" content={frontmatter.description} />
         <meta property="twitter:text:description" content={frontmatter.description} />
 

--- a/pages/spec/[slug].js
+++ b/pages/spec/[slug].js
@@ -118,17 +118,21 @@ export default function PostPage({ frontmatter, content, codeSnippets }) {
     return newId;
   }
 
+  const extractLibraryNameFromContent = () => {
+    return content.split("\n")[0].substring(2);
+  }
+
   return (
     <>
       <Head>
         <meta name="description" content={frontmatter.description} />
         <meta name="keywords" content={frontmatter.keywords} />
 
-        <title>{frontmatter.title}</title>
+        <title>{frontmatter.title || extractLibraryNameFromContent()}</title>
 
         {/* <!--FB--> */}
         <meta property="og:type" content="article" />
-        <meta property="og:title" content={`Ballerina - ${frontmatter.title}`} />
+        <meta property="og:title" content={`Ballerina - ${frontmatter.title  || extractLibraryNameFromContent()}`} />
         <meta property="og:description" content={frontmatter.description}></meta>
 
         {/* <!--LINKED IN  --> */}


### PR DESCRIPTION
## Purpose
> Fixes #6999 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
