### PR TITLE
Add compile time errors on interop calls of constructors of abstract classes as breaking changes

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -1273,6 +1273,16 @@ To view bug fixes, see the GitHub milestone for Swan Lake Update 9 (2201.9.0) of
 
 - To avoid clashes with Java identifiers, the character used for encoding and decoding identifiers has been changed from `$` to `&`.
 
+- Interop calls to constructors of Java abstract classes has been restricted at compile time.
+
+    For example, defining an external function to call as follows wil result in a compile-time error, says `{ballerina/jballerina.java}INSTANTIATION_ERROR ''java.io.InputStream' is abstract, and cannot be instantiated'` since `java.io.InputStream` is an abstract class.
+
+    ```ballerina
+    function newInputstream() returns handle = @java:Constructor {
+        'class: "java.io.InputStream"
+    } external;
+    ```
+
 ### Ballerina library changes
 
 #### `cloud` package

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -1273,7 +1273,7 @@ To view bug fixes, see the GitHub milestone for Swan Lake Update 9 (2201.9.0) of
 
 - To avoid clashes with Java identifiers, the character used for encoding and decoding identifiers has been changed from `$` to `&`.
 
-- Interop calls to Java abstract class constructors have been restricted at compile time.
+- A bug which resulted in no compilation errors for interop calls of Java abstract class constructors has been fixed.
 
     For example, defining an external function as follows will result in a compile-time error, says `{ballerina/jballerina.java}INSTANTIATION_ERROR ''java.io.InputStream' is abstract, and cannot be instantiated'` since `java.io.InputStream` is an abstract class.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -1273,9 +1273,9 @@ To view bug fixes, see the GitHub milestone for Swan Lake Update 9 (2201.9.0) of
 
 - To avoid clashes with Java identifiers, the character used for encoding and decoding identifiers has been changed from `$` to `&`.
 
-- A bug which resulted in no compilation errors for interop calls of Java abstract class constructors has been fixed.
+- A bug that resulted in no compilation errors for interop calls of Java abstract class constructors and interface methods has been fixed.
 
-    For example, defining an external function as follows will result in a compile-time error, says `{ballerina/jballerina.java}INSTANTIATION_ERROR ''java.io.InputStream' is abstract, and cannot be instantiated'` since `java.io.InputStream` is an abstract class.
+    For example, defining an external function as follows will result in a compile-time error, which states `{ballerina/jballerina.java}INSTANTIATION_ERROR ''java.io.InputStream' is abstract, and cannot be instantiated'`, since `java.io.InputStream` is an abstract class.
 
     ```ballerina
     function newInputstream() returns handle = @java:Constructor {

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -1273,9 +1273,9 @@ To view bug fixes, see the GitHub milestone for Swan Lake Update 9 (2201.9.0) of
 
 - To avoid clashes with Java identifiers, the character used for encoding and decoding identifiers has been changed from `$` to `&`.
 
-- Interop calls to constructors of Java abstract classes has been restricted at compile time.
+- Interop calls to Java abstract class constructors have been restricted at compile time.
 
-    For example, defining an external function to call as follows wil result in a compile-time error, says `{ballerina/jballerina.java}INSTANTIATION_ERROR ''java.io.InputStream' is abstract, and cannot be instantiated'` since `java.io.InputStream` is an abstract class.
+    For example, defining an external function as follows will result in a compile-time error, says `{ballerina/jballerina.java}INSTANTIATION_ERROR ''java.io.InputStream' is abstract, and cannot be instantiated'` since `java.io.InputStream` is an abstract class.
 
     ```ballerina
     function newInputstream() returns handle = @java:Constructor {


### PR DESCRIPTION
## Purpose
> $title

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
