### PR TITLE
[2201.9.2] Fix WSDL tool release note naming issue

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.2/RELEASE_NOTE.md
@@ -57,11 +57,11 @@ Introduced the WSDL CLI-tool as an experimental feature which generates Ballerin
 bal tool pull wsdl
 
 # To use the tool to generate Ballerina types from a WSDL file:
-bal wsdl -i <FileName> --operations <COMMA SEPARATED OPERATION NAMES>
+bal wsdl -i <FILE_NAME> --operations <COMMA_SEPARATED_OPERATION_NAMES>
 
-# -i <FileName>: Specifies the input WSDL file from which to generate Ballerina types.
+# -i <FILE_NAME>: Specifies the input WSDL file from which to generate Ballerina types.
 
-# --operations <COMMA SEPARATED OPERATION NAMES> (Optional):
+# --operations <COMMA_SEPARATED_OPERATION_NAMES> (Optional):
 #                Lists specific operations to generate Ballerina types for.
 ```
 


### PR DESCRIPTION
## Purpose
> $title.

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
