### PR TITLE
Fix the EDI Tool TOML file link

### DIFF
--- a/swan-lake/integration-tools/edi-tool.md
+++ b/swan-lake/integration-tools/edi-tool.md
@@ -257,7 +257,7 @@ Follow the steps below to use the generated package by running the cloned Baller
 
 1. Navigate to the `edi-package-generation/edi_service` directory.
 
-    >**Info:** You can change the dependency (name and version) of the generated package in the [`lib/porder/Ballerina.toml`](https://github.com/ballerina-guides/integration-samples/tree/main/edi-package-generation/lib/porder/Ballerina.toml) file of this cloned Ballerina project directory as preferred.
+    >**Info:** You can change the dependency (name and version) of the generated package in the `lib/porder/Ballerina.toml` file of the generated package as preferred.
 
 2. Run the cloned Ballerina project and validate the output.
 


### PR DESCRIPTION
## Purpose
Fix the EDI Tool TOML file link.

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
