### PR TITLE
Add viewport tags to spec pages

### DIFF
--- a/public/spec/lang/2019R1/index.html
+++ b/public/spec/lang/2019R1/index.html
@@ -6,6 +6,7 @@ redirect_from:
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification, 2019R1</title>
   <meta charset="utf-8" />
   <link rel="shortcut icon" href="/img/favicon.ico">
@@ -17,7 +18,7 @@ redirect_from:
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2019R2/index.html
+++ b/public/spec/lang/2019R2/index.html
@@ -8,6 +8,7 @@ redirect_from:
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification, 2019R2</title>
   <meta charset="utf-8" />
   <link rel="shortcut icon" href="/img/favicon.ico">
@@ -19,7 +20,7 @@ redirect_from:
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2019R3/experimental.html
+++ b/public/spec/lang/2019R3/experimental.html
@@ -6,6 +6,7 @@ redirect_from:
 ---
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina 1.0 Experimental Features</title>
   <meta charset="utf-8">
   <link rel="shortcut icon" href="/img/favicon.ico">
@@ -17,7 +18,7 @@ redirect_from:
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2019R3/index.html
+++ b/public/spec/lang/2019R3/index.html
@@ -8,6 +8,7 @@ redirect_from:
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification, 2019R3</title>
   <meta charset="utf-8">
   <link rel="shortcut icon" href="/img/favicon.ico">
@@ -19,7 +20,7 @@ redirect_from:
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2020R1/index.html
+++ b/public/spec/lang/2020R1/index.html
@@ -8,6 +8,7 @@ redirect_from:
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification, 2020R1</title>
   <meta charset="utf-8">
   <link rel="shortcut icon" href="/img/favicon.ico">
@@ -19,7 +20,7 @@ redirect_from:
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2021R1/index.html
+++ b/public/spec/lang/2021R1/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2022R1/index.html
+++ b/public/spec/lang/2022R1/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2022R2/index.html
+++ b/public/spec/lang/2022R2/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2022R3/index.html
+++ b/public/spec/lang/2022R3/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2022R4/index.html
+++ b/public/spec/lang/2022R4/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2023R1/index.html
+++ b/public/spec/lang/2023R1/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/2024R1/index.html
+++ b/public/spec/lang/2024R1/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/draft/index.html
+++ b/public/spec/lang/draft/index.html
@@ -1,8 +1,7 @@
----
----
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina spec - draft build</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -13,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/draft/v2020-06-18/index.html
+++ b/public/spec/lang/draft/v2020-06-18/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/draft/v2020-09-16/index.html
+++ b/public/spec/lang/draft/v2020-09-16/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/draft/v2020-09-22/index.html
+++ b/public/spec/lang/draft/v2020-09-22/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/draft/v2020-12-07/spec.html
+++ b/public/spec/lang/draft/v2020-12-07/spec.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/draft/v2020-12-17/index.html
+++ b/public/spec/lang/draft/v2020-12-17/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/draft/v2022-01-07/index.html
+++ b/public/spec/lang/draft/v2022-01-07/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/draft/v2022R1/build/index.html
+++ b/public/spec/lang/draft/v2022R1/build/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ballerina Language Specification</title>
   <meta charset="utf-8">
   <style type="text/css">
@@ -11,7 +12,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>

--- a/public/spec/lang/master/index.html
+++ b/public/spec/lang/master/index.html
@@ -11,7 +11,7 @@
     td, th { border: solid thin; padding: 0.5em; }
     p.status { font-size: large; font-weight: bold; }
   </style>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,100i,300,300i,400,400i,500,500i,700,700i,900,900i&amp;display=swap">
+<link rel="stylesheet" href="../../../css/roboto.css">
 <link rel="stylesheet" href="style/ballerina-language-specification.css">
 <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script><script src="style/ballerina-language-specification.js"></script>
 </head>


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #9147

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
