### PR TITLE
Update Mutual SSL example with descriptive certificate names

### DIFF
--- a/swan-lake/by-example/http-client-mutual-ssl/content.jsx
+++ b/swan-lake/by-example/http-client-mutual-ssl/content.jsx
@@ -18,10 +18,10 @@ public function main() returns error? {
     http:Client albumClient = check new ("localhost:9090",
         secureSocket = {
             key: {
-                certFile: "../resource/path/to/public.crt",
-                keyFile: "../resource/path/to/private.key"
+                certFile: "../resource/path/to/client-public.crt",
+                keyFile: "../resource/path/to/client-private.key"
             },
-            cert: "../resource/path/to/public.crt"
+            cert: "../resource/path/to/server-public.crt"
         }
     );
     Album[] payload = check albumClient->/albums;
@@ -67,7 +67,7 @@ export function HttpClientMutualSsl({ codeSnippets }) {
             onClick={() => {
               window.open(
                 "https://github.com/ballerina-platform/ballerina-distribution/tree/v2201.12.10/examples/http-client-mutual-ssl",
-                "_blank",
+                "_blank"
               );
             }}
             aria-label="Edit on Github"

--- a/swan-lake/by-example/http-service-mutual-ssl/content.jsx
+++ b/swan-lake/by-example/http-service-mutual-ssl/content.jsx
@@ -16,13 +16,13 @@ type Album readonly & record {|
 listener http:Listener securedEP = new (9090,
     secureSocket = {
         key: {
-            certFile: "../resource/path/to/public.crt",
-            keyFile: "../resource/path/to/private.key"
+            certFile: "../resource/path/to/client-public.crt",
+            keyFile: "../resource/path/to/client-private.key"
         },
         // Enables mutual SSL.
         mutualSsl: {
             verifyClient: http:REQUIRE,
-            cert: "../resource/path/to/public.crt"
+            cert: "../resource/path/to/server-public.crt"
         }
     }
 );
@@ -79,7 +79,7 @@ export function HttpServiceMutualSsl({ codeSnippets }) {
             onClick={() => {
               window.open(
                 "https://github.com/ballerina-platform/ballerina-distribution/tree/v2201.12.10/examples/http-service-mutual-ssl",
-                "_blank",
+                "_blank"
               );
             }}
             aria-label="Edit on Github"


### PR DESCRIPTION
## Purpose
> Improves clarity in mutual SSL examples by using descriptive certificate file names instead of generic names.
Pages updated:
https://ballerina.io/learn/by-example/http-client-mutual-ssl/
https://ballerina.io/learn/by-example/http-service-mutual-ssl/


> Fixes [[#6315](https://github.com/ballerina-platform/ballerina-library/issues/6315)]

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).
