### PR TITLE
Fix the VS Code ext docs intra links

### DIFF
--- a/swan-lake/vs-code-extension/configure-the-extension.md
+++ b/swan-lake/vs-code-extension/configure-the-extension.md
@@ -15,7 +15,7 @@ These configurations are the basic ones, which are used by the extension users.
 |---------------------------------------|-----------------------------------------------------------|
 | `ballerina.codeLens.all.enabled`        | Enable CodeLens that appear in the editor view.           |
 | `ballerina.enableConfigurableEditor`    | Enable the configurable editor. This will open a  form to set values for [configurable variables](https://ballerina.io/learn/by-example/configurable-variables/) in the code when you [run](/learn/vs-code-extension/run-a-program/) the Ballerina code. |
-| `ballerina.enableNotebookDebug`         | Enable the debug feature in [Ballerina notebook files](learn/vs-code-extension/notebooks/) (`.balnotebook`). |
+| `ballerina.enableNotebookDebug`         | Enable the debug feature in [Ballerina notebook files](/learn/vs-code-extension/notebooks/) (`.balnotebook`). |
 | `ballerina.enablePerformanceForecast`   | Enable the performance forecaster. This will show you the forecasted latency and other performance values for Ballerina services in the low-code diagram.     |
 | `ballerina.enableSemanticHighlighting`  | Enable [semantic code highlighting](https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide).               |
 | `ballerina.enableTelemetry`             | Enable telemetry logging. This will send log data to the extension developers. This will help developers to improve the extension. |


### PR DESCRIPTION
## Purpose
Fix the VS Code ext docs intra links.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
