### PR TITLE
Remove the UUID generation in the persist get started guide

### DIFF
--- a/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
+++ b/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
@@ -163,7 +163,6 @@ Let’s start with a query to create a new `Employee` record in the database and
 
 ```ballerina
 import ballerina/io;
-import ballerina/uuid;
 import rainier.store;
 
 

--- a/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
+++ b/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
@@ -172,7 +172,7 @@ final store:Client sClient = check new();
 
 public function main() returns error? {
    store:EmployeeInsert employee1 = {
-       id: uuid:createType4AsString(),
+       id: "16c6553a-373c-4b29-b1c8-c282f444248c",
        firstName: "John",
        lastName: "Doe",
        email: "johnd@xyz.com",


### PR DESCRIPTION
## Purpose
Remove the UUID generation in the persist get started guide.
> Fixes #8141 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
