### PR TITLE
Fix styling errors in 1.2.x release notes

### DIFF
--- a/downloads/1.2.x-release-notes/1.2.65.md
+++ b/downloads/1.2.x-release-notes/1.2.65.md
@@ -5,7 +5,7 @@ permalink: /downloads/1.2.x-release-notes/1.2.65/
 active: 1.2.65
 ---
 
-### Overview of jBallerina 1.2.65
+## Overview of jBallerina 1.2.65
 
 The jBallerina 1.2.65 patch release improves upon the 1.2.64 release by addressing a few security improvements.
 
@@ -13,25 +13,20 @@ You can use the update tool to update to jBallerina 1.2.65 as follows.
 
 **For existing users:**
 
-If you are already using jBallerina version 1.2.0, or above, you can directly update your distribution to jBallerina 1.2.65 by executing the following command:
+If you are already using jBallerina version 1.2.14, or above, you can directly update your distribution to jBallerina 1.2.65 by executing the following command:
 
 ```
-ballerina dist update
+bal dist update
 ```
 
-However, you need to use the following commands instead of the above if you have installed:
+However, if you are using
 
-- jBallerina 1.2.0 but switched to a previous version: `ballerina dist pull 1.2.65`
-- a jBallerina version below 1.1.0: install via the [installers](https://ballerina.io/downloads/)
+- jBallerina 1.2.0 to 1.2.13, run `ballerina dist update` to update
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.65` to update
+- a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**
 
 If you have not installed jBallerina, then download the [installers](https://ballerina.io/downloads/) to install.
 
-<style>
-
-.cBallerinaTocContainer  {
-    display:none;
-}
-
-</style>
+<style>.cGitButtonContainer, .cBallerinaTocContainer {display:none;}</style>

--- a/downloads/1.2.x-release-notes/1.2.66.md
+++ b/downloads/1.2.x-release-notes/1.2.66.md
@@ -5,7 +5,7 @@ permalink: /downloads/1.2.x-release-notes/1.2.66/
 active: 1.2.66
 ---
 
-### Overview of jBallerina 1.2.66
+## Overview of jBallerina 1.2.66
 
 The jBallerina 1.2.66 patch release improves upon the 1.2.65 release by addressing a few security improvements.
 
@@ -13,25 +13,20 @@ You can use the update tool to update to jBallerina 1.2.66 as follows.
 
 **For existing users:**
 
-If you are already using jBallerina version 1.2.0, or above, you can directly update your distribution to jBallerina 1.2.66 by executing the following command:
+If you are already using jBallerina version 1.2.14, or above, you can directly update your distribution to jBallerina 1.2.66 by executing the following command:
 
 ```
-ballerina dist update
+bal dist update
 ```
 
-However, you need to use the following commands instead of the above if you have installed:
+However, if you are using
 
-- jBallerina 1.2.0 but switched to a previous version: `ballerina dist pull 1.2.66`
-- a jBallerina version below 1.1.0: install via the [installers](https://ballerina.io/downloads/)
+- jBallerina 1.2.0 to 1.2.13, run `ballerina dist update` to update
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.66` to update
+- a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
 
 **For new users:**
 
 If you have not installed jBallerina, then download the [installers](https://ballerina.io/downloads/) to install.
 
-<style>
-
-.cBallerinaTocContainer  {
-    display:none;
-}
-
-</style>
+<style>.cGitButtonContainer, .cBallerinaTocContainer {display:none;}</style>


### PR DESCRIPTION
## Purpose

$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes Made

This pull request updates the 1.2.65 and 1.2.66 release notes to fix styling and clarify upgrade guidance.

### Documentation Updates
- Standardized section heading levels (updated "###" to "##").
- Replaced legacy command references (`ballerina dist update`) with the current `bal dist update` in examples.
- Refined version-specific upgrade instructions (updated version thresholds and clarified which commands to run for different 1.2.x ranges and very old versions).
- Simplified page styling by consolidating multi-line CSS blocks into a single inline style that hides specific UI elements.

### Impact
- Improves documentation consistency, readability, and styling without changing substantive content or code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->