### PR TITLE
Fix grammar issue in "Get started" documentation

### DIFF
--- a/swan-lake/integration/get-started.md
+++ b/swan-lake/integration/get-started.md
@@ -73,7 +73,7 @@ Running executable
 Hello, World!
 ```
 
-Alternatively, you can generate an executable file with `bal build`,
+Alternatively, you can generate an executable file using `bal build`.
 
 ```
 $ bal build


### PR DESCRIPTION
### Description
Fixed a minor grammar issue in the "Get started" documentation.

### Changes
- Updated sentence:
  "Alternatively, you can generate an executable file with `bal build`,"
  to
  "Alternatively, you can generate an executable file using `bal build`."

### Impact
Improves readability and correctness of the documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request improves the documentation in the "Get started" guide by correcting a minor grammar issue. The change updates a sentence in the `swan-lake/integration/get-started.md` file, replacing "with" with "using" in the context of the `bal build` command description. This enhancement increases the clarity and grammatical accuracy of the documentation without affecting any code, commands, or runtime functionality.

**Changes:**
- Fixed grammar in documentation text in `swan-lake/integration/get-started.md`
- 1 line modified

**Impact:**
- Documentation improvement with no code changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->