### PR TITLE
Remove redirect_from fields

### DIFF
--- a/.github/scripts/bbe/convertMarkdown.js
+++ b/.github/scripts/bbe/convertMarkdown.js
@@ -386,10 +386,6 @@ const generateContent = (
             .map((k) => k.trim()),
     permalink: `/learn/by-example/${bbeName}`,
     active: bbeName,
-    redirect_from: [
-      `/swan-lake/learn/by-example/${bbeName}`,
-      `/swan-lake/learn/by-example/${bbeName}.html`,
-    ],
   };
 
   // buttons

--- a/downloads/1.2.x-release-notes/1.2.0.md
+++ b/downloads/1.2.x-release-notes/1.2.0.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.0
 permalink: /downloads/1.2.x-release-notes/1.2.0/
 active: 1.2.0
-redirect_from: 
 ---
 
 ## Overview of jBallerina 1.2.0

--- a/downloads/1.2.x-release-notes/1.2.1.md
+++ b/downloads/1.2.x-release-notes/1.2.1.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.1
 permalink: /downloads/1.2.x-release-notes/1.2.1/
 active: 1.2.1
-redirect_from: 
 ---
 
 ### Overview of jBallerina 1.2.1

--- a/downloads/1.2.x-release-notes/1.2.10.md
+++ b/downloads/1.2.x-release-notes/1.2.10.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.10 
 permalink: /downloads/1.2.x-release-notes/1.2.10/
 active: 1.2.10
-redirect_from: 
 ---
 
 ### Overview of jBallerina 1.2.10

--- a/downloads/1.2.x-release-notes/1.2.11.md
+++ b/downloads/1.2.x-release-notes/1.2.11.md
@@ -2,8 +2,7 @@
 layout: ballerina-left-nav-release-notes
 title: 1.2.11 
 permalink: /downloads/1.2.x-release-notes/1.2.11/
-active: 1.2.11
-redirect_from: 
+active: 1.2.11 
 ---
 ### Overview of jBallerina 1.2.11
 

--- a/downloads/1.2.x-release-notes/1.2.12.md
+++ b/downloads/1.2.x-release-notes/1.2.12.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.12 
 permalink: /downloads/1.2.x-release-notes/1.2.12/
 active: 1.2.12
-redirect_from:
 ---
 ### Overview of jBallerina 1.2.12
 

--- a/downloads/1.2.x-release-notes/1.2.13.md
+++ b/downloads/1.2.x-release-notes/1.2.13.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.13 
 permalink: /downloads/1.2.x-release-notes/1.2.13/
 active: 1.2.13
