### PR TITLE
Update effective date in privacy policy

### DIFF
--- a/policy/privacy-policy.md
+++ b/policy/privacy-policy.md
@@ -131,4 +131,4 @@ We reserve the right to amend this privacy policy at any time. We will not send 
 
 By using the Sites, you consent to our privacy policy and any revisions thereto. If you do not agree with our privacy policy or any changes we make to it, you may delete your profile.
 
-**Effective April 07, 2026**
+**Effective April 09, 2026**


### PR DESCRIPTION
## Purpose
> $subject
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the effective date in the privacy policy document from April 07, 2026 to April 09, 2026. The change is a simple date update with no modifications to the policy content or structure.

## Changes

- **policy/privacy-policy.md**: Updated the "Effective" date field

The modification is minimal (1 line changed) and represents a straightforward content update to reflect the new effective date for the privacy policy document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->