### PR TITLE
Fix typo in release note

### DIFF
--- a/downloads/1.2.x-release-notes/1.2.66.md
+++ b/downloads/1.2.x-release-notes/1.2.66.md
@@ -7,7 +7,7 @@ active: 1.2.66
 
 ### Overview of jBallerina 1.2.66
 
-The jBallerina 1.2.66 patch release improves upon the 1.2.64 release by addressing a few security improvements.
+The jBallerina 1.2.66 patch release improves upon the 1.2.65 release by addressing a few security improvements.
 
 You can use the update tool to update to jBallerina 1.2.66 as follows.
 


### PR DESCRIPTION
## Purpose

$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fix typo in release note

Corrects the release notes for version 1.2.66 to accurately reference the previous release version as 1.2.65 instead of 1.2.64 in the Overview section.

**Changes:**
- Updated release notes documentation (1 line changed)

**Impact:**
- Minimal change to improve accuracy of release note references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->