### PR TITLE
Fix bullet indentation in style guide pages

### DIFF
--- a/swan-lake/development-tutorials/source-code-dependencies/style-guide/annotations-documentation-and-comments.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/style-guide/annotations-documentation-and-comments.md
@@ -13,137 +13,136 @@ intro: The sections below include the coding conventions with respect to annotat
 * Indent annotations to align them with the starting position of the owner (statement or definition).
 * Each annotation attribute (i.e., key-value pairs) can be expanded and block indented on its own line or kept as inline fields.
 
-**Example,**
+    **Example,**
 
-```ballerina
-// Function annotations are aligned with the starting position of the function.
-@test:Config {
-    before: beforeFunc,
-    after: afterFunc
-}
-function testFunction() {
-    io:println("I'm in test function!");
-    test:assertTrue(true, msg = "Failed!");
-}
-```
+    ```ballerina
+    // Function annotations are aligned with the starting position of the function.
+    @test:Config {
+        before: beforeFunc,
+        after: afterFunc
+    }
+    function testFunction() {
+        io:println("I'm in test function!");
+        test:assertTrue(true, msg = "Failed!");
+    }
+    ```
 
 * If an annotation is empty, place it in a single line and 
   do not have spaces between both braces.
   
-**Example,**
+    **Example,**
 
-```ballerina
-@test:Config {}
-```
+    ```ballerina
+    @test:Config {}
+    ```
 
 * If you are annotating a parameter or a return type, the annotation should be added inline to the parameter or the return type.
   
-**Example,**
-  
-```ballerina
-annotation validated on parameter, return;
+    **Example,**
+    
+    ```ballerina
+    annotation validated on parameter, return;
 
-// Parameter annotation.
-public function secureFunction1(@validated string secureInName, int secureInId, string insecureIn) {
-    ...
-}
+    // Parameter annotation.
+    public function secureFunction1(@validated string secureInName, int secureInId, string insecureIn) {
+        ...
+    }
 
-public function secureFunction2(string secureInName,
-    @validated int secureInId, string insecureIn) {
-    ...
-}
+    public function secureFunction2(string secureInName,
+        @validated int secureInId, string insecureIn) {
+        ...
+    }
 
-// Return type annotation.
-public function taintedReturn1() returns @validated string {
-    ...
-}
+    // Return type annotation.
+    public function taintedReturn1() returns @validated string {
+        ...
+    }
 
-public function taintedReturn2() returns
-    @validated string {
-    ...
-}
-```
+    public function taintedReturn2() returns
+        @validated string {
+        ...
+    }
+    ```
 
 ## Comments
   
 * Add a single space between the `//` and the content.
 * If the comment is in its own line, then indent it considering its context (i.e., top-level or in a block).
   
-**Example,**
+    **Example,**
 
-```ballerina
-// This is a top-level comment.
+    ```ballerina
+    // This is a top-level comment.
 
-function func1() {
-    // This is a block-level comment. 
-    int x = 10;
-}
+    function func1() {
+        // This is a block-level comment. 
+        int x = 10;
+    }
 
