### PR TITLE
Add the 2201.9.0 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -1,0 +1,86 @@
+---
+layout: ballerina-left-nav-release-notes
+title: 2201.9.0 (Swan Lake) 
+permalink: /downloads/swan-lake-release-notes/2201.9.0/
+active: 2201.9.0
+redirect_from: 
+    - /downloads/swan-lake-release-notes/2201.9.0
+    - /downloads/swan-lake-release-notes/2201.9.0-swan-lake/
+    - /downloads/swan-lake-release-notes/2201.9.0-swan-lake
+    - /downloads/swan-lake-release-notes/
+    - /downloads/swan-lake-release-notes
+---
+
+## Overview of Ballerina Swan Lake Update 9 (2201.9.0)
+
+<em> Swan Lake Update 9 (2201.9.0) is the ninth update release of Ballerina Swan Lake, and it includes a new set of features and significant improvements to the compiler, runtime, Ballerina library, and developer tooling. It is based on the 2023R1 version of the Language Specification.</em> 
+
+## Update Ballerina
+
+Update your current Ballerina installation directly to 2201.9.0 using the [Ballerina Update Tool](/learn/update-tool/) as follows.
+
+1. Run `bal update` to get the latest version of the Update Tool.
+2. Run `bal dist update` to update to this latest distribution.
+
+## Install Ballerina
+
+If you have not installed Ballerina, download the [installers](/downloads/#swanlake) to install.
+
+## Language updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for Swan Lake Update 9 (2201.9.0)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FCompilerFE+milestone%3A2201.9.0+is%3Aclosed+label%3AType%2FBug).
+
+## Runtime updates
+
+### New features
+
+### Improvements                             
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for Swan Lake Update 9 (2201.9.0)](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A2201.9.0+label%3ATeam%2FjBallerina+label%3AType%2FBug+is%3Aclosed).
+
+## Ballerina library updates
+
+### Deprecations
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for Swan Lake Update 9 (2201.9.0)](https://github.com/ballerina-platform/ballerina-standard-library/issues?q=is%3Aclosed+is%3Aissue+milestone%3A%222201.9.0%22+label%3AType%2FBug).
+
+## Developer tools updates
+
+### New features
+
+#### Language Server
+
+#### CLI
+
+#### OpenAPI tool
+
+### Improvements
+
+#### Language Server
+
+### Bug fixes
+
+To view bug fixes, see the GitHub milestone for Swan Lake Update 9 (2201.9.0) of the repositories below.
+
+- [Language server](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+label%3ATeam%2FLanguageServer+milestone%3A2201.9.0+is%3Aclosed+label%3AType%2FBug+)
+- [OpenAPI](https://github.com/ballerina-platform/openapi-tools/issues?q=is%3Aissue+label%3AType%2FBug+milestone%3A%22Swan+Lake+2201.9.0%22+is%3Aclosed)
+
+## Ballerina packages updates
+
+### New features
+
+### Improvements
+
+### Bug fixes
+
+## Backward-incompatible changes

--- a/utils/archived-lm.json
+++ b/utils/archived-lm.json
@@ -23,6 +23,14 @@
                     "id": "swan-lake-api-docs"
                 },
                 {
+                    "dirName": "2201.8.4",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "#2201.8.4",
+                    "id": "2201.8.4v"
+                },
+                {
                     "dirName": "2201.8.3",
                     "level": 2,
                     "position": 1,

--- a/utils/rl.json
+++ b/utils/rl.json
@@ -15,6 +15,14 @@
             "id": "swan-lake-release-notes",
             "subDirectories": [
                 {
+                    "dirName": "2201.9.0 (Swan Lake Update 9)",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.0",
+                    "id": "swan-lake-2201.9.0"
+                },
+                {
                     "dirName": "2201.8.4 (Swan Lake Update 8)",
                     "level": 2,
                     "position": 1,


### PR DESCRIPTION
## Purpose
Add the 2201.9.0 release note.

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
