### PR TITLE
Change `arguments` to `command options` in EDI tool page

### DIFF
--- a/swan-lake/integration-tools/edi-tool.md
+++ b/swan-lake/integration-tools/edi-tool.md
@@ -67,7 +67,7 @@ Follow the steps below to generate Ballerina records for the above EDI schema.
 
 1. Navigate to the cloned `edi-code-generation` directory.
 
-2. Run the tool with the [required arguments](#code-generation-command-options) to generate the package.
+2. Run the tool with the [required command options](#code-generation-command-options) to generate the package.
 
     ```
     $ bal edi codegen -s schemas/edi-schema.json -o orderRecords.bal


### PR DESCRIPTION
## Purpose
Change `arguments` to `command options` in EDI tool  page.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