-function func2() {
-    if valid {
-        if active {
-            // This is a nested if block-level comment.
-            string a = "hello";
+    function func2() {
+        if valid {
+            if active {
+                // This is a nested if block-level comment.
+                string a = "hello";
+            }
         }
     }
-}
-```
+    ```
 
 * If the comment is in line with the code, add a space before it.
 
-**Example,**
+    **Example,**
 
-```ballerina
-type People record {}; // Inline comment
+    ```ballerina
+    type People record {}; // Inline comment
 
-function func1() {
-    int a = 0; // Inline comment
-}
-```
-
+    function func1() {
+        int a = 0; // Inline comment
+    }
+    ```
 
 ## Documentation
 * Always, indent them to align with the starting position of the owner.
 * Add a space after the `#` symbol.
 * Add an empty line after the description.
 
-**Example,**
+    **Example,**
 
-```ballerina
-# Description.
-#
-# + value - value input parameter 
-# + return - return a integer value
-function getValue(int value) returns int {
-    return value;
-}
-```
+    ```ballerina
+    # Description.
+    #
+    # + value - value input parameter 
+    # + return - return a integer value
+    function getValue(int value) returns int {
+        return value;
+    }
+    ```
 
 * Add only one space after the parameter marker (`+`), divider (`-`), and `return`.
 * Begin the param identifier and description with a single space.
 
 **Example,**
   
-```ballerina
-# Description.
-#
-# + value - Parameter description
-# + return - Return value description
-function getValue(int value) returns int {
-    ...
-}
-
-# Description.
-service / on new http:Listener(8080) {
+    ```ballerina
     # Description.
     #
-    # + caller - Parameter description.
-    # + request - Parameter description.
-    resource function get greeting(http:Caller caller, http:Request request) {
+    # + value - Parameter description
+    # + return - Return value description
+    function getValue(int value) returns int {
         ...
     }
-}
-```
+
+    # Description.
+    service / on new http:Listener(8080) {
+        # Description.
+        #
+        # + caller - Parameter description.
+        # + request - Parameter description.
+        resource function get greeting(http:Caller caller, http:Request request) {
+            ...
+        }
+    }
+    ```
 
 <div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
 

--- a/swan-lake/development-tutorials/source-code-dependencies/style-guide/coding-conventions.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/style-guide/coding-conventions.md
@@ -12,271 +12,270 @@ intro: This Ballerina Style Guide aims at maintaining a standard coding style am
 * Use four spaces (not tabs) for each level of indentation.
 * Keep the maximum length of a line to 120 characters. 
 
-> **Note:** You can configure tools and plugins to use spaces when indenting and to change the maximum number of characters in a line.
+    > **Note:** You can configure tools and plugins to use spaces when indenting and to change the maximum number of characters in a line.
 
 ## Line spacing
 
 * Use only a single space to separate keywords, types, and identifiers. 
    
-**Do's**
+    **Do's**
 
-```ballerina
-public function getFullName() returns string {
-    string fullName = "john doe";
-    return fullName;
-}
-```
+    ```ballerina
+    public function getFullName() returns string {
+        string fullName = "john doe";
+        return fullName;
+    }
+    ```
 
-**Don'ts**
+    **Don'ts**
 
-```ballerina
-public   function   getFullName()   returns   string {
-    string   fullName = "john doe";
-    return     fullName;
-}
-```
+    ```ballerina
+    public   function   getFullName()   returns   string {
+        string   fullName = "john doe";
+        return     fullName;
+    }
+    ```
 
 Few exceptions for this rule are:
 - Do not keep spaces around a type when it is enclosed using angle brackets `<string>`. 
       
-**Example,**
+    **Example,**
 
-```ballerina
-map<string> names = {};
-```
+    ```ballerina
+    map<string> names = {};
+    ```
 
 - Do not keep spaces between the type and the opening bracket in the array definition `string[]`.
       
-**Example,**
+    **Example,**
 
-```ballerina
-    string[] names = [];
-```
+    ```ballerina
+        string[] names = [];
+    ```
 
 * If it is a list of values separated by commas, add only a single space after each comma and don't add spaces before the comma.
   
-**Example,**
+    **Example,**
 
-```ballerina
-[string, int, boolean] tupleVar = ["", 0, false];
+    ```ballerina
+    [string, int, boolean] tupleVar = ["", 0, false];
 
-int[] arrayOfInteger = [1, 2, 3, 4];
+    int[] arrayOfInteger = [1, 2, 3, 4];
 
-map<string> stringMap = {one: st1, two: st2, three: st3};
+    map<string> stringMap = {one: st1, two: st2, three: st3};
 
-Person personRecord = {name: "marcus", id: 0};
+    Person personRecord = {name: "marcus", id: 0};
 
-function foo(string name, int id) {
-}
-    
-service / on ep1, ep2 {
-    ...
-}
-```
+    function foo(string name, int id) {
+    }
+        
+    service / on ep1, ep2 {
+        ...
+    }
+    ```
 
 ## Blank lines
 
 Separate both statements and top-level definitions by zero or one blank lines.
 
-**Example,**
-  
-```ballerina
-import ballerina/http;
-import ballerina/io;
+    **Example,**
+    
+    ```ballerina
+    import ballerina/http;
+    import ballerina/io;
 
-const string CITY = "Colombo";
-const int CITY_NO = 1;
+    const string CITY = "Colombo";
+    const int CITY_NO = 1;
 
-function getName() returns string {
-    string firstName = "john";
-    string lastName = "doe";
+    function getName() returns string {
+        string firstName = "john";
+        string lastName = "doe";
 
-    return firstName + lastName;
-}
+        return firstName + lastName;
+    }
 
-function setName(string name) {
-}
+    function setName(string name) {
+    }
 
-function setAge(int age) {
-}
-```
+    function setAge(int age) {
+    }
+    ```
  
 ## Blocks
 * Opening curly braces of a block should be placed inline.
   
-**Do's**
+    **Do's**
 
-```ballerina
-if valid {
-}
-  
-function setName(string name) {
-    ...
-}
-```
-
-**Don'ts**
-
-```ballerina
-if valid
-{
+    ```ballerina
+    if valid {
+    }
     
-}
+    function setName(string name) {
+        ...
+    }
+    ```
 
-function setName(string name)
-{
-  
-}
-```
+    **Don'ts**
+
+    ```ballerina
+    if valid
+    {
+        
+    }
+
+    function setName(string name)
+    {
+    
+    }
+    ```
 
 * Add a single space before the opening curly braces. 
 
-**Example,**
+    **Example,**
 
-```ballerina
-function func1() {
-    if valid {
+    ```ballerina
+    function func1() {
+        if valid {
+        }
     }
-}
-```
+    ```
 
 * If an inline block is empty, do not keep spaces in between the opening and closing braces.
   
