### PR TITLE
Fix `sending-emails-from-a-service` tutorial

### DIFF
--- a/swan-lake/integration-tutorials/sending-emails-from-a-service.md
+++ b/swan-lake/integration-tutorials/sending-emails-from-a-service.md
@@ -530,7 +530,7 @@ function getEmailContent(int appointmentNumber, Appointment appointment, Payment
 > Alternatively, you can run this service by navigating to the project root and using the `bal run` command.
 >
 > ```
-> sending-a-message-to-a-service$ bal run
+> sending-emails-from-a-service$ bal run
 > Compiling source
 >         integration_tutorials/sending-emails-from-a-service:0.1.0
 >


### PR DESCRIPTION
## Purpose
Fix the project name in the `Build and run the service` section of the `sending-emails-from-a-service` tutorial

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
