### PR TITLE
Change the `bal persist overview` page title

### DIFF
--- a/swan-lake/development-tutorials/ballerina-persist/bal-persist-overview.md
+++ b/swan-lake/development-tutorials/ballerina-persist/bal-persist-overview.md
@@ -9,6 +9,7 @@ intro: The `bal persist` feature allows you to store data in different data stor
 redirect_from:
 - /learn/ballerina-persist/persist-overview/
 ---
+
 This feature has three main components: the data model, CLI tool, and type-safe client API. 
 * Data model: The data model definition is used to define the data model. 
 * CLI tool: The CLI tool is used to generate the client API for the data model. 

--- a/utils/learn-lm.json
+++ b/utils/learn-lm.json
@@ -481,7 +481,7 @@
                     "id": "ballerina-persist",
                     "subDirectories": [
                         {
-                            "dirName": "Overview",
+                            "dirName": "Bal persist overview",
                             "level": 3,
                             "position": 1,
                             "isDir": false,


### PR DESCRIPTION
## Purpose
Change the `bal persist overview` page title.

> Fixes #8586 

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
