### PR TITLE
Add maven proxy doc

### DIFF
--- a/components/learn/boxes/Boxes.js
+++ b/components/learn/boxes/Boxes.js
@@ -813,7 +813,7 @@ export default function Boxes(props) {
                       <div className={styles.content}>
                         <p className={styles.title}>
                           <a href={`${prefix}/learn/proxy-ballerina-central-with-maven-repository`} className={styles.titleLink}>
-                            Proxy Ballerina Central with a Maven repository
+                            Proxy Ballerina Central with a Maven Repository
                           </a>
                         </p>
                         <p className={styles.description}>Use a Maven repository as a proxy for Ballerina Central.</p>

--- a/components/learn/boxes/Boxes.js
+++ b/components/learn/boxes/Boxes.js
@@ -810,6 +810,14 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Perform operations with the Ballerina Central over an HTTP proxy.</p>
                       </div>
+                      <div className={styles.content}>
+                        <p className={styles.title}>
+                          <a href={`${prefix}/learn/proxy-ballerina-central-with-maven-repository`} className={styles.titleLink}>
+                            Proxy Ballerina Central with a Maven repository
+                          </a>
+                        </p>
+                        <p className={styles.description}>Use a Maven repository as a proxy for Ballerina Central.</p>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/next.config.js
+++ b/next.config.js
@@ -285,6 +285,10 @@ const nextConfig = {
         destination: `/${redirectBase}learn/development-tutorials/ballerina-central/configure-a-network-proxy`,
       },
       {
+        source: `/${redirectBase}learn/proxy-ballerina-central-with-maven-repository`,
+        destination: `/${redirectBase}learn/development-tutorials/ballerina-central/proxy-ballerina-central-with-maven-repository`,
+      },
+      {
         source: `/${redirectBase}learn/code-to-cloud-deployment`,
         destination: `/${redirectBase}learn/development-tutorials/run-in-the-cloud/code-to-cloud-deployment`,
       },

--- a/swan-lake/development-tutorials/ballerina-central/proxy-ballerina-central-with-maven-repository.md
+++ b/swan-lake/development-tutorials/ballerina-central/proxy-ballerina-central-with-maven-repository.md
@@ -1,0 +1,103 @@
+---
+layout: proxy-ballerina-central-with-maven-repository-left-nav-pages-swanlake
+title: Proxy Ballerina Central with a Maven Repository
+description: Organizations use repository managers such as Nexus or Artifactory to serve as a caching proxy for a remotely managed repository. The sections below include information about configuring such caching proxy for Ballerina Central.
+keywords: ballerina, programming language, ballerina packages, proxy alternative, caching proxy, ballerina central proxy
+permalink: /learn/proxy-ballerina-central-with-maven-repository/
+active: publish-packages-to-ballerina-central
+intro: Organizations use repository managers such as Nexus or Artifactory to serve as a caching proxy for a remotely managed repository. The sections below include information about configuring such caching proxy for Ballerina Central.
+---
+
+## Setting up the repository
+
+The organization should have a repository manager hosted on-premises or in the cloud with the following requirements satisfied.
+
+- Should support Maven repository format
+- Should support caching proxy repositories
+- Should support flexible MIME types
+
+Both JFrog Artifactory and Sonatype Nexus have been tested and verified against the above requirements. The sections below describe how to configure each of them.
+
+### Configure Sonatype Nexus
+
+Follow the steps below to configure a Maven proxy repository in Sonatype Nexus that points to Ballerina Central.
+
+1. Log in to your Nexus Repository Manager as an administrator.
+
+2. Navigate to **Settings → Repository → Repositories** and click **Create repository**.
+
+3. Select **maven2 (proxy)** as the recipe.
+
+4. Fill in the repository details.
+
+   | Field | Value |
+   | --- | --- |
+   | **Name** | A unique name for the repository (e.g., `ballerina-central-proxy`) |
+   | **Remote storage** | `https://api.central.ballerina.io/2.0/maven` |
+
+5. Under the **Maven 2** section, ensure **Strict Content Type Validation** is **disabled** (unchecked). Ballerina Central serves `.bala` package artifacts alongside customized Maven metadata, and enabling strict content type validation will cause downloads to fail for non-standard MIME types.
+
+6. Under the **Proxy** section, set **Maximum metadata age** to a low value such as `1` minute. This ensures that newly published packages in Ballerina Central are discovered promptly without waiting for a long metadata cache expiry.
+
+   > **Note:** Setting **Maximum metadata age** to `0` forces Nexus to re-fetch metadata on every request, which may increase latency. A value between `1` and `5` minutes is a good balance between freshness and performance.
+
+7. Click **Create repository** to save the configuration.
+
+8. Copy the repository URL displayed on the repository list page. You will use it when configuring the Ballerina client.
+
+### Configure JFrog Artifactory
+
+Follow the steps below to configure a Maven remote repository in JFrog Artifactory that proxies Ballerina Central.
+
+1. Log in to your Artifactory instance as an administrator.
+
+2. Navigate to **Administration → Repositories** and click **Create a Repository**, then select **Remote**.
+
+3. Select **Maven** as the package type.
+
+4. Fill in the repository details.
+
+   | Field | Value |
+   | --- | --- |
+   | **Repository Key** | A unique key for the repository (e.g., `ballerina-central-remote`) |
+   | **URL** | `https://api.central.ballerina.io/2.0/maven` |
+
+5. Under the **Advanced** tab, apply the following settings.
+
+   - **Block Mismatching MIME Types** — Ensure this is **disabled**. Ballerina Central serves `.bala` artifacts that do not conform to standard Maven MIME types. Enabling this option will cause artifact retrieval to fail.
+
+   - **Bypass HEAD Requests** — Ensure this is **enabled**. Ballerina Central does not fully support HTTP `HEAD` requests for all artifact paths. Enabling this bypass ensures that Artifactory falls back to a `GET` request when a `HEAD` request fails, preventing resolution errors.
+
+   - **Metadata Retrieval Cache Period** — Set this to a low value such as `60` seconds. This controls how long Artifactory caches repository metadata before re-fetching it from the remote. A lower value ensures that newly published packages in Ballerina Central become available in your proxy repository sooner.
+
+     > **Note:** Setting **Metadata Retrieval Cache Period** to `0` disables caching entirely and fetches metadata on every request, which may impact performance. A value between `60` and `300` seconds is a reasonable balance between freshness and performance.
+
+6. Click **Save & Finish** to create the repository.
+
+7. Copy the repository URL from the **Artifacts** view. You will use it when configuring the Ballerina client.
+
+## Setting up the Ballerina client
+
+You can configure only one proxy repository in the `<USER_HOME>/.ballerina/Settings.toml` file to use in place of Ballerina Central. A typical configuration looks like the following.
+
+```toml
+[[repository.maven]]
+id = "<repository-id>"        # This ID is used when pushing/pulling packages
+url = "<repository-url>"
+username = "<username>/<userId>"
+accesstoken = "<password>/<accesstoken>"
+proxyCentral = true
+```
+
+Replace the placeholders as follows.
+
+| Placeholder | Description |
+| --- | --- |
+| `<repository-id>` | A unique identifier for the repository entry (e.g., `nexus-ballerina-proxy` or `artifactory-ballerina-proxy`) |
+| `<repository-url>` | The full URL of the proxy repository you created in Nexus or Artifactory |
+| `<username>/<userId>` | Your Nexus or Artifactory username or user ID |
+| `<password>/<accesstoken>` | Your Nexus or Artifactory password or access token |
+
+Once the configuration is done, all Ballerina Central calls will be redirected through this Maven-based proxy repository.
+
+> **Note:** Only one `[[repository.maven]]` entry with `proxyCentral = true` is allowed at a time. If multiple entries have `proxyCentral = true`, the Ballerina will return an error.

--- a/swan-lake/development-tutorials/ballerina-central/proxy-ballerina-central-with-maven-repository.md
+++ b/swan-lake/development-tutorials/ballerina-central/proxy-ballerina-central-with-maven-repository.md
@@ -1,22 +1,22 @@
 ---
-layout: proxy-ballerina-central-with-maven-repository-left-nav-pages-swanlake
+layout: ballerina-proxy-ballerina-central-with-maven-repository-left-nav-pages-swanlake
 title: Proxy Ballerina Central with a Maven Repository
-description: Organizations use repository managers such as Nexus or Artifactory to serve as a caching proxy for a remotely managed repository. The sections below include information about configuring such caching proxy for Ballerina Central.
+description: Organizations use repository managers such as JFrog Artifactory or Sonatype Nexus to serve as a caching proxy for a remotely managed repository. The sections below include information about configuring such a caching proxy for Ballerina Central.
 keywords: ballerina, programming language, ballerina packages, proxy alternative, caching proxy, ballerina central proxy
 permalink: /learn/proxy-ballerina-central-with-maven-repository/
-active: publish-packages-to-ballerina-central
-intro: Organizations use repository managers such as Nexus or Artifactory to serve as a caching proxy for a remotely managed repository. The sections below include information about configuring such caching proxy for Ballerina Central.
+active: proxy-ballerina-central-with-maven-repository
+intro: Organizations use repository managers such as [JFrog Artifactory](https://jfrog.com/artifactory/) or [Sonatype Nexus](https://www.sonatype.com/products/sonatype-nexus-repository) to serve as a caching proxy for a remotely managed repository. The sections below include information about configuring such a caching proxy for Ballerina Central.
 ---
 
 ## Setting up the repository
 
 The organization should have a repository manager hosted on-premises or in the cloud with the following requirements satisfied.
 
-- Should support Maven repository format
-- Should support caching proxy repositories
-- Should support flexible MIME types
+- Support for Maven repository format
+- Support for caching proxy repositories
+- Support for flexible MIME types
 
-Both JFrog Artifactory and Sonatype Nexus have been tested and verified against the above requirements. The sections below describe how to configure each of them.
+Both [JFrog Artifactory](https://jfrog.com/artifactory/) and [Sonatype Nexus](https://www.sonatype.com/products/sonatype-nexus-repository) have been tested and verified against the above requirements. The sections below describe how to configure each of them.
 
 ### Configure Sonatype Nexus
 
@@ -84,8 +84,8 @@ You can configure only one proxy repository in the `<USER_HOME>/.ballerina/Setti
 [[repository.maven]]
 id = "<repository-id>"        # This ID is used when pushing/pulling packages
 url = "<repository-url>"
-username = "<username>/<userId>"
-accesstoken = "<password>/<accesstoken>"
+username = "<username> or <userId>"
+accesstoken = "<password> or <accesstoken>"
 proxyCentral = true
 ```
 
@@ -95,9 +95,9 @@ Replace the placeholders as follows.
 | --- | --- |
 | `<repository-id>` | A unique identifier for the repository entry (e.g., `nexus-ballerina-proxy` or `artifactory-ballerina-proxy`) |
 | `<repository-url>` | The full URL of the proxy repository you created in Nexus or Artifactory |
-| `<username>/<userId>` | Your Nexus or Artifactory username or user ID |
-| `<password>/<accesstoken>` | Your Nexus or Artifactory password or access token |
+| `<username> or <userId>` | Your Nexus or Artifactory username or user ID |
+| `<password> or <accesstoken>` | Your Nexus or Artifactory password or access token |
 
 Once the configuration is done, all Ballerina Central calls will be redirected through this Maven-based proxy repository.
 
-> **Note:** Only one `[[repository.maven]]` entry with `proxyCentral = true` is allowed at a time. If multiple entries have `proxyCentral = true`, the Ballerina will return an error.
+> **Note:** Only one `[[repository.maven]]` entry with `proxyCentral = true` is allowed at a time. If multiple entries have `proxyCentral = true`, Ballerina will return an error.

--- a/utils/learn-lm.json
+++ b/utils/learn-lm.json
@@ -839,7 +839,7 @@
                             "id": "configure-a-network-proxy"
                         },
                         {
-                            "dirName": "Proxy Ballerina Central with a Maven repository",
+                            "dirName": "Proxy Ballerina Central with a Maven Repository",
                             "level": 3,
                             "position": 3,
                             "isDir": false,

--- a/utils/learn-lm.json
+++ b/utils/learn-lm.json
@@ -837,6 +837,14 @@
                             "isDir": false,
                             "url": "/learn/configure-a-network-proxy",
                             "id": "configure-a-network-proxy"
+                        },
+                        {
+                            "dirName": "Proxy Ballerina Central with a Maven repository",
+                            "level": 3,
+                            "position": 3,
+                            "isDir": false,
+                            "url": "/learn/proxy-ballerina-central-with-maven-repository",
+                            "id": "proxy-ballerina-central-with-maven-repository"
                         }
                     ]
                 },


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Related https://github.com/ballerina-platform/ballerina-lang/issues/44464

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request adds documentation and site updates to document how to configure an on-premises or cloud Maven repository as a caching proxy for Ballerina Central, and includes a documentation checklist template for page lifecycle changes.

### Changes

- Documentation page
  - Added new page swan-lake/development-tutorials/ballerina-central/proxy-ballerina-central-with-maven-repository.md covering:
    - prerequisites for using a Maven repository as a proxy for Ballerina Central
    - step-by-step configuration for Sonatype Nexus and JFrog Artifactory (repository creation, MIME/type handling, caching metadata)
    - Ballerina client configuration via <USER_HOME>/.ballerina/Settings.toml with a sample [[repository.maven]] entry using proxyCentral = true
    - constraint that only one [[repository.maven]] entry may set proxyCentral = true and related error behavior
  - Added a documentation checklist template describing steps for adding, removing, renaming, and restructuring pages (checklist items initially unchecked).

- Navigation and routing
  - Updated utils/learn-lm.json to add a "Proxy Ballerina Central with a Maven Repository" entry under "Reuse code with Ballerina Central".
  - Added a discovery link in components/learn/boxes/Boxes.js to surface the new page in the "Reuse code with Ballerina Central" card.
  - Added a rewrite in next.config.js mapping the legacy/short route to the new documentation path.

### Outcome

Provides structured guidance for operators to deploy a Maven proxy for Ballerina Central and updates site navigation and routing to expose the new content, improving discoverability and support for offline or restricted-network package distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->