### PR TITLE
Add deprecated xmldata module to the release notes

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.10.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.10.0/RELEASE_NOTE.md
@@ -246,11 +246,11 @@ public function main() returns error? {
 
 - Added parameter passing support for XSLT transformations.
 
+### Deprecations
+
 #### `xmldata` package
 
 - The `xmldata` package has been deprecated and will no longer be maintained or updated. Instead, it is recommended to use the [`ballerina/data.xmldata`](https://central.ballerina.io/ballerina/data.xmldata/latest) library for continued support and updates. For more information, see the new [XML to Record conversion example](https://ballerina.io/learn/by-example/xml-to-record/) and [XML to record conversion with projection example](https://ballerina.io/learn/by-example/xml-to-record-with-projection/).
-
-### Deprecations
 
 ### Bug fixes
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.10.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.10.0/RELEASE_NOTE.md
@@ -246,6 +246,10 @@ public function main() returns error? {
 
 - Added parameter passing support for XSLT transformations.
 
+#### `xmldata` package
+
+- The `xmldata` package has been deprecated and will no longer be maintained or updated. Instead, it is recommended to use the [`ballerina/data.xmldata`](https://central.ballerina.io/ballerina/data.xmldata/latest) library for continued support and updates. For more information, see the new [XML to Record conversion example](https://ballerina.io/learn/by-example/xml-to-record/) and [XML to record conversion with projection example](https://ballerina.io/learn/by-example/xml-to-record-with-projection/).
+
 ### Deprecations
 
 ### Bug fixes


### PR DESCRIPTION
## Purpose
$subject.

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