-redirect_from: 
 ---
 ### Overview of jBallerina 1.2.13
 The jBallerina 1.2.13 patch release improves upon the 1.2.12 release by addressing a few [issues](https://github.com/ballerina-platform/ballerina-lang/issues?q=is%3Aissue+milestone%3A%22Ballerina+1.2.13%22+is%3Aclosed).

--- a/downloads/1.2.x-release-notes/1.2.14.md
+++ b/downloads/1.2.x-release-notes/1.2.14.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.14 
 permalink: /downloads/1.2.x-release-notes/1.2.14/
 active: 1.2.14
-redirect_from: 
 ---
 ### Overview of jBallerina 1.2.14
 The jBallerina 1.2.14 patch release fixes a reported security issue [CVE-2021-32700](https://github.com/ballerina-platform/ballerina-lang/security/advisories/GHSA-f5qg-fqrw-v5ww).

--- a/downloads/1.2.x-release-notes/1.2.15.md
+++ b/downloads/1.2.x-release-notes/1.2.15.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.15 
 permalink: /downloads/1.2.x-release-notes/1.2.15/
 active: 1.2.15
-redirect_from:
 ---
 ### Overview of jBallerina 1.2.15
 

--- a/downloads/1.2.x-release-notes/1.2.16.md
+++ b/downloads/1.2.x-release-notes/1.2.16.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.16
 permalink: /downloads/1.2.x-release-notes/1.2.16/
 active: 1.2.16
-redirect_from:
 ---
 ### Overview of jBallerina 1.2.16
 

--- a/downloads/1.2.x-release-notes/1.2.17.md
+++ b/downloads/1.2.x-release-notes/1.2.17.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.17
 permalink: /downloads/1.2.x-release-notes/1.2.17/
 active: 1.2.17
-redirect_from:
 ---
 
 ### Overview of jBallerina 1.2.17

--- a/downloads/1.2.x-release-notes/1.2.18.md
+++ b/downloads/1.2.x-release-notes/1.2.18.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.18
 permalink: /downloads/1.2.x-release-notes/1.2.18/
 active: 1.2.18
-redirect_from:
 ---
 
 ### Overview of jBallerina 1.2.18

--- a/downloads/1.2.x-release-notes/1.2.2.md
+++ b/downloads/1.2.x-release-notes/1.2.2.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.2
 permalink: /downloads/1.2.x-release-notes/1.2.2/
 active: 1.2.2
-redirect_from: 
 ---
 
 ### Overview of jBallerina 1.2.2

--- a/downloads/1.2.x-release-notes/1.2.21.md
+++ b/downloads/1.2.x-release-notes/1.2.21.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.21
 permalink: /downloads/1.2.x-release-notes/1.2.21/
 active: 1.2.21
-redirect_from:
 ---
 
 ### Overview of jBallerina 1.2.21

--- a/downloads/1.2.x-release-notes/1.2.22.md
+++ b/downloads/1.2.x-release-notes/1.2.22.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.22
 permalink: /downloads/1.2.x-release-notes/1.2.22/
 active: 1.2.22
-redirect_from:
 ---
 
 ### Overview of jBallerina 1.2.22

--- a/downloads/1.2.x-release-notes/1.2.28.md
+++ b/downloads/1.2.x-release-notes/1.2.28.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.28
 permalink: /downloads/1.2.x-release-notes/1.2.28/
 active: 1.2.28
-redirect_from:
 ---
 
 ### Overview of jBallerina 1.2.28

--- a/downloads/1.2.x-release-notes/1.2.29.md
+++ b/downloads/1.2.x-release-notes/1.2.29.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.29
 permalink: /downloads/1.2.x-release-notes/1.2.29/
 active: 1.2.29
-redirect_from:
 ---
 
 ### Overview of jBallerina 1.2.29

--- a/downloads/1.2.x-release-notes/1.2.3.md
+++ b/downloads/1.2.x-release-notes/1.2.3.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.3
 permalink: /downloads/1.2.x-release-notes/1.2.3/
 active: 1.2.3
-redirect_from: 
 ---
 
 ### Overview of jBallerina 1.2.3

--- a/downloads/1.2.x-release-notes/1.2.30.md
+++ b/downloads/1.2.x-release-notes/1.2.30.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.30
 permalink: /downloads/1.2.x-release-notes/1.2.30/
 active: 1.2.30
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.30

--- a/downloads/1.2.x-release-notes/1.2.31.md
+++ b/downloads/1.2.x-release-notes/1.2.31.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.31
 permalink: /downloads/1.2.x-release-notes/1.2.31/
 active: 1.2.31
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.31

--- a/downloads/1.2.x-release-notes/1.2.32.md
+++ b/downloads/1.2.x-release-notes/1.2.32.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.32
 permalink: /downloads/1.2.x-release-notes/1.2.32/
 active: 1.2.32
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.32

--- a/downloads/1.2.x-release-notes/1.2.33.md
+++ b/downloads/1.2.x-release-notes/1.2.33.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.33
 permalink: /downloads/1.2.x-release-notes/1.2.33/
 active: 1.2.33
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.33

--- a/downloads/1.2.x-release-notes/1.2.34.md
+++ b/downloads/1.2.x-release-notes/1.2.34.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.34
 permalink: /downloads/1.2.x-release-notes/1.2.34/
 active: 1.2.34
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.34

--- a/downloads/1.2.x-release-notes/1.2.35.md
+++ b/downloads/1.2.x-release-notes/1.2.35.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.35
 permalink: /downloads/1.2.x-release-notes/1.2.35/
 active: 1.2.35
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.35

--- a/downloads/1.2.x-release-notes/1.2.36.md
+++ b/downloads/1.2.x-release-notes/1.2.36.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.36
 permalink: /downloads/1.2.x-release-notes/1.2.36/
 active: 1.2.36
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.36

--- a/downloads/1.2.x-release-notes/1.2.37.md
+++ b/downloads/1.2.x-release-notes/1.2.37.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.37
 permalink: /downloads/1.2.x-release-notes/1.2.37/
 active: 1.2.37
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.37

--- a/downloads/1.2.x-release-notes/1.2.38.md
+++ b/downloads/1.2.x-release-notes/1.2.38.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.38
 permalink: /downloads/1.2.x-release-notes/1.2.38/
 active: 1.2.38
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.38

--- a/downloads/1.2.x-release-notes/1.2.39.md
+++ b/downloads/1.2.x-release-notes/1.2.39.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.39
 permalink: /downloads/1.2.x-release-notes/1.2.39/
 active: 1.2.39
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.39

--- a/downloads/1.2.x-release-notes/1.2.4.md
+++ b/downloads/1.2.x-release-notes/1.2.4.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.4
 permalink: /downloads/1.2.x-release-notes/1.2.4/
 active: 1.2.4
-redirect_from: 
 ---
 
 ### Overview of jBallerina 1.2.4

--- a/downloads/1.2.x-release-notes/1.2.40.md
+++ b/downloads/1.2.x-release-notes/1.2.40.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.40
 permalink: /downloads/1.2.x-release-notes/1.2.40/
 active: 1.2.40
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.40

--- a/downloads/1.2.x-release-notes/1.2.41.md
+++ b/downloads/1.2.x-release-notes/1.2.41.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.41
 permalink: /downloads/1.2.x-release-notes/1.2.41/
 active: 1.2.41
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.41

--- a/downloads/1.2.x-release-notes/1.2.42.md
+++ b/downloads/1.2.x-release-notes/1.2.42.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.42
 permalink: /downloads/1.2.x-release-notes/1.2.42/
 active: 1.2.42
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.42

--- a/downloads/1.2.x-release-notes/1.2.43.md
+++ b/downloads/1.2.x-release-notes/1.2.43.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.43
 permalink: /downloads/1.2.x-release-notes/1.2.43/
 active: 1.2.43
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.43

--- a/downloads/1.2.x-release-notes/1.2.44.md
+++ b/downloads/1.2.x-release-notes/1.2.44.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.44
 permalink: /downloads/1.2.x-release-notes/1.2.44/
 active: 1.2.44
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.44

--- a/downloads/1.2.x-release-notes/1.2.45.md
+++ b/downloads/1.2.x-release-notes/1.2.45.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.45
 permalink: /downloads/1.2.x-release-notes/1.2.45/
 active: 1.2.45
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.45

--- a/downloads/1.2.x-release-notes/1.2.46.md
+++ b/downloads/1.2.x-release-notes/1.2.46.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.46
 permalink: /downloads/1.2.x-release-notes/1.2.46/
 active: 1.2.46
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.46

--- a/downloads/1.2.x-release-notes/1.2.47.md
+++ b/downloads/1.2.x-release-notes/1.2.47.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.47
 permalink: /downloads/1.2.x-release-notes/1.2.47/
 active: 1.2.47
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.47

--- a/downloads/1.2.x-release-notes/1.2.48.md
+++ b/downloads/1.2.x-release-notes/1.2.48.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.48
 permalink: /downloads/1.2.x-release-notes/1.2.48/
 active: 1.2.48
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.48

--- a/downloads/1.2.x-release-notes/1.2.49.md
+++ b/downloads/1.2.x-release-notes/1.2.49.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.49
 permalink: /downloads/1.2.x-release-notes/1.2.49/
 active: 1.2.49
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.49

--- a/downloads/1.2.x-release-notes/1.2.5.md
+++ b/downloads/1.2.x-release-notes/1.2.5.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.5 
 permalink: /downloads/1.2.x-release-notes/1.2.5/
 active: 1.2.5
-redirect_from: 
 ---
 
 ### Overview of jBallerina 1.2.5

--- a/downloads/1.2.x-release-notes/1.2.50.md
+++ b/downloads/1.2.x-release-notes/1.2.50.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.50
 permalink: /downloads/1.2.x-release-notes/1.2.50/
 active: 1.2.50
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.50

--- a/downloads/1.2.x-release-notes/1.2.51.md
+++ b/downloads/1.2.x-release-notes/1.2.51.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.51
 permalink: /downloads/1.2.x-release-notes/1.2.51/
 active: 1.2.51
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ### Overview of jBallerina 1.2.51

--- a/downloads/1.2.x-release-notes/1.2.52.md
+++ b/downloads/1.2.x-release-notes/1.2.52.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.52
 permalink: /downloads/1.2.x-release-notes/1.2.52/
 active: 1.2.52
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ## Overview of jBallerina 1.2.52

--- a/downloads/1.2.x-release-notes/1.2.53.md
+++ b/downloads/1.2.x-release-notes/1.2.53.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.53
 permalink: /downloads/1.2.x-release-notes/1.2.53/
 active: 1.2.53
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ## Overview of jBallerina 1.2.53

--- a/downloads/1.2.x-release-notes/1.2.54.md
+++ b/downloads/1.2.x-release-notes/1.2.54.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.54
 permalink: /downloads/1.2.x-release-notes/<RELEASE_VERSION>/
 active: 1.2.54
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ## Overview of jBallerina 1.2.54

--- a/downloads/1.2.x-release-notes/1.2.6.md
+++ b/downloads/1.2.x-release-notes/1.2.6.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.6
 permalink: /downloads/1.2.x-release-notes/1.2.6/
 active: 1.2.6
-redirect_from: 
 ---
 
 ### Overview of jBallerina 1.2.6

--- a/downloads/1.2.x-release-notes/1.2.7.md
+++ b/downloads/1.2.x-release-notes/1.2.7.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.7
 permalink: /downloads/1.2.x-release-notes/1.2.7/
 active: 1.2.7
-redirect_from: 
 ---
 
 ### Overview of jBallerina 1.2.7

--- a/downloads/1.2.x-release-notes/1.2.8.md
+++ b/downloads/1.2.x-release-notes/1.2.8.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.8
 permalink: /downloads/1.2.x-release-notes/1.2.8/
 active: 1.2.8
-redirect_from: 
 ---
 
 ### Overview of jBallerina 1.2.8

--- a/downloads/1.2.x-release-notes/1.2.9.md
+++ b/downloads/1.2.x-release-notes/1.2.9.md
@@ -3,7 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 1.2.9 
 permalink: /downloads/1.2.x-release-notes/1.2.9/
 active: 1.2.9
-redirect_from: 
 ---
 
 ### Overview of jBallerina 1.2.9

--- a/downloads/1.2.x-release-notes/1.2.x-bug-fixes-template.md
+++ b/downloads/1.2.x-release-notes/1.2.x-bug-fixes-template.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: <RELEASE_VERSION>
 permalink: /downloads/1.2.x-release-notes/<RELEASE_VERSION>/
 active: <RELEASE_VERSION>
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ## Overview of jBallerina <RELEASE_VERSION>

--- a/downloads/1.2.x-release-notes/1.2.x-security-fixes-template copy.md
+++ b/downloads/1.2.x-release-notes/1.2.x-security-fixes-template copy.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: <RELEASE_VERSION>
 permalink: /downloads/1.2.x-release-notes/<RELEASE_VERSION>/
 active: <RELEASE_VERSION>
-redirect_from:
-    - /downloads/1.2.x-release-notes/
 ---
 
 ## Overview of jBallerina <RELEASE_VERSION>

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.0/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.0.0 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-0-0/
 active: 2201-0-0
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-0-0
-    - /downloads/swan-lake-release-notes/2201.0.0/
-    - /downloads/swan-lake-release-notes/2201-0-0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-0-0-swan-lake
 ---
 
 ### Overview of Ballerina 2201.0.0 (Swan Lake)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.1/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.0.1 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-0-1/
 active: 2201-0-1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-0-1
-    - /downloads/swan-lake-release-notes/2201.0.1/
-    - /downloads/swan-lake-release-notes/2201-0-1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-0-1-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.0.1

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.2/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.0.2 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-0-2/
 active: 2201-0-2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-0-2-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-0-2-swan-lake
-    - /downloads/swan-lake-release-notes/2201-0-2
-    - /downloads/swan-lake-release-notes/2201.0.2/
 ---
 
 ## Overview of Ballerina Swan Lake 2201.0.2

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.3/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.0.3 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-0-3/
 active: 2201-0-3
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-0-3
-    - /downloads/swan-lake-release-notes/2201.0.3/
-    - /downloads/swan-lake-release-notes/2201-0-3-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-0-3-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.0.3

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.4/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.0.4 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-0-4/
 active: 2201-0-4
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-0-4
-    - /downloads/swan-lake-release-notes/2201.0.4/
-    - /downloads/swan-lake-release-notes/2201-0-4-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-0-4-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.0.4

--- a/downloads/swan-lake-release-notes/swan-lake-2201.0.5/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.0.5/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.0.5 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-0-5/
 active: 2201-0-5
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-0-5
-    - /downloads/swan-lake-release-notes/2201.0.5/
-    - /downloads/swan-lake-release-notes/2201-0-5-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-0-5-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.0.5

--- a/downloads/swan-lake-release-notes/swan-lake-2201.1.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.1.0/RELEASE_NOTE.md
@@ -3,10 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.1.0 (Swan Lake Update 1)
 permalink: /downloads/swan-lake-release-notes/2201.1.0/
 active: 2201-1-0
-redirect_from:
-    - /downloads/swan-lake-release-notes/2201-1-0
-    - /downloads/swan-lake-release-notes/2201-1-0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-1-0-swan-lake
 ---
 
 ## Overview of Ballerina 2201.1.0 (Swan Lake Update 1)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.1.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.1.1/RELEASE_NOTE.md
@@ -3,12 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.1.1 (Swan Lake Update 1) 
 permalink: /downloads/swan-lake-release-notes/2201.1.1/
 active: 2201-1-1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-1-1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-1-1-swan-lake
-    - /downloads/swan-lake-release-notes/2201-1-1
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake 2201.1.1

--- a/downloads/swan-lake-release-notes/swan-lake-2201.1.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.1.2/RELEASE_NOTE.md
@@ -3,13 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.1.2 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.1.2/
 active: 2201.1.2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.1.2
-    - /downloads/swan-lake-release-notes/2201.1.2/
-    - /downloads/swan-lake-release-notes/2201.1.2-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.1.2-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake 2201.1.2

--- a/downloads/swan-lake-release-notes/swan-lake-2201.10.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.10.0/RELEASE_NOTE.md
@@ -3,12 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.10.0 (Swan Lake)
 permalink: /downloads/swan-lake-release-notes/2201.10.0/
 active: 2201.10.0
-redirect_from:
-    - /downloads/swan-lake-release-notes/2201.10.0
-    - /downloads/swan-lake-release-notes/2201.10.0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.10.0-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake Update 10 (2201.10.0)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.0/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.2.0 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-2-0/
 active: 2201-2-0
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-2-0
-    - /downloads/swan-lake-release-notes/2201.2.0/
-    - /downloads/swan-lake-release-notes/2201-2-0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-2-0-swan-lake
 ---
 
 ### Overview of Ballerina 2201.2.0 (Swan Lake)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.1/RELEASE_NOTE.md
@@ -3,13 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.2.1 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.2.1/
 active: 2201.2.1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.2.1
-    - /downloads/swan-lake-release-notes/2201.2.1/
-    - /downloads/swan-lake-release-notes/2201.2.1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.2.1-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake 2201.2.1

--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.2/RELEASE_NOTE.md
@@ -3,13 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.2.2 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.2.2/
 active: 2201.2.2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.2.2
-    - /downloads/swan-lake-release-notes/2201.2.2/
-    - /downloads/swan-lake-release-notes/2201.2.2-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.2.2-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake 2201.2.2

--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.3/RELEASE_NOTE.md
@@ -3,13 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.2.3 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.2.3/
 active: 2201.2.3
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.2.3
-    - /downloads/swan-lake-release-notes/2201.2.3/
-    - /downloads/swan-lake-release-notes/2201.2.3-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.2.3-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake 2201.2.3

--- a/downloads/swan-lake-release-notes/swan-lake-2201.2.4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.2.4/RELEASE_NOTE.md
@@ -3,13 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.2.4 (Swan Lake)
 permalink: /downloads/swan-lake-release-notes/2201.2.4/
 active: 2201.2.4
-redirect_from:
-    - /downloads/swan-lake-release-notes/2201.2.4
-    - /downloads/swan-lake-release-notes/2201.2.4/
-    - /downloads/swan-lake-release-notes/2201.2.4-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.2.4-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake 2201.2.4

--- a/downloads/swan-lake-release-notes/swan-lake-2201.3.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.3.0/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.3.0 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-3-0/
 active: 2201-3-0
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-3-0
-    - /downloads/swan-lake-release-notes/2201.3.0/
-    - /downloads/swan-lake-release-notes/2201-3-0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-3-0-swan-lake
 ---
 
 ## Overview of Ballerina 2201.3.0 (Swan Lake)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.3.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.3.1/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.3.1 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-3-1/
 active: 2201-3-1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-3-1
-    - /downloads/swan-lake-release-notes/2201.3.1/
-    - /downloads/swan-lake-release-notes/2201-3-1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-3-1-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.3.1

--- a/downloads/swan-lake-release-notes/swan-lake-2201.3.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.3.2/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.3.2 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-3-2/
 active: 2201-3-2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-3-2
-    - /downloads/swan-lake-release-notes/2201.3.2/
-    - /downloads/swan-lake-release-notes/2201-3-2-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-3-2-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.3.2

--- a/downloads/swan-lake-release-notes/swan-lake-2201.3.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.3.3/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.3.3 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-3-3/
 active: 2201-3-3
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-3-3
-    - /downloads/swan-lake-release-notes/2201.3.3/
-    - /downloads/swan-lake-release-notes/2201-3-3-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-3-3-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.3.3

--- a/downloads/swan-lake-release-notes/swan-lake-2201.3.4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.3.4/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.3.4 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-3-4/
 active: 2201-3-4
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-3-4
-    - /downloads/swan-lake-release-notes/2201.3.4/
-    - /downloads/swan-lake-release-notes/2201-3-4-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-3-4-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.3.4

--- a/downloads/swan-lake-release-notes/swan-lake-2201.3.5/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.3.5/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.3.5 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-3-5/
 active: 2201-3-5
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-3-5
-    - /downloads/swan-lake-release-notes/2201.3.5/
-    - /downloads/swan-lake-release-notes/2201-3-5-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-3-5-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.3.5

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.0/RELEASE_NOTE.md
@@ -3,13 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.4.0 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.4.0/
 active: 2201.4.0
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.4.0
-    - /downloads/swan-lake-release-notes/2201.4.0/
-    - /downloads/swan-lake-release-notes/2201.4.0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.4.0-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake 2201.4.0

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.1/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.4.1 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-4-1/
 active: 2201-4-1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-4-1
-    - /downloads/swan-lake-release-notes/2201.4.1/
-    - /downloads/swan-lake-release-notes/2201-4-1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-4-1-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.4.1

--- a/downloads/swan-lake-release-notes/swan-lake-2201.4.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.4.2/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.4.2 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-4-2/
 active: 2201-4-2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-4-2
-    - /downloads/swan-lake-release-notes/2201.4-2/
-    - /downloads/swan-lake-release-notes/2201-4-2-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-4-2-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.4.2

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.0/RELEASE_NOTE.md
@@ -3,12 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.5.0 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.5.0/
 active: 2201.5.0
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.5.0
-    - /downloads/swan-lake-release-notes/2201.5.0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.5.0-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake 2201.5.0

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.1/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.5.1 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-5-1/
 active: 2201-5-1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-5-1
-    - /downloads/swan-lake-release-notes/2201.5.1/
-    - /downloads/swan-lake-release-notes/2201-5-1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-5-1-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.5.1

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.2/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.5.2 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-5-2/
 active: 2201-5-2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-5-2
-    - /downloads/swan-lake-release-notes/2201.5.2/
-    - /downloads/swan-lake-release-notes/2201-5-2-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-5-2-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.5.2

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.3/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.5.3 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-5-3/
 active: 2201-5-3
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-5-3
-    - /downloads/swan-lake-release-notes/2201.5.3/
-    - /downloads/swan-lake-release-notes/2201-5-3-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-5-3-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.5.3

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.4/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.5.4 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-5-4/
 active: 2201-5-4
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-5-4
-    - /downloads/swan-lake-release-notes/2201.5.4/
-    - /downloads/swan-lake-release-notes/2201-5-4-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-5-4-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.5.4

--- a/downloads/swan-lake-release-notes/swan-lake-2201.5.5/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.5.5/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Update 5 (2201.5.5)
 permalink: /downloads/swan-lake-release-notes/2201.5.5/
 active: 2201.5.5
-redirect_from:
-- /downloads/swan-lake-release-notes/2201.5.5
-- /downloads/swan-lake-release-notes/2201.5.5/
-- /downloads/swan-lake-release-notes/2201.5.5-swan-lake/
-- /downloads/swan-lake-release-notes/2201.5.5-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake Update 5 (2201.5.5)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.0/RELEASE_NOTE.md
@@ -3,12 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.6.0 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.6.0/
 active: 2201.6.0
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.6.0
-    - /downloads/swan-lake-release-notes/2201.6.0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.6.0-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake 2201.6.0

--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.1/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.6.1 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-6-1/
 active: 2201-6-1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-6-1
-    - /downloads/swan-lake-release-notes/2201.6.1/
-    - /downloads/swan-lake-release-notes/2201-6-1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-6-1-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.6.1

--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.2/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.6.2 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-6-2/
 active: 2201-6-2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-6-2
-    - /downloads/swan-lake-release-notes/2201.6.2/
-    - /downloads/swan-lake-release-notes/2201-6-2-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-6-2-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.6.2

--- a/downloads/swan-lake-release-notes/swan-lake-2201.6.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.6.3/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.6.3 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-6-3/
 active: 2201-6-3
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-6-3
-    - /downloads/swan-lake-release-notes/2201.6.3/
-    - /downloads/swan-lake-release-notes/2201-6-3-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-6-3-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.6.3

--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.0/RELEASE_NOTE.md
@@ -3,12 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.7.0 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.7.0/
 active: 2201.7.0
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.7.0
-    - /downloads/swan-lake-release-notes/2201.7.0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.7.0-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake 2201.7.0

--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.1/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.7.1 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-7-1/
 active: 2201-7-1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-7-1
-    - /downloads/swan-lake-release-notes/2201.7.1/
-    - /downloads/swan-lake-release-notes/2201-7-1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-7-1-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.7.1

--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.2/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.7.2 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-7-2/
 active: 2201-7-2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-7-2
-    - /downloads/swan-lake-release-notes/2201.7.2/
-    - /downloads/swan-lake-release-notes/2201-7-2-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-7-2-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.7.2

--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.3/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.7.3 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-7-3/
 active: 2201-7-3
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-7-3
-    - /downloads/swan-lake-release-notes/2201.7.3/
-    - /downloads/swan-lake-release-notes/2201-7-3-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-7-3-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.7.3

--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.4/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.7.4 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201-7-4/
 active: 2201-7-4
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201-7-4
-    - /downloads/swan-lake-release-notes/2201.7.4/
-    - /downloads/swan-lake-release-notes/2201-7-4-swan-lake/
-    - /downloads/swan-lake-release-notes/2201-7-4-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake 2201.7.3

--- a/downloads/swan-lake-release-notes/swan-lake-2201.7.5/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.7.5/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Update 7 (2201.7.5)
 permalink: /downloads/swan-lake-release-notes/2201.7.5/
 active: 2201.7.5
-redirect_from:
-- /downloads/swan-lake-release-notes/2201.7.5
-- /downloads/swan-lake-release-notes/2201.7.5/
-- /downloads/swan-lake-release-notes/2201.7.5-swan-lake/
-- /downloads/swan-lake-release-notes/2201.7.5-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake Update 7 (2201.7.5)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.0/RELEASE_NOTE.md
@@ -3,12 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.8.0 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.8.0/
 active: 2201.8.0
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.8.0
-    - /downloads/swan-lake-release-notes/2201.8.0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.8.0-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake Update 8 (2201.8.0)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.1/RELEASE_NOTE.md
@@ -3,12 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.8.1 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.8.1/
 active: 2201.8.1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.8.1
-    - /downloads/swan-lake-release-notes/2201.8.1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.8.1-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake Update 8 (2201.8.1)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.2/RELEASE_NOTE.md
@@ -3,12 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.8.2 (Swan Lake) 
 permalink: /downloads/swan-lake-release-notes/2201.8.2/
 active: 2201.8.2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.8.2
-    - /downloads/swan-lake-release-notes/2201.8.2-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.8.2-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake Update 8 (2201.8.2)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.6/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.6/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Update 8 (2201.8.6) 
 permalink: /downloads/swan-lake-release-notes/2201.8.6/
 active: 2201.8.6
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.8.6
-    - /downloads/swan-lake-release-notes/2201.8.6/
-    - /downloads/swan-lake-release-notes/2201.8.6-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.8.6-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake Update 8 (2201.8.6)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.7/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.7/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Update 8 (2201.8.7) 
 permalink: /downloads/swan-lake-release-notes/2201.8.7/
 active: 2201.8.7
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.8.7
-    - /downloads/swan-lake-release-notes/2201.8.7/
-    - /downloads/swan-lake-release-notes/2201.8.7-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.8.7-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake Update 8 (2201.8.7)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.8.8/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.8.8/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Update 8 (2201.8.8) 
 permalink: /downloads/swan-lake-release-notes/2201.8.8/
 active: 2201.8.8
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.8.8
-    - /downloads/swan-lake-release-notes/2201.8.8/
-    - /downloads/swan-lake-release-notes/2201.8.8-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.8.8-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake Update 8 (2201.8.8)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.0/RELEASE_NOTE.md
@@ -3,12 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: 2201.9.0 (Swan Lake)
 permalink: /downloads/swan-lake-release-notes/2201.9.0/
 active: 2201.9.0
-redirect_from:
-    - /downloads/swan-lake-release-notes/2201.9.0
-    - /downloads/swan-lake-release-notes/2201.9.0-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.9.0-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake Update 9 (2201.9.0)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.1/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Update 9 (2201.9.1) 
 permalink: /downloads/swan-lake-release-notes/2201.9.1/
 active: 2201.9.1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.9.1
-    - /downloads/swan-lake-release-notes/2201.9.1/
-    - /downloads/swan-lake-release-notes/2201.9.1-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.9.1-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake Update 9 (2201.9.1)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.2/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Update 9 (2201.9.2) 
 permalink: /downloads/swan-lake-release-notes/2201.9.2/
 active: 2201.9.2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.9.2
-    - /downloads/swan-lake-release-notes/2201.9.2/
-    - /downloads/swan-lake-release-notes/2201.9.2-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.9.2-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake Update 9 (2201.9.2)

--- a/downloads/swan-lake-release-notes/swan-lake-2201.9.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.9.3/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Update 9 (2201.9.3) 
 permalink: /downloads/swan-lake-release-notes/2201.9.3/
 active: 2201.9.3
-redirect_from: 
-    - /downloads/swan-lake-release-notes/2201.9.3
-    - /downloads/swan-lake-release-notes/2201.9.3/
-    - /downloads/swan-lake-release-notes/2201.9.3-swan-lake/
-    - /downloads/swan-lake-release-notes/2201.9.3-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake Update 9 (2201.9.3)

--- a/downloads/swan-lake-release-notes/swan-lake-alpha1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-alpha1/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Alpha1
 permalink: /downloads/swan-lake-release-notes/swan-lake-alpha1/
 active: swan-lake-alpha1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-alpha1
 ---
 
 ### Overview of Ballerina Swan Lake Alpha1  

--- a/downloads/swan-lake-release-notes/swan-lake-alpha2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-alpha2/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Alpha2
 permalink: /downloads/swan-lake-release-notes/swan-lake-alpha2/
 active: swan-lake-alpha2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-alpha2
 ---
 ### Overview of Ballerina Swan Lake Alpha2
 

--- a/downloads/swan-lake-release-notes/swan-lake-alpha3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-alpha3/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Alpha3
 permalink: /downloads/swan-lake-release-notes/swan-lake-alpha3/
 active: swan-lake-alpha3
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-alpha3
 ---
 ### Overview of Ballerina Swan Lake Alpha3
 

--- a/downloads/swan-lake-release-notes/swan-lake-alpha4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-alpha4/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Alpha4 
 permalink: /downloads/swan-lake-release-notes/swan-lake-alpha4/
 active: swan-lake-alpha4
-redirect_from:
-    - /downloads/release-notes/swan-lake-alpha4
 ---
 ### Overview of Ballerina Swan Lake Alpha4
 

--- a/downloads/swan-lake-release-notes/swan-lake-alpha5/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-alpha5/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Alpha5 
 permalink: /downloads/swan-lake-release-notes/swan-lake-alpha5/
 active: swan-lake-alpha5
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-alpha5
 ---
 ### Overview of Ballerina Swan Lake Alpha5
 

--- a/downloads/swan-lake-release-notes/swan-lake-beta1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-beta1/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Beta1
 permalink: /downloads/swan-lake-release-notes/swan-lake-beta1/
 active: swan-lake-beta1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-beta1
 ---
 ## Overview of Ballerina Swan Lake Beta1
 

--- a/downloads/swan-lake-release-notes/swan-lake-beta2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-beta2/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Beta2
 permalink: /downloads/swan-lake-release-notes/swan-lake-beta2/
 active: swan-lake-beta2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-beta2
 ---
 ## Overview of Ballerina Swan Lake Beta2
 

--- a/downloads/swan-lake-release-notes/swan-lake-beta3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-beta3/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Beta3
 permalink: /downloads/swan-lake-release-notes/swan-lake-beta3/
 active: swan-lake-beta3
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-beta3
 ---
 ## Overview of Ballerina Swan Lake Beta3
 

--- a/downloads/swan-lake-release-notes/swan-lake-beta4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-beta4/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Beta4
 permalink: /downloads/swan-lake-release-notes/swan-lake-beta4/
 active: swan-lake-beta4
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-beta4
 ---
 ## Overview of Ballerina Swan Lake Beta4
 

--- a/downloads/swan-lake-release-notes/swan-lake-beta5/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-beta5/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Beta5
 permalink: /downloads/swan-lake-release-notes/swan-lake-beta5/
 active: swan-lake-beta5
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-beta5
 ---
 
 ### Overview of Ballerina Swan Lake Beta5

--- a/downloads/swan-lake-release-notes/swan-lake-beta6/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-beta6/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Beta6
 permalink: /downloads/swan-lake-release-notes/swan-lake-beta6/
 active: swan-lake-beta6
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-beta6
 ---
 
 ## Overview of Ballerina Swan Lake Beta6

--- a/downloads/swan-lake-release-notes/swan-lake-bug-fixes-template/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-bug-fixes-template/RELEASE_NOTE.md
@@ -3,11 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Update 8 (<RELEASE_VERSION>) 
 permalink: /downloads/swan-lake-release-notes/<RELEASE_VERSION>/
 active: <RELEASE_VERSION>
-redirect_from: 
-    - /downloads/swan-lake-release-notes/<RELEASE_VERSION>
-    - /downloads/swan-lake-release-notes/<RELEASE_VERSION>/
-    - /downloads/swan-lake-release-notes/<RELEASE_VERSION>-swan-lake/
-    - /downloads/swan-lake-release-notes/<RELEASE_VERSION>-swan-lake
 ---
 
 ## Overview of Ballerina Swan Lake Update 8 (<RELEASE_VERSION>)

--- a/downloads/swan-lake-release-notes/swan-lake-preview1/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview1/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Preview 1
 permalink: /downloads/swan-lake-release-notes/swan-lake-preview1/
 active: swan-lake-preview1
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-preview1
 ---
 ### Overview of Ballerina Swan Lake - Preview 1
 Ballerina Swan Lake will be a major new version of Ballerina that we plan to release in January 2021. We will be doing major releases every 6 months from then on. We also plan to use popular ballet names as the codename for each release - so the 2021-07 release will be the Nutcracker release. We will announce details on maintenance of released versions and will also have an LTS release model similar to Ubuntu or Java.

--- a/downloads/swan-lake-release-notes/swan-lake-preview2/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview2/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Preview 2
 permalink: /downloads/swan-lake-release-notes/swan-lake-preview2/
 active: swan-lake-preview2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-preview2
 ---
 ### Overview of Ballerina Swan Lake Preview 2
 This release is the second preview version of Ballerina Swan Lake. This release includes a new set of language features along with improvements and bug fixes to the compiler, runtime, standard libraries, and developer tooling.

--- a/downloads/swan-lake-release-notes/swan-lake-preview3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview3/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Preview 3
 permalink: /downloads/swan-lake-release-notes/swan-lake-preview3/
 active: swan-lake-preview3
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-preview3
 ---
 ### Overview of Ballerina Swan Lake Preview 3
 

--- a/downloads/swan-lake-release-notes/swan-lake-preview4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview4/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Preview 4
 permalink: /downloads/swan-lake-release-notes/swan-lake-preview4/
 active: swan-lake-preview4
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-preview4
 ---
 ### Overview of Ballerina Swan Lake Preview 4 
 

--- a/downloads/swan-lake-release-notes/swan-lake-preview5/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview5/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Preview 5
 permalink: /downloads/swan-lake-release-notes/swan-lake-preview5/
 active: swan-lake-preview5
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-preview5
 ---
 ### Overview of Ballerina Swan Lake Preview 5 
 

--- a/downloads/swan-lake-release-notes/swan-lake-preview6/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview6/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Preview 6
 permalink: /downloads/swan-lake-release-notes/swan-lake-preview6/
 active: swan-lake-preview6
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-preview6
 ---
 ### Overview of Ballerina Swan Lake Preview 6 
 

--- a/downloads/swan-lake-release-notes/swan-lake-preview7/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview7/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Preview 7
 permalink: /downloads/swan-lake-release-notes/swan-lake-preview7/
 active: swan-lake-preview7
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-preview7
 ---
 
 ### Overview of Ballerina Swan Lake Preview 7 

--- a/downloads/swan-lake-release-notes/swan-lake-preview8/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-preview8/RELEASE_NOTE.md
@@ -3,8 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Preview 8
 permalink: /downloads/swan-lake-release-notes/swan-lake-preview8/
 active: swan-lake-preview8
-redirect_from: 
-    - /downloads/swan-lake-release-notes/swan-lake-preview8
 ---
 
 ### Overview of Ballerina Swan Lake Preview 8 

--- a/downloads/swan-lake-release-notes/swan-lake-security-fixes-template/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-security-fixes-template/RELEASE_NOTE.md
@@ -3,12 +3,6 @@ layout: ballerina-left-nav-release-notes
 title: Swan Lake Update 8 (<RELEASE_VERSION>)
 permalink: /downloads/swan-lake-release-notes/<RELEASE_VERSION>/
 active: 2201.8.2
-redirect_from: 
-    - /downloads/swan-lake-release-notes/<RELEASE_VERSION>
-    - /downloads/swan-lake-release-notes/<RELEASE_VERSION>-swan-lake/
-    - /downloads/swan-lake-release-notes/<RELEASE_VERSION>-swan-lake
-    - /downloads/swan-lake-release-notes/
-    - /downloads/swan-lake-release-notes
 ---
 
 ## Overview of Ballerina Swan Lake Update 8 (<RELEASE_VERSION>)

--- a/policy/security-policy.md
+++ b/policy/security-policy.md
@@ -5,10 +5,6 @@ description: Read our Security Policy to understand the measures we take to prot
 keywords: ballerina, programming language, security, security-policy, security advisories
 intro: We take security issues very seriously and all the vulnerability reports are treated with the highest priority and confidentiality.
 permalink: /security-policy/
-redirect_from:
-    - /security/
-    - /security
-    - /security-policy
 ---
 
 Thank you for taking the time to <a target="_blank" href="https://en.wikipedia.org/wiki/Responsible_disclosure">responsibly disclose</a> any vulnerabilities you find.

--- a/swan-lake/development-tutorials/ballerina-persist/bal-persist-overview.md
+++ b/swan-lake/development-tutorials/ballerina-persist/bal-persist-overview.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages, persist, data mod
 permalink: /learn/ballerina-persist/persist-overview/
 active: persist_overview
 intro: The `bal persist` feature allows you to store data in different data stores and retrieve them when needed. A data store can be a database or an in-memory cache. The `bal persist` feature currently supports in-memory tables, MySQL, MSSQL, PostgreSQL databases, Google Sheets, and Redis as data stores. As you can use the same syntax to access data in all these data stores, you do not need to learn different syntaxes to access data in different data stores.
-redirect_from:
-  - /learn/ballerina-persist/persist-overview/
 ---
 
 This feature has three main components: the data model, CLI tool, and type-safe client API. 

--- a/swan-lake/development-tutorials/ballerina-persist/persist-cli-tool.md
+++ b/swan-lake/development-tutorials/ballerina-persist/persist-cli-tool.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages, persist, persist 
 permalink: /learn/ballerina-persist/persist-cli/
 active: persist_cli
 intro: The CLI tool is used to initialize the project with the bal persist command and generate the required files.
-redirect_from:
-   - /learn/ballerina-persist/persist-cli/
 ---
 
 There are two ways that you can use the `bal persist` feature.

--- a/swan-lake/development-tutorials/ballerina-persist/persist-client-api.md
+++ b/swan-lake/development-tutorials/ballerina-persist/persist-client-api.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages, persist, type-saf
 permalink: /learn/ballerina-persist/persist-client-api/
 active: persist_client_api
 intro: The generated client API is used to perform CRUD operations on the data source. Each entity type will have five resource methods for each operation. The resource methods are get, get(get by identity), post, put, and delete. The CLI tool will generate the derived Entity Types and the Clients from the model definition.
-redirect_from:
-  - /learn/ballerina-persist/persist-client-api
 ---
 
 ## Derived entity types

--- a/swan-lake/development-tutorials/ballerina-persist/persist-introspection.md
+++ b/swan-lake/development-tutorials/ballerina-persist/persist-introspection.md
@@ -7,8 +7,6 @@ permalink: /learn/ballerina-persist/persist-instrospection/
 active: persist_introspection
 intro: Bal persist can work with existing databases by providing the facility to introspect an existing database to 
  generate the persist data model.
-redirect_from:
-- /learn/ballerina-persist/persist-introspection
 ---
 
 Introspection lets you use `bal persist` with existing databases without having to write a

--- a/swan-lake/development-tutorials/ballerina-persist/persist-model.md
+++ b/swan-lake/development-tutorials/ballerina-persist/persist-model.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages, persist, data mod
 permalink: /learn/ballerina-persist/persist-model/
 active: persist_model
 intro: The data model defines a mechanism to express the application's data using the Ballerina record type. Any record type that is a subtype of the `EntityType` will be an entity in the model.
-redirect_from:
- - /learn/ballerina-persist/persist-model/
 ---
 
 Within a Ballerina project, the data model should be defined in a separate BAL file under the `persist` directory. This file is not considered as a part of the Ballerina project and is used only for the data model definition.

--- a/swan-lake/development-tutorials/ballerina-persist/supported-data-stores.md
+++ b/swan-lake/development-tutorials/ballerina-persist/supported-data-stores.md
@@ -6,8 +6,6 @@ keywords: ballerina, programming language, ballerina packages, persist, data sto
 permalink: /learn/ballerina-persist/supported-datastores/
 active: persist_supported_datastores
 intro: In the realm of the `bal persist` feature, selecting the right data store is crucial for ensuring reliable data storage and retrieval. Various data stores exist, each with its strengths and weaknesses. The `bal persist` currently supports four data stores. The configurations and supported types will vary depending on the data store you selected for your application.
-redirect_from:
-   - /learn/ballerina-persist/supported-datastores/
 ---
 
 Following are the supported data stores.

--- a/swan-lake/development-tutorials/build-and-run/update-tool.md
+++ b/swan-lake/development-tutorials/build-and-run/update-tool.md
@@ -6,16 +6,6 @@ keywords: ballerina, programming language, release, update
 permalink: /learn/build-and-run/update-tool/
 active: update-tool
 intro: This guide explains how to maintain your Ballerina installation up to date with the latest patch and minor releases.
-redirect_from:
-  - /learn/how-to-keep-ballerina-up-to-date
-  - /learn/how-to-keep-ballerina-up-to-date/
-  - /learn/keeping-ballerina-up-to-date/
-  - /learn/keeping-ballerina-up-to-date
-  - /swan-lake/learn/keeping-ballerina-up-to-date/
-  - /swan-lake/learn/keeping-ballerina-up-to-date
-  - /learn/tooling-guide/cli-tools/update-tool
-  - /learn/tooling-guide/cli-tools/update-tool/
-  - /learn/update-tool
 ---
 
 ## Understand Ballerina distributions 

--- a/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
+++ b/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
@@ -6,12 +6,6 @@ keywords: Ballerina, data service, data store, database, SQL, in-memory, Google 
 permalink: /learn/manage_data_persistence-with-bal-persist/
 active: manage_data_persistence-with-bal-persist
 intro: This guide helps you understand the basics of the `bal persist` feature, which allows you to manage data persistence easily. This same data service can also be written using the Ballerina SQL connectors, which require you to write SQL queries to perform CRUD operations against the DB servers. With the `bal persist` feature, you only need to write the `data model`. Based on the model, the client object and record types are generated to interact with the data store.
-redirect_from:
-- /learn/manage-data-persistence-with-bal-persist/
-- /learn/manage-data-persistence-with-bal-persist
-- /learn/manage-data-persistence-with-bal-persist
-- /learn/getting-started/manage-data-persistence-with-bal-persist/
-- /learn/getting-started/manage_data_persistence-with-bal-persist
 ---
 
 ## Set up the prerequisites


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #6069

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
