### PR TITLE
Fix a few lib broken links 

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0/RELEASE_NOTE.md
@@ -75,7 +75,7 @@ public function main() {
 }
 ```
 
-For more information, see the new [RegExp type example](/learn/by-example/regexp-type), [RegExp operations example](/learn/by-example/regexp-operations), [API Documentation](https://lib.ballerina.io/ballerina/lang.regexp/0.0.0), and [Regular expressions feature guide](/learn/advanced-general-purpose-language-features/#regular-expressions).
+For more information, see the new [RegExp type example](/learn/by-example/regexp-type), [RegExp operations example](/learn/by-example/regexp-operations), [API Documentation](https://central.ballerina.io/ballerina/lang.regexp/latest), and [Regular expressions feature guide](/learn/advanced-general-purpose-language-features/#regular-expressions).
 
 ### Bug fixes
 

--- a/swan-lake/vs-code-extension/implement-the-code/data-mapper.md
+++ b/swan-lake/vs-code-extension/implement-the-code/data-mapper.md
@@ -274,7 +274,7 @@ Once the array is initialized, click the **+ Add Element** button to add the arr
 
 3. Fill in the `totalCredits` field by getting the summation of the credits in each CS course.
 
-    >**Tip:** You can use the [`reduce()`](https://lib.ballerina.io/ballerina/lang.array/0.0.0/functions#reduce) array function for this by passing the combining function below to get the sum.
+    >**Tip:** You can use the [`reduce()`](https://central.ballerina.io/ballerina/lang.array/latest#reduce) array function for this by passing the combining function below to get the sum.
 
     ```ballerina
     var totalCredits = function(int total, record {string id; string name; int credits;} course) returns int => total + (course.id.startsWith("CS") ? course.credits : 0);

--- a/swan-lake/vs-code-extension/references/statement-editor/call-a-ballerina-package-function.md
+++ b/swan-lake/vs-code-extension/references/statement-editor/call-a-ballerina-package-function.md
@@ -7,7 +7,7 @@ intro: The Statement Editor allows you to easily navigate between Ballerina stan
 
 The **libraries** tab in the Statement Editor lists all the supported standard and language libraries. This guide helps you to understand how to call a Ballerina package function using the Statement Editor.
 
-Let's call the Ballerina [`printError`](https://lib.ballerina.io/ballerina/log/2.5.0/functions#printError) function of the [`log` module](https://lib.ballerina.io/ballerina/log/2.5.0) to log an error in the given sample code below.
+Let's call the Ballerina [`printError`](https://central.ballerina.io/ballerina/log/latest#printError) function of the [`log` module](https://lib.ballerina.io/ballerina/log/2.5.0) to log an error in the given sample code below.
 
 ```ballerina
 public function main() returns error? {


### PR DESCRIPTION
## Purpose
Fix a few lib broken links.

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
