### PR TITLE
Remove backticks from Downloads page

### DIFF
--- a/pages/downloads/index.js
+++ b/pages/downloads/index.js
@@ -120,7 +120,7 @@ export default function Downloads() {
                   <a id="packVsCode" href="vscode://wso2.ballerina/open-file?gist=74cea880fefcb463d26a0c46f38fce39&file=hello_world.bal" 
                   className={styles.cVSCodeSample} data-download="downloads" 
                   target="_blank" rel="noreferrer">
-                     <div className={styles.cSize}>Open `hello_world.bal` on <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Visual Studio Code</p></div>
+                     <div className={styles.cSize}>Open <code style={{padding:"3px", color:"#585a5e"}}>hello_world.bal</code> on <p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Visual Studio Code</p></div>
                   </a>
                </Col>
 


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #8638
![image](https://github.com/ballerina-platform/ballerina-dev-website/assets/7709843/91ca76e9-8c48-4344-a589-fc2b6b4686ea)


## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
