### PR TITLE
Fix Character Display by Removing Unwanted Spaces

### DIFF
--- a/swan-lake/development-tutorials/source-code-dependencies/style-guide/coding-conventions.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/style-guide/coding-conventions.md
@@ -328,18 +328,18 @@ intro: This Ballerina Style Guide aims at maintaining a standard coding style am
   ```
 
 * Use function pointers to improve performance:
-  ```ballerina  
-  isolated function getDuration() returns float {  
-      log:printInfo("Calculating duration optimally");  
-      return random:createDecimal() * 100.0;  
-  }  
+  ```ballerina
+  isolated function getDuration() returns float {
+      log:printInfo("Calculating duration optimally");
+      return random:createDecimal() * 100.0;
+  }
 
   // Bad practice - function executes even if debug log is disabled
   float duration = getDuration();
   log:printDebug("Checking the duration", duration = duration);
 
   // Good practice - function executes only if debug log is enabled
-  log:printDebug("Checking the duration", duration = getDuration);  
+  log:printDebug("Checking the duration", duration = getDuration); 
   ```
 
 * Avoid logging sensitive information like passwords, tokens, or personal data


### PR DESCRIPTION
## Purpose

Extra whitespaces at the end of line in code snippets leads to first few missing characters.

> Fixes #10078 

Localhost after the fix:

<img width="1919" height="1078" alt="Screenshot 2025-10-01 154250" src="https://github.com/user-attachments/assets/6c34629d-72da-4d63-875f-a814950118ba" />
