### PR TITLE
Add accordions to list release versions 

### DIFF
--- a/components/common/left-nav/LeftNav.js
+++ b/components/common/left-nav/LeftNav.js
@@ -16,11 +16,11 @@
  * under the License.
  */
 
-import * as React from 'react';
-import Accordion from 'react-bootstrap/Accordion';
+import * as React from "react";
+import Accordion from "react-bootstrap/Accordion";
 
-import { prefix } from '../../../utils/prefix';
-import styles from './LeftNav.module.css';
+import { prefix } from "../../../utils/prefix";
+import styles from "./LeftNav.module.css";
 
 export default function LeftNav(props) {
   const launcher = props.launcher;
@@ -34,30 +34,41 @@ export default function LeftNav(props) {
     return a.position - b.position;
   }
 
-  function CheckActive(eventKey) {console.log(eventKey);
+  function CheckActive(eventKey) {
+    console.log(eventKey);
 
     if (mainDir !== eventKey) {
-      document.querySelectorAll('[item-id=' + "\'" + mainDir + "\'" + ']')[0].getElementsByTagName('button')[0].style.color = '#20b6b0';
-      document.querySelectorAll('[item-id=' + "\'" + mainDir + "\'" + ']')[0].getElementsByTagName('button')[0].style.fontWeight = '500';
+      document
+        .querySelectorAll("[item-id=" + "'" + mainDir + "'" + "]")[0]
+        .getElementsByTagName("button")[0].style.color = "#20b6b0";
+      document
+        .querySelectorAll("[item-id=" + "'" + mainDir + "'" + "]")[0]
+        .getElementsByTagName("button")[0].style.fontWeight = "500";
     }
 
     if (sub && sub !== eventKey) {
-      document.querySelectorAll('[item-id=' + sub + ']')[0].getElementsByTagName('button')[0].style.color = '#20b6b0';
-      document.querySelectorAll('[item-id=' + sub + ']')[0].getElementsByTagName('button')[0].style.fontWeight = '500';
+      document
+        .querySelectorAll("[item-id=" + "'" + sub + "'" + "]")[0]
+        .getElementsByTagName("button")[0].style.color = "#20b6b0";
+      document
+        .querySelectorAll("[item-id=" + "'" + sub + "'" + "]")[0]
+        .getElementsByTagName("button")[0].style.fontWeight = "500";
     }
 
     if (third && third !== eventKey) {
-      document.querySelectorAll('[item-id=' + third + ']')[0].getElementsByTagName('button')[0].style.color = '#20b6b0';
-      document.querySelectorAll('[item-id=' + third + ']')[0].getElementsByTagName('button')[0].style.fontWeight = '500';
+      document
+        .querySelectorAll("[item-id=" + third + "]")[0]
+        .getElementsByTagName("button")[0].style.color = "#20b6b0";
+      document
+        .querySelectorAll("[item-id=" + third + "]")[0]
+        .getElementsByTagName("button")[0].style.fontWeight = "500";
     }
   }
 
   function goto(url) {
-    window.location.href=url;
+    window.location.href = url;
     //document.querySelectorAll('[item-id=' + "\'" + id + "\'" + ']')[0].getElementsByTagName('button')[0].style.color = '#20b6b0';
   }
-
-
 
   const SortedDir = Elements.sort(comparePositions);
 
@@ -66,34 +77,49 @@ export default function LeftNav(props) {
 
     //if (category.isDir && category.position > 0) {
 
-    return <Accordion.Item eventKey={category.id} className={styles.acItem}>
-      
-      {
-        (category.isDir) ?
+    return (
+      <Accordion.Item eventKey={category.id} className={styles.acItem}>
+        {category.isDir ? (
           <>
-          <Accordion.Header className={styles.mainDir} onClick={() => CheckActive(category.id)} item-id={category.id}>{category.dirName}</Accordion.Header> 
-          <Accordion.Body className={styles.accordionBody}>
-            <ul className={styles.firstTier}>
-              {
-                (category.subDirectories) ?
+            <Accordion.Header
+              className={styles.mainDir}
+              onClick={() => CheckActive(category.id)}
+              item-id={category.id}
+            >
+              {category.dirName}
+            </Accordion.Header>
+            <Accordion.Body className={styles.accordionBody}>
+              <ul className={styles.firstTier}>
+                {category.subDirectories ? (
                   <Accordion defaultActiveKey={sub}>
-                    <SubDir directories={category.subDirectories} activeKey={sub} />
+                    <SubDir
+                      directories={category.subDirectories}
+                      activeKey={sub}
+                    />
                   </Accordion>
-                  : null
-              }
-            </ul>
-          </Accordion.Body>
+                ) : null}
+              </ul>
+            </Accordion.Body>
           </>
-        : <h2 item-id={category.id} className={`${styles.mainDir} accordion-header`}>
-            <button  
-              className={(id === category.id) ? `${styles.nonAcBtn} ${styles.active}` : `${styles.nonAcBtn}`} 
-              onClick={() => goto(category.url)}>
+        ) : (
+          <h2
+            item-id={category.id}
+            className={`${styles.mainDir} accordion-header`}
+          >
+            <button
+              className={
+                id === category.id
+                  ? `${styles.nonAcBtn} ${styles.active}`
+                  : `${styles.nonAcBtn}`
+              }
+              onClick={() => goto(category.url)}
+            >
               {category.dirName}
             </button>
           </h2>
-      }
-      
-    </Accordion.Item>;
+        )}
+      </Accordion.Item>
+    );
   }
 
   function SubDir(props) {
@@ -101,48 +127,59 @@ export default function LeftNav(props) {
 
     return directories.map((directory) => (
       <>
-        {
-          (directory.isDir && directory.position > 0) ?
-            <>
-              <Accordion.Item eventKey={directory.id} className={styles.acItem}>
-                <Accordion.Header onClick={() => CheckActive(directory.id)} item-id={directory.id}>{directory.dirName}</Accordion.Header>
-                <Accordion.Body className={styles.acBody}>
-                  <ul className={styles.secondTier}>
-                    {
-                      (directory.subDirectories) ?
-                        <Accordion defaultActiveKey={third}>
-                          <ThirdDir directories={directory.subDirectories} activeKey={third} />
-                        </Accordion>
-                        : null
-                    }
-
-                  </ul>
-                </Accordion.Body>
-              </Accordion.Item>
-            </>
-            :
-            (directory.position > 0) ?
-              <li key={directory.id}>
-                {(directory.dirName === 'API Docs' || directory.dirName === "Ballerina by Example" || 
-                  directory.dirName === "Visual Studio Code extension" || directory.dirName === "Ballerina API Docs" ||
-                  directory.dirName === "Enterprise Integration Patterns (EIP)" || directory.dirName === "Pre-built integrations") ||
-                  directory.dirName === "Integration tutorials" ?
-                  <a id={directory.id} className={(id === directory.id) ? styles.active : null}
-                    href={(`${prefix}`) ? `${prefix}` + directory.url : directory.url}
-                    target='_blank' rel="noreferrer">
-                    {directory.dirName}
-                  </a>
-                  :
-                  <a id={directory.id} className={(id === directory.id) ? styles.active : null}
-                    href={(`${prefix}`) ? `${prefix}` + directory.url : directory.url}>
-                    {directory.dirName}
-                  </a>
-                }
-              </li>
-              : null
-        }
+        {directory.isDir && directory.position > 0 ? (
+          <>
+            <Accordion.Item eventKey={directory.id} className={styles.acItem}>
+              <Accordion.Header
+                onClick={() => CheckActive(directory.id)}
+                item-id={directory.id}
+              >
+                {directory.dirName}
+              </Accordion.Header>
+              <Accordion.Body className={styles.acBody}>
+                <ul className={styles.secondTier}>
+                  {directory.subDirectories ? (
+                    <Accordion defaultActiveKey={third}>
+                      <ThirdDir
+                        directories={directory.subDirectories}
+                        activeKey={third}
+                      />
+                    </Accordion>
+                  ) : null}
+                </ul>
+              </Accordion.Body>
+            </Accordion.Item>
+          </>
+        ) : directory.position > 0 ? (
+          <li key={directory.id}>
+            {directory.dirName === "API Docs" ||
+            directory.dirName === "Ballerina by Example" ||
+            directory.dirName === "Visual Studio Code extension" ||
+            directory.dirName === "Ballerina API Docs" ||
+            directory.dirName === "Enterprise Integration Patterns (EIP)" ||
+            directory.dirName === "Pre-built integrations" ||
+            directory.dirName === "Integration tutorials" ? (
+              <a
+                id={directory.id}
+                className={id === directory.id ? styles.active : null}
+                href={`${prefix}` ? `${prefix}` + directory.url : directory.url}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {directory.dirName}
+              </a>
+            ) : (
+              <a
+                id={directory.id}
+                className={id === directory.id ? styles.active : null}
+                href={`${prefix}` ? `${prefix}` + directory.url : directory.url}
+              >
+                {directory.dirName}
+              </a>
+            )}
+          </li>
+        ) : null}
       </>
-
     ));
   }
 
@@ -151,53 +188,73 @@ export default function LeftNav(props) {
 
     return tdirectories.map((directory) => (
       <>
-        {
-          (directory.isDir && directory.position > 0) ?
-            <>
-              <Accordion.Item eventKey={directory.id} className={styles.acItem}>
-                <Accordion.Header onClick={() => CheckActive(directory.id)} item-id={directory.id}>{directory.dirName}</Accordion.Header>
-                <Accordion.Body className={styles.acBody}>
-                  <ul className={styles.secondTier}>
-                    {
-                      (directory.subDirectories) ?
-                        <Accordion defaultActiveKey={third}>
-                          <ThirdDir directories={directory.subDirectories} activeKey={third} />
-                        </Accordion>
-                        : null
-                    }
-                  </ul>
-                </Accordion.Body>
-              </Accordion.Item>
-            </>
-            :
-            (directory.position > 0) ?
-              <li key={directory.id}>
-                <a id={directory.id} className={(id === directory.id) ? styles.active : null}
-                  href={(`${prefix}`) ? `${prefix}` + directory.url : directory.url}>
-                  {directory.dirName}
-                </a>
-              </li>
-              : null
-        }
+        {directory.isDir && directory.position > 0 ? (
+          <>
+            <Accordion.Item eventKey={directory.id} className={styles.acItem}>
+              <Accordion.Header
+                onClick={() => CheckActive(directory.id)}
+                item-id={directory.id}
+              >
+                {directory.dirName}
+              </Accordion.Header>
+              <Accordion.Body className={styles.acBody}>
+                <ul className={styles.secondTier}>
+                  {directory.subDirectories ? (
+                    <Accordion defaultActiveKey={third}>
+                      <ThirdDir
+                        directories={directory.subDirectories}
+                        activeKey={third}
+                      />
+                    </Accordion>
+                  ) : null}
+                </ul>
+              </Accordion.Body>
+            </Accordion.Item>
+          </>
+        ) : directory.position > 0 ? (
+          <li key={directory.id}>
+            <a
+              id={directory.id}
+              className={id === directory.id ? styles.active : null}
+              href={`${prefix}` ? `${prefix}` + directory.url : directory.url}
+            >
+              {directory.dirName}
+            </a>
+          </li>
+        ) : null}
       </>
-
     ));
   }
 
   return (
     <>
-
-      <Accordion defaultActiveKey={mainDir} flush className={styles.leftNavAccordian}>
-        {SortedDir.map((category, index) => (
-          {
-            'learn': (category.position > 0) ? <MainDir category={category} key={index}/> : null,
-            'rn': (category.position > 0) ? <MainDir category={category} key={index}/> : null,
-            'archived': (category.position > 0) ? <MainDir category={category} key={index}/> : null,
-            'vs-code': (category.position > 0) ? <MainDir category={category} key={index}/> : null,
-          }[launcher]
-        ))}
+      <Accordion
+        defaultActiveKey={mainDir}
+        flush
+        className={styles.leftNavAccordian}
+      >
+        {SortedDir.map(
+          (category, index) =>
+            ({
+              learn:
+                category.position > 0 ? (
+                  <MainDir category={category} key={index} />
+                ) : null,
+              rn:
+                category.position > 0 ? (
+                  <MainDir category={category} key={index} />
+                ) : null,
+              archived:
+                category.position > 0 ? (
+                  <MainDir category={category} key={index} />
+                ) : null,
+              "vs-code":
+                category.position > 0 ? (
+                  <MainDir category={category} key={index} />
+                ) : null,
+            }[launcher])
+        )}
       </Accordion>
-
     </>
   );
 }

--- a/components/common/left-nav/LeftNav.js
+++ b/components/common/left-nav/LeftNav.js
@@ -16,11 +16,11 @@
  * under the License.
  */
 
-import * as React from "react";
-import Accordion from "react-bootstrap/Accordion";
+import * as React from 'react';
+import Accordion from 'react-bootstrap/Accordion';
 
-import { prefix } from "../../../utils/prefix";
-import styles from "./LeftNav.module.css";
+import { prefix } from '../../../utils/prefix';
+import styles from './LeftNav.module.css';
 
 export default function LeftNav(props) {
   const launcher = props.launcher;
@@ -34,41 +34,30 @@ export default function LeftNav(props) {
     return a.position - b.position;
   }
 
-  function CheckActive(eventKey) {
-    console.log(eventKey);
+  function CheckActive(eventKey) {console.log(eventKey);
 
     if (mainDir !== eventKey) {
-      document
-        .querySelectorAll("[item-id=" + "'" + mainDir + "'" + "]")[0]
-        .getElementsByTagName("button")[0].style.color = "#20b6b0";
-      document
-        .querySelectorAll("[item-id=" + "'" + mainDir + "'" + "]")[0]
-        .getElementsByTagName("button")[0].style.fontWeight = "500";
+      document.querySelectorAll('[item-id=' + "\'" + mainDir + "\'" + ']')[0].getElementsByTagName('button')[0].style.color = '#20b6b0';
+      document.querySelectorAll('[item-id=' + "\'" + mainDir + "\'" + ']')[0].getElementsByTagName('button')[0].style.fontWeight = '500';
     }
 
     if (sub && sub !== eventKey) {
-      document
-        .querySelectorAll("[item-id=" + "'" + sub + "'" + "]")[0]
-        .getElementsByTagName("button")[0].style.color = "#20b6b0";
-      document
-        .querySelectorAll("[item-id=" + "'" + sub + "'" + "]")[0]
-        .getElementsByTagName("button")[0].style.fontWeight = "500";
+      document.querySelectorAll('[item-id=' + "'" + sub + "'" + ']')[0].getElementsByTagName('button')[0].style.color = '#20b6b0';
+      document.querySelectorAll('[item-id=' + "'" + sub + "'" + ']')[0].getElementsByTagName('button')[0].style.fontWeight = '500';
     }
 
     if (third && third !== eventKey) {
-      document
-        .querySelectorAll("[item-id=" + third + "]")[0]
-        .getElementsByTagName("button")[0].style.color = "#20b6b0";
-      document
-        .querySelectorAll("[item-id=" + third + "]")[0]
-        .getElementsByTagName("button")[0].style.fontWeight = "500";
+      document.querySelectorAll('[item-id=' + third + ']')[0].getElementsByTagName('button')[0].style.color = '#20b6b0';
+      document.querySelectorAll('[item-id=' + third + ']')[0].getElementsByTagName('button')[0].style.fontWeight = '500';
     }
   }
 
   function goto(url) {
-    window.location.href = url;
+    window.location.href=url;
     //document.querySelectorAll('[item-id=' + "\'" + id + "\'" + ']')[0].getElementsByTagName('button')[0].style.color = '#20b6b0';
   }
+
+
 
   const SortedDir = Elements.sort(comparePositions);
 
@@ -77,49 +66,34 @@ export default function LeftNav(props) {
 
     //if (category.isDir && category.position > 0) {
 
-    return (
-      <Accordion.Item eventKey={category.id} className={styles.acItem}>
-        {category.isDir ? (
+    return <Accordion.Item eventKey={category.id} className={styles.acItem}>
+      
+      {
+        (category.isDir) ?
           <>
-            <Accordion.Header
-              className={styles.mainDir}
-              onClick={() => CheckActive(category.id)}
-              item-id={category.id}
-            >
-              {category.dirName}
-            </Accordion.Header>
-            <Accordion.Body className={styles.accordionBody}>
-              <ul className={styles.firstTier}>
-                {category.subDirectories ? (
+          <Accordion.Header className={styles.mainDir} onClick={() => CheckActive(category.id)} item-id={category.id}>{category.dirName}</Accordion.Header> 
+          <Accordion.Body className={styles.accordionBody}>
+            <ul className={styles.firstTier}>
+              {
+                (category.subDirectories) ?
                   <Accordion defaultActiveKey={sub}>
-                    <SubDir
-                      directories={category.subDirectories}
-                      activeKey={sub}
-                    />
+                    <SubDir directories={category.subDirectories} activeKey={sub} />
                   </Accordion>
-                ) : null}
-              </ul>
-            </Accordion.Body>
-          </>
-        ) : (
-          <h2
-            item-id={category.id}
-            className={`${styles.mainDir} accordion-header`}
-          >
-            <button
-              className={
-                id === category.id
-                  ? `${styles.nonAcBtn} ${styles.active}`
-                  : `${styles.nonAcBtn}`
+                  : null
               }
-              onClick={() => goto(category.url)}
-            >
+            </ul>
+          </Accordion.Body>
+          </>
+        : <h2 item-id={category.id} className={`${styles.mainDir} accordion-header`}>
+            <button  
+              className={(id === category.id) ? `${styles.nonAcBtn} ${styles.active}` : `${styles.nonAcBtn}`} 
+              onClick={() => goto(category.url)}>
               {category.dirName}
             </button>
           </h2>
-        )}
-      </Accordion.Item>
-    );
+      }
+      
+    </Accordion.Item>;
   }
 
   function SubDir(props) {
@@ -127,59 +101,48 @@ export default function LeftNav(props) {
 
     return directories.map((directory) => (
       <>
-        {directory.isDir && directory.position > 0 ? (
-          <>
-            <Accordion.Item eventKey={directory.id} className={styles.acItem}>
-              <Accordion.Header
-                onClick={() => CheckActive(directory.id)}
-                item-id={directory.id}
-              >
-                {directory.dirName}
-              </Accordion.Header>
-              <Accordion.Body className={styles.acBody}>
-                <ul className={styles.secondTier}>
-                  {directory.subDirectories ? (
-                    <Accordion defaultActiveKey={third}>
-                      <ThirdDir
-                        directories={directory.subDirectories}
-                        activeKey={third}
-                      />
-                    </Accordion>
-                  ) : null}
-                </ul>
-              </Accordion.Body>
-            </Accordion.Item>
-          </>
-        ) : directory.position > 0 ? (
-          <li key={directory.id}>
-            {directory.dirName === "API Docs" ||
-            directory.dirName === "Ballerina by Example" ||
-            directory.dirName === "Visual Studio Code extension" ||
-            directory.dirName === "Ballerina API Docs" ||
-            directory.dirName === "Enterprise Integration Patterns (EIP)" ||
-            directory.dirName === "Pre-built integrations" ||
-            directory.dirName === "Integration tutorials" ? (
-              <a
-                id={directory.id}
-                className={id === directory.id ? styles.active : null}
-                href={`${prefix}` ? `${prefix}` + directory.url : directory.url}
-                target="_blank"
-                rel="noreferrer"
-              >
-                {directory.dirName}
-              </a>
-            ) : (
-              <a
-                id={directory.id}
-                className={id === directory.id ? styles.active : null}
-                href={`${prefix}` ? `${prefix}` + directory.url : directory.url}
-              >
-                {directory.dirName}
-              </a>
-            )}
-          </li>
-        ) : null}
+        {
+          (directory.isDir && directory.position > 0) ?
+            <>
+              <Accordion.Item eventKey={directory.id} className={styles.acItem}>
+                <Accordion.Header onClick={() => CheckActive(directory.id)} item-id={directory.id}>{directory.dirName}</Accordion.Header>
+                <Accordion.Body className={styles.acBody}>
+                  <ul className={styles.secondTier}>
+                    {
+                      (directory.subDirectories) ?
+                        <Accordion defaultActiveKey={third}>
+                          <ThirdDir directories={directory.subDirectories} activeKey={third} />
+                        </Accordion>
+                        : null
+                    }
+
+                  </ul>
+                </Accordion.Body>
+              </Accordion.Item>
+            </>
+            :
+            (directory.position > 0) ?
+              <li key={directory.id}>
+                {(directory.dirName === 'API Docs' || directory.dirName === "Ballerina by Example" || 
+                  directory.dirName === "Visual Studio Code extension" || directory.dirName === "Ballerina API Docs" ||
+                  directory.dirName === "Enterprise Integration Patterns (EIP)" || directory.dirName === "Pre-built integrations") ||
+                  directory.dirName === "Integration tutorials" ?
+                  <a id={directory.id} className={(id === directory.id) ? styles.active : null}
+                    href={(`${prefix}`) ? `${prefix}` + directory.url : directory.url}
+                    target='_blank' rel="noreferrer">
+                    {directory.dirName}
+                  </a>
+                  :
+                  <a id={directory.id} className={(id === directory.id) ? styles.active : null}
+                    href={(`${prefix}`) ? `${prefix}` + directory.url : directory.url}>
+                    {directory.dirName}
+                  </a>
+                }
+              </li>
+              : null
+        }
       </>
+
     ));
   }
 
@@ -188,73 +151,53 @@ export default function LeftNav(props) {
 
     return tdirectories.map((directory) => (
       <>
-        {directory.isDir && directory.position > 0 ? (
-          <>
-            <Accordion.Item eventKey={directory.id} className={styles.acItem}>
-              <Accordion.Header
-                onClick={() => CheckActive(directory.id)}
-                item-id={directory.id}
-              >
-                {directory.dirName}
-              </Accordion.Header>
-              <Accordion.Body className={styles.acBody}>
-                <ul className={styles.secondTier}>
-                  {directory.subDirectories ? (
-                    <Accordion defaultActiveKey={third}>
-                      <ThirdDir
-                        directories={directory.subDirectories}
-                        activeKey={third}
-                      />
-                    </Accordion>
-                  ) : null}
-                </ul>
-              </Accordion.Body>
-            </Accordion.Item>
-          </>
-        ) : directory.position > 0 ? (
-          <li key={directory.id}>
-            <a
-              id={directory.id}
-              className={id === directory.id ? styles.active : null}
-              href={`${prefix}` ? `${prefix}` + directory.url : directory.url}
-            >
-              {directory.dirName}
-            </a>
-          </li>
-        ) : null}
+        {
+          (directory.isDir && directory.position > 0) ?
+            <>
+              <Accordion.Item eventKey={directory.id} className={styles.acItem}>
+                <Accordion.Header onClick={() => CheckActive(directory.id)} item-id={directory.id}>{directory.dirName}</Accordion.Header>
+                <Accordion.Body className={styles.acBody}>
+                  <ul className={styles.secondTier}>
+                    {
+                      (directory.subDirectories) ?
+                        <Accordion defaultActiveKey={third}>
+                          <ThirdDir directories={directory.subDirectories} activeKey={third} />
+                        </Accordion>
+                        : null
+                    }
+                  </ul>
+                </Accordion.Body>
+              </Accordion.Item>
+            </>
+            :
+            (directory.position > 0) ?
+              <li key={directory.id}>
+                <a id={directory.id} className={(id === directory.id) ? styles.active : null}
+                  href={(`${prefix}`) ? `${prefix}` + directory.url : directory.url}>
+                  {directory.dirName}
+                </a>
+              </li>
+              : null
+        }
       </>
+
     ));
   }
 
   return (
     <>
-      <Accordion
-        defaultActiveKey={mainDir}
-        flush
-        className={styles.leftNavAccordian}
-      >
-        {SortedDir.map(
-          (category, index) =>
-            ({
-              learn:
-                category.position > 0 ? (
-                  <MainDir category={category} key={index} />
-                ) : null,
-              rn:
-                category.position > 0 ? (
-                  <MainDir category={category} key={index} />
-                ) : null,
-              archived:
-                category.position > 0 ? (
-                  <MainDir category={category} key={index} />
-                ) : null,
-              "vs-code":
-                category.position > 0 ? (
-                  <MainDir category={category} key={index} />
-                ) : null,
-            }[launcher])
-        )}
+
+      <Accordion defaultActiveKey={mainDir} flush className={styles.leftNavAccordian}>
+        {SortedDir.map((category, index) => (
+          {
+            'learn': (category.position > 0) ? <MainDir category={category} key={index}/> : null,
+            'rn': (category.position > 0) ? <MainDir category={category} key={index}/> : null,
+            'archived': (category.position > 0) ? <MainDir category={category} key={index}/> : null,
+            'vs-code': (category.position > 0) ? <MainDir category={category} key={index}/> : null,
+          }[launcher]
+        ))}
       </Accordion>
+
     </>
   );
 }

--- a/pages/downloads/swan-lake-release-notes/[...slug].js
+++ b/pages/downloads/swan-lake-release-notes/[...slug].js
@@ -36,15 +36,16 @@ import GenerateHeadingComponent from "../../../components/common/heading/RenderH
 
 String.prototype.hashCode = function () {
   var hash = 0,
-      i, chr;
+    i,
+    chr;
   if (this.length === 0) return hash;
   for (i = 0; i < this.length; i++) {
-      chr = this.charCodeAt(i);
-      hash = ((hash << 5) - hash) + chr;
-      hash |= 0;
+    chr = this.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0;
   }
   return hash;
-}
+};
 
 // import { Liquid } from 'liquidjs';
 
@@ -102,7 +103,7 @@ export async function getStaticProps({ params: { slug } }) {
       frontmatter,
       content,
       id,
-      codeSnippets
+      codeSnippets,
     },
   };
 }
@@ -117,6 +118,14 @@ export default function PostPage({ frontmatter, content, id, codeSnippets }) {
 
   // Show page toc
   const [showToc, setShowToc] = React.useState(false);
+
+  // Get the sub id based on id
+  const getSubId = () => {
+    if (id.includes("preview") || id.includes("beta") || id.includes("alpha")) {
+      return id.substring(0, id.length - 1);
+    }
+    return id.substring(0, id.lastIndexOf("."));
+  };
 
   return (
     <>
@@ -144,10 +153,16 @@ export default function PostPage({ frontmatter, content, id, codeSnippets }) {
         />
 
         {/* <!--LINKED IN  --> */}
-        <meta property="og:title" content={`${frontmatter.title} - The Ballerina programming language`} />
+        <meta
+          property="og:title"
+          content={`${frontmatter.title} - The Ballerina programming language`}
+        />
 
         {/* <!--TWITTER--> */}
-        <meta name="twitter:title" content={`${frontmatter.title} - The Ballerina programming language`} />
+        <meta
+          name="twitter:title"
+          content={`${frontmatter.title} - The Ballerina programming language`}
+        />
         <meta
           property="twitter:description"
           content={`${frontmatter.title} - Release note`}
@@ -163,6 +178,7 @@ export default function PostPage({ frontmatter, content, id, codeSnippets }) {
             launcher="rn"
             id={id}
             mainDir="swan-lake-release-notes"
+            sub={getSubId()}
             Toc={RNToc}
           />
         </Col>
@@ -214,27 +230,45 @@ export default function PostPage({ frontmatter, content, id, codeSnippets }) {
                 h5: GenerateHeadingComponent(5, setShowToc),
                 h6: GenerateHeadingComponent(6, setShowToc),
                 code({ node, inline, className, children, ...props }) {
-                  const key = (children[0]).trim().split(/\r?\n/).map(row => row.trim()).join('\n');
+                  const key = children[0]
+                    .trim()
+                    .split(/\r?\n/)
+                    .map((row) => row.trim())
+                    .join("\n");
                   const highlightedCode = codes.get(key.hashCode());
                   if (highlightedCode) {
-                    return <div dangerouslySetInnerHTML={{ __html: highlightedCode }} />
+                    return (
+                      <div
+                        dangerouslySetInnerHTML={{ __html: highlightedCode }}
+                      />
+                    );
                   }
-                  const match = /language-(\w+)/.exec(className || '')
-                  return inline ?
+                  const match = /language-(\w+)/.exec(className || "");
+                  return inline ? (
                     <code className={className} {...props}>
                       {children}
                     </code>
-                    : match ?
-                      <div dangerouslySetInnerHTML={{ __html: String(children).replace(/\n$/, '') }} />
-                      : <pre className='default'>
-                        <code className={className} {...props}>
-                          {children}
-                        </code>
-                      </pre>
+                  ) : match ? (
+                    <div
+                      dangerouslySetInnerHTML={{
+                        __html: String(children).replace(/\n$/, ""),
+                      }}
+                    />
+                  ) : (
+                    <pre className="default">
+                      <code className={className} {...props}>
+                        {children}
+                      </code>
+                    </pre>
+                  );
                 },
-                table({node, className, children, ...props}) { 
-                  return <div className='mdTable'><table {...props}>{children}</table></div>
-                }
+                table({ node, className, children, ...props }) {
+                  return (
+                    <div className="mdTable">
+                      <table {...props}>{children}</table>
+                    </div>
+                  );
+                },
               }}
               remarkPlugins={[remarkGfm]}
               rehypePlugins={[rehypeRaw]}

--- a/pages/downloads/swan-lake-release-notes/[...slug].js
+++ b/pages/downloads/swan-lake-release-notes/[...slug].js
@@ -36,16 +36,15 @@ import GenerateHeadingComponent from "../../../components/common/heading/RenderH
 
 String.prototype.hashCode = function () {
   var hash = 0,
-    i,
-    chr;
+      i, chr;
   if (this.length === 0) return hash;
   for (i = 0; i < this.length; i++) {
-    chr = this.charCodeAt(i);
-    hash = (hash << 5) - hash + chr;
-    hash |= 0;
+      chr = this.charCodeAt(i);
+      hash = ((hash << 5) - hash) + chr;
+      hash |= 0;
   }
   return hash;
-};
+}
 
 // import { Liquid } from 'liquidjs';
 
@@ -103,7 +102,7 @@ export async function getStaticProps({ params: { slug } }) {
       frontmatter,
       content,
       id,
-      codeSnippets,
+      codeSnippets
     },
   };
 }
@@ -153,16 +152,10 @@ export default function PostPage({ frontmatter, content, id, codeSnippets }) {
         />
 
         {/* <!--LINKED IN  --> */}
-        <meta
-          property="og:title"
-          content={`${frontmatter.title} - The Ballerina programming language`}
-        />
+        <meta property="og:title" content={`${frontmatter.title} - The Ballerina programming language`} />
 
         {/* <!--TWITTER--> */}
-        <meta
-          name="twitter:title"
-          content={`${frontmatter.title} - The Ballerina programming language`}
-        />
+        <meta name="twitter:title" content={`${frontmatter.title} - The Ballerina programming language`} />
         <meta
           property="twitter:description"
           content={`${frontmatter.title} - Release note`}
@@ -193,6 +186,7 @@ export default function PostPage({ frontmatter, content, id, codeSnippets }) {
                 launcher="rn"
                 id={id}
                 mainDir="swan-lake-release-notes"
+                sub={getSubId()}
                 Toc={RNToc}
               />
             </Offcanvas.Body>
@@ -230,45 +224,27 @@ export default function PostPage({ frontmatter, content, id, codeSnippets }) {
                 h5: GenerateHeadingComponent(5, setShowToc),
                 h6: GenerateHeadingComponent(6, setShowToc),
                 code({ node, inline, className, children, ...props }) {
-                  const key = children[0]
-                    .trim()
-                    .split(/\r?\n/)
-                    .map((row) => row.trim())
-                    .join("\n");
+                  const key = (children[0]).trim().split(/\r?\n/).map(row => row.trim()).join('\n');
                   const highlightedCode = codes.get(key.hashCode());
                   if (highlightedCode) {
-                    return (
-                      <div
-                        dangerouslySetInnerHTML={{ __html: highlightedCode }}
-                      />
-                    );
+                    return <div dangerouslySetInnerHTML={{ __html: highlightedCode }} />
                   }
-                  const match = /language-(\w+)/.exec(className || "");
-                  return inline ? (
+                  const match = /language-(\w+)/.exec(className || '')
+                  return inline ?
                     <code className={className} {...props}>
                       {children}
                     </code>
-                  ) : match ? (
-                    <div
-                      dangerouslySetInnerHTML={{
-                        __html: String(children).replace(/\n$/, ""),
-                      }}
-                    />
-                  ) : (
-                    <pre className="default">
-                      <code className={className} {...props}>
-                        {children}
-                      </code>
-                    </pre>
-                  );
+                    : match ?
+                      <div dangerouslySetInnerHTML={{ __html: String(children).replace(/\n$/, '') }} />
+                      : <pre className='default'>
+                        <code className={className} {...props}>
+                          {children}
+                        </code>
+                      </pre>
                 },
-                table({ node, className, children, ...props }) {
-                  return (
-                    <div className="mdTable">
-                      <table {...props}>{children}</table>
-                    </div>
-                  );
-                },
+                table({node, className, children, ...props}) { 
+                  return <div className='mdTable'><table {...props}>{children}</table></div>
+                }
               }}
               remarkPlugins={[remarkGfm]}
               rehypePlugins={[rehypeRaw]}

--- a/utils/rl.json
+++ b/utils/rl.json
@@ -1,1894 +1,1894 @@
 {
-  "dirName": "downloads",
-  "level": 0,
-  "position": 0,
-  "isDir": true,
-  "url": "/downloads",
-  "id": "downloads",
-  "subDirectories": [
-    {
-      "dirName": "Swan Lake release notes",
-      "level": 1,
-      "position": 1,
-      "isDir": true,
-      "url": "/downloads/swan-lake-release-notes",
-      "id": "swan-lake-release-notes",
-      "subDirectories": [
+    "dirName": "downloads",
+    "level": 0,
+    "position": 0,
+    "isDir": true,
+    "url": "/downloads",
+    "id": "downloads",
+    "subDirectories": [
         {
-          "dirName": "Swan Lake Update 10",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.10",
-          "id": "swan-lake-2201.10",
-          "subDirectories": [
-            {
-              "dirName": "2201.10.2 (Swan Lake Update 10)",
-              "level": 3,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.2",
-              "id": "swan-lake-2201.10.2"
-            },
-            {
-              "dirName": "2201.10.1 (Swan Lake Update 10)",
-              "level": 3,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.1",
-              "id": "swan-lake-2201.10.1"
-            },
-            {
-              "dirName": "2201.10.0 (Swan Lake Update 10)",
-              "level": 3,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.0",
-              "id": "swan-lake-2201.10.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Update 9",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.9",
-          "id": "swan-lake-2201.9",
-          "subDirectories": [
-            {
-              "dirName": "2201.9.4 (Swan Lake Update 9)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.4",
-              "id": "swan-lake-2201.9.4"
-            },
-            {
-              "dirName": "2201.9.3 (Swan Lake Update 9)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.3",
-              "id": "swan-lake-2201.9.3"
-            },
-            {
-              "dirName": "2201.9.2 (Swan Lake Update 9)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.2",
-              "id": "swan-lake-2201.9.2"
-            },
-            {
-              "dirName": "2201.9.1 (Swan Lake Update 9)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.1",
-              "id": "swan-lake-2201.9.1"
-            },
-            {
-              "dirName": "2201.9.0 (Swan Lake Update 9)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.0",
-              "id": "swan-lake-2201.9.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Update 8",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.8",
-          "id": "swan-lake-2201.8",
-          "subDirectories": [
-            {
-              "dirName": "2201.8.8 (Swan Lake Update 8)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.8",
-              "id": "swan-lake-2201.8.8"
-            },
-            {
-              "dirName": "2201.8.7 (Swan Lake Update 8)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.7",
-              "id": "swan-lake-2201.8.7"
-            },
-            {
-              "dirName": "2201.8.6 (Swan Lake Update 8)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.6",
-              "id": "swan-lake-2201.8.6"
-            },
-            {
-              "dirName": "2201.8.5 (Swan Lake Update 8)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.5",
-              "id": "swan-lake-2201.8.5"
-            },
-            {
-              "dirName": "2201.8.4 (Swan Lake Update 8)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.4",
-              "id": "swan-lake-2201.8.4"
-            },
-            {
-              "dirName": "2201.8.3 (Swan Lake Update 8)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.3",
-              "id": "swan-lake-2201.8.3"
-            },
-            {
-              "dirName": "2201.8.2 (Swan Lake Update 8)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.2",
-              "id": "swan-lake-2201.8.2"
-            },
-            {
-              "dirName": "2201.8.1 (Swan Lake Update 8)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.1",
-              "id": "swan-lake-2201.8.1"
-            },
-            {
-              "dirName": "2201.8.0 (Swan Lake Update 8)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.0",
-              "id": "swan-lake-2201.8.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Update 7",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.7",
-          "id": "swan-lake-2201.7",
-          "subDirectories": [
-            {
-              "dirName": "2201.7.5 (Swan Lake Update 7)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.5",
-              "id": "swan-lake-2201.7.5"
-            },
-            {
-              "dirName": "2201.7.4 (Swan Lake Update 7)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.4",
-              "id": "swan-lake-2201.7.4"
-            },
-            {
-              "dirName": "2201.7.3 (Swan Lake Update 7)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.3",
-              "id": "swan-lake-2201.7.3"
-            },
-            {
-              "dirName": "2201.7.2 (Swan Lake Update 7)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.2",
-              "id": "swan-lake-2201.7.2"
-            },
-            {
-              "dirName": "2201.7.1 (Swan Lake Update 7)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.1",
-              "id": "swan-lake-2201.7.1"
-            },
-            {
-              "dirName": "2201.7.0 (Swan Lake Update 7)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.0",
-              "id": "swan-lake-2201.7.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Update 6",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.6",
-          "id": "swan-lake-2201.6",
-          "subDirectories": [
-            {
-              "dirName": "2201.6.3 (Swan Lake Update 6)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.3",
-              "id": "swan-lake-2201.6.3"
-            },
-            {
-              "dirName": "2201.6.2 (Swan Lake Update 6)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.2",
-              "id": "swan-lake-2201.6.2"
-            },
-            {
-              "dirName": "2201.6.1 (Swan Lake Update 6)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.1",
-              "id": "swan-lake-2201.6.1"
-            },
-            {
-              "dirName": "2201.6.0 (Swan Lake Update 6)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.0",
-              "id": "swan-lake-2201.6.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Update 5",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.5",
-          "id": "swan-lake-2201.5",
-          "subDirectories": [
-            {
-              "dirName": "2201.5.5 (Swan Lake Update 5)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.5",
-              "id": "swan-lake-2201.5.5"
-            },
-            {
-              "dirName": "2201.5.4 (Swan Lake Update 5)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.4",
-              "id": "swan-lake-2201.5.4"
-            },
-            {
-              "dirName": "2201.5.3 (Swan Lake Update 5)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.3",
-              "id": "swan-lake-2201.5.3"
-            },
-            {
-              "dirName": "2201.5.2 (Swan Lake Update 5)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.2",
-              "id": "swan-lake-2201.5.2"
-            },
-            {
-              "dirName": "2201.5.1 (Swan Lake Update 5)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.1",
-              "id": "swan-lake-2201.5.1"
-            },
-            {
-              "dirName": "2201.5.0 (Swan Lake Update 5)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.0",
-              "id": "swan-lake-2201.5.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Update 4",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.4",
-          "id": "swan-lake-2201.4",
-          "subDirectories": [
-            {
-              "dirName": "2201.4.3 (Swan Lake Update 4)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.3",
-              "id": "swan-lake-2201.4.3"
-            },
-            {
-              "dirName": "2201.4.2 (Swan Lake Update 4)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.2",
-              "id": "swan-lake-2201.4.2"
-            },
-            {
-              "dirName": "2201.4.1 (Swan Lake Update 4)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.1",
-              "id": "swan-lake-2201.4.1"
-            },
-            {
-              "dirName": "2201.4.0 (Swan Lake Update 4)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.0",
-              "id": "swan-lake-2201.4.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Update 3",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.3",
-          "id": "swan-lake-2201.3",
-          "subDirectories": [
-            {
-              "dirName": "2201.3.5 (Swan Lake Update 3)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.5",
-              "id": "swan-lake-2201.3.5"
-            },
-            {
-              "dirName": "2201.3.4 (Swan Lake Update 3)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.4",
-              "id": "swan-lake-2201.3.4"
-            },
-            {
-              "dirName": "2201.3.3 (Swan Lake Update 3)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.3",
-              "id": "swan-lake-2201.3.3"
-            },
-            {
-              "dirName": "2201.3.2 (Swan Lake Update 3)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.2",
-              "id": "swan-lake-2201.3.2"
-            },
-            {
-              "dirName": "2201.3.1 (Swan Lake Update 3)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.1",
-              "id": "swan-lake-2201.3.1"
-            },
-            {
-              "dirName": "2201.3.0 (Swan Lake Update 3)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.0",
-              "id": "swan-lake-2201.3.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Update 2",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.2",
-          "id": "swan-lake-2201.2",
-          "subDirectories": [
-            {
-              "dirName": "2201.2.4 (Swan Lake Update 2)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.4",
-              "id": "swan-lake-2201.2.4"
-            },
-            {
-              "dirName": "2201.2.3 (Swan Lake Update 2)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.3",
-              "id": "swan-lake-2201.2.3"
-            },
-            {
-              "dirName": "2201.2.2 (Swan Lake Update 2)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.2",
-              "id": "swan-lake-2201.2.2"
-            },
-            {
-              "dirName": "2201.2.1 (Swan Lake Update 2)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.1",
-              "id": "swan-lake-2201.2.1"
-            },
-            {
-              "dirName": "2201.2.0 (Swan Lake Update 2)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.0",
-              "id": "swan-lake-2201.2.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Update 1",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.1",
-          "id": "swan-lake-2201.1",
-          "subDirectories": [
-            {
-              "dirName": "2201.1.2 (Swan Lake Update 1)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.2",
-              "id": "swan-lake-2201.1.2"
-            },
-            {
-              "dirName": "2201.1.1 (Swan Lake Update 1)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.1",
-              "id": "swan-lake-2201.1.1"
-            },
-            {
-              "dirName": "2201.1.0 (Swan Lake Update 1)",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.0",
-              "id": "swan-lake-2201.1.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-2201.0",
-          "id": "swan-lake-2201.0",
-          "subDirectories": [
-            {
-              "dirName": "2201.0.5 (Swan Lake) ",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.5",
-              "id": "swan-lake-2201.0.5"
-            },
-            {
-              "dirName": "2201.0.4 (Swan Lake) ",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.4",
-              "id": "swan-lake-2201.0.4"
-            },
-            {
-              "dirName": "2201.0.3 (Swan Lake) ",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.3",
-              "id": "swan-lake-2201.0.3"
-            },
-            {
-              "dirName": "2201.0.2 (Swan Lake) ",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.2",
-              "id": "swan-lake-2201.0.2"
-            },
-            {
-              "dirName": "2201.0.1 (Swan Lake) ",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.1",
-              "id": "swan-lake-2201.0.1"
-            },
-            {
-              "dirName": "2201.0.0 (Swan Lake) ",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.0",
-              "id": "swan-lake-2201.0.0"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Beta",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-beta",
-          "id": "swan-lake-beta",
-          "subDirectories": [
-            {
-              "dirName": "Swan Lake Beta6",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-beta6",
-              "id": "swan-lake-beta6"
-            },
-            {
-              "dirName": "Swan Lake Beta5",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-beta5",
-              "id": "swan-lake-beta5"
-            },
-            {
-              "dirName": "Swan Lake Beta4",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-beta4",
-              "id": "swan-lake-beta4"
-            },
-            {
-              "dirName": "Swan Lake Beta3",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-beta3",
-              "id": "swan-lake-beta3"
-            },
-            {
-              "dirName": "Swan Lake Beta2",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-beta2",
-              "id": "swan-lake-beta2"
-            },
-            {
-              "dirName": "Swan Lake Beta1",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-beta1",
-              "id": "swan-lake-beta1"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Alpha",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-alpha",
-          "id": "swan-lake-alpha",
-          "subDirectories": [
-            {
-              "dirName": "Swan Lake Alpha5 ",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-alpha5",
-              "id": "swan-lake-alpha5"
-            },
-            {
-              "dirName": "Swan Lake Alpha4 ",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-alpha4",
-              "id": "swan-lake-alpha4"
-            },
+            "dirName": "Swan Lake release notes",
+            "level": 1,
+            "position": 1,
+            "isDir": true,
+            "url": "/downloads/swan-lake-release-notes",
+            "id": "swan-lake-release-notes",
+            "subDirectories": [
+                {
+                    "dirName": "Swan Lake Update 10",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.10",
+                    "id": "swan-lake-2201.10",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.10.2 (Swan Lake Update 10)",
+                            "level": 3,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.2",
+                            "id": "swan-lake-2201.10.2"
+                        },
+                        {
+                            "dirName": "2201.10.1 (Swan Lake Update 10)",
+                            "level": 3,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.1",
+                            "id": "swan-lake-2201.10.1"
+                        },
+                        {
+                            "dirName": "2201.10.0 (Swan Lake Update 10)",
+                            "level": 3,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.0",
+                            "id": "swan-lake-2201.10.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Update 9",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.9",
+                    "id": "swan-lake-2201.9",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.9.4 (Swan Lake Update 9)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.4",
+                            "id": "swan-lake-2201.9.4"
+                        },
+                        {
+                            "dirName": "2201.9.3 (Swan Lake Update 9)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.3",
+                            "id": "swan-lake-2201.9.3"
+                        },
+                        {
+                            "dirName": "2201.9.2 (Swan Lake Update 9)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.2",
+                            "id": "swan-lake-2201.9.2"
+                        },
+                        {
+                            "dirName": "2201.9.1 (Swan Lake Update 9)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.1",
+                            "id": "swan-lake-2201.9.1"
+                        },
+                        {
+                            "dirName": "2201.9.0 (Swan Lake Update 9)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.0",
+                            "id": "swan-lake-2201.9.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Update 8",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.8",
+                    "id": "swan-lake-2201.8",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.8.8 (Swan Lake Update 8)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.8",
+                            "id": "swan-lake-2201.8.8"
+                        },
+                        {
+                            "dirName": "2201.8.7 (Swan Lake Update 8)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.7",
+                            "id": "swan-lake-2201.8.7"
+                        },
+                        {
+                            "dirName": "2201.8.6 (Swan Lake Update 8)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.6",
+                            "id": "swan-lake-2201.8.6"
+                        },
+                        {
+                            "dirName": "2201.8.5 (Swan Lake Update 8)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.5",
+                            "id": "swan-lake-2201.8.5"
+                        },
+                        {
+                            "dirName": "2201.8.4 (Swan Lake Update 8)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.4",
+                            "id": "swan-lake-2201.8.4"
+                        },
+                        {
+                            "dirName": "2201.8.3 (Swan Lake Update 8)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.3",
+                            "id": "swan-lake-2201.8.3"
+                        },
+                        {
+                            "dirName": "2201.8.2 (Swan Lake Update 8)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.2",
+                            "id": "swan-lake-2201.8.2"
+                        },
+                        {
+                            "dirName": "2201.8.1 (Swan Lake Update 8)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.1",
+                            "id": "swan-lake-2201.8.1"
+                        },
+                        {
+                            "dirName": "2201.8.0 (Swan Lake Update 8)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.0",
+                            "id": "swan-lake-2201.8.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Update 7",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.7",
+                    "id": "swan-lake-2201.7",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.7.5 (Swan Lake Update 7)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.5",
+                            "id": "swan-lake-2201.7.5"
+                        },
+                        {
+                            "dirName": "2201.7.4 (Swan Lake Update 7)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.4",
+                            "id": "swan-lake-2201.7.4"
+                        },
+                        {
+                            "dirName": "2201.7.3 (Swan Lake Update 7)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.3",
+                            "id": "swan-lake-2201.7.3"
+                        },
+                        {
+                            "dirName": "2201.7.2 (Swan Lake Update 7)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.2",
+                            "id": "swan-lake-2201.7.2"
+                        },
+                        {
+                            "dirName": "2201.7.1 (Swan Lake Update 7)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.1",
+                            "id": "swan-lake-2201.7.1"
+                        },
+                        {
+                            "dirName": "2201.7.0 (Swan Lake Update 7)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.0",
+                            "id": "swan-lake-2201.7.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Update 6",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.6",
+                    "id": "swan-lake-2201.6",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.6.3 (Swan Lake Update 6)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.3",
+                            "id": "swan-lake-2201.6.3"
+                        },
+                        {
+                            "dirName": "2201.6.2 (Swan Lake Update 6)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.2",
+                            "id": "swan-lake-2201.6.2"
+                        },
+                        {
+                            "dirName": "2201.6.1 (Swan Lake Update 6)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.1",
+                            "id": "swan-lake-2201.6.1"
+                        },
+                        {
+                            "dirName": "2201.6.0 (Swan Lake Update 6)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.0",
+                            "id": "swan-lake-2201.6.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Update 5",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.5",
+                    "id": "swan-lake-2201.5",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.5.5 (Swan Lake Update 5)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.5",
+                            "id": "swan-lake-2201.5.5"
+                        },
+                        {
+                            "dirName": "2201.5.4 (Swan Lake Update 5)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.4",
+                            "id": "swan-lake-2201.5.4"
+                        },
+                        {
+                            "dirName": "2201.5.3 (Swan Lake Update 5)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.3",
+                            "id": "swan-lake-2201.5.3"
+                        },
+                        {
+                            "dirName": "2201.5.2 (Swan Lake Update 5)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.2",
+                            "id": "swan-lake-2201.5.2"
+                        },
+                        {
+                            "dirName": "2201.5.1 (Swan Lake Update 5)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.1",
+                            "id": "swan-lake-2201.5.1"
+                        },
+                        {
+                            "dirName": "2201.5.0 (Swan Lake Update 5)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.0",
+                            "id": "swan-lake-2201.5.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Update 4",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.4",
+                    "id": "swan-lake-2201.4",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.4.3 (Swan Lake Update 4)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.3",
+                            "id": "swan-lake-2201.4.3"
+                        },
+                        {
+                            "dirName": "2201.4.2 (Swan Lake Update 4)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.2",
+                            "id": "swan-lake-2201.4.2"
+                        },
+                        {
+                            "dirName": "2201.4.1 (Swan Lake Update 4)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.1",
+                            "id": "swan-lake-2201.4.1"
+                        },
+                        {
+                            "dirName": "2201.4.0 (Swan Lake Update 4)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.0",
+                            "id": "swan-lake-2201.4.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Update 3",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.3",
+                    "id": "swan-lake-2201.3",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.3.5 (Swan Lake Update 3)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.5",
+                            "id": "swan-lake-2201.3.5"
+                        },
+                        {
+                            "dirName": "2201.3.4 (Swan Lake Update 3)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.4",
+                            "id": "swan-lake-2201.3.4"
+                        },
+                        {
+                            "dirName": "2201.3.3 (Swan Lake Update 3)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.3",
+                            "id": "swan-lake-2201.3.3"
+                        },
+                        {
+                            "dirName": "2201.3.2 (Swan Lake Update 3)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.2",
+                            "id": "swan-lake-2201.3.2"
+                        },
+                        {
+                            "dirName": "2201.3.1 (Swan Lake Update 3)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.1",
+                            "id": "swan-lake-2201.3.1"
+                        },
+                        {
+                            "dirName": "2201.3.0 (Swan Lake Update 3)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.0",
+                            "id": "swan-lake-2201.3.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Update 2",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.2",
+                    "id": "swan-lake-2201.2",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.2.4 (Swan Lake Update 2)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.4",
+                            "id": "swan-lake-2201.2.4"
+                        },
+                        {
+                            "dirName": "2201.2.3 (Swan Lake Update 2)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.3",
+                            "id": "swan-lake-2201.2.3"
+                        },
+                        {
+                            "dirName": "2201.2.2 (Swan Lake Update 2)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.2",
+                            "id": "swan-lake-2201.2.2"
+                        },
+                        {
+                            "dirName": "2201.2.1 (Swan Lake Update 2)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.1",
+                            "id": "swan-lake-2201.2.1"
+                        },
+                        {
+                            "dirName": "2201.2.0 (Swan Lake Update 2)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.0",
+                            "id": "swan-lake-2201.2.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Update 1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.1",
+                    "id": "swan-lake-2201.1",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.1.2 (Swan Lake Update 1)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.2",
+                            "id": "swan-lake-2201.1.2"
+                        },
+                        {
+                            "dirName": "2201.1.1 (Swan Lake Update 1)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.1",
+                            "id": "swan-lake-2201.1.1"
+                        },
+                        {
+                            "dirName": "2201.1.0 (Swan Lake Update 1)",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.0",
+                            "id": "swan-lake-2201.1.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-2201.0",
+                    "id": "swan-lake-2201.0",
+                    "subDirectories": [
+                        {
+                            "dirName": "2201.0.5 (Swan Lake) ",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.5",
+                            "id": "swan-lake-2201.0.5"
+                        },
+                        {
+                            "dirName": "2201.0.4 (Swan Lake) ",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.4",
+                            "id": "swan-lake-2201.0.4"
+                        },
+                        {
+                            "dirName": "2201.0.3 (Swan Lake) ",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.3",
+                            "id": "swan-lake-2201.0.3"
+                        },
+                        {
+                            "dirName": "2201.0.2 (Swan Lake) ",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.2",
+                            "id": "swan-lake-2201.0.2"
+                        },
+                        {
+                            "dirName": "2201.0.1 (Swan Lake) ",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.1",
+                            "id": "swan-lake-2201.0.1"
+                        },
+                        {
+                            "dirName": "2201.0.0 (Swan Lake) ",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.0",
+                            "id": "swan-lake-2201.0.0"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Beta",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-beta",
+                    "id": "swan-lake-beta",
+                    "subDirectories": [
+                        {
+                            "dirName": "Swan Lake Beta6",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-beta6",
+                            "id": "swan-lake-beta6"
+                        },
+                        {
+                            "dirName": "Swan Lake Beta5",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-beta5",
+                            "id": "swan-lake-beta5"
+                        },
+                        {
+                            "dirName": "Swan Lake Beta4",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-beta4",
+                            "id": "swan-lake-beta4"
+                        },
+                        {
+                            "dirName": "Swan Lake Beta3",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-beta3",
+                            "id": "swan-lake-beta3"
+                        },
+                        {
+                            "dirName": "Swan Lake Beta2",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-beta2",
+                            "id": "swan-lake-beta2"
+                        },
+                        {
+                            "dirName": "Swan Lake Beta1",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-beta1",
+                            "id": "swan-lake-beta1"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Alpha",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-alpha",
+                    "id": "swan-lake-alpha",
+                    "subDirectories": [
+                        {
+                            "dirName": "Swan Lake Alpha5 ",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-alpha5",
+                            "id": "swan-lake-alpha5"
+                        },
+                        {
+                            "dirName": "Swan Lake Alpha4 ",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-alpha4",
+                            "id": "swan-lake-alpha4"
+                        },
 
-            {
-              "dirName": "Swan Lake Alpha3",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-alpha3",
-              "id": "swan-lake-alpha3"
-            },
-            {
-              "dirName": "Swan Lake Alpha2",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-alpha2",
-              "id": "swan-lake-alpha2"
-            },
-            {
-              "dirName": "Swan Lake Alpha1",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-alpha1",
-              "id": "swan-lake-alpha1"
-            }
-          ]
-        },
-        {
-          "dirName": "Swan Lake Preview",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes-preview",
-          "id": "swan-lake-preview",
-          "subDirectories": [
-            {
-              "dirName": "Swan Lake Preview 8",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-preview8",
-              "id": "swan-lake-preview8"
-            },
-            {
-              "dirName": "Swan Lake Preview 7",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-preview7",
-              "id": "swan-lake-preview7"
-            },
-            {
-              "dirName": "Swan Lake Preview 6",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-preview6",
-              "id": "swan-lake-preview6"
-            },
-            {
-              "dirName": "Swan Lake Preview 5",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-preview5",
-              "id": "swan-lake-preview5"
-            },
-            {
-              "dirName": "Swan Lake Preview 4",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-preview4",
-              "id": "swan-lake-preview4"
-            },
-            {
-              "dirName": "Swan Lake Preview 3",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-preview3",
-              "id": "swan-lake-preview3"
-            },
-            {
-              "dirName": "Swan Lake Preview 2",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-preview2",
-              "id": "swan-lake-preview2"
-            },
-            {
-              "dirName": "Swan Lake Preview 1",
-              "level": 2,
-              "position": 1,
-              "isDir": false,
-              "url": "/downloads/swan-lake-release-notes/swan-lake-preview1",
-              "id": "swan-lake-preview1"
-            }
-          ]
-        },
+                        {
+                            "dirName": "Swan Lake Alpha3",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-alpha3",
+                            "id": "swan-lake-alpha3"
+                        },
+                        {
+                            "dirName": "Swan Lake Alpha2",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-alpha2",
+                            "id": "swan-lake-alpha2"
+                        },
+                        {
+                            "dirName": "Swan Lake Alpha1",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-alpha1",
+                            "id": "swan-lake-alpha1"
+                        }
+                    ]
+                },
+                {
+                    "dirName": "Swan Lake Preview",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes-preview",
+                    "id": "swan-lake-preview",
+                    "subDirectories": [
+                        {
+                            "dirName": "Swan Lake Preview 8",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-preview8",
+                            "id": "swan-lake-preview8"
+                        },
+                        {
+                            "dirName": "Swan Lake Preview 7",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-preview7",
+                            "id": "swan-lake-preview7"
+                        },
+                        {
+                            "dirName": "Swan Lake Preview 6",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-preview6",
+                            "id": "swan-lake-preview6"
+                        },
+                        {
+                            "dirName": "Swan Lake Preview 5",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-preview5",
+                            "id": "swan-lake-preview5"
+                        },
+                        {
+                            "dirName": "Swan Lake Preview 4",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-preview4",
+                            "id": "swan-lake-preview4"
+                        },
+                        {
+                            "dirName": "Swan Lake Preview 3",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-preview3",
+                            "id": "swan-lake-preview3"
+                        },
+                        {
+                            "dirName": "Swan Lake Preview 2",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-preview2",
+                            "id": "swan-lake-preview2"
+                        },
+                        {
+                            "dirName": "Swan Lake Preview 1",
+                            "level": 2,
+                            "position": 1,
+                            "isDir": false,
+                            "url": "/downloads/swan-lake-release-notes/swan-lake-preview1",
+                            "id": "swan-lake-preview1"
+                        }
+                    ]
+                },
 
+                {
+                    "dirName": "2201.1.0",
+                    "level": 2,
+                    "position": 0,
+                    "isDir": true,
+                    "url": "/downloads/swan-lake-release-notes/2201.1.0",
+                    "id": "2201.1.0",
+                    "subDirectories": []
+                }
+            ]
+        },
         {
-          "dirName": "2201.1.0",
-          "level": 2,
-          "position": 0,
-          "isDir": true,
-          "url": "/downloads/swan-lake-release-notes/2201.1.0",
-          "id": "2201.1.0",
-          "subDirectories": []
+            "dirName": "1.2.x release notes",
+            "level": 1,
+            "position": 2,
+            "isDir": true,
+            "url": "/downloads/1.2.x-release-notes",
+            "id": "1.2.x-release-notes",
+            "subDirectories": [
+                {
+                    "dirName": "1.2.54",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.54",
+                    "id": "1.2.54"
+                },
+                {
+                    "dirName": "1.2.53",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.53",
+                    "id": "1.2.53"
+                },
+                {
+                    "dirName": "1.2.52",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.52",
+                    "id": "1.2.52"
+                },
+                {
+                    "dirName": "1.2.51",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.51",
+                    "id": "1.2.51"
+                },
+                {
+                    "dirName": "1.2.50",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.50",
+                    "id": "1.2.50"
+                },
+                {
+                    "dirName": "1.2.49",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.49",
+                    "id": "1.2.49"
+                },
+                {
+                    "dirName": "1.2.48",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.48",
+                    "id": "1.2.48"
+                },
+                {
+                    "dirName": "1.2.47",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.47",
+                    "id": "1.2.47"
+                },
+                {
+                    "dirName": "1.2.46",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.46",
+                    "id": "1.2.46"
+                },
+                {
+                    "dirName": "1.2.45",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.45",
+                    "id": "1.2.45"
+                },
+                {
+                    "dirName": "1.2.44",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.44",
+                    "id": "1.2.44"
+                },
+                {
+                    "dirName": "1.2.43",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.43",
+                    "id": "1.2.43"
+                },
+                {
+                    "dirName": "1.2.42",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.42",
+                    "id": "1.2.42"
+                },
+                {
+                    "dirName": "1.2.41",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.41",
+                    "id": "1.2.41"
+                },
+                {
+                    "dirName": "1.2.40",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.40",
+                    "id": "1.2.40"
+                },
+                {
+                    "dirName": "1.2.39",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.39",
+                    "id": "1.2.39"
+                },
+                {
+                    "dirName": "1.2.38",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.38",
+                    "id": "1.2.38"
+                },
+                {
+                    "dirName": "1.2.37",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.37",
+                    "id": "1.2.37"
+                },
+                {
+                    "dirName": "1.2.36",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.36",
+                    "id": "1.2.36"
+                },
+                {
+                    "dirName": "1.2.35",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.35",
+                    "id": "1.2.35"
+                },
+                {
+                    "dirName": "1.2.34",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.34",
+                    "id": "1.2.34"
+                },
+                {
+                    "dirName": "1.2.33",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.33",
+                    "id": "1.2.33"
+                },
+                {
+                    "dirName": "1.2.32",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.32",
+                    "id": "1.2.32"
+                },
+                {
+                    "dirName": "1.2.31",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.31",
+                    "id": "1.2.31"
+                },
+                {
+                    "dirName": "1.2.30",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.30",
+                    "id": "1.2.30"
+                },
+                {
+                    "dirName": "1.2.29",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.29",
+                    "id": "1.2.29"
+                },
+                {
+                    "dirName": "1.2.28",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.28",
+                    "id": "1.2.28"
+                },
+                {
+                    "dirName": "1.2.27",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.27",
+                    "id": "1.2.27"
+                },
+                {
+                    "dirName": "1.2.26",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.26",
+                    "id": "1.2.26"
+                },
+                {
+                    "dirName": "1.2.25",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.25",
+                    "id": "1.2.25"
+                },
+                {
+                    "dirName": "1.2.24",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.24",
+                    "id": "1.2.24"
+                },
+                {
+                    "dirName": "1.2.23",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.23",
+                    "id": "1.2.23"
+                },
+                {
+                    "dirName": "1.2.22",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.22",
+                    "id": "1.2.22"
+                },
+                {
+                    "dirName": "1.2.21",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.21",
+                    "id": "1.2.21"
+                },
+                {
+                    "dirName": "1.2.20",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.20",
+                    "id": "1.2.20"
+                },
+                {
+                    "dirName": "1.2.19",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.19",
+                    "id": "1.2.19"
+                },
+                {
+                    "dirName": "1.2.18",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.18",
+                    "id": "1.2.18"
+                },
+                {
+                    "dirName": "1.2.17",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.17",
+                    "id": "1.2.17"
+                },
+                {
+                    "dirName": "1.2.16",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.16",
+                    "id": "1.2.16"
+                },
+                {
+                    "dirName": "1.2.15 ",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.15",
+                    "id": "1.2.15"
+                },
+                {
+                    "dirName": "1.2.14 ",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.14",
+                    "id": "1.2.14"
+                },
+                {
+                    "dirName": "1.2.13 ",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.13",
+                    "id": "1.2.13"
+                },
+                {
+                    "dirName": "1.2.12 ",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.12",
+                    "id": "1.2.12"
+                },
+                {
+                    "dirName": "1.2.11 ",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.11",
+                    "id": "1.2.11"
+                },
+                {
+                    "dirName": "1.2.10 ",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.10",
+                    "id": "1.2.10"
+                },
+                {
+                    "dirName": "1.2.9 ",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.9",
+                    "id": "1.2.9"
+                },
+                {
+                    "dirName": "1.2.8",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.8",
+                    "id": "1.2.8"
+                },
+                {
+                    "dirName": "1.2.7",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.7",
+                    "id": "1.2.7"
+                },
+                {
+                    "dirName": "1.2.6",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.6",
+                    "id": "1.2.6"
+                },
+                {
+                    "dirName": "1.2.5 ",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.5",
+                    "id": "1.2.5"
+                },
+                {
+                    "dirName": "1.2.4",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.4",
+                    "id": "1.2.4"
+                },
+                {
+                    "dirName": "1.2.3",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.3",
+                    "id": "1.2.3"
+                },
+                {
+                    "dirName": "1.2.2",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.2",
+                    "id": "1.2.2"
+                },
+                {
+                    "dirName": "1.2.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.1",
+                    "id": "1.2.1"
+                },
+                {
+                    "dirName": "1.2.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.2.x-release-notes/1.2.0",
+                    "id": "1.2.0"
+                }
+            ]
+        },
+        {
+            "dirName": "1.2.x archived versions",
+            "level": 1,
+            "position": 0,
+            "isDir": false,
+            "url": "/downloads/archived",
+            "id": "archived"
+        },
+        {
+            "dirName": "Release Note",
+            "level": 1,
+            "position": 0,
+            "isDir": false,
+            "url": "/downloads/RELEASE_NOTE",
+            "id": "RELEASE_NOTE"
+        },
+        {
+            "dirName": "Swan Lake Release Notes",
+            "level": 1,
+            "position": 0,
+            "isDir": false,
+            "url": "/downloads/swan-lake-release-notes",
+            "id": "swan-lake-release-notes"
+        },
+        {
+            "dirName": "Swan Lake archived versions",
+            "level": 1,
+            "position": 0,
+            "isDir": false,
+            "url": "/downloads/swan-lake-archived",
+            "id": "swan-lake-archived"
+        },
+        {
+            "dirName": "1.1.x release notes",
+            "level": 1,
+            "position": 3,
+            "isDir": true,
+            "url": "/downloads/1.1.x-release-notes",
+            "id": "1.1.x-release-notes",
+            "subDirectories": [
+                {
+                    "dirName": "1.1.4",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.1.x-release-notes/1.1.4",
+                    "id": "1.1.4",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.1.3",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.1.x-release-notes/1.1.3",
+                    "id": "1.1.3",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.1.2",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.1.x-release-notes/1.1.2",
+                    "id": "1.1.2",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.1.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.1.x-release-notes/1.1.1",
+                    "id": "1.1.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.1.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.1.x-release-notes/1.1.0",
+                    "id": "1.1.0",
+                    "subDirectories": []
+                }
+            ]
+        },
+        {
+            "dirName": "1.0.x. release notes",
+            "level": 1,
+            "position": 4,
+            "isDir": true,
+            "url": "/downloads/1.0.x-release-notes",
+            "id": "1.0.x-release-notes",
+            "subDirectories": [
+                {
+                    "dirName": "1.0.5",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.0.x-release-notes/1.0.5",
+                    "id": "1.0.5",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.4",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.0.x-release-notes/1.0.4",
+                    "id": "1.0.4",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.3",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.0.x-release-notes/1.0.3",
+                    "id": "1.0.3",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.2",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.0.x-release-notes/1.0.2",
+                    "id": "1.0.2",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.0.x-release-notes/1.0.1",
+                    "id": "1.0.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/1.0.x-release-notes/1.0.0",
+                    "id": "1.0.0",
+                    "subDirectories": []
+                }
+            ]
+        },
+        {
+            "dirName": "0.9.x release notes",
+            "level": 1,
+            "position": 5,
+            "isDir": true,
+            "url": "/downloads/0.9.x-release-notes",
+            "id": "0.9.x-release-notes",
+            "subDirectories": [
+                {
+                    "dirName": "0.991.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.991.0",
+                    "id": "0.991.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.990.3",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.990.3",
+                    "id": "0.990.3",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.990.2",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.990.2",
+                    "id": "0.990.2",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.990.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.990.1",
+                    "id": "0.990.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.990.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.990.0",
+                    "id": "0.990.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.983.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.983.0",
+                    "id": "0.983.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.982.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.982.0",
+                    "id": "0.982.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.981.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.981.1",
+                    "id": "0.981.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.981.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.981.0",
+                    "id": "0.981.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.980.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.980.1",
+                    "id": "0.980.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.980.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.980.0",
+                    "id": "0.980.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.975.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.975.0",
+                    "id": "0.975.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.970.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.970.1",
+                    "id": "0.970.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.970.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": false,
+                    "url": "/downloads/0.9.x-release-notes/0.970.0",
+                    "id": "0.970.0",
+                    "subDirectories": []
+                }
+            ]
+        },
+        {
+            "dirName": "stable release notes",
+            "level": 1,
+            "position": 0,
+            "isDir": true,
+            "url": "/downloads/stable-release-notes",
+            "id": "stable-release-notes",
+            "subDirectories": [
+                {
+                    "dirName": "0.970.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.970.0",
+                    "id": "0.970.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.14",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.14",
+                    "id": "1.2.14",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.1.2",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.1.2",
+                    "id": "1.1.2",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.3",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.0.3",
+                    "id": "1.0.3",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.7",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.7",
+                    "id": "1.2.7",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.13",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.13",
+                    "id": "1.2.13",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.0",
+                    "id": "1.2.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.980.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.980.1",
+                    "id": "0.980.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.8",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.8",
+                    "id": "1.2.8",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.4",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.4",
+                    "id": "1.2.4",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.10",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.10",
+                    "id": "1.2.10",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.0.1",
+                    "id": "1.0.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.5",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.5",
+                    "id": "1.2.5",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.990.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.990.0",
+                    "id": "0.990.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.970.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.970.1",
+                    "id": "0.970.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.4",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.0.4",
+                    "id": "1.0.4",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.1.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.1.1",
+                    "id": "1.1.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.1.3",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.1.3",
+                    "id": "1.1.3",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.981.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.981.1",
+                    "id": "0.981.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.5",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.0.5",
+                    "id": "1.0.5",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.983.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.983.0",
+                    "id": "0.983.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.981.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.981.0",
+                    "id": "0.981.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.975.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.975.0",
+                    "id": "0.975.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.11",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.11",
+                    "id": "1.2.11",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.12",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.12",
+                    "id": "1.2.12",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.980.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.980.0",
+                    "id": "0.980.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.1",
+                    "id": "1.2.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.1.4",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.1.4",
+                    "id": "1.1.4",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.9",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.9",
+                    "id": "1.2.9",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.2",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.2",
+                    "id": "1.2.2",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.6",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.6",
+                    "id": "1.2.6",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.0.0",
+                    "id": "1.0.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.990.3",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.990.3",
+                    "id": "0.990.3",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.990.1",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.990.1",
+                    "id": "0.990.1",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.991.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.991.0",
+                    "id": "0.991.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.2.3",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.2.3",
+                    "id": "1.2.3",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.0.2",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.0.2",
+                    "id": "1.0.2",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.982.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.982.0",
+                    "id": "0.982.0",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "0.990.2",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/0.990.2",
+                    "id": "0.990.2",
+                    "subDirectories": []
+                },
+                {
+                    "dirName": "1.1.0",
+                    "level": 2,
+                    "position": 1,
+                    "isDir": true,
+                    "url": "/downloads/stable-release-notes/1.1.0",
+                    "id": "1.1.0",
+                    "subDirectories": []
+                }
+            ]
+        },
+        {
+            "dirName": " 1.2.x Release Notes Old",
+            "level": 1,
+            "position": 0,
+            "isDir": false,
+            "url": "/downloads/release-notes",
+            "id": "release-notes"
         }
-      ]
-    },
-    {
-      "dirName": "1.2.x release notes",
-      "level": 1,
-      "position": 2,
-      "isDir": true,
-      "url": "/downloads/1.2.x-release-notes",
-      "id": "1.2.x-release-notes",
-      "subDirectories": [
-        {
-          "dirName": "1.2.54",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.54",
-          "id": "1.2.54"
-        },
-        {
-          "dirName": "1.2.53",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.53",
-          "id": "1.2.53"
-        },
-        {
-          "dirName": "1.2.52",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.52",
-          "id": "1.2.52"
-        },
-        {
-          "dirName": "1.2.51",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.51",
-          "id": "1.2.51"
-        },
-        {
-          "dirName": "1.2.50",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.50",
-          "id": "1.2.50"
-        },
-        {
-          "dirName": "1.2.49",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.49",
-          "id": "1.2.49"
-        },
-        {
-          "dirName": "1.2.48",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.48",
-          "id": "1.2.48"
-        },
-        {
-          "dirName": "1.2.47",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.47",
-          "id": "1.2.47"
-        },
-        {
-          "dirName": "1.2.46",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.46",
-          "id": "1.2.46"
-        },
-        {
-          "dirName": "1.2.45",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.45",
-          "id": "1.2.45"
-        },
-        {
-          "dirName": "1.2.44",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.44",
-          "id": "1.2.44"
-        },
-        {
-          "dirName": "1.2.43",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.43",
-          "id": "1.2.43"
-        },
-        {
-          "dirName": "1.2.42",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.42",
-          "id": "1.2.42"
-        },
-        {
-          "dirName": "1.2.41",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.41",
-          "id": "1.2.41"
-        },
-        {
-          "dirName": "1.2.40",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.40",
-          "id": "1.2.40"
-        },
-        {
-          "dirName": "1.2.39",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.39",
-          "id": "1.2.39"
-        },
-        {
-          "dirName": "1.2.38",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.38",
-          "id": "1.2.38"
-        },
-        {
-          "dirName": "1.2.37",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.37",
-          "id": "1.2.37"
-        },
-        {
-          "dirName": "1.2.36",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.36",
-          "id": "1.2.36"
-        },
-        {
-          "dirName": "1.2.35",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.35",
-          "id": "1.2.35"
-        },
-        {
-          "dirName": "1.2.34",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.34",
-          "id": "1.2.34"
-        },
-        {
-          "dirName": "1.2.33",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.33",
-          "id": "1.2.33"
-        },
-        {
-          "dirName": "1.2.32",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.32",
-          "id": "1.2.32"
-        },
-        {
-          "dirName": "1.2.31",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.31",
-          "id": "1.2.31"
-        },
-        {
-          "dirName": "1.2.30",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.30",
-          "id": "1.2.30"
-        },
-        {
-          "dirName": "1.2.29",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.29",
-          "id": "1.2.29"
-        },
-        {
-          "dirName": "1.2.28",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.28",
-          "id": "1.2.28"
-        },
-        {
-          "dirName": "1.2.27",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.27",
-          "id": "1.2.27"
-        },
-        {
-          "dirName": "1.2.26",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.26",
-          "id": "1.2.26"
-        },
-        {
-          "dirName": "1.2.25",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.25",
-          "id": "1.2.25"
-        },
-        {
-          "dirName": "1.2.24",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.24",
-          "id": "1.2.24"
-        },
-        {
-          "dirName": "1.2.23",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.23",
-          "id": "1.2.23"
-        },
-        {
-          "dirName": "1.2.22",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.22",
-          "id": "1.2.22"
-        },
-        {
-          "dirName": "1.2.21",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.21",
-          "id": "1.2.21"
-        },
-        {
-          "dirName": "1.2.20",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.20",
-          "id": "1.2.20"
-        },
-        {
-          "dirName": "1.2.19",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.19",
-          "id": "1.2.19"
-        },
-        {
-          "dirName": "1.2.18",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.18",
-          "id": "1.2.18"
-        },
-        {
-          "dirName": "1.2.17",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.17",
-          "id": "1.2.17"
-        },
-        {
-          "dirName": "1.2.16",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.16",
-          "id": "1.2.16"
-        },
-        {
-          "dirName": "1.2.15 ",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.15",
-          "id": "1.2.15"
-        },
-        {
-          "dirName": "1.2.14 ",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.14",
-          "id": "1.2.14"
-        },
-        {
-          "dirName": "1.2.13 ",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.13",
-          "id": "1.2.13"
-        },
-        {
-          "dirName": "1.2.12 ",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.12",
-          "id": "1.2.12"
-        },
-        {
-          "dirName": "1.2.11 ",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.11",
-          "id": "1.2.11"
-        },
-        {
-          "dirName": "1.2.10 ",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.10",
-          "id": "1.2.10"
-        },
-        {
-          "dirName": "1.2.9 ",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.9",
-          "id": "1.2.9"
-        },
-        {
-          "dirName": "1.2.8",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.8",
-          "id": "1.2.8"
-        },
-        {
-          "dirName": "1.2.7",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.7",
-          "id": "1.2.7"
-        },
-        {
-          "dirName": "1.2.6",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.6",
-          "id": "1.2.6"
-        },
-        {
-          "dirName": "1.2.5 ",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.5",
-          "id": "1.2.5"
-        },
-        {
-          "dirName": "1.2.4",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.4",
-          "id": "1.2.4"
-        },
-        {
-          "dirName": "1.2.3",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.3",
-          "id": "1.2.3"
-        },
-        {
-          "dirName": "1.2.2",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.2",
-          "id": "1.2.2"
-        },
-        {
-          "dirName": "1.2.1",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.1",
-          "id": "1.2.1"
-        },
-        {
-          "dirName": "1.2.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.2.x-release-notes/1.2.0",
-          "id": "1.2.0"
-        }
-      ]
-    },
-    {
-      "dirName": "1.2.x archived versions",
-      "level": 1,
-      "position": 0,
-      "isDir": false,
-      "url": "/downloads/archived",
-      "id": "archived"
-    },
-    {
-      "dirName": "Release Note",
-      "level": 1,
-      "position": 0,
-      "isDir": false,
-      "url": "/downloads/RELEASE_NOTE",
-      "id": "RELEASE_NOTE"
-    },
-    {
-      "dirName": "Swan Lake Release Notes",
-      "level": 1,
-      "position": 0,
-      "isDir": false,
-      "url": "/downloads/swan-lake-release-notes",
-      "id": "swan-lake-release-notes"
-    },
-    {
-      "dirName": "Swan Lake archived versions",
-      "level": 1,
-      "position": 0,
-      "isDir": false,
-      "url": "/downloads/swan-lake-archived",
-      "id": "swan-lake-archived"
-    },
-    {
-      "dirName": "1.1.x release notes",
-      "level": 1,
-      "position": 3,
-      "isDir": true,
-      "url": "/downloads/1.1.x-release-notes",
-      "id": "1.1.x-release-notes",
-      "subDirectories": [
-        {
-          "dirName": "1.1.4",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.1.x-release-notes/1.1.4",
-          "id": "1.1.4",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.1.3",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.1.x-release-notes/1.1.3",
-          "id": "1.1.3",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.1.2",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.1.x-release-notes/1.1.2",
-          "id": "1.1.2",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.1.1",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.1.x-release-notes/1.1.1",
-          "id": "1.1.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.1.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.1.x-release-notes/1.1.0",
-          "id": "1.1.0",
-          "subDirectories": []
-        }
-      ]
-    },
-    {
-      "dirName": "1.0.x. release notes",
-      "level": 1,
-      "position": 4,
-      "isDir": true,
-      "url": "/downloads/1.0.x-release-notes",
-      "id": "1.0.x-release-notes",
-      "subDirectories": [
-        {
-          "dirName": "1.0.5",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.0.x-release-notes/1.0.5",
-          "id": "1.0.5",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.4",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.0.x-release-notes/1.0.4",
-          "id": "1.0.4",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.3",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.0.x-release-notes/1.0.3",
-          "id": "1.0.3",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.2",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.0.x-release-notes/1.0.2",
-          "id": "1.0.2",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.1",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.0.x-release-notes/1.0.1",
-          "id": "1.0.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/1.0.x-release-notes/1.0.0",
-          "id": "1.0.0",
-          "subDirectories": []
-        }
-      ]
-    },
-    {
-      "dirName": "0.9.x release notes",
-      "level": 1,
-      "position": 5,
-      "isDir": true,
-      "url": "/downloads/0.9.x-release-notes",
-      "id": "0.9.x-release-notes",
-      "subDirectories": [
-        {
-          "dirName": "0.991.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.991.0",
-          "id": "0.991.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.990.3",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.990.3",
-          "id": "0.990.3",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.990.2",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.990.2",
-          "id": "0.990.2",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.990.1",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.990.1",
-          "id": "0.990.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.990.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.990.0",
-          "id": "0.990.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.983.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.983.0",
-          "id": "0.983.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.982.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.982.0",
-          "id": "0.982.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.981.1",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.981.1",
-          "id": "0.981.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.981.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.981.0",
-          "id": "0.981.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.980.1",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.980.1",
-          "id": "0.980.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.980.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.980.0",
-          "id": "0.980.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.975.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.975.0",
-          "id": "0.975.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.970.1",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.970.1",
-          "id": "0.970.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.970.0",
-          "level": 2,
-          "position": 1,
-          "isDir": false,
-          "url": "/downloads/0.9.x-release-notes/0.970.0",
-          "id": "0.970.0",
-          "subDirectories": []
-        }
-      ]
-    },
-    {
-      "dirName": "stable release notes",
-      "level": 1,
-      "position": 0,
-      "isDir": true,
-      "url": "/downloads/stable-release-notes",
-      "id": "stable-release-notes",
-      "subDirectories": [
-        {
-          "dirName": "0.970.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.970.0",
-          "id": "0.970.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.14",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.14",
-          "id": "1.2.14",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.1.2",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.1.2",
-          "id": "1.1.2",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.3",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.0.3",
-          "id": "1.0.3",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.7",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.7",
-          "id": "1.2.7",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.13",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.13",
-          "id": "1.2.13",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.0",
-          "id": "1.2.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.980.1",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.980.1",
-          "id": "0.980.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.8",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.8",
-          "id": "1.2.8",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.4",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.4",
-          "id": "1.2.4",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.10",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.10",
-          "id": "1.2.10",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.1",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.0.1",
-          "id": "1.0.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.5",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.5",
-          "id": "1.2.5",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.990.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.990.0",
-          "id": "0.990.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.970.1",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.970.1",
-          "id": "0.970.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.4",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.0.4",
-          "id": "1.0.4",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.1.1",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.1.1",
-          "id": "1.1.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.1.3",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.1.3",
-          "id": "1.1.3",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.981.1",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.981.1",
-          "id": "0.981.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.5",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.0.5",
-          "id": "1.0.5",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.983.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.983.0",
-          "id": "0.983.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.981.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.981.0",
-          "id": "0.981.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.975.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.975.0",
-          "id": "0.975.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.11",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.11",
-          "id": "1.2.11",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.12",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.12",
-          "id": "1.2.12",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.980.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.980.0",
-          "id": "0.980.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.1",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.1",
-          "id": "1.2.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.1.4",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.1.4",
-          "id": "1.1.4",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.9",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.9",
-          "id": "1.2.9",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.2",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.2",
-          "id": "1.2.2",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.6",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.6",
-          "id": "1.2.6",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.0.0",
-          "id": "1.0.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.990.3",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.990.3",
-          "id": "0.990.3",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.990.1",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.990.1",
-          "id": "0.990.1",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.991.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.991.0",
-          "id": "0.991.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.2.3",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.2.3",
-          "id": "1.2.3",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.0.2",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.0.2",
-          "id": "1.0.2",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.982.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.982.0",
-          "id": "0.982.0",
-          "subDirectories": []
-        },
-        {
-          "dirName": "0.990.2",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/0.990.2",
-          "id": "0.990.2",
-          "subDirectories": []
-        },
-        {
-          "dirName": "1.1.0",
-          "level": 2,
-          "position": 1,
-          "isDir": true,
-          "url": "/downloads/stable-release-notes/1.1.0",
-          "id": "1.1.0",
-          "subDirectories": []
-        }
-      ]
-    },
-    {
-      "dirName": " 1.2.x Release Notes Old",
-      "level": 1,
-      "position": 0,
-      "isDir": false,
-      "url": "/downloads/release-notes",
-      "id": "release-notes"
-    }
-  ]
+    ]
 }

--- a/utils/rl.json
+++ b/utils/rl.json
@@ -1,1754 +1,1894 @@
 {
-    "dirName": "downloads",
-    "level": 0,
-    "position": 0,
-    "isDir": true,
-    "url": "/downloads",
-    "id": "downloads",
-    "subDirectories": [
+  "dirName": "downloads",
+  "level": 0,
+  "position": 0,
+  "isDir": true,
+  "url": "/downloads",
+  "id": "downloads",
+  "subDirectories": [
+    {
+      "dirName": "Swan Lake release notes",
+      "level": 1,
+      "position": 1,
+      "isDir": true,
+      "url": "/downloads/swan-lake-release-notes",
+      "id": "swan-lake-release-notes",
+      "subDirectories": [
         {
-            "dirName": "Swan Lake release notes",
-            "level": 1,
-            "position": 1,
-            "isDir": true,
-            "url": "/downloads/swan-lake-release-notes",
-            "id": "swan-lake-release-notes",
-            "subDirectories": [
-                {
-                    "dirName": "2201.10.2 (Swan Lake Update 10)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.2",
-                    "id": "swan-lake-2201.10.2"
-                },
-                {
-                    "dirName": "2201.10.1 (Swan Lake Update 10)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.1",
-                    "id": "swan-lake-2201.10.1"
-                },
-                {
-                    "dirName": "2201.10.0 (Swan Lake Update 10)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.0",
-                    "id": "swan-lake-2201.10.0"
-                },
-                {
-                    "dirName": "2201.9.4 (Swan Lake Update 9)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.4",
-                    "id": "swan-lake-2201.9.4"
-                },
-                {
-                    "dirName": "2201.9.3 (Swan Lake Update 9)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.3",
-                    "id": "swan-lake-2201.9.3"
-                },
-                {
-                    "dirName": "2201.9.2 (Swan Lake Update 9)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.2",
-                    "id": "swan-lake-2201.9.2"
-                },
-                {
-                    "dirName": "2201.9.1 (Swan Lake Update 9)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.1",
-                    "id": "swan-lake-2201.9.1"
-                },
-                {
-                    "dirName": "2201.9.0 (Swan Lake Update 9)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.0",
-                    "id": "swan-lake-2201.9.0"
-                },
-                {
-                    "dirName": "2201.8.8 (Swan Lake Update 8)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.8",
-                    "id": "swan-lake-2201.8.8"
-                },
-                {
-                    "dirName": "2201.8.7 (Swan Lake Update 8)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.7",
-                    "id": "swan-lake-2201.8.7"
-                },
-                {
-                    "dirName": "2201.8.6 (Swan Lake Update 8)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.6",
-                    "id": "swan-lake-2201.8.6"
-                },
-                {
-                    "dirName": "2201.8.5 (Swan Lake Update 8)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.5",
-                    "id": "swan-lake-2201.8.5"
-                },
-                {
-                    "dirName": "2201.8.4 (Swan Lake Update 8)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.4",
-                    "id": "swan-lake-2201.8.4"
-                },
-                {
-                    "dirName": "2201.8.3 (Swan Lake Update 8)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.3",
-                    "id": "swan-lake-2201.8.3"
-                },
-                {
-                    "dirName": "2201.8.2 (Swan Lake Update 8)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.2",
-                    "id": "swan-lake-2201.8.2"
-                },
-                {
-                    "dirName": "2201.8.1 (Swan Lake Update 8)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.1",
-                    "id": "swan-lake-2201.8.1"
-                },
-                {
-                    "dirName": "2201.8.0 (Swan Lake Update 8)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.0",
-                    "id": "swan-lake-2201.8.0"
-                },
-                {
-                    "dirName": "2201.7.5 (Swan Lake Update 7)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.5",
-                    "id": "swan-lake-2201.7.5"
-                },
-                {
-                    "dirName": "2201.7.4 (Swan Lake Update 7)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.4",
-                    "id": "swan-lake-2201.7.4"
-                },
-                {
-                    "dirName": "2201.7.3 (Swan Lake Update 7)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.3",
-                    "id": "swan-lake-2201.7.3"
-                },
-                {
-                    "dirName": "2201.7.2 (Swan Lake Update 7)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.2",
-                    "id": "swan-lake-2201.7.2"
-                },
-                {
-                    "dirName": "2201.7.1 (Swan Lake Update 7)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.1",
-                    "id": "swan-lake-2201.7.1"
-                },
-                {
-                    "dirName": "2201.7.0 (Swan Lake Update 7)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.0",
-                    "id": "swan-lake-2201.7.0"
-                },
-                {
-                    "dirName": "2201.6.3 (Swan Lake Update 6)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.3",
-                    "id": "swan-lake-2201.6.3"
-                },
-                {
-                    "dirName": "2201.6.2 (Swan Lake Update 6)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.2",
-                    "id": "swan-lake-2201.6.2"
-                },
-                {
-                    "dirName": "2201.6.1 (Swan Lake Update 6)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.1",
-                    "id": "swan-lake-2201.6.1"
-                },
-                {
-                    "dirName": "2201.6.0 (Swan Lake Update 6)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.0",
-                    "id": "swan-lake-2201.6.0"
-                },
-                {
-                    "dirName": "2201.5.5 (Swan Lake Update 5)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.5",
-                    "id": "swan-lake-2201.5.5"
-                },
-                {
-                    "dirName": "2201.5.4 (Swan Lake Update 5)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.4",
-                    "id": "swan-lake-2201.5.4"
-                },
-                {
-                    "dirName": "2201.5.3 (Swan Lake Update 5)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.3",
-                    "id": "swan-lake-2201.5.3"
-                },
-                {
-                    "dirName": "2201.5.2 (Swan Lake Update 5)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.2",
-                    "id": "swan-lake-2201.5.2"
-                }, 
-                {
-                    "dirName": "2201.5.1 (Swan Lake Update 5)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.1",
-                    "id": "swan-lake-2201.5.1"
-                },       
-                {
-                    "dirName": "2201.5.0 (Swan Lake Update 5)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.0",
-                    "id": "swan-lake-2201.5.0"
-                },
-                {
-                    "dirName": "2201.4.3 (Swan Lake Update 4)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.3",
-                    "id": "swan-lake-2201.4.3"
-                },
-                {
-                    "dirName": "2201.4.2 (Swan Lake Update 4)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.2",
-                    "id": "swan-lake-2201.4.2"
-                },
-                {
-                    "dirName": "2201.4.1 (Swan Lake Update 4)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.1",
-                    "id": "swan-lake-2201.4.1"
-                },
-                {
-                    "dirName": "2201.4.0 (Swan Lake Update 4)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.0",
-                    "id": "swan-lake-2201.4.0"
-                },
-                {
-                    "dirName": "2201.3.5 (Swan Lake Update 3)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.5",
-                    "id": "swan-lake-2201.3.5"
-                },
-                {
-                    "dirName": "2201.3.4 (Swan Lake Update 3)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.4",
-                    "id": "swan-lake-2201.3.4"
-                },
-                {
-                    "dirName": "2201.3.3 (Swan Lake Update 3)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.3",
-                    "id": "swan-lake-2201.3.3"
-                },
-                {
-                    "dirName": "2201.3.2 (Swan Lake Update 3)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.2",
-                    "id": "swan-lake-2201.3.2"
-                },
-                {
-                    "dirName": "2201.3.1 (Swan Lake Update 3)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.1",
-                    "id": "swan-lake-2201.3.1"
-                },
-                {
-                    "dirName": "2201.3.0 (Swan Lake Update 3)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.0",
-                    "id": "swan-lake-2201.3.0"
-                },
-                {
-                    "dirName": "2201.2.4 (Swan Lake Update 2)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.4",
-                    "id": "swan-lake-2201.2.4"
-                },
-                {
-                    "dirName": "2201.2.3 (Swan Lake Update 2)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.3",
-                    "id": "swan-lake-2201.2.3"
-                },
-                {
-                    "dirName": "2201.2.2 (Swan Lake Update 2)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.2",
-                    "id": "swan-lake-2201.2.2"
-                },
-                {
-                    "dirName": "2201.2.1 (Swan Lake Update 2)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.1",
-                    "id": "swan-lake-2201.2.1"
-                },
-                {
-                    "dirName": "2201.2.0 (Swan Lake Update 2)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.0",
-                    "id": "swan-lake-2201.2.0"
-                },
-                {
-                    "dirName": "2201.1.2 (Swan Lake Update 1)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.2",
-                    "id": "swan-lake-2201.1.2"
-                },
-                {
-                    "dirName": "2201.1.1 (Swan Lake Update 1)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.1",
-                    "id": "swan-lake-2201.1.1"
-                },
-                {
-                    "dirName": "2201.1.0 (Swan Lake Update 1)",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.0",
-                    "id": "swan-lake-2201.1.0"
-                },
-                {
-                    "dirName": "2201.0.5 (Swan Lake) ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.5",
-                    "id": "swan-lake-2201.0.5"
-                },
-                {
-                    "dirName": "2201.0.4 (Swan Lake) ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.4",
-                    "id": "swan-lake-2201.0.4"
-                },
-                {
-                    "dirName": "2201.0.3 (Swan Lake) ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.3",
-                    "id": "swan-lake-2201.0.3"
-                },
-                {
-                    "dirName": "2201.0.2 (Swan Lake) ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.2",
-                    "id": "swan-lake-2201.0.2"
-                },
-                {
-                    "dirName": "2201.0.1 (Swan Lake) ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.1",
-                    "id": "swan-lake-2201.0.1"
-                },
-                {
-                    "dirName": "2201.0.0 (Swan Lake) ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.0",
-                    "id": "swan-lake-2201.0.0"
-                },
-                {
-                    "dirName": "Swan Lake Beta6",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-beta6",
-                    "id": "swan-lake-beta6"
-                },
-                {
-                    "dirName": "Swan Lake Beta5",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-beta5",
-                    "id": "swan-lake-beta5"
-                },
-                {
-                    "dirName": "Swan Lake Beta4",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-beta4",
-                    "id": "swan-lake-beta4"
-                },
-                {
-                    "dirName": "Swan Lake Beta3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-beta3",
-                    "id": "swan-lake-beta3"
-                },
-                {
-                    "dirName": "Swan Lake Beta2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-beta2",
-                    "id": "swan-lake-beta2"
-                },
-                {
-                    "dirName": "Swan Lake Beta1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-beta1",
-                    "id": "swan-lake-beta1"
-                },
-                {
-                    "dirName": "Swan Lake Alpha5 ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-alpha5",
-                    "id": "swan-lake-alpha5"
-                },
-                {
-                    "dirName": "Swan Lake Alpha4 ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-alpha4",
-                    "id": "swan-lake-alpha4"
-                },
+          "dirName": "Swan Lake Update 10",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.10",
+          "id": "swan-lake-2201.10",
+          "subDirectories": [
+            {
+              "dirName": "2201.10.2 (Swan Lake Update 10)",
+              "level": 3,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.2",
+              "id": "swan-lake-2201.10.2"
+            },
+            {
+              "dirName": "2201.10.1 (Swan Lake Update 10)",
+              "level": 3,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.1",
+              "id": "swan-lake-2201.10.1"
+            },
+            {
+              "dirName": "2201.10.0 (Swan Lake Update 10)",
+              "level": 3,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.10.0",
+              "id": "swan-lake-2201.10.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Update 9",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.9",
+          "id": "swan-lake-2201.9",
+          "subDirectories": [
+            {
+              "dirName": "2201.9.4 (Swan Lake Update 9)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.4",
+              "id": "swan-lake-2201.9.4"
+            },
+            {
+              "dirName": "2201.9.3 (Swan Lake Update 9)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.3",
+              "id": "swan-lake-2201.9.3"
+            },
+            {
+              "dirName": "2201.9.2 (Swan Lake Update 9)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.2",
+              "id": "swan-lake-2201.9.2"
+            },
+            {
+              "dirName": "2201.9.1 (Swan Lake Update 9)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.1",
+              "id": "swan-lake-2201.9.1"
+            },
+            {
+              "dirName": "2201.9.0 (Swan Lake Update 9)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.9.0",
+              "id": "swan-lake-2201.9.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Update 8",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.8",
+          "id": "swan-lake-2201.8",
+          "subDirectories": [
+            {
+              "dirName": "2201.8.8 (Swan Lake Update 8)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.8",
+              "id": "swan-lake-2201.8.8"
+            },
+            {
+              "dirName": "2201.8.7 (Swan Lake Update 8)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.7",
+              "id": "swan-lake-2201.8.7"
+            },
+            {
+              "dirName": "2201.8.6 (Swan Lake Update 8)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.6",
+              "id": "swan-lake-2201.8.6"
+            },
+            {
+              "dirName": "2201.8.5 (Swan Lake Update 8)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.5",
+              "id": "swan-lake-2201.8.5"
+            },
+            {
+              "dirName": "2201.8.4 (Swan Lake Update 8)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.4",
+              "id": "swan-lake-2201.8.4"
+            },
+            {
+              "dirName": "2201.8.3 (Swan Lake Update 8)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.3",
+              "id": "swan-lake-2201.8.3"
+            },
+            {
+              "dirName": "2201.8.2 (Swan Lake Update 8)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.2",
+              "id": "swan-lake-2201.8.2"
+            },
+            {
+              "dirName": "2201.8.1 (Swan Lake Update 8)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.1",
+              "id": "swan-lake-2201.8.1"
+            },
+            {
+              "dirName": "2201.8.0 (Swan Lake Update 8)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.8.0",
+              "id": "swan-lake-2201.8.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Update 7",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.7",
+          "id": "swan-lake-2201.7",
+          "subDirectories": [
+            {
+              "dirName": "2201.7.5 (Swan Lake Update 7)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.5",
+              "id": "swan-lake-2201.7.5"
+            },
+            {
+              "dirName": "2201.7.4 (Swan Lake Update 7)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.4",
+              "id": "swan-lake-2201.7.4"
+            },
+            {
+              "dirName": "2201.7.3 (Swan Lake Update 7)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.3",
+              "id": "swan-lake-2201.7.3"
+            },
+            {
+              "dirName": "2201.7.2 (Swan Lake Update 7)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.2",
+              "id": "swan-lake-2201.7.2"
+            },
+            {
+              "dirName": "2201.7.1 (Swan Lake Update 7)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.1",
+              "id": "swan-lake-2201.7.1"
+            },
+            {
+              "dirName": "2201.7.0 (Swan Lake Update 7)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.7.0",
+              "id": "swan-lake-2201.7.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Update 6",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.6",
+          "id": "swan-lake-2201.6",
+          "subDirectories": [
+            {
+              "dirName": "2201.6.3 (Swan Lake Update 6)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.3",
+              "id": "swan-lake-2201.6.3"
+            },
+            {
+              "dirName": "2201.6.2 (Swan Lake Update 6)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.2",
+              "id": "swan-lake-2201.6.2"
+            },
+            {
+              "dirName": "2201.6.1 (Swan Lake Update 6)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.1",
+              "id": "swan-lake-2201.6.1"
+            },
+            {
+              "dirName": "2201.6.0 (Swan Lake Update 6)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.6.0",
+              "id": "swan-lake-2201.6.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Update 5",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.5",
+          "id": "swan-lake-2201.5",
+          "subDirectories": [
+            {
+              "dirName": "2201.5.5 (Swan Lake Update 5)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.5",
+              "id": "swan-lake-2201.5.5"
+            },
+            {
+              "dirName": "2201.5.4 (Swan Lake Update 5)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.4",
+              "id": "swan-lake-2201.5.4"
+            },
+            {
+              "dirName": "2201.5.3 (Swan Lake Update 5)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.3",
+              "id": "swan-lake-2201.5.3"
+            },
+            {
+              "dirName": "2201.5.2 (Swan Lake Update 5)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.2",
+              "id": "swan-lake-2201.5.2"
+            },
+            {
+              "dirName": "2201.5.1 (Swan Lake Update 5)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.1",
+              "id": "swan-lake-2201.5.1"
+            },
+            {
+              "dirName": "2201.5.0 (Swan Lake Update 5)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.5.0",
+              "id": "swan-lake-2201.5.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Update 4",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.4",
+          "id": "swan-lake-2201.4",
+          "subDirectories": [
+            {
+              "dirName": "2201.4.3 (Swan Lake Update 4)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.3",
+              "id": "swan-lake-2201.4.3"
+            },
+            {
+              "dirName": "2201.4.2 (Swan Lake Update 4)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.2",
+              "id": "swan-lake-2201.4.2"
+            },
+            {
+              "dirName": "2201.4.1 (Swan Lake Update 4)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.1",
+              "id": "swan-lake-2201.4.1"
+            },
+            {
+              "dirName": "2201.4.0 (Swan Lake Update 4)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.4.0",
+              "id": "swan-lake-2201.4.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Update 3",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.3",
+          "id": "swan-lake-2201.3",
+          "subDirectories": [
+            {
+              "dirName": "2201.3.5 (Swan Lake Update 3)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.5",
+              "id": "swan-lake-2201.3.5"
+            },
+            {
+              "dirName": "2201.3.4 (Swan Lake Update 3)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.4",
+              "id": "swan-lake-2201.3.4"
+            },
+            {
+              "dirName": "2201.3.3 (Swan Lake Update 3)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.3",
+              "id": "swan-lake-2201.3.3"
+            },
+            {
+              "dirName": "2201.3.2 (Swan Lake Update 3)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.2",
+              "id": "swan-lake-2201.3.2"
+            },
+            {
+              "dirName": "2201.3.1 (Swan Lake Update 3)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.1",
+              "id": "swan-lake-2201.3.1"
+            },
+            {
+              "dirName": "2201.3.0 (Swan Lake Update 3)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.3.0",
+              "id": "swan-lake-2201.3.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Update 2",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.2",
+          "id": "swan-lake-2201.2",
+          "subDirectories": [
+            {
+              "dirName": "2201.2.4 (Swan Lake Update 2)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.4",
+              "id": "swan-lake-2201.2.4"
+            },
+            {
+              "dirName": "2201.2.3 (Swan Lake Update 2)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.3",
+              "id": "swan-lake-2201.2.3"
+            },
+            {
+              "dirName": "2201.2.2 (Swan Lake Update 2)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.2",
+              "id": "swan-lake-2201.2.2"
+            },
+            {
+              "dirName": "2201.2.1 (Swan Lake Update 2)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.1",
+              "id": "swan-lake-2201.2.1"
+            },
+            {
+              "dirName": "2201.2.0 (Swan Lake Update 2)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.2.0",
+              "id": "swan-lake-2201.2.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Update 1",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.1",
+          "id": "swan-lake-2201.1",
+          "subDirectories": [
+            {
+              "dirName": "2201.1.2 (Swan Lake Update 1)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.2",
+              "id": "swan-lake-2201.1.2"
+            },
+            {
+              "dirName": "2201.1.1 (Swan Lake Update 1)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.1",
+              "id": "swan-lake-2201.1.1"
+            },
+            {
+              "dirName": "2201.1.0 (Swan Lake Update 1)",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.1.0",
+              "id": "swan-lake-2201.1.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-2201.0",
+          "id": "swan-lake-2201.0",
+          "subDirectories": [
+            {
+              "dirName": "2201.0.5 (Swan Lake) ",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.5",
+              "id": "swan-lake-2201.0.5"
+            },
+            {
+              "dirName": "2201.0.4 (Swan Lake) ",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.4",
+              "id": "swan-lake-2201.0.4"
+            },
+            {
+              "dirName": "2201.0.3 (Swan Lake) ",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.3",
+              "id": "swan-lake-2201.0.3"
+            },
+            {
+              "dirName": "2201.0.2 (Swan Lake) ",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.2",
+              "id": "swan-lake-2201.0.2"
+            },
+            {
+              "dirName": "2201.0.1 (Swan Lake) ",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.1",
+              "id": "swan-lake-2201.0.1"
+            },
+            {
+              "dirName": "2201.0.0 (Swan Lake) ",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-2201.0.0",
+              "id": "swan-lake-2201.0.0"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Beta",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-beta",
+          "id": "swan-lake-beta",
+          "subDirectories": [
+            {
+              "dirName": "Swan Lake Beta6",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-beta6",
+              "id": "swan-lake-beta6"
+            },
+            {
+              "dirName": "Swan Lake Beta5",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-beta5",
+              "id": "swan-lake-beta5"
+            },
+            {
+              "dirName": "Swan Lake Beta4",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-beta4",
+              "id": "swan-lake-beta4"
+            },
+            {
+              "dirName": "Swan Lake Beta3",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-beta3",
+              "id": "swan-lake-beta3"
+            },
+            {
+              "dirName": "Swan Lake Beta2",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-beta2",
+              "id": "swan-lake-beta2"
+            },
+            {
+              "dirName": "Swan Lake Beta1",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-beta1",
+              "id": "swan-lake-beta1"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Alpha",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-alpha",
+          "id": "swan-lake-alpha",
+          "subDirectories": [
+            {
+              "dirName": "Swan Lake Alpha5 ",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-alpha5",
+              "id": "swan-lake-alpha5"
+            },
+            {
+              "dirName": "Swan Lake Alpha4 ",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-alpha4",
+              "id": "swan-lake-alpha4"
+            },
 
-                {
-                    "dirName": "Swan Lake Alpha3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-alpha3",
-                    "id": "swan-lake-alpha3"
-                },
-                {
-                    "dirName": "Swan Lake Alpha2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-alpha2",
-                    "id": "swan-lake-alpha2"
-                },
-                {
-                    "dirName": "Swan Lake Alpha1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-alpha1",
-                    "id": "swan-lake-alpha1"
-                },
-                {
-                    "dirName": "Swan Lake Preview 8",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-preview8",
-                    "id": "swan-lake-preview8"
-                },
-                {
-                    "dirName": "Swan Lake Preview 7",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-preview7",
-                    "id": "swan-lake-preview7"
-                },
-                {
-                    "dirName": "Swan Lake Preview 6",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-preview6",
-                    "id": "swan-lake-preview6"
-                },
-                {
-                    "dirName": "Swan Lake Preview 5",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-preview5",
-                    "id": "swan-lake-preview5"
-                },
-                {
-                    "dirName": "Swan Lake Preview 4",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-preview4",
-                    "id": "swan-lake-preview4"
-                },
-                {
-                    "dirName": "Swan Lake Preview 3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-preview3",
-                    "id": "swan-lake-preview3"
-                },
-                {
-                    "dirName": "Swan Lake Preview 2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-preview2",
-                    "id": "swan-lake-preview2"
-                },
-                {
-                    "dirName": "Swan Lake Preview 1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/swan-lake-release-notes/swan-lake-preview1",
-                    "id": "swan-lake-preview1"
-                },
+            {
+              "dirName": "Swan Lake Alpha3",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-alpha3",
+              "id": "swan-lake-alpha3"
+            },
+            {
+              "dirName": "Swan Lake Alpha2",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-alpha2",
+              "id": "swan-lake-alpha2"
+            },
+            {
+              "dirName": "Swan Lake Alpha1",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-alpha1",
+              "id": "swan-lake-alpha1"
+            }
+          ]
+        },
+        {
+          "dirName": "Swan Lake Preview",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes-preview",
+          "id": "swan-lake-preview",
+          "subDirectories": [
+            {
+              "dirName": "Swan Lake Preview 8",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-preview8",
+              "id": "swan-lake-preview8"
+            },
+            {
+              "dirName": "Swan Lake Preview 7",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-preview7",
+              "id": "swan-lake-preview7"
+            },
+            {
+              "dirName": "Swan Lake Preview 6",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-preview6",
+              "id": "swan-lake-preview6"
+            },
+            {
+              "dirName": "Swan Lake Preview 5",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-preview5",
+              "id": "swan-lake-preview5"
+            },
+            {
+              "dirName": "Swan Lake Preview 4",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-preview4",
+              "id": "swan-lake-preview4"
+            },
+            {
+              "dirName": "Swan Lake Preview 3",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-preview3",
+              "id": "swan-lake-preview3"
+            },
+            {
+              "dirName": "Swan Lake Preview 2",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-preview2",
+              "id": "swan-lake-preview2"
+            },
+            {
+              "dirName": "Swan Lake Preview 1",
+              "level": 2,
+              "position": 1,
+              "isDir": false,
+              "url": "/downloads/swan-lake-release-notes/swan-lake-preview1",
+              "id": "swan-lake-preview1"
+            }
+          ]
+        },
 
-                {
-                    "dirName": "2201.1.0",
-                    "level": 2,
-                    "position": 0,
-                    "isDir": true,
-                    "url": "/downloads/swan-lake-release-notes/2201.1.0",
-                    "id": "2201.1.0",
-                    "subDirectories": []
-                }
-            ]
-        },
         {
-            "dirName": "1.2.x release notes",
-            "level": 1,
-            "position": 2,
-            "isDir": true,
-            "url": "/downloads/1.2.x-release-notes",
-            "id": "1.2.x-release-notes",
-            "subDirectories": [
-                {
-                    "dirName": "1.2.54",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.54",
-                    "id": "1.2.54"
-                },
-                {
-                    "dirName": "1.2.53",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.53",
-                    "id": "1.2.53"
-                },
-                {
-                    "dirName": "1.2.52",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.52",
-                    "id": "1.2.52"
-                },
-                {
-                    "dirName": "1.2.51",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.51",
-                    "id": "1.2.51"
-                },
-                {
-                    "dirName": "1.2.50",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.50",
-                    "id": "1.2.50"
-                },
-                {
-                    "dirName": "1.2.49",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.49",
-                    "id": "1.2.49"
-                },
-                {
-                    "dirName": "1.2.48",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.48",
-                    "id": "1.2.48"
-                },
-                {
-                    "dirName": "1.2.47",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.47",
-                    "id": "1.2.47"
-                },
-                {
-                    "dirName": "1.2.46",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.46",
-                    "id": "1.2.46"
-                },
-                {
-                    "dirName": "1.2.45",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.45",
-                    "id": "1.2.45"
-                },
-                {
-                    "dirName": "1.2.44",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.44",
-                    "id": "1.2.44"
-                },
-                {
-                    "dirName": "1.2.43",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.43",
-                    "id": "1.2.43"
-                },
-                {
-                    "dirName": "1.2.42",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.42",
-                    "id": "1.2.42"
-                },
-                {
-                    "dirName": "1.2.41",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.41",
-                    "id": "1.2.41"
-                },
-                {
-                    "dirName": "1.2.40",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.40",
-                    "id": "1.2.40"
-                },
-                {
-                    "dirName": "1.2.39",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.39",
-                    "id": "1.2.39"
-                },
-                {
-                    "dirName": "1.2.38",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.38",
-                    "id": "1.2.38"
-                },
-                {
-                    "dirName": "1.2.37",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.37",
-                    "id": "1.2.37"
-                },
-                {
-                    "dirName": "1.2.36",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.36",
-                    "id": "1.2.36"
-                },
-                {
-                    "dirName": "1.2.35",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.35",
-                    "id": "1.2.35"
-                },
-                {
-                    "dirName": "1.2.34",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.34",
-                    "id": "1.2.34"
-                },
-                {
-                    "dirName": "1.2.33",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.33",
-                    "id": "1.2.33"
-                },
-                {
-                    "dirName": "1.2.32",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.32",
-                    "id": "1.2.32"
-                },
-                {
-                    "dirName": "1.2.31",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.31",
-                    "id": "1.2.31"
-                },
-                {
-                    "dirName": "1.2.30",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.30",
-                    "id": "1.2.30"
-                },
-                {
-                    "dirName": "1.2.29",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.29",
-                    "id": "1.2.29"
-                },
-                {
-                    "dirName": "1.2.28",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.28",
-                    "id": "1.2.28"
-                },
-                {
-                    "dirName": "1.2.27",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.27",
-                    "id": "1.2.27"
-                },
-                {
-                    "dirName": "1.2.26",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.26",
-                    "id": "1.2.26"
-                },
-                {
-                    "dirName": "1.2.25",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.25",
-                    "id": "1.2.25"
-                },
-                {
-                    "dirName": "1.2.24",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.24",
-                    "id": "1.2.24"
-                },
-                {
-                    "dirName": "1.2.23",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.23",
-                    "id": "1.2.23"
-                },
-                {
-                    "dirName": "1.2.22",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.22",
-                    "id": "1.2.22"
-                },
-                {
-                    "dirName": "1.2.21",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.21",
-                    "id": "1.2.21"
-                },
-                {
-                    "dirName": "1.2.20",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.20",
-                    "id": "1.2.20"
-                },
-                {
-                    "dirName": "1.2.19",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.19",
-                    "id": "1.2.19"
-                },
-                {
-                    "dirName": "1.2.18",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.18",
-                    "id": "1.2.18"
-                },
-                {
-                    "dirName": "1.2.17",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.17",
-                    "id": "1.2.17"
-                },
-                {
-                    "dirName": "1.2.16",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.16",
-                    "id": "1.2.16"
-                },
-                {
-                    "dirName": "1.2.15 ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.15",
-                    "id": "1.2.15"
-                },
-                {
-                    "dirName": "1.2.14 ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.14",
-                    "id": "1.2.14"
-                },
-                {
-                    "dirName": "1.2.13 ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.13",
-                    "id": "1.2.13"
-                },
-                {
-                    "dirName": "1.2.12 ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.12",
-                    "id": "1.2.12"
-                },
-                {
-                    "dirName": "1.2.11 ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.11",
-                    "id": "1.2.11"
-                },
-                {
-                    "dirName": "1.2.10 ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.10",
-                    "id": "1.2.10"
-                },
-                {
-                    "dirName": "1.2.9 ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.9",
-                    "id": "1.2.9"
-                },
-                {
-                    "dirName": "1.2.8",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.8",
-                    "id": "1.2.8"
-                },
-                {
-                    "dirName": "1.2.7",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.7",
-                    "id": "1.2.7"
-                },
-                {
-                    "dirName": "1.2.6",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.6",
-                    "id": "1.2.6"
-                },
-                {
-                    "dirName": "1.2.5 ",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.5",
-                    "id": "1.2.5"
-                },
-                {
-                    "dirName": "1.2.4",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.4",
-                    "id": "1.2.4"
-                },
-                {
-                    "dirName": "1.2.3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.3",
-                    "id": "1.2.3"
-                },
-                {
-                    "dirName": "1.2.2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.2",
-                    "id": "1.2.2"
-                },
-                {
-                    "dirName": "1.2.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.1",
-                    "id": "1.2.1"
-                },                
-                {
-                    "dirName": "1.2.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.2.x-release-notes/1.2.0",
-                    "id": "1.2.0"
-                }
-            ]
-        },
-        {
-            "dirName": "1.2.x archived versions",
-            "level": 1,
-            "position": 0,
-            "isDir": false,
-            "url": "/downloads/archived",
-            "id": "archived"
-        },
-        {
-            "dirName": "Release Note",
-            "level": 1,
-            "position": 0,
-            "isDir": false,
-            "url": "/downloads/RELEASE_NOTE",
-            "id": "RELEASE_NOTE"
-        },
-        {
-            "dirName": "Swan Lake Release Notes",
-            "level": 1,
-            "position": 0,
-            "isDir": false,
-            "url": "/downloads/swan-lake-release-notes",
-            "id": "swan-lake-release-notes"
-        },
-        {
-            "dirName": "Swan Lake archived versions",
-            "level": 1,
-            "position": 0,
-            "isDir": false,
-            "url": "/downloads/swan-lake-archived",
-            "id": "swan-lake-archived"
-        },
-        {
-            "dirName": "1.1.x release notes",
-            "level": 1,
-            "position": 3,
-            "isDir": true,
-            "url": "/downloads/1.1.x-release-notes",
-            "id": "1.1.x-release-notes",
-            "subDirectories": [
-                {
-                    "dirName": "1.1.4",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.1.x-release-notes/1.1.4",
-                    "id": "1.1.4",
-                    "subDirectories": []
-                },  
-                {
-                    "dirName": "1.1.3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.1.x-release-notes/1.1.3",
-                    "id": "1.1.3",
-                    "subDirectories": []
-                },  
-                {
-                    "dirName": "1.1.2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.1.x-release-notes/1.1.2",
-                    "id": "1.1.2",
-                    "subDirectories": []
-                },  
-                {
-                    "dirName": "1.1.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.1.x-release-notes/1.1.1",
-                    "id": "1.1.1",
-                    "subDirectories": []
-                },    
-                {
-                    "dirName": "1.1.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.1.x-release-notes/1.1.0",
-                    "id": "1.1.0",
-                    "subDirectories": []
-                }
-            ]
-        },
-        {
-            "dirName": "1.0.x. release notes",
-            "level": 1,
-            "position": 4,
-            "isDir": true,
-            "url": "/downloads/1.0.x-release-notes",
-            "id": "1.0.x-release-notes",
-            "subDirectories": [                
-                {
-                    "dirName": "1.0.5",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.0.x-release-notes/1.0.5",
-                    "id": "1.0.5",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.0.4",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.0.x-release-notes/1.0.4",
-                    "id": "1.0.4",
-                    "subDirectories": []
-                },   
-                {
-                    "dirName": "1.0.3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.0.x-release-notes/1.0.3",
-                    "id": "1.0.3",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.0.2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.0.x-release-notes/1.0.2",
-                    "id": "1.0.2",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.0.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.0.x-release-notes/1.0.1",
-                    "id": "1.0.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.0.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/1.0.x-release-notes/1.0.0",
-                    "id": "1.0.0",
-                    "subDirectories": []
-                }
-            ]
-        },
-        {
-            "dirName": "0.9.x release notes",
-            "level": 1,
-            "position": 5,
-            "isDir": true,
-            "url": "/downloads/0.9.x-release-notes",
-            "id": "0.9.x-release-notes",
-            "subDirectories": [
-                {
-                    "dirName": "0.991.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.991.0",
-                    "id": "0.991.0",
-                    "subDirectories": []
-                }, 
-                {
-                    "dirName": "0.990.3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.990.3",
-                    "id": "0.990.3",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.990.2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.990.2",
-                    "id": "0.990.2",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.990.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.990.1",
-                    "id": "0.990.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.990.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.990.0",
-                    "id": "0.990.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.983.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.983.0",
-                    "id": "0.983.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.982.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.982.0",
-                    "id": "0.982.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.981.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.981.1",
-                    "id": "0.981.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.981.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.981.0",
-                    "id": "0.981.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.980.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.980.1",
-                    "id": "0.980.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.980.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.980.0",
-                    "id": "0.980.0",
-                    "subDirectories": []
-                }, 
-                {
-                    "dirName": "0.975.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.975.0",
-                    "id": "0.975.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.970.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.970.1",
-                    "id": "0.970.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.970.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": false,
-                    "url": "/downloads/0.9.x-release-notes/0.970.0",
-                    "id": "0.970.0",
-                    "subDirectories": []
-                }
-            ]
-        },
-        {
-            "dirName": "stable release notes",
-            "level": 1,
-            "position": 0,
-            "isDir": true,
-            "url": "/downloads/stable-release-notes",
-            "id": "stable-release-notes",
-            "subDirectories": [
-                {
-                    "dirName": "0.970.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.970.0",
-                    "id": "0.970.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.14",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.14",
-                    "id": "1.2.14",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.1.2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.1.2",
-                    "id": "1.1.2",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.0.3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.0.3",
-                    "id": "1.0.3",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.7",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.7",
-                    "id": "1.2.7",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.13",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.13",
-                    "id": "1.2.13",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.0",
-                    "id": "1.2.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.980.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.980.1",
-                    "id": "0.980.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.8",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.8",
-                    "id": "1.2.8",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.4",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.4",
-                    "id": "1.2.4",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.10",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.10",
-                    "id": "1.2.10",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.0.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.0.1",
-                    "id": "1.0.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.5",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.5",
-                    "id": "1.2.5",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.990.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.990.0",
-                    "id": "0.990.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.970.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.970.1",
-                    "id": "0.970.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.0.4",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.0.4",
-                    "id": "1.0.4",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.1.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.1.1",
-                    "id": "1.1.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.1.3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.1.3",
-                    "id": "1.1.3",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.981.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.981.1",
-                    "id": "0.981.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.0.5",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.0.5",
-                    "id": "1.0.5",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.983.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.983.0",
-                    "id": "0.983.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.981.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.981.0",
-                    "id": "0.981.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.975.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.975.0",
-                    "id": "0.975.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.11",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.11",
-                    "id": "1.2.11",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.12",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.12",
-                    "id": "1.2.12",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.980.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.980.0",
-                    "id": "0.980.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.1",
-                    "id": "1.2.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.1.4",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.1.4",
-                    "id": "1.1.4",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.9",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.9",
-                    "id": "1.2.9",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.2",
-                    "id": "1.2.2",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.6",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.6",
-                    "id": "1.2.6",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.0.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.0.0",
-                    "id": "1.0.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.990.3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.990.3",
-                    "id": "0.990.3",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.990.1",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.990.1",
-                    "id": "0.990.1",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.991.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.991.0",
-                    "id": "0.991.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.2.3",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.2.3",
-                    "id": "1.2.3",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.0.2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.0.2",
-                    "id": "1.0.2",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.982.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.982.0",
-                    "id": "0.982.0",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "0.990.2",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/0.990.2",
-                    "id": "0.990.2",
-                    "subDirectories": []
-                },
-                {
-                    "dirName": "1.1.0",
-                    "level": 2,
-                    "position": 1,
-                    "isDir": true,
-                    "url": "/downloads/stable-release-notes/1.1.0",
-                    "id": "1.1.0",
-                    "subDirectories": []
-                }
-            ]
-        },
-        {
-            "dirName": " 1.2.x Release Notes Old",
-            "level": 1,
-            "position": 0,
-            "isDir": false,
-            "url": "/downloads/release-notes",
-            "id": "release-notes"
+          "dirName": "2201.1.0",
+          "level": 2,
+          "position": 0,
+          "isDir": true,
+          "url": "/downloads/swan-lake-release-notes/2201.1.0",
+          "id": "2201.1.0",
+          "subDirectories": []
         }
-    ]
+      ]
+    },
+    {
+      "dirName": "1.2.x release notes",
+      "level": 1,
+      "position": 2,
+      "isDir": true,
+      "url": "/downloads/1.2.x-release-notes",
+      "id": "1.2.x-release-notes",
+      "subDirectories": [
+        {
+          "dirName": "1.2.54",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.54",
+          "id": "1.2.54"
+        },
+        {
+          "dirName": "1.2.53",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.53",
+          "id": "1.2.53"
+        },
+        {
+          "dirName": "1.2.52",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.52",
+          "id": "1.2.52"
+        },
+        {
+          "dirName": "1.2.51",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.51",
+          "id": "1.2.51"
+        },
+        {
+          "dirName": "1.2.50",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.50",
+          "id": "1.2.50"
+        },
+        {
+          "dirName": "1.2.49",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.49",
+          "id": "1.2.49"
+        },
+        {
+          "dirName": "1.2.48",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.48",
+          "id": "1.2.48"
+        },
+        {
+          "dirName": "1.2.47",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.47",
+          "id": "1.2.47"
+        },
+        {
+          "dirName": "1.2.46",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.46",
+          "id": "1.2.46"
+        },
+        {
+          "dirName": "1.2.45",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.45",
+          "id": "1.2.45"
+        },
+        {
+          "dirName": "1.2.44",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.44",
+          "id": "1.2.44"
+        },
+        {
+          "dirName": "1.2.43",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.43",
+          "id": "1.2.43"
+        },
+        {
+          "dirName": "1.2.42",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.42",
+          "id": "1.2.42"
+        },
+        {
+          "dirName": "1.2.41",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.41",
+          "id": "1.2.41"
+        },
+        {
+          "dirName": "1.2.40",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.40",
+          "id": "1.2.40"
+        },
+        {
+          "dirName": "1.2.39",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.39",
+          "id": "1.2.39"
+        },
+        {
+          "dirName": "1.2.38",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.38",
+          "id": "1.2.38"
+        },
+        {
+          "dirName": "1.2.37",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.37",
+          "id": "1.2.37"
+        },
+        {
+          "dirName": "1.2.36",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.36",
+          "id": "1.2.36"
+        },
+        {
+          "dirName": "1.2.35",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.35",
+          "id": "1.2.35"
+        },
+        {
+          "dirName": "1.2.34",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.34",
+          "id": "1.2.34"
+        },
+        {
+          "dirName": "1.2.33",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.33",
+          "id": "1.2.33"
+        },
+        {
+          "dirName": "1.2.32",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.32",
+          "id": "1.2.32"
+        },
+        {
+          "dirName": "1.2.31",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.31",
+          "id": "1.2.31"
+        },
+        {
+          "dirName": "1.2.30",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.30",
+          "id": "1.2.30"
+        },
+        {
+          "dirName": "1.2.29",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.29",
+          "id": "1.2.29"
+        },
+        {
+          "dirName": "1.2.28",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.28",
+          "id": "1.2.28"
+        },
+        {
+          "dirName": "1.2.27",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.27",
+          "id": "1.2.27"
+        },
+        {
+          "dirName": "1.2.26",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.26",
+          "id": "1.2.26"
+        },
+        {
+          "dirName": "1.2.25",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.25",
+          "id": "1.2.25"
+        },
+        {
+          "dirName": "1.2.24",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.24",
+          "id": "1.2.24"
+        },
+        {
+          "dirName": "1.2.23",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.23",
+          "id": "1.2.23"
+        },
+        {
+          "dirName": "1.2.22",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.22",
+          "id": "1.2.22"
+        },
+        {
+          "dirName": "1.2.21",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.21",
+          "id": "1.2.21"
+        },
+        {
+          "dirName": "1.2.20",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.20",
+          "id": "1.2.20"
+        },
+        {
+          "dirName": "1.2.19",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.19",
+          "id": "1.2.19"
+        },
+        {
+          "dirName": "1.2.18",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.18",
+          "id": "1.2.18"
+        },
+        {
+          "dirName": "1.2.17",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.17",
+          "id": "1.2.17"
+        },
+        {
+          "dirName": "1.2.16",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.16",
+          "id": "1.2.16"
+        },
+        {
+          "dirName": "1.2.15 ",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.15",
+          "id": "1.2.15"
+        },
+        {
+          "dirName": "1.2.14 ",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.14",
+          "id": "1.2.14"
+        },
+        {
+          "dirName": "1.2.13 ",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.13",
+          "id": "1.2.13"
+        },
+        {
+          "dirName": "1.2.12 ",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.12",
+          "id": "1.2.12"
+        },
+        {
+          "dirName": "1.2.11 ",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.11",
+          "id": "1.2.11"
+        },
+        {
+          "dirName": "1.2.10 ",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.10",
+          "id": "1.2.10"
+        },
+        {
+          "dirName": "1.2.9 ",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.9",
+          "id": "1.2.9"
+        },
+        {
+          "dirName": "1.2.8",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.8",
+          "id": "1.2.8"
+        },
+        {
+          "dirName": "1.2.7",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.7",
+          "id": "1.2.7"
+        },
+        {
+          "dirName": "1.2.6",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.6",
+          "id": "1.2.6"
+        },
+        {
+          "dirName": "1.2.5 ",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.5",
+          "id": "1.2.5"
+        },
+        {
+          "dirName": "1.2.4",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.4",
+          "id": "1.2.4"
+        },
+        {
+          "dirName": "1.2.3",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.3",
+          "id": "1.2.3"
+        },
+        {
+          "dirName": "1.2.2",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.2",
+          "id": "1.2.2"
+        },
+        {
+          "dirName": "1.2.1",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.1",
+          "id": "1.2.1"
+        },
+        {
+          "dirName": "1.2.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.2.x-release-notes/1.2.0",
+          "id": "1.2.0"
+        }
+      ]
+    },
+    {
+      "dirName": "1.2.x archived versions",
+      "level": 1,
+      "position": 0,
+      "isDir": false,
+      "url": "/downloads/archived",
+      "id": "archived"
+    },
+    {
+      "dirName": "Release Note",
+      "level": 1,
+      "position": 0,
+      "isDir": false,
+      "url": "/downloads/RELEASE_NOTE",
+      "id": "RELEASE_NOTE"
+    },
+    {
+      "dirName": "Swan Lake Release Notes",
+      "level": 1,
+      "position": 0,
+      "isDir": false,
+      "url": "/downloads/swan-lake-release-notes",
+      "id": "swan-lake-release-notes"
+    },
+    {
+      "dirName": "Swan Lake archived versions",
+      "level": 1,
+      "position": 0,
+      "isDir": false,
+      "url": "/downloads/swan-lake-archived",
+      "id": "swan-lake-archived"
+    },
+    {
+      "dirName": "1.1.x release notes",
+      "level": 1,
+      "position": 3,
+      "isDir": true,
+      "url": "/downloads/1.1.x-release-notes",
+      "id": "1.1.x-release-notes",
+      "subDirectories": [
+        {
+          "dirName": "1.1.4",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.1.x-release-notes/1.1.4",
+          "id": "1.1.4",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.1.3",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.1.x-release-notes/1.1.3",
+          "id": "1.1.3",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.1.2",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.1.x-release-notes/1.1.2",
+          "id": "1.1.2",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.1.1",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.1.x-release-notes/1.1.1",
+          "id": "1.1.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.1.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.1.x-release-notes/1.1.0",
+          "id": "1.1.0",
+          "subDirectories": []
+        }
+      ]
+    },
+    {
+      "dirName": "1.0.x. release notes",
+      "level": 1,
+      "position": 4,
+      "isDir": true,
+      "url": "/downloads/1.0.x-release-notes",
+      "id": "1.0.x-release-notes",
+      "subDirectories": [
+        {
+          "dirName": "1.0.5",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.0.x-release-notes/1.0.5",
+          "id": "1.0.5",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.4",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.0.x-release-notes/1.0.4",
+          "id": "1.0.4",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.3",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.0.x-release-notes/1.0.3",
+          "id": "1.0.3",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.2",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.0.x-release-notes/1.0.2",
+          "id": "1.0.2",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.1",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.0.x-release-notes/1.0.1",
+          "id": "1.0.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/1.0.x-release-notes/1.0.0",
+          "id": "1.0.0",
+          "subDirectories": []
+        }
+      ]
+    },
+    {
+      "dirName": "0.9.x release notes",
+      "level": 1,
+      "position": 5,
+      "isDir": true,
+      "url": "/downloads/0.9.x-release-notes",
+      "id": "0.9.x-release-notes",
+      "subDirectories": [
+        {
+          "dirName": "0.991.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.991.0",
+          "id": "0.991.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.990.3",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.990.3",
+          "id": "0.990.3",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.990.2",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.990.2",
+          "id": "0.990.2",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.990.1",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.990.1",
+          "id": "0.990.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.990.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.990.0",
+          "id": "0.990.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.983.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.983.0",
+          "id": "0.983.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.982.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.982.0",
+          "id": "0.982.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.981.1",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.981.1",
+          "id": "0.981.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.981.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.981.0",
+          "id": "0.981.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.980.1",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.980.1",
+          "id": "0.980.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.980.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.980.0",
+          "id": "0.980.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.975.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.975.0",
+          "id": "0.975.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.970.1",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.970.1",
+          "id": "0.970.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.970.0",
+          "level": 2,
+          "position": 1,
+          "isDir": false,
+          "url": "/downloads/0.9.x-release-notes/0.970.0",
+          "id": "0.970.0",
+          "subDirectories": []
+        }
+      ]
+    },
+    {
+      "dirName": "stable release notes",
+      "level": 1,
+      "position": 0,
+      "isDir": true,
+      "url": "/downloads/stable-release-notes",
+      "id": "stable-release-notes",
+      "subDirectories": [
+        {
+          "dirName": "0.970.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.970.0",
+          "id": "0.970.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.14",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.14",
+          "id": "1.2.14",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.1.2",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.1.2",
+          "id": "1.1.2",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.3",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.0.3",
+          "id": "1.0.3",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.7",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.7",
+          "id": "1.2.7",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.13",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.13",
+          "id": "1.2.13",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.0",
+          "id": "1.2.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.980.1",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.980.1",
+          "id": "0.980.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.8",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.8",
+          "id": "1.2.8",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.4",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.4",
+          "id": "1.2.4",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.10",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.10",
+          "id": "1.2.10",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.1",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.0.1",
+          "id": "1.0.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.5",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.5",
+          "id": "1.2.5",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.990.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.990.0",
+          "id": "0.990.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.970.1",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.970.1",
+          "id": "0.970.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.4",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.0.4",
+          "id": "1.0.4",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.1.1",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.1.1",
+          "id": "1.1.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.1.3",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.1.3",
+          "id": "1.1.3",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.981.1",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.981.1",
+          "id": "0.981.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.5",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.0.5",
+          "id": "1.0.5",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.983.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.983.0",
+          "id": "0.983.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.981.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.981.0",
+          "id": "0.981.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.975.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.975.0",
+          "id": "0.975.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.11",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.11",
+          "id": "1.2.11",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.12",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.12",
+          "id": "1.2.12",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.980.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.980.0",
+          "id": "0.980.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.1",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.1",
+          "id": "1.2.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.1.4",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.1.4",
+          "id": "1.1.4",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.9",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.9",
+          "id": "1.2.9",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.2",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.2",
+          "id": "1.2.2",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.6",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.6",
+          "id": "1.2.6",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.0.0",
+          "id": "1.0.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.990.3",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.990.3",
+          "id": "0.990.3",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.990.1",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.990.1",
+          "id": "0.990.1",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.991.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.991.0",
+          "id": "0.991.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.2.3",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.2.3",
+          "id": "1.2.3",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.0.2",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.0.2",
+          "id": "1.0.2",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.982.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.982.0",
+          "id": "0.982.0",
+          "subDirectories": []
+        },
+        {
+          "dirName": "0.990.2",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/0.990.2",
+          "id": "0.990.2",
+          "subDirectories": []
+        },
+        {
+          "dirName": "1.1.0",
+          "level": 2,
+          "position": 1,
+          "isDir": true,
+          "url": "/downloads/stable-release-notes/1.1.0",
+          "id": "1.1.0",
+          "subDirectories": []
+        }
+      ]
+    },
+    {
+      "dirName": " 1.2.x Release Notes Old",
+      "level": 1,
+      "position": 0,
+      "isDir": false,
+      "url": "/downloads/release-notes",
+      "id": "release-notes"
+    }
+  ]
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Redesign the release notes page to have a nested view with the patch releases listed under the main update releases as follows. The below pattern will be ordered based on latest releases unlike presented below.
- 2201.0.0 (Swan Lake)
  - 2201.0.1
  - 2201.0.2
  - 2201.0.3
  - 2201.0.4
  - 2201.0.5
- 2201.1.0 (Swan Lake Update 1)
  - 2201.1.1
  - 2201.1.2
- 2201.2.0 (Swan Lake Update 2)
  - 2201.2.1

> Fixes #5627 

https://github.com/user-attachments/assets/af712f0f-01b9-4a9e-bd03-f3b4e1738de1