-**Example,**
+    **Example,**
 
-```ballerina
-function func1() {
-}
-``` 
+    ```ballerina
+    function func1() {
+    }
+    ``` 
 
 * Indent all the statements inside a block to be at the same level.
 * Indent the closing brace of a block to align it with the starting position of the block statement.
 
-**Example,**
-  
-```ballerina
-if valid {
-   int x = 2;
-   string a = "hello";
-}
-  
-match a {
-   ...
-}
-```
+    **Example,**
+    
+    ```ballerina
+    if valid {
+    int x = 2;
+    string a = "hello";
+    }
+    
+    match a {
+    ...
+    }
+    ```
 
 ## Parentheses and brackets
 * Do not have spaces after opening parenthesis/bracket and before closing parenthesis/bracket.
   
-**Example,**
+    **Example,**
 
-```ballerina
-[string, int] tupleVar = ["", 0];
+    ```ballerina
+    [string, int] tupleVar = ["", 0];
 
-function setValue(string value) {
-    ...
-}
+    function setValue(string value) {
+        ...
+    }
 
-public function main() {
-    setValue("value");
-}
-```
+    public function main() {
+        setValue("value");
+    }
+    ```
 
 * To define empty parentheses/brackets, do not keep spaces between the opening and closing parentheses/brackets. i.e. `()` ,`[]`.
   
-**Example,**
+    **Example,**
 
-```ballerina
-int[] a = [];
-int|() result = getResult();
-```
+    ```ballerina
+    int[] a = [];
+    int|() result = getResult();
+    ```
   
 ## Line breaks
 
 * Have only one statement in a line.
 * When splitting lines, which contain operator(s), split them right before an operator.
   
-**Example,**
-  
-```ballerina
-// Binary operations.
-string s = "added " + People.name
-    + " in to database.";
-  
-// Function invocation.
-string s = person
-    .getName();
-  
-// Binary operations in if condition
-if isNameAvailable
-    && i == 1 {
-    ...
-}
-```
+    **Example,**
+    
+    ```ballerina
+    // Binary operations.
+    string s = "added " + People.name
+        + " in to database.";
+    
+    // Function invocation.
+    string s = person
+        .getName();
+    
+    // Binary operations in if condition
+    if isNameAvailable
+        && i == 1 {
+        ...
+    }
+    ```
 
 * When splitting lines, which contains separator(s), split them right after a separator.
   
-**Example,**
-    
-```ballerina
-// Function parameters.
-function getName(int id, int age,
-    string searchValue) returns string {
-    ...
-}
-```
+    **Example,**
+        
+    ```ballerina
+    // Function parameters.
+    function getName(int id, int age,
+        string searchValue) returns string {
+        ...
+    }
+    ```
 
 * If there isn't any operator or separator to break the line from, move the whole expression to a new line.
   
-**Example,**
+    **Example,**
 
