### PR TITLE
Remove extra space in the EDI page cURL command

### DIFF
--- a/swan-lake/integration-tools/edi-tool.md
+++ b/swan-lake/integration-tools/edi-tool.md
@@ -272,7 +272,7 @@ Follow the steps below to use the generated package by running the cloned Baller
     >**Info:** You can convert EDI text to JSON using a cURL command, as shown below. 
 
     ```
-    curl --location 'http://localhost:8090/getEDI' \ 
+    curl --location 'http://localhost:8090/getEDI' \
     --header 'Content-Type: text/plain' \
     --data 'BGM+380+4467862+9'\''
     DTM+137:20230719:102'\''


### PR DESCRIPTION
## Purpose
Remove extra space in the EDI page cURL command.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
