### PR TITLE
Fix typos in ProductReceived handling

### DIFF
--- a/pages/learn/integration/pre-built-integrations/mysql-to-salesforce-integration.js
+++ b/pages/learn/integration/pre-built-integrations/mysql-to-salesforce-integration.js
@@ -45,7 +45,7 @@ type Product record {
     string CurrencyIsoCode;
 };
 
-type ProductRecieved record {
+type ProductReceived record {
     string name;
     string unitType;
     string currencyISO;
@@ -74,19 +74,19 @@ sf:Client salesforce = check new ({
 
 public function main() returns error? {
     mysql:Client mysql = check new (host, user, password, database, port);
-    stream<ProductRecieved, error?> streamOutput = mysql->query(
+    stream<ProductReceived, error?> streamOutput = mysql->query(
         \`SELECT name, unitType, currencyISO, productId FROM products WHERE processed = false\`);
-    ProductRecieved[] productsRecieved = check from ProductRecieved items in streamOutput
+    ProductReceived[] productsReceived = check from ProductReceived items in streamOutput
         select items;
-    foreach ProductRecieved prductRecieved in productsRecieved {
+    foreach ProductReceived productReceived in productsReceived {
         Product product = {
-            Name: prductRecieved.name,
-            Product_Unit__c: prductRecieved.unitType,
-            CurrencyIsoCode: prductRecieved.currencyISO
+            Name: productReceived.name,
+            Product_Unit__c: productReceived.unitType,
+            CurrencyIsoCode: productReceived.currencyISO
         };
         _ = check salesforce->create("Product2", product);
         _ = check mysql->execute(
-            \`UPDATE products SET processed = true WHERE productId = \${prductRecieved.productId}\`);
+            \`UPDATE products SET processed = true WHERE productId = \${productReceived.productId}\`);
     }
 }
   


### PR DESCRIPTION
## Purpose

Fix a typo in the MySQL to Salesforce integration example code.

The variable name `prductReceived` was misspelled and has been renamed to `productReceived` for consistency and readability.

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request corrects spelling errors in the embedded Ballerina example code for the MySQL to Salesforce integration documentation page. The record type name and associated variable names were updated from their misspelled versions to use consistent, correct naming conventions (`ProductReceived`, `productsReceived`, `productReceived`). These corrections improve code clarity and ensure the example code reflects proper naming standards throughout the streaming query and foreach loop logic.

**File modified:**
- `pages/learn/integration/pre-built-integrations/mysql-to-salesforce-integration.js`

**Changes:** Lines changed: +8/-8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->