### PR TITLE
Prepare for 1.2.66 release

### DIFF
--- a/_data/stable-latest/metadata.json
+++ b/_data/stable-latest/metadata.json
@@ -1,15 +1,15 @@
 {
-  "version": "1.2.65",
+  "version": "1.2.66",
   "release-date": "2026-02-10",
-  "windows-installer": "ballerina-windows-installer-x64-1.2.65.msi",
+  "windows-installer": "ballerina-windows-installer-x64-1.2.66.msi",
   "windows-installer-size": "148mb",
-  "linux-installer": "ballerina-linux-installer-x64-1.2.65.deb",
+  "linux-installer": "ballerina-linux-installer-x64-1.2.66.deb",
   "linux-installer-size": "145mb",
-  "macos-installer": "ballerina-macos-installer-x64-1.2.65.pkg",
+  "macos-installer": "ballerina-macos-installer-x64-1.2.66.pkg",
   "macos-installer-size": "165mb",
-  "rpm-installer": "ballerina-linux-installer-x64-1.2.65.rpm",
+  "rpm-installer": "ballerina-linux-installer-x64-1.2.66.rpm",
   "rpm-installer-size": "168mb",
-  "other-artefacts": ["ballerina-1.2.65.zip", "ballerina-1.2.65.vsix"],
-  "api-docs": "ballerina-api-docs-1.2.65.zip",
-  "release-notes": "ballerina-release-notes-1.2.65.md"
+  "other-artefacts": ["ballerina-1.2.66.zip", "ballerina-1.2.66.vsix"],
+  "api-docs": "ballerina-api-docs-1.2.66.zip",
+  "release-notes": "ballerina-release-notes-1.2.66.md"
 }

--- a/downloads/1.2.x-release-notes/1.2.66.md
+++ b/downloads/1.2.x-release-notes/1.2.66.md
@@ -1,0 +1,37 @@
+---
+layout: ballerina-left-nav-release-notes
+title: 1.2.66
+permalink: /downloads/1.2.x-release-notes/1.2.66/
+active: 1.2.66
+---
+
+### Overview of jBallerina 1.2.66
+
+The jBallerina 1.2.66 patch release improves upon the 1.2.64 release by addressing a few security improvements.
+
+You can use the update tool to update to jBallerina 1.2.66 as follows.
+
+**For existing users:**
+
+If you are already using jBallerina version 1.2.0, or above, you can directly update your distribution to jBallerina 1.2.66 by executing the following command:
+
+```
+ballerina dist update
+```
+
+However, you need to use the following commands instead of the above if you have installed:
+
+- jBallerina 1.2.0 but switched to a previous version: `ballerina dist pull 1.2.66`
+- a jBallerina version below 1.1.0: install via the [installers](https://ballerina.io/downloads/)
+
+**For new users:**
+
+If you have not installed jBallerina, then download the [installers](https://ballerina.io/downloads/) to install.
+
+<style>
+
+.cBallerinaTocContainer  {
+    display:none;
+}
+
+</style>


### PR DESCRIPTION
## Purpose

$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Preparation for Version 1.2.66

This PR prepares the Ballerina development website for the 1.2.66 release by updating release metadata and documentation.

### Changes Made

**Metadata Updates:**
- Updated version metadata in `_data/stable-latest/metadata.json` from 1.2.65 to 1.2.66
- Updated all installer artifact filenames to reflect the new version:
  - Windows installer (.msi)
  - Linux installer (.deb)
  - macOS installer (.pkg)
  - RPM installer
  - Archive distribution (.zip)
  - VS Code extension (.vsix)
- Updated API documentation and release notes file references to 1.2.66

**New Documentation:**
- Added release notes document at `downloads/1.2.x-release-notes/1.2.66.md` containing overview, update instructions for new and existing users, and relevant configuration details.

All changes support the upcoming 1.2.66 release rollout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->