### PR TITLE
Update the workspaces doc

### DIFF
--- a/swan-lake/development-tutorials/source-code-dependencies/workspaces.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/workspaces.md
@@ -88,6 +88,8 @@ The workspace configuration is automatically updated to include the new package:
 packages = ["hello-app", "utils"]
 ```
 
+>**Note:** Workspaces do not support multiple organizations. If packages in the workspace declare different organizations, the workspace defaults to a single organization.
+
 ## Import packages from the same workspace
 
 You can import and use modules from other packages in the workspace using standard import statements. The packages are resolved automatically from the workspace without needing to publish them to a repository.
@@ -101,8 +103,6 @@ public function main() {
     string result = utils:sanitize("sample data !");
 }
 ```
-
->**Note:** Workspaces do not support multiple organizations. If packages in the workspace declare different organizations, the workspace defaults to a single organization.
 
 ## Dependency resolution in workspaces
 


### PR DESCRIPTION
## Purpose
> Update the workspaces doc

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the workspaces documentation by relocating a note regarding workspace organization limitations. The note clarifying that workspaces do not support multiple organizations was moved from the "Import packages from the same workspace" section to the "Add packages to the workspace" section to improve documentation clarity and ensure readers encounter this important constraint at the most relevant point in the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/ballerina-dev-website/pull/10316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->