### PR TITLE
Move proxy configuration to a separate page

### DIFF
--- a/components/learn/boxes/Boxes.js
+++ b/components/learn/boxes/Boxes.js
@@ -759,6 +759,14 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Publish your library package to Ballerina Central.</p>
                       </div>
+                      <div className={styles.content}>
+                        <p className={styles.title}>
+                          <a href={`${prefix}/learn/configure-a-network-proxy`} className={styles.titleLink}>
+                            Configure a network proxy
+                          </a>
+                        </p>
+                        <p className={styles.description}>Perform operations with the Ballerina Central over an HTTP proxy.</p>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/swan-lake/development-tutorials/ballerina-central/configure-a-network-proxy.md
+++ b/swan-lake/development-tutorials/ballerina-central/configure-a-network-proxy.md
@@ -1,0 +1,48 @@
+---
+layout: ballerina-configure-a-network-proxy-left-nav-pages-swanlake
+title: Configure a network proxy
+description: In corporate environments, direct HTTP internet access is often restricted, with a preference for routing traffic through proxies. The following section provides a detailed guide on configuring your system to ensure access to Ballerina Central, even when working behind a proxy.
+keywords: ballerina, programming language, ballerina packages, network proxy
+permalink: /learn/configure-a-network-proxy/
+active: configure-a-network-proxy
+intro: In corporate environments, direct HTTP internet access is often restricted, with a preference for routing traffic through proxy servers. The following section provides a detailed guide on configuring your system to ensure access to Ballerina Central, even when working behind a proxy.
+---
+
+## Configure a network proxy
+
+If you are connected to the internet via an HTTP proxy, you need to configure it in the `<USER_HOME>/.ballerina/Settings.toml` file to carry out operations related to the Ballerina Central such as publishing a package, pulling a package, and resolving packages. Below is the TOML syntax for the proxy settings.
+
+```toml
+[proxy]
+host = "HOST_NAME"
+port = PORT
+username = "PROXY_USERNAME"
+password = "PROXY_PASSWORD"
+
+If your proxy does not require any credentials, keep `username` and `password` fields empty as shown below.
+
+```toml
+[proxy]
+host = "HOST_NAME"
+port = PORT
+username = ""
+password = ""
+```
+
+### Add necessary certificates to the truststore
+
+If you encounter any certificate-related issues such as the one below when connecting via a proxy:
+
+> PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target.
+
+ follow the steps below to trust the certificates associated with the proxy.
+
+1) Navigate to the `dependencies/` folder in the Ballerina installation directory. Here, you should notice one or more Java Runtime Environment (JRE) instances.
+2) Identify the certificates associated with the proxy. This information is typically found in the documentation provided by your proxy vendor.
+3) Execute the below command in a command line with administrative privileges.
+
+    ```
+    <BALLERINA_JRE>/bin/keytool.exe -import -trustcacerts -file <CERTS_PATH> -alias <ALIAS_NAME> -keystore <BALLERINA_JRE>/lib/security/cacerts
+    ```
+
+> **Note:** If you are using multiple Ballerina distributions, you may need to follow the above steps to all the JRE instances individually for each distribution.

--- a/swan-lake/development-tutorials/ballerina-central/publish-packages-to-ballerina-central.md
+++ b/swan-lake/development-tutorials/ballerina-central/publish-packages-to-ballerina-central.md
@@ -68,45 +68,7 @@ You can publish a Ballerina archive to the <a href="https://central.ballerina.io
 
 3. Download and place the `Settings.toml` file in your home repository (`<USER_HOME>/.ballerina/`). If you already have a `Settings.toml` file configured in your home repository, follow the other option and copy the access token into the `Settings.toml`. 
 
-### Configure proxy settings (optional)
-
-If you are connected to the internet via an HTTP proxy, you need to configure it in the `Settings.toml` file to carry out the Ballerina Central related operations such as publishing a package, pulling a package or resolving packages. Add the following section to `Settings.toml`.
-
-```toml
-[proxy]
-host = "HOST_NAME"
-port = PORT
-username = "PROXY_USERNAME"
-password = "PROXY_PASSWORD"
-```
-
-If your proxy does not require any credentials, keep username, password fields as empty as below.
-
-```toml
-[proxy]
-host = "HOST_NAME"
-port = PORT
-username = ""
-password = ""
-```
-
-##### Add necessary certificates to the truststore
-
-If you encounter any certificate-related issues such as the one below when connecting via a proxy:
-
-> PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target.
-
- follow the steps below to trust the certificates associated with the proxy.
-
-1) Navigate to the `dependencies/` folder located in the Ballerina installation directory. Here, you should notice one or more Java Runtime Environment (JRE) instances.
-2) Identify the certificates associated with the proxy. This information is typically found in the documentation provided by your proxy vendor.
-3) Execute the below command in a command line with administrative privileges.
-
-    ```
-    <BALLERINA_JRE>/bin/keytool.exe -import -trustcacerts -file <CERTS_PATH> -alias <ALIAS_NAME> -keystore <BALLERINA_JRE>/lib/security/cacerts
-    ```
-
-> **Note:** If you are using multiple Ballerina distributions, you may need to follow the above steps to all the JRE instances individually for each distribution.
+4. Optionally, if you are connected to the internet via an HTTP proxy, configure the proxy settings in the `Settings.toml` file to access the Ballerina Central to publish packages. For more information on proxy settings, see [Configure a network proxy](/learn/configure-a-network-proxy).
 
 ### Define the organization
 

--- a/swan-lake/development-tutorials/source-code-dependencies/manage-dependencies.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/manage-dependencies.md
@@ -24,6 +24,8 @@ The distribution repository is a file system repository added with the local Bal
 
 The Ballerina Central is a remote repository and creates a local file system cache at `<USER_HOME>/.ballerina/repositories/central.ballerina.io/bala`. Ballerina queries the remote repository only if the specified dependency version is not present in its local cache.
 
+> **Note:** If you are connected to the internet via an HTTP proxy, you need to configure the proxy settings to perform operations with the Ballerina Central. For more information on proxy settings, see [Configure a network proxy](/learn/configure-a-network-proxy).
+
 **Local repository**
 
 The local repository is also a file system repository, which will be created in the `<USER_HOME>` location. The repository location is `<USER_HOME>/.ballerina/repositories/local/bala`. 

--- a/utils/learn-lm.json
+++ b/utils/learn-lm.json
@@ -715,6 +715,14 @@
                             "isDir": false,
                             "url": "/learn/publish-packages-to-ballerina-central",
                             "id": "publish-packages-to-ballerina-central"
+                        },
+                        {
+                            "dirName": "Configure a network proxy",
+                            "level": 3,
+                            "position": 2,
+                            "isDir": false,
+                            "url": "/learn/configure-a-network-proxy",
+                            "id": "configure-a-network-proxy"
                         }
                     ]
                 },


### PR DESCRIPTION
## Purpose
> Fixes #8728 

## Checklist

- [ ] **Page addition**
  - [x] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
