### PR TITLE
Fix styling issues in VSCode doc landing page

### DIFF
--- a/components/vs-code-extension/code/Code.js
+++ b/components/vs-code-extension/code/Code.js
@@ -91,7 +91,7 @@ export default function UseCases(props) {
                                                 <img src={`${prefix}/images/ai_ask.png`}/>
                                             </div>
                                         </Tab>
-                                        <Tab eventKey="copilotView4" title="Test Generation">
+                                        <Tab eventKey="copilotView4" title="Test generation">
                                         <div className={styles.codeSnippet}>
                                                 <img src={`${prefix}/images/ai_test.png`}/>
                                             </div>
@@ -295,17 +295,17 @@ export default function UseCases(props) {
                             <Col xs={12} md={7} lg={7} className={styles.box}>
                                 <div id="code-tab">
                                     <Tabs defaultActiveKey="sample1" id="code" className="mb-3 codeTabs">
-                                        <Tab eventKey="sample1" title="Code Completion">
+                                        <Tab eventKey="sample1" title="Code completion">
                                             <div className={styles.codeSnippet}>
                                             <img src={`${prefix}/images/code-completion.png`}/>
                                             </div>
                                         </Tab>
-                                        <Tab eventKey="sample2" title="Code Actions">
+                                        <Tab eventKey="sample2" title="Code actions">
                                             <div className={styles.codeSnippet}>
                                             <img src={`${prefix}/images/code-actions.png`}/>
                                             </div>
                                         </Tab>
-                                        <Tab eventKey="sample3" title="Go to References">
+                                        <Tab eventKey="sample3" title="Go to references">
                                             <div className={styles.codeSnippet}>
                                             <img src={`${prefix}/images/go-to-references.png`}/>
                                             </div>
@@ -444,20 +444,18 @@ export default function UseCases(props) {
                                 </div>
                             </Col>
                             <Col xs={12} md={7} lg={7} className={styles.box}>
-                                <div id="code-tab">
-                                    <Tabs defaultActiveKey="serviceDesigning1" id="code" className="mb-3 codeTabs">
-                                        <Tab eventKey="serviceDesigning1" title="Try HTTP services">
-                                            <div className={styles.codeSnippet}>
-                                            <img src={`${prefix}/images/http-try-it.png`}/>
-                                            </div>
-                                        </Tab>
-                                        {/* <Tab eventKey="serviceDesigning2" title="Try GraphQL services"> */}
-                                            {/* <div className={styles.codeSnippet}>
-                                            <img src={`${prefix}/images/graphql-try-it.png`}/>
-                                            </div> */}
-                                        {/* </Tab> */}
-                                    </Tabs>
-                                </div>
+                                {
+                                    (tryIt.code && tryIt.code !== '') ?
+                                        <div className={styles.codeSnippet}>
+                                            <div className="highlight" dangerouslySetInnerHTML={{ __html: tryIt.code }} />
+                                        </div>
+                                        : null
+                                }
+                                {
+                                    (tryIt.frontmatter.image && tryIt.frontmatter.image !== '') ?
+                                        <img src={`${prefix}/${tryIt.frontmatter.image}`} alt={tryIt.frontmatter.title} />
+                                        : null
+                                }
                             </Col>
                         </Row>
                     </Container>
@@ -580,7 +578,6 @@ export default function UseCases(props) {
             </Row>
 
              {/* Notebooks */}
-
              <Row className="pageContentRow integration code odd">
                 <Col xs={12}>
                     <Container>

--- a/components/vs-code-extension/code/vs-code-extension-bbe/try-the-services.md
+++ b/components/vs-code-extension/code/vs-code-extension-bbe/try-the-services.md
@@ -1,4 +1,5 @@
 ---
 title: 'Try the services'
 description: "Try out the HTTP and GraphQL services directly within the VS Code development environment using the built-in Try it tools, eliminating the need for external software."
+image: 'images/http-try-it.png'
 ---


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
