### PR TITLE
Add 2201.13.4 release note

### DIFF
--- a/_data/swanlake-latest/metadata.json
+++ b/_data/swanlake-latest/metadata.json
@@ -1,23 +1,23 @@
 {
-    "version":"2201.13.3",
-    "short-version":"2201.13.3",
-    "display-version":"2201.13.3 (Swan Lake Update 13)",
-    "release-date":"2026-04-20",
-    "windows-installer":"ballerina-2201.13.3-swan-lake-windows-x64.msi",
-    "windows-installer-size":"271mb",
-    "linux-installer":"ballerina-2201.13.3-swan-lake-linux-x64.deb",
-    "linux-installer-size":"306mb",
-    "linux-arm-installer":"ballerina-2201.13.3-swan-lake-linux-arm-x64.deb",
-    "linux-arm-installer-size":"305mb",
-    "macos-installer":"ballerina-2201.13.3-swan-lake-macos-x64.pkg",
-    "macos-installer-size":"345mb",
-    "macos-arm-installer":"ballerina-2201.13.3-swan-lake-macos-arm-x64.pkg",
-    "macos-arm-installer-size":"344mb",
-    "rpm-installer":"ballerina-2201.13.3-swan-lake-linux-x64.rpm",
-    "rpm-installer-size":"347mb",
-    "other-artefacts":[
-        "ballerina-2201.13.3-swan-lake.zip"
-    ],
-    "api-docs":"ballerina-api-docs-2201.13.3.zip",
-    "release-notes":"ballerina-release-notes-2201.13.3.md"
+	"version":"2201.13.4",
+	"short-version":"2201.13.4",
+	"display-version":"2201.13.4 (Swan Lake Update 13)",
+	"release-date":"2026-05-09",
+	"windows-installer":"ballerina-2201.13.4-swan-lake-windows-x64.msi",
+	"windows-installer-size":"272mb",
+	"linux-installer":"ballerina-2201.13.4-swan-lake-linux-x64.deb",
+	"linux-installer-size":"306mb",
+	"linux-arm-installer":"ballerina-2201.13.4-swan-lake-linux-arm-x64.deb",
+	"linux-arm-installer-size":"305mb",
+	"macos-installer":"ballerina-2201.13.4-swan-lake-macos-x64.pkg",
+	"macos-installer-size":"345mb",
+	"macos-arm-installer":"ballerina-2201.13.4-swan-lake-macos-arm-x64.pkg",
+	"macos-arm-installer-size":"344mb",
+	"rpm-installer":"ballerina-2201.13.4-swan-lake-linux-x64.rpm",
+	"rpm-installer-size":"347mb",
+	"other-artefacts":[
+		"ballerina-2201.13.4-swan-lake.zip"
+ 	],
+	"api-docs":"ballerina-api-docs-2201.13.4.zip",
+	"release-notes":"ballerina-release-notes-2201.13.4.md"
 }

--- a/_data/swanlake_release_notes_versions.json
+++ b/_data/swanlake_release_notes_versions.json
@@ -2047,6 +2047,29 @@
   ],
   "api-docs":"ballerina-api-docs-2201.13.2.zip",
   "release-notes":"ballerina-release-notes-2201.13.2.md"
+},
+{
+  "version":"2201.13.3",
+  "short-version":"2201.13.3",
+  "display-version":"2201.13.3 (Swan Lake Update 13)",
+  "release-date":"2026-04-20",
+  "windows-installer":"ballerina-2201.13.3-swan-lake-windows-x64.msi",
+  "windows-installer-size":"271mb",
+  "linux-installer":"ballerina-2201.13.3-swan-lake-linux-x64.deb",
+  "linux-installer-size":"306mb",
+  "linux-arm-installer":"ballerina-2201.13.3-swan-lake-linux-arm-x64.deb",
+  "linux-arm-installer-size":"305mb",
+  "macos-installer":"ballerina-2201.13.3-swan-lake-macos-x64.pkg",
+  "macos-installer-size":"345mb",
+  "macos-arm-installer":"ballerina-2201.13.3-swan-lake-macos-arm-x64.pkg",
+  "macos-arm-installer-size":"344mb",
+  "rpm-installer":"ballerina-2201.13.3-swan-lake-linux-x64.rpm",
+  "rpm-installer-size":"347mb",
+  "other-artefacts":[
+    "ballerina-2201.13.3-swan-lake.zip"
+  ],
+  "api-docs":"ballerina-api-docs-2201.13.3.zip",
+  "release-notes":"ballerina-release-notes-2201.13.3.md"
 }
 
 ]

