### PR TITLE
Fix "Edit in GitHub" button and update uninstallation instructions

### DIFF
--- a/downloads/installation-options/installation-options.md
+++ b/downloads/installation-options/installation-options.md
@@ -139,3 +139,10 @@ For example, for the RPM file:
 $ rpm -e ballerina-<VERSION>-swan-lake
 ```
 
+If you installed Ballerina on **macOS** via **Homebrew**, uninstall it with:
+```
+$ brew uninstall bal
+```
+
+
+

--- a/pages/downloads/installation-options/index.js
+++ b/pages/downloads/installation-options/index.js
@@ -35,7 +35,7 @@ export async function getStaticProps() {
 
     const fileName = fs.readFileSync(`downloads/installation-options/installation-options.md`, "utf-8");
     const { data: frontmatter, content } = matter(fileName);
-    const id = "installation-options";
+    const id = "installation-options/installation-options";
 
     return {
         props: {


### PR DESCRIPTION
## Issue
- "Edit in Github" button in [Installation options](https://ballerina.io/downloads/installation-options/) page landing into [404 - page not found](https://github.com/ballerina-platform/ballerina-dev-website/blob/master/downloads/installation-options.md) on github.

## Fix
- Changed `const id = "installation-options";` into `const id = "installation-options/installation-options"; ` in [pages/downloads/installation-options/index.js](https://github.com/ballerina-platform/ballerina-dev-website/blob/master/pages/downloads/installation-options/index.js) file.
Fixes issue in #10091 

## Updates / Improvements 
- Added macOS Homebrew uninstallation instructions to installation-options.md file.
Added this Improvements in #10092 