### PR TITLE
Fix formatting issue in expressions page

### DIFF
--- a/swan-lake/development-tutorials/source-code-dependencies/style-guide/expressions.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/style-guide/expressions.md
@@ -148,7 +148,7 @@ string[] names = [
 **Example,**
 
 ```ballerina
-<int>id;
+<int>id
 ```
 
 * Do not keep spaces between the closing angle bracket and value reference, which will be casted.

--- a/swan-lake/development-tutorials/source-code-dependencies/style-guide/expressions.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/style-guide/expressions.md
@@ -143,7 +143,12 @@ string[] names = [
 
 ## Type casting
 
-* Do not keep spaces between the type and the angle brackets (i.e., `<string>`).
+* Do not keep spaces between the type and the angle brackets. 
+
+**Example,**
+
+`<string>`
+
 * Do not keep spaces between the closing angle bracket and value reference, which will be casted.
 
 **Example,**

--- a/swan-lake/development-tutorials/source-code-dependencies/style-guide/expressions.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/style-guide/expressions.md
@@ -147,7 +147,9 @@ string[] names = [
 
 **Example,**
 
-`<string>`
+```ballerina
+<int>id;
+```
 
 * Do not keep spaces between the closing angle bracket and value reference, which will be casted.
 


### PR DESCRIPTION
## Purpose
> Fix formatting issue in expressions page[1].

[1] https://ballerina.io/learn/style-guide/expressions/#type-casting

> Fixes #8551 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
