### PR TITLE
Improve xml-access BBE description and add missing keywords

### DIFF
--- a/swan-lake/by-example/xml-access/content.jsx
+++ b/swan-lake/by-example/xml-access/content.jsx
@@ -46,7 +46,7 @@ export function XmlAccess({ codeSnippets }) {
     <Container className="bbeBody d-flex flex-column h-100">
       <h1>XML access</h1>
 
-      <p>It is possible to access elements in XML.</p>
+      <p>It is possible to access both elements and attributes in XML. The x[i] syntax retrieves the i-th item in the XML sequence. The x.id syntax accesses a required attribute, while x?.id accesses an optional attribute. The lang.xml langlib provides the other operations.</p>
 
       <ul style={{ marginLeft: "0px" }}>
         <li>

--- a/swan-lake/by-example/xml-access/liquid.json
+++ b/swan-lake/by-example/xml-access/liquid.json
@@ -7,7 +7,9 @@
     "bbe",
     "xml data model",
     "xml",
-    "get element"
+    "get element",
+    "attribute access",
+    "optional attribute"
   ],
   "permalink": "/learn/by-example/xml-access/",
   "active": "xml-access"


### PR DESCRIPTION
## Purpose
Fixes #10233

Improved the xml-access BBE description to clearly reflect 
both element and attribute access. The original description 
only mentioned element access, which was misleading since 
the example also demonstrates attribute access using x.id 
and x?.id syntax. Also added missing keywords to liquid.json.

## Checklist
- [ ] (none applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request improves the XML access "By Example" (BBE) documentation to better reflect the full scope of supported operations.

### Changes Made

**Documentation Update (content.jsx)**
- Enhanced the XML access section description to comprehensively cover both element and attribute access operations
- Explicitly documents the `x[i]` syntax for sequence indexing
- Clarifies required attribute access (`x.id`) with its error semantics when attributes are missing or the XML value isn't a singleton
- Documents optional attribute access (`x?.id`) which returns `()` when missing
- Reinforces references to the `lang.xml` module for additional operations

**Metadata Enhancement (liquid.json)**
- Added two missing keywords to improve search and discoverability: `"attribute access"` and `"optional attribute"`
- Complements the existing `"get element"` keyword

### Outcome

These changes improve documentation clarity and alignment between the example description and actual usage patterns, while enhancing searchability through comprehensive keyword coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->