### PR TITLE
Fix the data mapper link in Graphical page

### DIFF
--- a/swan-lake/why-ballerina/graphical.md
+++ b/swan-lake/why-ballerina/graphical.md
@@ -26,4 +26,4 @@ The [Sequence Diagram View](https://wso2.com/ballerina/vscode/docs/implement-the
 
 ## Data Mapper
 
-The Ballerina VS Code extension supports [creating and updating the data mappings]((https://wso2.com/ballerina/vscode/docs/implement-the-code/data-mapper/)) to convert data between the corresponding input and output types. The user interface eases performing data integration, migration, and transformation elements of the data mapping process via the graphical representation of the source code.
+The Ballerina VS Code extension supports [creating and updating the data mappings](/learn/vs-code-extension/implement-the-code/data-mapper/) to convert data between the corresponding input and output types. The user interface eases performing data integration, migration, and transformation elements of the data mapping process via the graphical representation of the source code.


### PR DESCRIPTION
## Purpose
Fix the data mapper link in the Graphical Why Ballerina page.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
