### PR TITLE
Change the `bal build` command in Package references page

### DIFF
--- a/swan-lake/development-tutorials/source-code-dependencies/package-references.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/package-references.md
@@ -59,7 +59,7 @@ visibility = "private"
 
 ### The `org` field
 
-The organization is a logical name used for grouping modules together under a common namespace within a repository. Building a library package with `bal build` and pushing a library package into a repository will fail without an organization name.
+The organization is a logical name used for grouping modules together under a common namespace within a repository. Building a library package with `bal pack` and pushing a library package into a repository will fail without an organization name.
 
 Organization names can only contain alphanumerics, underscore, and the maximum length is 256 characters.
 

--- a/swan-lake/development-tutorials/source-code-dependencies/package-references.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/package-references.md
@@ -59,7 +59,7 @@ visibility = "private"
 
 ### The `org` field
 
-The organization is a logical name used for grouping modules together under a common namespace within a repository. Building a library package with `bal pack` and pushing a library package into a repository will fail without an organization name.
+The organization is a logical name used for grouping modules together under a common namespace within a repository. 
 
 Organization names can only contain alphanumerics, underscore, and the maximum length is 256 characters.
 

--- a/swan-lake/development-tutorials/source-code-dependencies/package-references.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/package-references.md
@@ -61,7 +61,7 @@ visibility = "private"
 
 The organization is a logical name used for grouping modules together under a common namespace within a repository. 
 
-Organization names can only contain alphanumerics, underscore, and the maximum length is 256 characters.
+Organization name is mandatory and can only contain alphanumerics, underscore, and the maximum length is 256 characters.
 
 When you run the `bal new` command, the organization name by default will be set to the user name of your machine. You can choose to update the `Ballerina.toml` file to amend the organization name appropriately.
 


### PR DESCRIPTION
## Purpose
Change the `bal build` command to `bal pack` in the `Package references` page.

> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