-```ballerina
-// String literal.
-string s1 =
-    "My name is not in this description";
-  
-// Function invocation.
-string s2 =
-    getPersonNameWithUpperCaseLetters();
-``` 
+    ```ballerina
+    // String literal.
+    string s1 =
+        "My name is not in this description";
+    
+    // Function invocation.
+    string s2 =
+        getPersonNameWithUpperCaseLetters();
+    ``` 
 
 * If a line exceeds the maximum line length, start from the end of the line and come towards the start of the line until you find a point, which matches the above rules to break the line.
 * Indent split lines with relation to the starting position of the statement or definition.
   
-**Example,**
+    **Example,**
 
-```ballerina
-if isNameAvailable
-    && i == 1 {
-    ...
-}
-  
-// Function parameters.
-function getName(int id, int age,
-    string searchValue) returns string {
-    ...
-}
-```  
+    ```ballerina
+    if isNameAvailable
+        && i == 1 {
+        ...
+    }
+    
+    // Function parameters.
+    function getName(int id, int age,
+        string searchValue) returns string {
+        ...
+    }
+    ```  
 
-* However, if you cannot add the type-casting expression or statement with the constrained type in a single line 
-  due to it exceeding the max line length, 
+* However, if you cannot add the type-casting expression or statement with the constrained type in a single line due to it exceeding the max line length, 
   - move the casting type with the operators to a new line.
   
-**Example,**
-      
-```ballerina
-string name =
-    <string>person.name;
-```
+    **Example,**
+        
+    ```ballerina
+    string name =
+        <string>person.name;
+    ```
   
   - keep the constrained type on the same line by splitting the statement from a point before the constraint type.
       
-**Example,**
+    **Example,**
 
-```ballerina
-map<int|string> registry = {
-    name: "marcus"
-};
-```
+    ```ballerina
+    map<int|string> registry = {
+        name: "marcus"
+    };
+    ```
 
 <style> #tree-expand-all , #tree-collapse-all, .cTocElements {display:none;} .cGitButtonContainer {padding-left: 40px;} </style>

