### PR TITLE
Remove the word `Docerina` from docs

### DIFF
--- a/swan-lake/development-tutorials/test-document-the-code/generate-code-documentation.md
+++ b/swan-lake/development-tutorials/test-document-the-code/generate-code-documentation.md
@@ -5,7 +5,7 @@ description: Learn how to write unstructured documents with a bit of structure t
 keywords: ballerina, programming language, api documentation, api docs
 permalink: /learn/generate-code-documentation/
 active: generate-code-documentation
-intro: Ballerina has a built-in Ballerina Flavored Markdown (BFM) documentation framework named Docerina. The documentation framework allows you to write unstructured documents with a bit of structure to generate HTML content as API documentation.
+intro: Ballerina has a built-in Ballerina Flavored Markdown (BFM) documentation framework, which allows you to write unstructured documents with a bit of structure to generate HTML content as API documentation.
 ---
 
 ## Generate documentation for modules


### PR DESCRIPTION
## Purpose
Remove the word `Docerina` from docs.

> Fixes #8585 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
