### PR TITLE
Improve the health tool page content

### DIFF
--- a/swan-lake/integration-tools/health-tool.md
+++ b/swan-lake/integration-tools/health-tool.md
@@ -1,26 +1,34 @@
 ---
 layout: ballerina-health-support-left-nav-pages-swanlake
 title: Health tool (FHIR/HL7)
-description: The health tool generates accelerators for developing healthcare integrations in Ballerina.
+description: The health tool generates API templates and library packages for developing healthcare integrations.
 keywords: ballerina, programming language, health, contract
 permalink: /learn/health-tool/
 active: health-tool
-intro: The health tool generates accelerators for developing healthcare integrations in Ballerina.
+intro: The health tool generates API templates and library packages for developing healthcare integrations.
 ---
 
-The Health tool can generate accelerators primarily focussed on the <a href="https://www.hl7.org/fhir/overview.html" target="_blank">Fast Healthcare Interoperability Resources (FHIR)</a> standard. The Health tool is supported from Ballerina Swan Lake version 2201.7.0 onwards.
+They are primarily focused on the [Fast Healthcare Interoperability Resources (FHIR)](https://www.hl7.org/fhir/overview.html) standard and are developed using Ballerina.
+
+>**Info:** It is supported from Ballerina Swan Lake version 2201.7.0 onwards.
 
 ## Prerequisites
 
-Download a directory containing all FHIR specification definition files. You can download a preferred standard implementation guide from the [FHIR Implementation Guide registry](http://fhir.org/guides/registry/).
+Download a directory containing all FHIR specification definition files. You can download a preferred standard implementation guide from the [FHIR Implementation Guide registry](https://fhir.org/guides/registry/).
 
->**Note:** It is recommended to use the STU version of the implementation guides. Make sure that the downloaded specification archive has the `StructureDefinition`, `ValueSet`, and `CodeSystem` files for the Implementation Guide (IG) resources when extracted.
+>**Note:** It is recommended to use a Standard for Trial Use (STU) or higher release level of the implementation guides. Make sure that the downloaded specification archive has the StructureDefinition, ValueSet, and CodeSystem files for the Implementation Guide (IG) resources when extracted.
 
 ## Usage
 
-This tool generates a Ballerina package for a given FHIR implementation guide. The FHIR resources in the implementation guide will be represented as Ballerina records including the correct cardinality constraints and metadata.
+This tool uses the command below to generate a Ballerina package for a given FHIR implementation guide. 
 
-FHIR integration developers can leverage the generated package when transforming custom health data into FHIR format without referring to the specification.
+```
+$ bal health fhir -m <Mode: package> [OPTIONS] <fhir-specification-directory-path>
+```
+
+>**Note:** Make sure to give the directory path of the downloaded FHIR definitions as the last argument. 
+
+The FHIR resources in the implementation guide will be represented as Ballerina records including the correct cardinality constraints and metadata. FHIR integration developers can leverage the generated package when transforming custom health data into FHIR format without referring to the specification.
 
 ## Command options
 
@@ -30,14 +38,14 @@ The parameters that are available with the tool are listed below.
 |----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
 | `-m, --mode`     | Mode can be `package`. If `mode` is set to `package`, a Ballerina package will be generated including all the records and types. New modes will be added in future releases.                                                                                                                                                                                                      | Mandatory          |
 | `-o, --output`   | Location of the generated Ballerina artifacts. If this path is not specified, the output will be written to the same directory from which the command is run.                                                                                                                                                                                                                   | Optional           |
-| `--package-name` | Name of the Ballerina package to be generated. The package name can be explicitly set using this argument. Unless specified, the default name of the implementation guide will be taken to construct the name of the package. For more information, see <a href="https://ballerina.io/learn/package-references/#the-name-field" target="_blank">the <code>name</code> field</a>. | Optional           |
+| `--package-name` | Name of the Ballerina package to be generated. The package name can be explicitly set using this argument. Unless specified, the default name of the implementation guide will be taken to construct the name of the package. For more information, see the <a href="https://ballerina.io/learn/package-references/#the-name-field" target="_blank">the <code>name</code> field</a>. | Optional           |
 | `--org-name`     | Organization name of the Ballerina package to be generated. For more information, see <a href="https://ballerina.io/learn/package-references/#the-org-field" target="_blank"> the <code>org</code> field</a>.                                                                                                                                                                   | Optional           |
 | `-v, --version`  | Print the version information of the Health tool.                                                                                                                                                                                                                                                                                                                               | Optional           |
-| `-h, --help`     | Print the usage details of the Health tool.                                                                                                                                                                                                                                                                                                                                     | Optional           |
+| `-h, --help`     | Print the usage information of the Health tool.                                                                                                                                                                                                                                                                                                                                     | Optional           |
 
 ## Install the tool
 
-Pull the Health tool from Ballerina Central.
+Execute the command below to pull the Health tool from Ballerina Central.
 
     ```
     $ bal tool pull health
@@ -45,25 +53,35 @@ Pull the Health tool from Ballerina Central.
     health:1.0.0 successfully set as the active version.
     ```
 
-## Create the package
+## Example
 
-Follow the steps below to create the package.
+Follow the steps below to try out an example use case of the Health tool.
 
-1. Download the **JSON Definitions ZIP archive** from the [Carin BB implementation guide](http://hl7.org/fhir/us/carin-bb/STU2/downloads.html) and extract it to your current directory.
+### Clone the sample project
 
-2. Run the tool with the [required arguments](#available-parameters) to generate the package.
+Clone the [artifacts of the example](https://github.com/ballerina-guides/healthcare-samples/tree/main/working_with_health_tool) and extract them to a preferred location.
 
-    >**Note:** Provide values for mandatory arguments. Make sure to give the directory path of the downloaded FHIR definitions as the last argument.
+>**Info:** The cloned directory includes the artifacts that will be required to try out this example (Ballerina project and the FHIR specification files). This Ballerina project includes the [`Ballerina.toml`](https://github.com/ballerina-guides/healthcare-samples/blob/main/working_with_health_tool/Ballerina.toml) file, which specifies the dependency of the package (name and version) that is to be generated. Also, the [`main.bal`](https://github.com/ballerina-guides/healthcare-samples/blob/main/working_with_health_tool/main.bal) file includes the import of it together with the business logic/mapping implemented using the generated FHIR resource records.
+
+### Generate the package
+
+Follow the steps below to run the Health tool and create the Ballerina package.
+
+1. Navigate to the cloned `working_with_health_tool` directory.
+
+2. Run the tool with the [required arguments](#command-options) to generate the package.
+
+    >**Note:** This example uses the [definitions files](https://github.com/ballerina-guides/healthcare-samples/tree/main/working_with_health_tool/ig_carinbb/definitions) downloaded from the **JSON Definitions ZIP archive** of the [Carin BB implementation guide](https://hl7.org/fhir/us/carin-bb/STU2/downloads.html) to generate the package.
 
     ```
-    $ bal health fhir -m package --org-name healthcare_samples --package-name carinbb_package -o gen ./definitions.json
+    $ bal health fhir -m package -o ig_carinbb/gen --org-name healthcare_samples --package-name carinbb_package ig_carinbb/definitions/
     Ballerina FHIR package generation completed successfully.
     ```
 
 3. Build the generated package.
 
     ```
-    $ cd gen/carinbb_package
+    $ cd ig_carinbb/gen/carinbb_package
     $ bal pack
     Compiling source
             healthcare_samples/carinbb_package:0.0.1
@@ -81,15 +99,15 @@ Follow the steps below to create the package.
     Successfully pushed target/bala/healthcare_samples-carinbb_package-any-0.0.1.bala to 'local' repository.
     ```
 
-## Example
+### Use the generated package
 
-Follow the steps below to try out an example use case of the Health tool.
+Follow the steps below to use the generated package by running the cloned Ballerina project.
 
-1. Clone the [artifacts of the example](https://github.com/ballerina-guides/healthcare-samples/tree/main/working_with_health_tool) and extract them to a preferred location.
+1. Navigate to the cloned `working_with_health_tool` directory.
 
-    >**Note:** Make sure to add the correct version and repository to the [`Ballerina.toml`](https://github.com/ballerina-guides/healthcare-samples/blob/main/working_with_health_tool/Ballerina.toml) file. The generated package is imported and the business logic/mapping is implemented using the generated FHIR resource records in the [`main.bal`](https://github.com/ballerina-guides/healthcare-samples/blob/main/working_with_health_tool/main.bal) file.
+    >**Info:** You can change the dependency (name and version) of the generated package in the [`Ballerina.toml`](https://github.com/ballerina-guides/healthcare-samples/blob/main/working_with_health_tool/Ballerina.toml) file of this cloned Ballerina project directory as preferred. 
 
-2. Run the Ballerina project and validate the output.
+2. Run the cloned Ballerina project and validate the output.
 
     ```
     $ bal run
@@ -102,7 +120,7 @@ Follow the steps below to try out an example use case of the Health tool.
 3. Invoke the API to try it out.
 
     ```
-    $ curl --location --request GET 'http://localhost:9090/Patient/2121'
+    $ curl http://localhost:9090/Patient/2121
     ```
 
     You can view the response shown below.


### PR DESCRIPTION
## Purpose
Improve the health tool page content.

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
