### PR TITLE
Fix persist tutorial examples for in-memory datastore

### DIFF
--- a/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
+++ b/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
@@ -206,10 +206,29 @@ import rainier.store;
 import ballerina/persist;
 
 
-final store:Client sClient = check new ();
+final store:Client sClient = check new();
 
 
 public function main() returns error? {
+   store:EmployeeInsert employee1 = {
+       id: "emp_01",
+       firstName: "John",
+       lastName: "Doe",
+       email: "johnd@xyz.com",
+       phone: "1234567890",
+       hireDate: {
+           year: 2020,
+           month: 10,
+           day: 10
+       },
+       managerId: "mng_01",
+       jobTitle: "Software Engineer"
+   };
+
+
+   string[] employeeIds = check sClient->/employees.post([employee1]);
+   io:println("Inserted employee id: " + employeeIds[0]);
+
    // Get the complete `Employee` record.
    stream<store:Employee, persist:Error?> employees = sClient->/employees;
    check from var employee in employees
@@ -225,7 +244,6 @@ public function main() returns error? {
            io:println(name);
        };
 }
-
 
 type EmployeeName record {|
    string id;

--- a/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
+++ b/swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md
@@ -198,7 +198,7 @@ This creates the first database record with the client API. The next sections de
 
 Let’s try to fetch all the records inserted into the database. The client API offers the `get` resource method, which returns a stream of the return type. The return type can be either a complete `Employee` record or a custom record with a subset of fields.
 
-Replace the previous code and add the new `get` call instead.
+Note: This guide uses an in-memory datastore, which does not persist data between application runs. Each of the following examples either includes the insert operation (as shown here) or assumes the employee record from earlier steps exists. To reproduce these examples, either run all operations in a single bal run or re-insert the employee in each example.
 
 ```ballerina
 import ballerina/io;


### PR DESCRIPTION
## Summary

This PR clarifies the behavior of the `inmemory` datastore used in the "Manage data persistence with bal persist" guide.

## Issue

The guide generates the client using:

```bash
bal persist generate --datastore inmemory --module store
```

The first example inserts an employee record and then terminates.

Subsequent sections instruct users to replace the previous code and run the application again while showing outputs that assume the previously inserted employee record still exists.

However, because the guide uses the in-memory datastore, all data is lost when the application exits. Each `bal run` starts with a new empty datastore.

## Changes

* Added clarification that data is not persisted between application runs when using the in-memory datastore.
* Clarified that the later examples assume the employee record already exists or that the insert operation is executed in the same application run.

## Why

This helps readers understand the behavior of the in-memory datastore and prevents confusion when reproducing the examples locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Updated the “Manage data persistence with bal persist” tutorial documentation to fix confusing example behavior for the in-memory datastore. The guide now clarifies that in-memory data is not retained between separate application runs, and adjusts the “Retrieve all `Employee` records” example so readers either insert the required record within the same run or understand the prerequisite that the record already exists.

## Changes Made

- **File**: `swan-lake/resources/featured-scenarios/manage-data-persistence-with-bal-persist.md`
- **Scope**: Documentation update (clarifying in-memory datastore lifecycle and updating example code/ordering and explanatory notes to match that behavior)
- **Line changes**: +21/-3
<!-- end of auto-generated comment: release notes by coderabbit.ai -->