### PR TITLE
Fix syntax error in news-api-to-email integration sample

### DIFF
--- a/pages/learn/integration/pre-built-integrations/news-api-to-email-integration.js
+++ b/pages/learn/integration/pre-built-integrations/news-api-to-email-integration.js
@@ -70,7 +70,7 @@ public function main() returns error? {
     }
     email:Message message = {
         to: emailAddress,
-        'from: fromAddress,
+        "from": fromAddress,
         subject: "BBC Headlines",
         body: mailBody
     };


### PR DESCRIPTION
## Purpose
>   This PR partially addresses issue [#9731](https://github.com/ballerina-platform/ballerina-dev-website/issues/9731) by fixing a syntax error in the News API to Email integration sample. The integration sample contains invalid syntax (`'from:`) that prevents compilation with Ballerina version 2201.11.0.

  ## Changes Made
  - Fixed syntax error in `pages/learn/integration/pre-built-integrations/news-api-to-email-integration.js` by changing `'from:` to 
  `"from":` (line 73)

  ## Testing
  - Extracted the Ballerina code and tested compilation with Ballerina 2201.11.0
  - Confirmed the code now compiles without errors
  - Verified the fix allows the integration sample to work correctly  