### PR TITLE
Update regex usage in mocking learn page

### DIFF
--- a/swan-lake/development-tutorials/test-document-the-code/test-ballerina-code/mocking.md
+++ b/swan-lake/development-tutorials/test-document-the-code/test-ballerina-code/mocking.md
@@ -35,19 +35,18 @@ Consider the following example in which an `http:Client` interacts with an exter
 
 ```ballerina
 import ballerina/http;
-import ballerina/regex;
 
 http:Client clientEndpoint = check new ("https://api.chucknorris.io/jokes/");
 
-type Joke readonly & record {|
+type Joke readonly & record {
     string value;
-|};
+};
 
 // This function performs a `get` request to the Chuck Norris API and returns a random joke 
 // with the name replaced by the provided name or an error if the API invocation fails.
 function getRandomJoke(string name) returns string|error {
     Joke joke = check clientEndpoint->get("/random");
-    string replacedText = regex:replaceAll(joke.value, "Chuck Norris", name);
+    string replacedText = re `Chuck Norris`.replaceAll(joke.value, name);
     return replacedText;
 }
 ```
@@ -110,9 +109,9 @@ import ballerina/io;
 
 http:Client clientEndpoint = check new ("https://api.chucknorris.io/jokes/");
 
-type Joke readonly & record {|
+type Joke readonly & record {
     string value;
-|};
+};
 
 // This function performs a `get` request to the Chuck Norris API and returns a random joke 
 // or an error if the API invocations fail.


### PR DESCRIPTION
## Purpose
> $Subject
> Fixes #8423

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