--- a/swan-lake/development-tutorials/source-code-dependencies/style-guide/expressions.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/style-guide/expressions.md
@@ -14,184 +14,184 @@ intro: The sections below include the coding conventions with respect to express
   
 * If it is not possible to keep the function invocation in a single line due to it exceeding the maximum line length, split it into a new line based on the best practices given in [Line breaks](/learn/style-guide/coding-conventions/#line-breaks).
     
-**Example,**
+    **Example,**
 
-```ballerina
-setAgeForEmployee(employeeName,
-    employeeID);
-```
+    ```ballerina
+    setAgeForEmployee(employeeName,
+        employeeID);
+    ```
 
 ## Record literal
 
 * If empty, keep it as an empty block.
       
-**Example,**
+    **Example,**
 
-```ballerina
-Person p = {};
-```
+    ```ballerina
+    Person p = {};
+    ```
 
 * In a record literal, arrange the fields in a single line.
   Then, add a space after the comma and leave no spaces between the braces and fields.
       
-**Example,**
+    **Example,**
 
-```ballerina
-Person p = {name: "john", age: 20};
-``` 
+    ```ballerina
+    Person p = {name: "john", age: 20};
+    ``` 
 
 * Do not keep any spaces between the key and the colon. Also, keep only one space between the colon and the value.
   
 **Example,**
 
-```ballerina
-Person person = {
-    name: "john" // in this field key is the "name" and value is "john".
-};
-```
+    ```ballerina
+    Person person = {
+        name: "john" // in this field key is the "name" and value is "john".
+    };
+    ```
 
 * You can define the fields in new lines. If you do so, make sure each field is in a separate line and is block-indented.
 
-**Do's**
+    **Do's**
 
-```ballerina
-Person p = {
+    ```ballerina
+    Person p = {
+        name: "john",
+        age: 20
+    };
+    ``` 
+
+    **Don'ts**
+
+    ```ballerina
+    Person p = {name: "john",
+        age: 20};
+    
+    //Or
+    
+    Person p = {
     name: "john",
     age: 20
-};
-``` 
-
-**Don'ts**
-
-```ballerina
-Person p = {name: "john",
-    age: 20};
-  
-//Or
-  
-Person p = {
-name: "john",
-age: 20
-};
-  
-//Or
-  
-Person p = {
-    name: "john",
-    age: 20};
-```
+    };
+    
+    //Or
+    
+    Person p = {
+        name: "john",
+        age: 20};
+    ```
 
 ## Map literal
 
 * For map literals, follow the same formatting guidelines as [Record literals](/learn/style-guide/expressions/#record-literal).
   
-**Example,**
+    **Example,**
 
-```ballerina
-// Inline map literal.
-map<string> mapOfString1 = {name: "john", id: "0"};
-  
-// Mulitline map literal.
-map<string> mapOfString2 = {
-    name: "john",
-    id: "0"
-};
-```
+    ```ballerina
+    // Inline map literal.
+    map<string> mapOfString1 = {name: "john", id: "0"};
+    
+    // Mulitline map literal.
+    map<string> mapOfString2 = {
+        name: "john",
+        id: "0"
+    };
+    ```
 
 ## Tuple
 
 * Always, place a tuple in a single line.
 
-**Example,**
+    **Example,**
 
-```ballerina
-[string, int] tuple = ["john", 20];
-```
+    ```ballerina
+    [string, int] tuple = ["john", 20];
+    ```
 
 * If a tuple exceeds the maximum line length limit, move the whole tuple to a new line and indent with four spaces from the starting position of the statement or definition.
   
-**Example,**
+    **Example,**
 
-```ballerina
-[string, int] tuple = 
-    [nameOfEmployee, ageOfTheEmployee];
-```
+    ```ballerina
+    [string, int] tuple = 
+        [nameOfEmployee, ageOfTheEmployee];
+    ```
 
 ## Array literal
 
 * Place simple arrays in a single line.
 * Do not keep any spaces between the opening bracket, value, and the closing bracket.
   
-**Example,**
+    **Example,**
 
-```ballerina
-string[] names = ["john", "doe", "jane", "doe"];
-```
+    ```ballerina
+    string[] names = ["john", "doe", "jane", "doe"];
+    ```
 
 * If an array cannot be placed on a single line due to it exceeding the maximum line length, split each value in the array to its own block-indented line.
     
 **Example,**
 
-```ballerina
-string[] names = [
-    "john",
-    "doe",
-    "jane",
-    "doe"
-];
-```
+    ```ballerina
+    string[] names = [
+        "john",
+        "doe",
+        "jane",
+        "doe"
+    ];
+    ```
 
 ## Type casting
 
 * Do not keep spaces between the type and the angle brackets (i.e., `<string>`).
 * Do not keep spaces between the closing angle bracket and value reference, which will be casted.
 
-**Example,**
+    **Example,**
 
-```ballerina
-string name = <string>person.name;
-```
+    ```ballerina
+    string name = <string>person.name;
+    ```
 
 * Avoid line breaks in type casting.
   
-**Do's**
+    **Do's**
 
-```ballerina
-<string>
-```
+    ```ballerina
+    <string>
+    ```
   
-**Don'ts**
+    **Don'ts**
 
-```ballerina
-<
-    string
->
-```
+    ```ballerina
+    <
+        string
+    >
+    ```
 
 ## Table literal
 
 * Follow the formatting guidelines of [Record literals](/learn/style-guide/expressions/#record-literal) when formatting a table block.
   
-**Example,**
-  
-```ballerina
-type Employee record {
-    readonly int id;
-    string name;
-    float salary;
-};
+    **Example,**
+    
+    ```ballerina
+    type Employee record {
+        readonly int id;
+        string name;
+        float salary;
+    };
 
-type EmployeeTable table<Employee> key(id);
+    type EmployeeTable table<Employee> key(id);
 
-public function main() {
+    public function main() {
 
-    EmployeeTable employeeTab = table [
-        {id: 1, name: "John", salary: 300.50},
-        {id: 2, name: "Bella", salary: 500.50},
-        {id: 3, name: "Peter", salary: 750.0}
-    ];
-}
-```
+        EmployeeTable employeeTab = table [
+            {id: 1, name: "John", salary: 300.50},
+            {id: 2, name: "Bella", salary: 500.50},
+            {id: 3, name: "Peter", salary: 750.0}
+        ];
+    }
+    ```
   
 <div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
 

--- a/swan-lake/development-tutorials/source-code-dependencies/style-guide/operators-keywords-and-types.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/style-guide/operators-keywords-and-types.md
@@ -11,86 +11,86 @@ intro: The sections below include the coding conventions with respect to operato
 ## Keywords and Types
 * Do not keep spaces between the type and the pipe operator when it is in a union type (e.g., `string|int`).
   
-**Example,**
+    **Example,**
 
-```ballerina
-type method "POST"|"GET"|"PUT";
+    ```ballerina
+    type method "POST"|"GET"|"PUT";
+        
+    int|string variable = 0;
     
-int|string variable = 0;
-  
-function getValue(string key) returns string|error {
-    ...
-}
-  
-function getName() returns string|error {
-    string|error valueOrError = getValue("name");
-    ...
-}
-```
+    function getValue(string key) returns string|error {
+        ...
+    }
+    
+    function getName() returns string|error {
+        string|error valueOrError = getValue("name");
+        ...
+    }
+    ```
 
 * Do not keep spaces between the type and the optional operator `?`.
-  
-**Example,**
+    
+    **Example,**
 
-```ballerina
-string? name;
-```
+    ```ballerina
+    string? name;
+    ```
 
 * Avoid line breaks inside constrained types.
   
-**Do's**
+    **Do's**
 
-```ballerina
-map<int|string> x; // map reference type
-```
+    ```ballerina
+    map<int|string> x; // map reference type
+    ```
   
-**Don'ts**
+    **Don'ts**
 
-```ballerina
-map<
-    int
-    |
-    string
-> x;
-```
+    ```ballerina
+    map<
+        int
+        |
+        string
+    > x;
+    ```
 
 ## Operators
 * Keep only a single space before and after the `=` operator.
   
-**Example,**
+    **Example,**
 
-```ballerina
-int a = 0;
-```
+    ```ballerina
+    int a = 0;
+    ```
 
 * Do not keep spaces around the semicolon `;`.
 * Do not keep spaces between the unary operator and the expression.
 
-**Example,**
+    **Example,**
 
-```ballerina
-a = -a;
-``` 
+    ```ballerina
+    a = -a;
+    ``` 
 
 * Keep a single space before and after any `binary` or `ternary` operator.
 
-**Example,**
+    **Example,**
 
-```ballerina
-var fullName = firstName + lastName;
-  
-string? name = isNameAvailable() ? getName() : "Unknown";
-  
-var elvisOperator = name ?: "Unknown";
-```
+    ```ballerina
+    var fullName = firstName + lastName;
+    
+    string? name = isNameAvailable() ? getName() : "Unknown";
+    
+    var elvisOperator = name ?: "Unknown";
+    ```
 
 * Keep a single space before and after a compound operator such as `-=` and `+=`.
 
-**Example,**
+    **Example,**
 
-```ballerina
-name += lastName;
-```
+    ```ballerina
+    name += lastName;
+    ```
 
 <div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
 

--- a/swan-lake/development-tutorials/source-code-dependencies/style-guide/statements.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/style-guide/statements.md
@@ -12,26 +12,26 @@ intro: The sections below include the coding conventions with respect to stateme
 
 * Avoid enclosing the condition with parentheses.
   
-**Do's**
+    **Do's**
 
-```ballerina
-if valid {
-    ...
-} else if active {
-    ...
-}
-```
+    ```ballerina
+    if valid {
+        ...
+    } else if active {
+        ...
+    }
+    ```
   
-**Don'ts**
+    **Don'ts**
 
 
-```ballerina
-if (valid) {
-    ...
-} else if (active) {
-    ...
-}
-```
+    ```ballerina
+    if (valid) {
+        ...
+    } else if (active) {
+        ...
+    }
+    ```
 
 * Keep the `else` and `else if` keywords in the same line with the matching `if` or `else if` block's
   closing brace separated only by a single space.
@@ -41,17 +41,17 @@ if (valid) {
 * Do not have any empty `if`, `else if`, or `else` blocks.
 * If empty, add an empty line between the opening and closing braces.
       
-**Example,**
+    **Example,**
 
-```ballerina
-if inProperSallaryRange {
-      
-} else if inSallaryRange {
-      
-} else {
-      
-}
-```
+    ```ballerina
+    if inProperSallaryRange {
+        
+    } else if inSallaryRange {
+        
+    } else {
+        
+    }
+    ```
 
 ## Match statement
 
@@ -60,43 +60,43 @@ if inProperSallaryRange {
 * Block indent each pattern clause in its own line.
 * Keep a single space before and after the `=>` sign.
 
-**Example,**
+    **Example,**
 
-```ballerina
-function foo(string|int|boolean a) returns string {
-    match a {
-        12 => {
-            return "Value is '12'";
+    ```ballerina
+    function foo(string|int|boolean a) returns string {
+        match a {
+            12 => {
+                return "Value is '12'";
+            }
         }
+    
+        return "Value is 'Default'";
     }
-  
-    return "Value is 'Default'";
-}
-```
+    ```
 
 * If a pattern clause has more than one statement, block indent each statement in its own line.
 
-**Example,**
+    **Example,**
 
-```ballerina
-match x {
-    var [s, i] if s is string => {
-        io:println("string");
+    ```ballerina
+    match x {
+        var [s, i] if s is string => {
+            io:println("string");
+        }
+        var [s, i] if s is int => {
+            io:println("int");
+        }
     }
-    var [s, i] if s is int => {
-        io:println("int");
-    }
-}
-```
+    ```
 
 * If the pattern body is empty, then keep it as an empty block.
   
   
   **Example,**
 
-```ballerina
-match x {
-    var [s, i] if s is string => {}
-    var [s, i] if s is int => {}
-}
-```
+    ```ballerina
+    match x {
+        var [s, i] if s is string => {}
+        var [s, i] if s is int => {}
+    }
+    ```

--- a/swan-lake/development-tutorials/source-code-dependencies/style-guide/top-level-definitions.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/style-guide/top-level-definitions.md
@@ -10,118 +10,118 @@ intro: The sections below include the coding conventions with respect to top-lev
 
 * Do not indent the top-level definitions. 
   
-**Do's**
+    **Do's**
 
-```ballerina
-import ballerina/http;
+    ```ballerina
+    import ballerina/http;
 
-const int MIN_AGE = 20;
-int repetitions = 0;
+    const int MIN_AGE = 20;
+    int repetitions = 0;
 
-service / on ep1 {
-    ...
-}
-```
-
-**Don'ts**
-  
-```ballerina
-// This import is indented correctly.
-import ballerina/http; 
-    
-    const int MIN_AGE = 20; // Not indented correctly.
-    int repetitions = 0; // Not indented correctly.
-        
-// Not indented correctly.
-service / on ep1 {
-    ...
+    service / on ep1 {
+        ...
     }
-```
+    ```
+
+    **Don'ts**
+    
+    ```ballerina
+    // This import is indented correctly.
+    import ballerina/http; 
+        
+        const int MIN_AGE = 20; // Not indented correctly.
+        int repetitions = 0; // Not indented correctly.
+            
+    // Not indented correctly.
+    service / on ep1 {
+        ...
+        }
+    ```
 
 ## Import declaration
 
 * Do not keep spaces between the organization name, divider `/`, and module name.
 
-**Example,**
+    **Example,**
 
-```ballerina
-import ballerina/http;
-```
+    ```ballerina
+    import ballerina/http;
+    ```
 
 * Imports should be sorted alphabetically, first by the organization name and then by the module name.
 
 ## Function definition
 * Do not keep spaces between the function name and the open parentheses `(` of the function signature.
 
-**Example,**
+    **Example,**
 
-```ballerina
-function func1() {
-}
-```
+    ```ballerina
+    function func1() {
+    }
+    ```
 
 * If the function needs to be split into new lines due to it exceeding the max line length, you can break lines from the parameter list by moving only a parameter value to a new line and indenting it with four spaces from the starting position of the function.
     
-**Example,**
+    **Example,**
 
-```ballerina
-function getAddress(int value,
-    string name) returns string? {
-    ...
-}
-```
+    ```ballerina
+    function getAddress(int value,
+        string name) returns string? {
+        ...
+    }
+    ```
 
   - You can break before the `returns` keyword and indent it with four spaces from the starting position of the function.
     
-**Example,**
+    **Example,**
 
-```ballerina
-function getAddress(int value, string name)
-    returns string? {
-    ...
-}    
-```
+    ```ballerina
+    function getAddress(int value, string name)
+        returns string? {
+        ...
+    }    
+    ```
 
   - You can break after the `returns` keyword by moving the return value to a new line
     and indenting it with four spaces from the starting position of the function.
     
-**Example,**
+    **Example,**
 
-```ballerina
-function getAddress(int value, string name) returns
-    string? {
-    ...
-}          
-```
+    ```ballerina
+    function getAddress(int value, string name) returns
+        string? {
+        ...
+    }          
+    ```
 
 ## Service definition
 
 * Keep the listener inline with the service signature.
   
-**Example,**
+    **Example,**
 
-```ballerina
-service / on new http:Listener(9090) {
-  ...
-}
-```
+    ```ballerina
+    service / on new http:Listener(9090) {
+    ...
+    }
+    ```
 
 * When formatting service-level method definitions, block indent each element and
   follow the [Function definition](/learn/style-guide/top-level-definitions/#function-definition) formatting guidelines.
   
-**Example,**
+    **Example,**
 
-```ballerina
-import ballerina/http;
+    ```ballerina
+    import ballerina/http;
 
-service / on new http:Listener(9090) {
+    service / on new http:Listener(9090) {
 
-    resource function get greeting() returns string {
-        return "Hello, World!";
+        resource function get greeting() returns string {
+            return "Hello, World!";
+        }
+        
     }
-    
-}
-```
+    ```
 
 * Block indent each method definition, and field definition inside a service definition.
  
@@ -131,95 +131,95 @@ service / on new http:Listener(9090) {
 * The `init` method should be placed before all the other methods.
 * For method definitions in the class definition, follow the [Function definition](/learn/style-guide/top-level-definitions/#function-definition) formatting guidelines.
 
-**Example,**
+    **Example,**
 
-```ballerina
-class Person {
-    public boolean isMarried = false;
-    int age;
-    string name;
+    ```ballerina
+    class Person {
+        public boolean isMarried = false;
+        int age;
+        string name;
 
-    function init(string name, int age = 0) {
-        self.age = age;
-        self.name = name;
+        function init(string name, int age = 0) {
+            self.age = age;
+            self.name = name;
+        }
+
+        function getName() returns string {
+            return self.name;
+        }
+
+        function setIsMarried(boolean isMarried) {
+            self.isMarried = isMarried;
+        }
+
+        function getIsMarried() returns boolean {
+            return self.isMarried;
+        }
     }
-
-    function getName() returns string {
-        return self.name;
-    }
-
-    function setIsMarried(boolean isMarried) {
-        self.isMarried = isMarried;
-    }
-
-    function getIsMarried() returns boolean {
-        return self.isMarried;
-    }
-}
-```
+    ```
 
 ## Record definition
-Block indent each of the field definitions (including the rest field) in their own line.
+* Block indent each of the field definitions (including the rest field) in their own line.
 
-**Example,**
+    **Example,**
 
-```ballerina
-type Person record {|
-    string name;
-    int...;
-|};
+    ```ballerina
+    type Person record {|
+        string name;
+        int...;
+    |};
 
-// or
+    // or
 
-type Person record {|
-    int id;
-    string name;
-|};
-```
+    type Person record {|
+        int id;
+        string name;
+    |};
+    ```
 
 ## Reference record or object
 * Do not keep spaces between the `*` and the object name or the record name.
   
-**Example,**
-  
-```ballerina
-*Person;
-```
+    **Example,**
+    
+    ```ballerina
+    *Person;
+    ```
 * Also, block-indent.
 
-**Example:**
+    **Example:**
 
-```ballerina
-type UserId record {
-    string id = "";
-};
-  
-type User record {
-    *UserId; // Reference to UserId record.
-    string name = "john";
-    int age = 20;
-};
+    ```ballerina
+    type UserId record {
+        string id = "";
+    };
+    
+    type User record {
+        *UserId; // Reference to UserId record.
+        string name = "john";
+        int age = 20;
+    };
 
-// or
-type Person object {
-    string name;
+    // or
+    type Person object {
+        string name;
 
-    // Object function definitions.
-    function getName() returns string;
-};
+        // Object function definitions.
+        function getName() returns string;
+    };
 
-class Employee {
-    *Person; // Reference to Person object type.
+    class Employee {
+        *Person; // Reference to Person object type.
 
-    function init() {
-        self.name = "John Doe";
+        function init() {
+            self.name = "John Doe";
+        }
+
+        function getName() returns string {
+            return self.name;
+        }
     }
-
-    function getName() returns string {
-        return self.name;
-    }
-}
-```
+    ```
 
 <div class="cGitButtonContainer"><p data-button="iGitStarText">"Star"</p><p data-button="iGitWatchText">"Watch"</p></div>
 


### PR DESCRIPTION
## Purpose
Fix bullet indentation in style guide pages.

> Fixes #8564 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
