### PR TITLE
Fix typo: covdiEntry → covidEntry in RESTful API guide

### DIFF
--- a/swan-lake/resources/featured-scenarios/write-a-restful-api-with-ballerina.md
+++ b/swan-lake/resources/featured-scenarios/write-a-restful-api-with-ballerina.md
@@ -149,7 +149,7 @@ resource function post countries(@http:Payload CovidEntry[] covidEntries)
             }
         };
     } else {
-        covidEntries.forEach(covdiEntry => covidTable.add(covdiEntry));
+        covidEntries.forEach(covidEntry => covidTable.add(covidEntry));
         return covidEntries;
     }
 }
@@ -248,7 +248,7 @@ service /covid/status on new http:Listener(9000) {
                 }
             };
         } else {
-            covidEntries.forEach(covdiEntry => covidTable.add(covdiEntry));
+            covidEntries.forEach(covidEntry => covidTable.add(covidEntry));
             return covidEntries;
         }
     }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request corrects a typo in code examples within the RESTful API with Ballerina guide documentation. The variable name `covdiEntry` has been corrected to the proper spelling `covidEntry` throughout code snippets that demonstrate processing COVID-19 entry records in a database table. The corrections appear in query expressions and iteration operations within the guide's example resource implementation sections.

## Changes

- **File modified:** `swan-lake/resources/featured-scenarios/write-a-restful-api-with-ballerina.md`
- **Type:** Documentation typo correction
- **Scope:** Code example corrections applied in two locations (standalone resource example and complete code section)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->