### PR TITLE
Document the required command for c2c build in MacOS

### DIFF
--- a/swan-lake/development-tutorials/run-in-the-cloud/code-to-cloud-deployment.md
+++ b/swan-lake/development-tutorials/run-in-the-cloud/code-to-cloud-deployment.md
@@ -21,7 +21,8 @@ To complete this tutorial, you need:
 1. <a href="https://www.docker.com/" target="_blank">Docker</a> installed and configured in your machine
 2. <a href="https://kubernetes.io/docs/tasks/tools/" target="_blank">Kubectl</a> installed and configured in a <a href="https://minikube.sigs.k8s.io/docs/start/" target="_blank">Kubernetes cluster</a>
 
->**Note:** The macOS users with Apple silicon chip need set an environment variable `DOCKER_DEFAULT_PLATFORM` to `linux/amd64`, before building the image. This is because the Ballerina Docker image is not supported on Apple silicon chips yet.
+>**Note:** macOS users with Apple Silicon chips need to set an environment variable named `DOCKER_DEFAULT_PLATFORM` to `linux/amd64`, before building the image. This is because the Ballerina Docker image is not supported on Apple Silicon chips yet.
+
 > ```
 > export DOCKER_DEFAULT_PLATFORM=linux/amd64
 > ```

--- a/swan-lake/development-tutorials/run-in-the-cloud/code-to-cloud-deployment.md
+++ b/swan-lake/development-tutorials/run-in-the-cloud/code-to-cloud-deployment.md
@@ -21,6 +21,11 @@ To complete this tutorial, you need:
 1. <a href="https://www.docker.com/" target="_blank">Docker</a> installed and configured in your machine
 2. <a href="https://kubernetes.io/docs/tasks/tools/" target="_blank">Kubectl</a> installed and configured in a <a href="https://minikube.sigs.k8s.io/docs/start/" target="_blank">Kubernetes cluster</a>
 
+>**Note:** The macOS users with Apple silicon chip need set an environment variable `DOCKER_DEFAULT_PLATFORM` to `linux/amd64`, before building the image. This is because the Ballerina Docker image is not supported on Apple silicon chips yet.
+> ```
+> export DOCKER_DEFAULT_PLATFORM=linux/amd64
+> ```
+
 ## How Code to Cloud works
 
 Code to cloud builds the containers and required artifacts by deriving the required values from the code. This process happens when the package is being compiled. To override the default values given by the compiler, the `Cloud.toml` file needs to be created in the package directory. 


### PR DESCRIPTION
## Purpose
- Document the required command for c2c build in MacOS
- Fixes https://github.com/ballerina-platform/ballerina-dev-website/issues/9431

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
