### PR TITLE
Add connector updates to the 2201.9.0 release note

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -279,23 +279,23 @@ All the connectors listed below have been released under new major versions, due
 
 #### `confluent.cregistry` package
 
-- Introduced support for integrating with the Confluent Schema Registry.
+- Introduced new APIs to connect with the Confluent Schema Registry.
 
 #### `docusign.dsadmin` package
 
-- Enhanced the connector APIs to align with DocuSign Admin APIs by incorporating resource functions.
-- With the new changes the package name is changed to `docusign.dsadmin` which was previously maintained under the name `docusign.admin`.
+- Enhanced the connector APIs by incorporating resource functions.
+- The package name has been changed to `docusign.dsadmin` from its previous name, `docusign.admin`.
 - Add the documentation and examples.
 
 #### `docusign.dsclick` package
 
-- Enhanced the connector APIs to align with DocuSign Click APIs by incorporating resource functions.
-- With the new changes the package name is changed to `docusign.dsclick` which was previously maintained under the name `docusign.click`.
+- Enhanced the connector APIs by incorporating resource functions.
+- The package name has been changed to `docusign.dsclick` from its previous name, `docusign.click`.
 - Add the documentation and examples.
 
 #### `docusign.dsesign` package
 
-- Introduced new APIs to align with DocuSign eSignature APIs by incorporating resource functions.
+- Introduced new APIs to connect with DocuSign eSignature REST APIs.
 - Add the documentation and examples.
 
 #### `github` package
@@ -305,7 +305,7 @@ All the connectors listed below have been released under new major versions, due
 #### `googleapis.gcalendar` package
 
 - Enhanced the connector APIs by incorporating resource functions.
-- With the new changes the package name is changed to `googleapis.gcalendar` which was previously maintained under the name `googleapis.calendar`.
+- The package name has been changed to `googleapis.gcalendar` from its previous name, `googleapis.calendar`.
 - Improved the documentation and examples.
 
 #### `guidewire.insnow` package

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -283,15 +283,20 @@ All the connectors listed below have been released under new major versions, due
 
 #### `docusign.dsadmin` package
 
-- Introduced new APIs to be consistent with DocuSign Admin APIs.
+- Introduced new APIs to be consistent with DocuSign Admin APIs by incorporating resource functions.
+- With the new changes the package name is changed to `docusign.dsadmin` which was previously maintained under the name `docusign.admin`.
+- Add the documentation and examples.
 
 #### `docusign.dsclick` package
 
-- Introduced new APIs to be consistent with DocuSign Click APIs.
+- Enhance new APIs to be consistent with DocuSign Click APIs by incorporating resource functions.
+- With the new changes the package name is changed to `docusign.dsclick` which was previously maintained under the name `docusign.click`.
+- Add the documentation and examples.
 
 #### `docusign.dsesign` package
 
-- Introduced new APIs to be consistent with DocuSign eSignature APIs.
+- Introduced new APIs to be consistent with DocuSign eSignature APIs by incorporating resource functions.
+- Add the documentation and examples.
 
 #### `github` package
 
@@ -299,7 +304,9 @@ All the connectors listed below have been released under new major versions, due
 
 #### `googleapis.gcalendar` package
 
-- Introduced support for connecting to Google Calendar REST APIs.
+- Enhanced the connector APIs by incorporating resource functions.
+- With the new changes the package name is changed to `googleapis.gcalendar` which was previously maintained under the name `googleapis.calendar`.
+- Improved the documentation and examples.
 
 #### `guidewire.insnow` package
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -293,13 +293,13 @@ All the connectors listed below have been released under new major versions, due
 
 - Introduced new APIs to be consistent with DocuSign eSignature APIs.
 
+#### `github` package
+
+- Introduced support for connecting to GitHub REST API version 2022-11-28, replacing the GitHub GraphQL API based connector.
+
 #### `googleapis.gcalendar` package
 
 - Introduced support for connecting to Google Calendar REST APIs.
