### PR TITLE
Modify 2201.11.0 release notes with changes of the openapi-tools

### DIFF
--- a/downloads/swan-lake-release-notes/swan-lake-2201.11.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.11.0/RELEASE_NOTE.md
@@ -106,10 +106,10 @@ To view bug fixes, see the [GitHub milestone for Swan Lake Update 11 (2201.11.0)
   ```
   $ bal openapi flatten <openapi.yaml>
   ```
-- Introduced the `sanitize` sub-command, which sanitizes the OpenAPI contract file according to Ballerina's best naming practices. The Ballerina name extensions are added to the schemas which can not be modified directly. The output is a modified OpenAPI contract.
+- Introduced the `align` sub-command, which alignes the OpenAPI contract file according to Ballerina's best naming practices. The Ballerina name extensions are added to the schemas which can not be modified directly. The output is a modified OpenAPI contract.
 
   ```
-  $ bal openpai sanitize <openapi.yaml>
+  $ bal openpai align <openapi.yaml>
   ```
 - Add code generation support with the new Ballerina name extensions. These extensions are mapped as relevant annotations in the generated types, parameters and record fields.
 

--- a/downloads/swan-lake-release-notes/swan-lake-2201.11.0/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.11.0/RELEASE_NOTE.md
@@ -106,7 +106,7 @@ To view bug fixes, see the [GitHub milestone for Swan Lake Update 11 (2201.11.0)
   ```
   $ bal openapi flatten <openapi.yaml>
   ```
-- Introduced the `align` sub-command, which alignes the OpenAPI contract file according to Ballerina's best naming practices. The Ballerina name extensions are added to the schemas which can not be modified directly. The output is a modified OpenAPI contract.
+- Introduced the `align` sub-command, which aligns the OpenAPI contract file according to Ballerina's best naming practices. The Ballerina name extensions are added to the schemas which can not be modified directly. The output is a modified OpenAPI contract.
 
   ```
   $ bal openpai align <openapi.yaml>


### PR DESCRIPTION
## Purpose
- This PR includes the changes to Ballerina U11 release notes by including the sub-command name change from `sanitize` to `align` in Ballerina OpenAPI tool.

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
