### PR TITLE
Fix broken link for observability guide

### DIFF
--- a/swan-lake/by-example/counter-metrics/content.jsx
+++ b/swan-lake/by-example/counter-metrics/content.jsx
@@ -101,7 +101,7 @@ export function CounterMetrics({ codeSnippets }) {
 
       <p>
         For more information about configs and observing applications, see{" "}
-        <a href="/learn/observe-ballerina-programs/">
+        <a href="/learn/overview-of-ballerina-observability/">
           Observe Ballerina programs
         </a>
         .

--- a/swan-lake/by-example/gauge-metrics/content.jsx
+++ b/swan-lake/by-example/gauge-metrics/content.jsx
@@ -155,7 +155,7 @@ export function GaugeMetrics({ codeSnippets }) {
 
       <p>
         For more information about configs and observing applications, see{" "}
-        <a href="/learn/observe-ballerina-programs/">
+        <a href="/learn/overview-of-ballerina-observability/">
           Observe Ballerina programs
         </a>
         .

--- a/swan-lake/by-example/tracing/content.jsx
+++ b/swan-lake/by-example/tracing/content.jsx
@@ -102,7 +102,7 @@ export function Tracing({ codeSnippets }) {
         <p>
           <strong>Info:</strong> For more information about configs and
           observing applications, see{" "}
-          <a href="/learn/observe-ballerina-programs/">
+          <a href="/learn/overview-of-ballerina-observability/">
             Observe Ballerina programs
           </a>
           .


### PR DESCRIPTION
## Purpose

The link to `https://ballerina.io/learn/observe-ballerina-programs/` needs to be corrected to `https://ballerina.io/learn/overview-of-ballerina-observability/`

Fixes https://github.com/ballerina-platform/ballerina-dev-website/issues/9971

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
