### PR TITLE
docs: update the release notes for 1.2.67

### DIFF
--- a/_data/stable-latest/metadata.json
+++ b/_data/stable-latest/metadata.json
@@ -1,15 +1,15 @@
 {
-  "version": "1.2.66",
+  "version": "1.2.67",
   "release-date": "2026-02-10",
-  "windows-installer": "ballerina-windows-installer-x64-1.2.66.msi",
+  "windows-installer": "ballerina-windows-installer-x64-1.2.67.msi",
   "windows-installer-size": "148mb",
-  "linux-installer": "ballerina-linux-installer-x64-1.2.66.deb",
+  "linux-installer": "ballerina-linux-installer-x64-1.2.67.deb",
   "linux-installer-size": "145mb",
-  "macos-installer": "ballerina-macos-installer-x64-1.2.66.pkg",
+  "macos-installer": "ballerina-macos-installer-x64-1.2.67.pkg",
   "macos-installer-size": "165mb",
-  "rpm-installer": "ballerina-linux-installer-x64-1.2.66.rpm",
+  "rpm-installer": "ballerina-linux-installer-x64-1.2.67.rpm",
   "rpm-installer-size": "168mb",
-  "other-artefacts": ["ballerina-1.2.66.zip", "ballerina-1.2.66.vsix"],
-  "api-docs": "ballerina-api-docs-1.2.66.zip",
-  "release-notes": "ballerina-release-notes-1.2.66.md"
+  "other-artefacts": ["ballerina-1.2.67.zip", "ballerina-1.2.67.vsix"],
+  "api-docs": "ballerina-api-docs-1.2.67.zip",
+  "release-notes": "ballerina-release-notes-1.2.67.md"
 }

--- a/downloads/1.2.x-release-notes/1.2.67.md
+++ b/downloads/1.2.x-release-notes/1.2.67.md
@@ -1,0 +1,32 @@
+---
+layout: ballerina-left-nav-release-notes
+title: 1.2.67
+permalink: /downloads/1.2.x-release-notes/1.2.67/
+active: 1.2.67
+---
+
+## Overview of jBallerina 1.2.67
+
+The jBallerina 1.2.67 patch release improves upon the 1.2.66 release by addressing a few security improvements.
+
+You can use the update tool to update to jBallerina 1.2.67 as follows.
+
+**For existing users:**
+
+If you are already using jBallerina version 1.2.14, or above, you can directly update your distribution to jBallerina 1.2.67 by executing the following command:
+
+```
+bal dist update
+```
+
+However, if you are using
+
+- jBallerina 1.2.0 to 1.2.13, run `ballerina dist update` to update
+- jBallerina 1.2.0 but being switched to a previous version, run `ballerina dist pull jballerina-1.2.67` to update
+- a jBallerina version below 1.1.0, install via the [installers](https://ballerina.io/downloads/)
+
+**For new users:**
+
+If you have not installed jBallerina, then download the [installers](https://ballerina.io/downloads/) to install.
+
+<style>.cGitButtonContainer, .cBallerinaTocContainer {display:none;}</style>


### PR DESCRIPTION
## Purpose

$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the release documentation for jBallerina version 1.2.67. The changes include:

- **Metadata update**: Incremented version references in the metadata file from 1.2.66 to 1.2.67 across all installer and artifact links
- **Release notes**: Added comprehensive release notes documentation for version 1.2.67, including an overview, security improvements, and detailed upgrade instructions with installer links for both existing and new users

The documentation updates enable users to access the latest release information and guidance for upgrading to the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->