### PR TITLE
Reorganize titles in proxy doc

### DIFF
--- a/swan-lake/development-tutorials/ballerina-central/configure-a-network-proxy.md
+++ b/swan-lake/development-tutorials/ballerina-central/configure-a-network-proxy.md
@@ -8,7 +8,7 @@ active: configure-a-network-proxy
 intro: In corporate environments, direct HTTP internet access is often restricted, with a preference for routing traffic through proxy servers. The following section provides a detailed guide on configuring your system to ensure access to Ballerina Central, even when working behind a proxy.
 ---
 
-## Configure a network proxy
+## Configure proxy settings
 
 If you are connected to the internet via an HTTP proxy, you need to configure it in the `<USER_HOME>/.ballerina/Settings.toml` file to carry out operations related to the Ballerina Central such as publishing a package, pulling a package, and resolving packages. Below is the TOML syntax for the proxy settings.
 
@@ -30,7 +30,7 @@ username = ""
 password = ""
 ```
 
-### Add necessary certificates to the truststore
+## Add necessary certificates to the truststore
 
 If you encounter any certificate-related issues such as the one below when connecting via a proxy:
 

--- a/swan-lake/development-tutorials/ballerina-central/publish-packages-to-ballerina-central.md
+++ b/swan-lake/development-tutorials/ballerina-central/publish-packages-to-ballerina-central.md
@@ -68,7 +68,8 @@ You can publish a Ballerina archive to the <a href="https://central.ballerina.io
 
 3. Download and place the `Settings.toml` file in your home repository (`<USER_HOME>/.ballerina/`). If you already have a `Settings.toml` file configured in your home repository, follow the other option and copy the access token into the `Settings.toml`. 
 
-4. Optionally, if you are connected to the internet via an HTTP proxy, configure the proxy settings in the `Settings.toml` file to access the Ballerina Central to publish packages. For more information on proxy settings, see [Configure a network proxy](/learn/configure-a-network-proxy).
+### Configure proxy settings (optional)
+If you are connected to the internet via an HTTP proxy, configure the proxy settings in the `Settings.toml` file to access the Ballerina Central to publish packages. For more information on proxy settings, see [Configure a network proxy](/learn/configure-a-network-proxy).
 
 ### Define the organization
 


### PR DESCRIPTION
## Purpose
> Fixes # 8858

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