-
-#### `github` package 
-
-- Introduced support for connecting to GitHub REST API version 2022-11-28, replacing the GitHub GraphQL API based connector.
 
 #### `guidewire.insnow` package
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -264,7 +264,7 @@ To view bug fixes, see the [GitHub milestone for Swan Lake Update 9 (2201.9.0)](
 
 The following new connectors along with major updates have been added to the Ballerina library, as part of the Ballerina connector revamp initiative.
 All the connectors listed below have been released under new major versions, due to significant changes in the APIs and functionalities.
-These updates also include improvements to the documentation and examples to enhance clarity for users.
+These updates also include improvements to the documentation and examples.
 
 #### `asana` package
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -258,6 +258,9 @@ All the connectors listed below have been released under new major versions, due
 #### `candid` package 
 
 - Introduced support for connecting to Candid's Charity Check, Essentials and Premier REST APIs.
+#### `googleapis.gcalendar` package
+
+- Introduced support for connecting to Google Calendar REST APIs.
 
 #### `github` package 
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -248,16 +248,24 @@ To view bug fixes, see the [GitHub milestone for Swan Lake Update 9 (2201.9.0)](
 
 ### Revamped connector updates
 
-The following new connectors along with major updates have been added to the Ballerina library, as part of the Ballerina connector revamp initiative. 
+The following new connectors along with major updates have been added to the Ballerina library, as part of the Ballerina connector revamp initiative.
 All the connectors listed below have been released under new major versions, due to significant changes in the APIs and functionalities.
 
 #### `asana` package
 
 - Enhanced connector APIs by incorporating resource function syntax, along with improved documentation and examples.
 
-#### `candid` package 
+#### `candid` package
 
 - Introduced support for connecting to Candid's Charity Check, Essentials and Premier REST APIs.
+
+#### `confluent.cavroserdes` package
+
+- Introduced support for serializing and deserializing data using Avro schemas stored in the Confluent Schmema Registry.
+
+#### `confluent.cregistry` package
+
+- Introduced support for integrating with the Confluent Schema Registry.
 
 #### `docusign.dsadmin` package
 
@@ -279,7 +287,7 @@ All the connectors listed below have been released under new major versions, due
 
 - Introduced support for connecting to GitHub REST API version 2022-11-28, replacing the GitHub GraphQL API based connector.
 
-#### `guidewire.insnow` package 
+#### `guidewire.insnow` package
 
 - Introduced support for connecting to Guidewire InsuranceNow REST API.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -263,8 +263,7 @@ To view bug fixes, see the [GitHub milestone for Swan Lake Update 9 (2201.9.0)](
 ### Revamped connector updates
 
 The following new connectors along with major updates have been added to the Ballerina library, as part of the Ballerina connector revamp initiative.
-All the connectors listed below have been released under new major versions, due to significant changes in the APIs and functionalities.
-These updates also include improvements to the documentation and examples.
+All listed connectors have been released under new major versions, featuring significant API and functionality changes, along with improved documentation and examples.
 
 #### `asana` package
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -285,18 +285,15 @@ All the connectors listed below have been released under new major versions, due
 
 - Enhanced the connector APIs by incorporating resource functions.
 - The package name has been changed to `docusign.dsadmin` from its previous name, `docusign.admin`.
-- Add the documentation and examples.
 
 #### `docusign.dsclick` package
 
 - Enhanced the connector APIs by incorporating resource functions.
 - The package name has been changed to `docusign.dsclick` from its previous name, `docusign.click`.
-- Add the documentation and examples.
 
 #### `docusign.dsesign` package
 
 - Introduced new APIs to connect with DocuSign eSignature REST APIs.
-- Add the documentation and examples.
 
 #### `github` package
 
@@ -306,7 +303,6 @@ All the connectors listed below have been released under new major versions, due
 
 - Enhanced the connector APIs by incorporating resource functions.
 - The package name has been changed to `googleapis.gcalendar` from its previous name, `googleapis.calendar`.
-- Improved the documentation and examples.
 
 #### `guidewire.insnow` package
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -283,19 +283,19 @@ All the connectors listed below have been released under new major versions, due
 
 #### `docusign.dsadmin` package
 
-- Introduced new APIs to be consistent with DocuSign Admin APIs by incorporating resource functions.
+- Enhanced the connector APIs to align with DocuSign Admin APIs by incorporating resource functions.
 - With the new changes the package name is changed to `docusign.dsadmin` which was previously maintained under the name `docusign.admin`.
 - Add the documentation and examples.
 
 #### `docusign.dsclick` package
 
-- Enhance new APIs to be consistent with DocuSign Click APIs by incorporating resource functions.
+- Enhanced the connector APIs to align with DocuSign Click APIs by incorporating resource functions.
 - With the new changes the package name is changed to `docusign.dsclick` which was previously maintained under the name `docusign.click`.
 - Add the documentation and examples.
 
 #### `docusign.dsesign` package
 
-- Introduced new APIs to be consistent with DocuSign eSignature APIs by incorporating resource functions.
+- Introduced new APIs to align with DocuSign eSignature APIs by incorporating resource functions.
 - Add the documentation and examples.
 
 #### `github` package

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -264,6 +264,7 @@ To view bug fixes, see the [GitHub milestone for Swan Lake Update 9 (2201.9.0)](
 
 The following new connectors along with major updates have been added to the Ballerina library, as part of the Ballerina connector revamp initiative.
 All the connectors listed below have been released under new major versions, due to significant changes in the APIs and functionalities.
+These updates also include improvements to the documentation and examples to enhance clarity for users.
 
 #### `asana` package
 
@@ -302,7 +303,7 @@ All the connectors listed below have been released under new major versions, due
 #### `googleapis.gcalendar` package
 
 - Enhanced the connector APIs by incorporating resource functions.
-- The package name has been changed to `googleapis.gcalendar` from its previous name, `googleapis.calendar`.
+- The package name has been changed to `googleapis.gcalendar` from its previous name, `googleapis.calendar`, which is still available for users.
 
 #### `guidewire.insnow` package
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -258,6 +258,19 @@ All the connectors listed below have been released under new major versions, due
 #### `candid` package 
 
 - Introduced support for connecting to Candid's Charity Check, Essentials and Premier REST APIs.
+
+#### `docusign.dsadmin` package
+
+- Introduced new APIs to be consistent with DocuSign Admin APIs.
+
+#### `docusign.dsclick` package
+
+- Introduced new APIs to be consistent with DocuSign Click APIs.
+
+#### `docusign.dsesign` package
+
+- Introduced new APIs to be consistent with DocuSign eSignature APIs.
+
 #### `googleapis.gcalendar` package
 
 - Introduced support for connecting to Google Calendar REST APIs.


### PR DESCRIPTION
## Purpose
Update the release note 2201.9.0 with the following connector updates.

> Google Calendar
> Docusign eSignature
> Docusign Admin
> Docusign Click
> Confluent Schema Registry
> Confluent Avro Serialization/Deserialization