--- a/downloads/swan-lake-release-notes/swan-lake-2201.13.4/RELEASE_NOTE.md
+++ b/downloads/swan-lake-release-notes/swan-lake-2201.13.4/RELEASE_NOTE.md
@@ -1,0 +1,28 @@
+---
+layout: ballerina-left-nav-release-notes
+title: Swan Lake Update 13 (2201.13.4)
+permalink: /downloads/swan-lake-release-notes/2201.13.4/
+active: 2201.13.4
+---
+
+## Overview of Ballerina Swan Lake Update 13 (2201.13.4)
+
+<em>Swan Lake Update 13 (2201.13.4) is the fourth patch release of Ballerina 2201.13.0 (Swan Lake Update 13) and includes a new set of bug fixes to the compiler and runtime. It also includes a few security improvements.</em>
+
+## Update Ballerina
+
+Run the command below to update your current Ballerina installation directly to 2201.13.4 by using the [Ballerina Update Tool](/learn/update-tool/).
+
+```
+$ bal dist pull 2201.13.4
+```
+
+## Install Ballerina
+
+If you have not installed Ballerina, then, download the [installers](/downloads/#swanlake) to install.
+
+## Language updates
+
+### Bug fixes
+
+To view bug fixes, see the [GitHub milestone for Swan Lake Update 13 (2201.13.4)](https://github.com/ballerina-platform/ballerina-lang/milestone/203?closed=1).

--- a/utils/archived-lm.json
+++ b/utils/archived-lm.json
@@ -23,6 +23,14 @@
                     "id": "swan-lake-api-docs"
                 },
                 {
+                  "dirName": "2201.13.3",
+                  "level": 2,
+                  "position": 1,
+                  "isDir": false,
+                  "url": "#2201.13.3",
+                  "id": "2201.13.3v"
+                },
+                {
                   "dirName": "2201.13.2",
                   "level": 2,
                   "position": 1,

--- a/utils/rl.json
+++ b/utils/rl.json
@@ -23,6 +23,14 @@
                     "id": "swan-lake-2201.13",
                     "subDirectories": [
                         {
+                          "dirName": "2201.13.4 (Swan Lake Update 13)",
+                          "level": 3,
+                          "position": 1,
+                          "isDir": false,
+                          "url": "/downloads/swan-lake-release-notes/swan-lake-2201.13.4",
+                          "id": "swan-lake-2201.13.4"
+                        },
+                        {
                           "dirName": "2201.13.3 (Swan Lake Update 13)",
                           "level": 3,
                           "position": 1,


### PR DESCRIPTION
## Purpose
Add release notes and metadata for Ballerina Swan Lake version 2201.13.4.

## Changes

- Updated `_data/swanlake-latest/metadata.json` from 2201.13.3 to 2201.13.4
- Added 2201.13.3 entry to `_data/swanlake_release_notes_versions.json`
- Created `downloads/swan-lake-release-notes/swan-lake-2201.13.4/RELEASE_NOTE.md`
- Added 2201.13.3 archived entry to `utils/archived-lm.json`
- Added 2201.13.4 navigation entry to `utils/rl.json`

GitHub milestone: https://github.com/ballerina-platform/ballerina-lang/milestone/203?closed=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request adds release notes and metadata for Ballerina Swan Lake version 2201.13.4 (Update 13), the fourth patch release from 2201.13.0.

## Changes

**Metadata Updates:**
- Updated `_data/swanlake-latest/metadata.json` to reflect the new 2201.13.4 release, including version identifiers, release date, and all platform-specific installer filenames and sizes (Windows MSI, Linux DEB/ARM DEB, macOS PKG, Linux RPM, and additional artifacts).

**Release Documentation:**
- Created a new release note document for 2201.13.4 with instructions for updating via `bal dist pull 2201.13.4` and references to related language bug fixes.

**Version Tracking:**
- Added 2201.13.3 to the release notes versions index (`_data/swanlake_release_notes_versions.json`) with complete metadata for that release.
- Added 2201.13.3 as an archived version entry to `utils/archived-lm.json` for historical reference.
- Added navigation entry for 2201.13.4 to `utils/rl.json` to enable access to the release notes.

## Impact

These changes enable users to access release notes and download instructions for Swan Lake 2201.13.4 while maintaining proper version history and navigation structures for the documentation site.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-dev-website/pull/10307)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->