### PR TITLE
Add 2201.13.3 release note

### DIFF
--- a/_data/swanlake-latest/metadata.json
+++ b/_data/swanlake-latest/metadata.json
@@ -1,23 +1,23 @@
 {
-	"version":"2201.13.2",
-	"short-version":"2201.13.2",
-	"display-version":"2201.13.2 (Swan Lake Update 13)",
-	"release-date":"2026-03-17",
-	"windows-installer":"ballerina-2201.13.2-swan-lake-windows-x64.msi",
-	"windows-installer-size":"271mb",
-	"linux-installer":"ballerina-2201.13.2-swan-lake-linux-x64.deb",
-	"linux-installer-size":"305mb",
-	"linux-arm-installer":"ballerina-2201.13.2-swan-lake-linux-arm-x64.deb",
-	"linux-arm-installer-size":"304mb",
-	"macos-installer":"ballerina-2201.13.2-swan-lake-macos-x64.pkg",
-	"macos-installer-size":"344mb",
-	"macos-arm-installer":"ballerina-2201.13.2-swan-lake-macos-arm-x64.pkg",
-	"macos-arm-installer-size":"343mb",
-	"rpm-installer":"ballerina-2201.13.2-swan-lake-linux-x64.rpm",
-	"rpm-installer-size":"346mb",
-	"other-artefacts":[  
-		"ballerina-2201.13.2-swan-lake.zip"
- 	],
-	"api-docs":"ballerina-api-docs-2201.13.2.zip",
-	"release-notes":"ballerina-release-notes-2201.13.2.md"
+  "version":"2201.13.3",
+  "short-version":"2201.13.3",
+  "display-version":"2201.13.3 (Swan Lake Update 13)",
+  "release-date":"2026-04-20",
+  "windows-installer":"ballerina-2201.13.3-swan-lake-windows-x64.msi",
+  "windows-installer-size":"271mb",
+  "linux-installer":"ballerina-2201.13.3-swan-lake-linux-x64.deb",
+  "linux-installer-size":"306mb",
+  "linux-arm-installer":"ballerina-2201.13.3-swan-lake-linux-arm-x64.deb",
+  "linux-arm-installer-size":"305mb",
+  "macos-installer":"ballerina-2201.13.3-swan-lake-macos-x64.pkg",
+  "macos-installer-size":"345mb",
+  "macos-arm-installer":"ballerina-2201.13.3-swan-lake-macos-arm-x64.pkg",
+  "macos-arm-installer-size":"344mb",
+  "rpm-installer":"ballerina-2201.13.3-swan-lake-linux-x64.rpm",
+  "rpm-installer-size":"347mb",
+  "other-artefacts":[
+    "ballerina-2201.13.3-swan-lake.zip"
+  ],
+  "api-docs":"ballerina-api-docs-2201.13.3.zip",
+  "release-notes":"ballerina-release-notes-2201.13.3.md"
 }

--- a/_data/swanlake-latest/metadata.json
+++ b/_data/swanlake-latest/metadata.json
@@ -1,23 +1,23 @@
 {
-  "version":"2201.13.3",
-  "short-version":"2201.13.3",
-  "display-version":"2201.13.3 (Swan Lake Update 13)",
-  "release-date":"2026-04-20",
-  "windows-installer":"ballerina-2201.13.3-swan-lake-windows-x64.msi",
-  "windows-installer-size":"271mb",
-  "linux-installer":"ballerina-2201.13.3-swan-lake-linux-x64.deb",
-  "linux-installer-size":"306mb",
-  "linux-arm-installer":"ballerina-2201.13.3-swan-lake-linux-arm-x64.deb",
-  "linux-arm-installer-size":"305mb",
-  "macos-installer":"ballerina-2201.13.3-swan-lake-macos-x64.pkg",
-  "macos-installer-size":"345mb",
-  "macos-arm-installer":"ballerina-2201.13.3-swan-lake-macos-arm-x64.pkg",
-  "macos-arm-installer-size":"344mb",
-  "rpm-installer":"ballerina-2201.13.3-swan-lake-linux-x64.rpm",
-  "rpm-installer-size":"347mb",
-  "other-artefacts":[
-    "ballerina-2201.13.3-swan-lake.zip"
-  ],
-  "api-docs":"ballerina-api-docs-2201.13.3.zip",
-  "release-notes":"ballerina-release-notes-2201.13.3.md"
+    "version":"2201.13.3",
+    "short-version":"2201.13.3",
+    "display-version":"2201.13.3 (Swan Lake Update 13)",
+    "release-date":"2026-04-20",
+    "windows-installer":"ballerina-2201.13.3-swan-lake-windows-x64.msi",
+    "windows-installer-size":"271mb",
+    "linux-installer":"ballerina-2201.13.3-swan-lake-linux-x64.deb",
+    "linux-installer-size":"306mb",
+    "linux-arm-installer":"ballerina-2201.13.3-swan-lake-linux-arm-x64.deb",
+    "linux-arm-installer-size":"305mb",
+    "macos-installer":"ballerina-2201.13.3-swan-lake-macos-x64.pkg",
+    "macos-installer-size":"345mb",
+    "macos-arm-installer":"ballerina-2201.13.3-swan-lake-macos-arm-x64.pkg",
+    "macos-arm-installer-size":"344mb",
+    "rpm-installer":"ballerina-2201.13.3-swan-lake-linux-x64.rpm",
+    "rpm-installer-size":"347mb",
+    "other-artefacts":[
+        "ballerina-2201.13.3-swan-lake.zip"
+    ],
+    "api-docs":"ballerina-api-docs-2201.13.3.zip",
+    "release-notes":"ballerina-release-notes-2201.13.3.md"
 }

