### PR TITLE
Add org restriction to workspace doc

### DIFF
--- a/swan-lake/development-tutorials/source-code-dependencies/workspaces.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/workspaces.md
@@ -102,6 +102,8 @@ public function main() {
 }
 ```
 
+>**Note:** Workspaces do not support multiple organizations. If packages in the workspace declare different organizations, the workspace defaults to a single organization.
+
 ## Dependency resolution in workspaces
 
 When working with workspaces, the dependency resolution algorithm prioritizes workspace packages over the distribution and Ballerina Central repositories. By default, package imports are searched within the workspace first. If a matching package is found in the workspace, the resolution request is not sent to other repositories. Only if the package is not available in the workspace will the resolver search in the distribution and Ballerina Central repositories.


### PR DESCRIPTION
## Purpose
> Add org restriction to workspace doc

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Added documentation to the workspace guidance clarifying that Ballerina workspaces enforce organization restrictions by supporting only a single organization. When packages within a workspace declare different organizations, the workspace defaults to a single organization. This change improves clarity around workspace configuration constraints and helps developers understand platform limitations when managing packages across multiple organizational contexts.

**Changes:**
- Added explanatory note to the "Import packages from the same workspace" section in the workspace documentation
- 2 lines added

**Impact:** Documentation-only change providing clearer guidance on workspace organization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-dev-website/pull/10314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->