### PR TITLE
Remove invalid options from VSCode guide

### DIFF
--- a/swan-lake/vs-code-extension/run-a-program.md
+++ b/swan-lake/vs-code-extension/run-a-program.md
@@ -37,33 +37,13 @@ Follow the steps below to use the code view to run a Ballerina program.
 
 Follow the steps below to use the code view to run a Ballerina program.
   
-1. View the diagram using one of the options below.
-
-    - **Option 1**
-
-        Click **Show Diagram** on the title bar of the editor to view the graphical representation of the program.
+1. Click **Show Diagram** on the title bar of the editor to view the graphical representation of the program.
         
-        <img src="/learn/images/vs-code-extension/build-and-try/build-and-run/show-diagram-button.png" class="cInlineImage-full"/>
+   <img src="/learn/images/vs-code-extension/build-and-try/build-and-run/show-diagram-button.png" class="cInlineImage-full"/>
+   
+2. Click **Run** on the title bar of the editor.
 
-    - **Option 2**
-
-        Click the Ballerina icon in the VS Code side menu to open the diagram explorer tree.
-        
-        <img src="/learn/images/vs-code-extension/build-and-try/build-and-run/diagram-explorer.png" class="cInlineImage-full"/>
-
-2. Run the program using one of the options below.
-
-    - **Option 1**
-
-        Click **Run** in the diagram options menu.
-
-        <img src="/learn/images/vs-code-extension/build-and-try/build-and-run/run-diagram-button.png" class="cInlineImage-full"/>
-
-    - **Option 2**
-    
-        Click **Run** on the title bar of the editor.
-
-        <img src="/learn/images/vs-code-extension/build-and-try/build-and-run/run-diagram-header-button.png" class="cInlineImage-full"/>
+   <img src="/learn/images/vs-code-extension/build-and-try/build-and-run/run-diagram-header-button.png" class="cInlineImage-full"/>
 
 The integrated terminal will open automatically and run the program.
 


### PR DESCRIPTION
## Purpose
- Remove invalid options from VSCode guide
- Fixes https://github.com/ballerina-platform/ballerina-dev-website/issues/8975

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