--- a/_data/swanlake_release_notes_versions.json
+++ b/_data/swanlake_release_notes_versions.json
@@ -2024,6 +2024,29 @@
  	],
 	"api-docs":"ballerina-api-docs-2201.13.1.zip",
 	"release-notes":"ballerina-release-notes-2201.13.1.md"
+},
+{
+  "version":"2201.13.2",
+  "short-version":"2201.13.2",
+  "display-version":"2201.13.2 (Swan Lake Update 13)",
+  "release-date":"2026-03-17",
+  "windows-installer":"ballerina-2201.13.2-swan-lake-windows-x64.msi",
+  "windows-installer-size":"271mb",
+  "linux-installer":"ballerina-2201.13.2-swan-lake-linux-x64.deb",
+  "linux-installer-size":"305mb",
+  "linux-arm-installer":"ballerina-2201.13.2-swan-lake-linux-arm-x64.deb",
+  "linux-arm-installer-size":"304mb",
+  "macos-installer":"ballerina-2201.13.2-swan-lake-macos-x64.pkg",
+  "macos-installer-size":"344mb",
+  "macos-arm-installer":"ballerina-2201.13.2-swan-lake-macos-arm-x64.pkg",
+  "macos-arm-installer-size":"343mb",
+  "rpm-installer":"ballerina-2201.13.2-swan-lake-linux-x64.rpm",
+  "rpm-installer-size":"346mb",
+  "other-artefacts":[
+    "ballerina-2201.13.2-swan-lake.zip"
+  ],
+  "api-docs":"ballerina-api-docs-2201.13.2.zip",
+  "release-notes":"ballerina-release-notes-2201.13.2.md"
 }
 
 ]

--- a/downloads/swan-lake-release-notes/swan-lake-2201.13.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.13.3/RELEASE_NOTE.md
@@ -1,0 +1,28 @@
+---
+layout: ballerina-left-nav-release-notes
+title: Swan Lake Update 13 (2201.13.3)
+permalink: /downloads/swan-lake-release-notes/2201.13.3/
+active: 2201.13.3
+---
+
+## Overview of Ballerina Swan Lake Update 13 (2201.13.3)
+
+<em>Swan Lake Update 13 (2201.13.3) is the third patch release of Ballerina 2201.13.0 (Swan Lake Update 13) and includes a new set of bug fixes to the compiler and runtime. It also includes a few security improvements.</em>
+
+## Update Ballerina
+
+Run the command below to update your current Ballerina installation directly to 2201.13.3 by using the [Ballerina Update Tool](/learn/update-tool/).
+
+```
+$ bal dist pull 2201.13.3
+```
+
+## Install Ballerina
+
+If you have not installed Ballerina, then, download the [installers](/downloads/#swanlake) to install.
+
+## Language updates
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for Swan Lake Update 12 (2201.13.3)](https://github.com/ballerina-platform/ballerina-lang/milestone/202?closed=1).

--- a/downloads/swan-lake-release-notes/swan-lake-2201.13.3/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.13.3/RELEASE_NOTE.md
@@ -25,4 +25,4 @@ If you have not installed Ballerina, then, download the [installers](/downloads/
 
 ### Bug fixes
 
-To view bug fixes, see the [GitHub milestone for Swan Lake Update 12 (2201.13.3)](https://github.com/ballerina-platform/ballerina-lang/milestone/202?closed=1).
+To view bug fixes, see the [GitHub milestone for Swan Lake Update 13 (2201.13.3)](https://github.com/ballerina-platform/ballerina-lang/milestone/202?closed=1).

--- a/utils/archived-lm.json
+++ b/utils/archived-lm.json
@@ -23,6 +23,14 @@
                     "id": "swan-lake-api-docs"
                 },
                 {
+                  "dirName": "2201.13.2",
+                  "level": 2,
+                  "position": 1,
+                  "isDir": false,
+                  "url": "#2201.13.2",
+                  "id": "2201.13.2v"
+                },
+                {
                     "dirName": "2201.13.1",
                     "level": 2,
                     "position": 1,

--- a/utils/rl.json
+++ b/utils/rl.json
@@ -23,6 +23,14 @@
                     "id": "swan-lake-2201.13",
                     "subDirectories": [
                         {
+                          "dirName": "2201.13.3 (Swan Lake Update 13)",
+                          "level": 3,
+                          "position": 1,
+                          "isDir": false,
+                          "url": "/downloads/swan-lake-release-notes/swan-lake-2201.13.3",
+                          "id": "swan-lake-2201.13.3"
+                        },
+                        {
                             "dirName": "2201.13.2 (Swan Lake Update 13)",
                             "level": 3,
                             "position": 1,


### PR DESCRIPTION
## Purpose
$subject

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request adds release notes and metadata for Ballerina Swan Lake version 2201.13.3. The changes update the website's release information and navigation structures to reflect the new patch release.

## Changes

**Release Metadata Updates:**
- Updated the active Swan Lake release metadata from version 2201.13.2 to 2201.13.3, including updated release date and revised installer/artifact filenames and file sizes across all platforms (Windows MSI, Linux DEB, macOS PKG, Linux RPM)
- Added a new release entry for version 2201.13.2 to the release notes versions data file with complete artifact references and metadata

**Documentation:**
- Added a new release note markdown file for Swan Lake Update 13 (2201.13.3) containing overview, update instructions, and reference to bug fixes via GitHub milestone

**Navigation:**
- Added archived release entry for version 2201.13.2 to enable proper historical release organization
- Added release notes navigation entry for version 2201.13.3 to the release notes directory structure

All changes maintain consistency across data files and navigation structures to ensure proper presentation and discoverability of the new release information on the website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->