### PR TITLE
Remove the incomplete sentence in `Package references` page

### DIFF
--- a/swan-lake/development-tutorials/source-code-dependencies/package-references.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/package-references.md
@@ -270,10 +270,9 @@ username = "<maven-repository-username>"
 password = "<maven-repository-password>"
 ```
 
-
 When working with JAR file dependencies, it is a best practice to attach them to the default root module of your package if your package has only the default root module. This makes it easy to manage and maintain the dependencies. However, if your package is a Ballerina library package, it is recommended that you specify the JAR file dependencies in each Ballerina module that depends on the JAR file.
 
-By default, the `bal build` command will package all JAR files specified in the `Ballerina.toml` file along with the executable JAR file. This ensures that the executable JAR file includes all necessary dependencies making the package self-contained and easy to use. This approach allows for a more organized and efficient way of managing dependencies and ensures that the 
+By default, the `bal build` command will package all JAR files specified in the `Ballerina.toml` file along with the executable JAR file. This ensures that the executable JAR file includes all necessary dependencies making the package self-contained and easy to use.
 
 **Provide the path of JAR file**
 


### PR DESCRIPTION
## Purpose
Remove the incomplete sentence in the `Package references` page.

> Fixes #8549

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
