### PR TITLE
Add dollar signs to new cURL commands

### DIFF
--- a/swan-lake/resources/featured-scenarios/build-a-data-service-in-ballerina.md
+++ b/swan-lake/resources/featured-scenarios/build-a-data-service-in-ballerina.md
@@ -474,7 +474,7 @@ be accessed via a browser by visiting `http://locahost:8080/employees`.
 Invoke the defined resource method by sending the `POST` request below to `http://localhost:8080/employees` with the required data as a JSON payload.
 
 ```
-curl -X POST http://localhost:8080/employees/ -H "Content-Type: application/json" -d "{ \"employee_id\": 6, \"first_name\": \"test\", \"last_name\": \"test\", \"email\": \"test@test.com\", \"phone\": \"882 771 110\", \"hire_date\": { \"year\": 2021, \"month\": 12, \"day\": 16 }, \"manager_id\": 1, \"job_title\": \"Sales Manager\" }"
+$ curl -X POST http://localhost:8080/employees/ -H "Content-Type: application/json" -d "{ \"employee_id\": 6, \"first_name\": \"test\", \"last_name\": \"test\", \"email\": \"test@test.com\", \"phone\": \"882 771 110\", \"hire_date\": { \"year\": 2021, \"month\": 12, \"day\": 16 }, \"manager_id\": 1, \"job_title\": \"Sales Manager\" }"
 ```
 
 You view a row added to the **Employees** table as shown below.

--- a/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
+++ b/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
@@ -473,7 +473,7 @@ Running executable
 Invoke the defined resource method by sending the POST request below to http://localhost:8080/employees with the required data as a JSON payload.
 
 ```
-curl -X POST http://localhost:8080/employees/ -H "Content-Type: application/json" -d "{ \"id\": \"6\", \"firstName\": \"test\", \"lastName\": \"test\", \"email\": \"test@test.com\", \"phone\": \"882 771 110\", \"hireDate\": { \"year\": 2021, \"month\": 12, \"day\": 16 }, \"managerId\": \"1\", \"jobTitle\": \"Sales Manager\" }"
+$ curl -X POST http://localhost:8080/employees/ -H "Content-Type: application/json" -d "{ \"id\": \"6\", \"firstName\": \"test\", \"lastName\": \"test\", \"email\": \"test@test.com\", \"phone\": \"882 771 110\", \"hireDate\": { \"year\": 2021, \"month\": 12, \"day\": 16 }, \"managerId\": \"1\", \"jobTitle\": \"Sales Manager\" }"
 ```
  
 The entered employee ID `6` will be returned as the response.

--- a/swan-lake/resources/featured-scenarios/write-a-graphql-api-with-ballerina.md
+++ b/swan-lake/resources/featured-scenarios/write-a-graphql-api-with-ballerina.md
@@ -421,7 +421,7 @@ type Mutation {
 Execute the cURL command below to retrieve all the data from the endpoint.
 
 ```
-curl -X POST -H "Content-type: application/json" -H "scope: unknown" -d "{ \"query\": \"query { all { country cases active} }\" }" http://localhost:9000/covid19
+$ curl -X POST -H "Content-type: application/json" -H "scope: unknown" -d "{ \"query\": \"query { all { country cases active} }\" }" http://localhost:9000/covid19
 ```
 
 In this request:

--- a/swan-lake/resources/featured-scenarios/write-a-restful-api-with-ballerina.md
+++ b/swan-lake/resources/featured-scenarios/write-a-restful-api-with-ballerina.md
@@ -328,7 +328,7 @@ In another terminal, execute the cURL commands below one by one to try out the s
 Execute the cURL command below.
 
 ```
-curl http://localhost:9000/covid/status/countries
+$ curl http://localhost:9000/covid/status/countries
 ```
 
 You view the output below.
@@ -342,7 +342,7 @@ You view the output below.
 Execute the cURL command below.
 
 ```
-curl http://localhost:9000/covid/status/countries -d "[{\"iso_code\":\"DEU\", \"country\":\"Germany\", \"cases\":159333, \"deaths\":7390, \"recovered\":126084, \"active\":6833}]" -H "Content-Type: application/json"
+$ curl http://localhost:9000/covid/status/countries -d "[{\"iso_code\":\"DEU\", \"country\":\"Germany\", \"cases\":159333, \"deaths\":7390, \"recovered\":126084, \"active\":6833}]" -H "Content-Type: application/json"
 ```
 
 You view the output below.
@@ -356,7 +356,7 @@ You view the output below.
 Execute the cURL command below.
 
 ```
-curl http://localhost:9000/covid/status/countries/AFG
+$ curl http://localhost:9000/covid/status/countries/AFG
 ```
 
 You view the output below.


### PR DESCRIPTION
## Purpose
Add dollar signs to new cURL commands.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
