### PR TITLE
Fix dependency update information

### DIFF
--- a/swan-lake/development-tutorials/source-code-dependencies/manage-dependencies.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/manage-dependencies.md
@@ -104,7 +104,7 @@ The `Dependencies.toml` file generated during the compiler will automatically up
 
 >**Note:** The automatic update runs only once a day to optimize the time taken during frequent builds. Run the `bal clean` command if you want to enable automatic updates for the next build.
 
-To update the minor or the major version of a dependency, specify the dependency version in the `Ballerina.toml` file. The provided version is considered as the minimum required version for compiling the package, which will update the dependency to the latest version that is compatible with the version provided in the `Ballerina.toml` as well as the version locked in the`Dependencies.toml`.
+To update the minor version of a dependency, specify the dependency version in the `Ballerina.toml` file. The provided version is considered as the minimum required version for compiling the package, which will update the dependency to the latest version that is compatible with the version provided in the `Ballerina.toml` as well as the version locked in the `Dependencies.toml`.
 
 For example, the minimum version of the `ballerinax/mysql` dependency can be specified in the following way.
 


### PR DESCRIPTION
## Purpose
> Fix dependency update information

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request updates documentation guidance on managing dependency versions in Ballerina projects. It clarifies that dependency version updates specified in Ballerina.toml should be limited to minor version increments only (rather than permitting both minor and major updates), while preserving the existing explanations about minimum required versions and interaction with Dependencies.toml.

## Changes

- Restrict guidance in swan-lake/development-tutorials/source-code-dependencies/manage-dependencies.md to recommend only minor-version updates in Ballerina.toml; retains existing behavior for minimum required versions and Dependencies.toml interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->