### PR TITLE
Add AI coding assistants documentation page

### DIFF
--- a/components/learn/boxes/Boxes.js
+++ b/components/learn/boxes/Boxes.js
@@ -250,6 +250,14 @@ export default function Boxes(props) {
                         </p>
                         <p className={styles.description}>Features of the Ballerina Visual Studio Code extension.</p>
                       </div>
+                      <div className={styles.content}>
+                        <p className={styles.title}>
+                          <a href={`${prefix}/learn/ai-coding-assistants/`} className={styles.titleLink}>
+                            AI coding assistants
+                          </a>
+                        </p>
+                        <p className={styles.description}>Give AI coding assistants the context and tooling to write real Ballerina.</p>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/pages/learn/ai-coding-assistants/index.js
+++ b/pages/learn/ai-coding-assistants/index.js
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC (http://www.wso2.com) All Rights Reserved.
+ *
+ * WSO2 LLC licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import fs from "fs";
+import matter from "gray-matter";
+import React from "react";
+import { Container, Col } from "react-bootstrap";
+import Image from "next-image-export-optimizer";
+import Head from "next/head";
+import Link from "next/link";
+
+import Layout from "../../../layouts/LayoutDocs";
+import MainContent from "../../../components/common/main-content/MainContent";
+import { prefix } from "../../../utils/prefix";
+import Toc from "../../../components/common/pg-toc/Toc";
+
+export async function getStaticProps() {
+  const fileName = fs.readFileSync(`swan-lake/ai-coding-assistants.md`, "utf-8");
+  const { data: frontmatter, content } = matter(fileName);
+  const id = "ai-coding-assistants";
+
+  return {
+    props: {
+      frontmatter,
+      content,
+      id,
+    },
+  };
+}
+
+export default function PostPage({ frontmatter, content, id }) {
+
+  // Show page toc
+  const [showToc, setShowToc] = React.useState(false);
+
+  const handleToc = (data) => {
+    setShowToc(data);
+  };
+
+  return (
+    <>
+      <Head>
+        <meta name="description" content={frontmatter.description} />
+        <meta name="keywords" content={frontmatter.keywords} />
+
+        <title>{`${frontmatter.title} - The Ballerina programming language`}</title>
+
+        {/* <!--FB--> */}
+        <meta property="og:type" content="article" />
+        <meta
+          property="og:title"
+          content={`${frontmatter.title} - The Ballerina programming language`}
+        />
+        <meta property="og:description" content={frontmatter.description}></meta>
+        <meta
+          property="og:image"
+          itemProp="image"
+          content="https://ballerina.io/images/ballerina-generic-social-media-image-2023.png"
+        />
+
+        {/* <!--LINKED IN  --> */}
+        <meta
+          property="og:title"
+          content={`${frontmatter.title} - The Ballerina programming language`}
+        />
+        <meta property="og:description" content={frontmatter.description} />
+        <meta
+          property="og:image"
+          content="https://ballerina.io/images/ballerina-generic-social-media-image-2023.png"
+        />
+
+        {/* <!--TWITTER--> */}
+        <meta
+          name="twitter:title"
+          content={`${frontmatter.title} - The Ballerina programming language`}
+        />
+        <meta property="twitter:description" content={frontmatter.description} />
+        <meta property="twitter:text:description" content={frontmatter.description} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@ballerinalang" />
+        <meta name="twitter:creator" content="@ballerinalang" />
+        <meta
+          name="twitter:image"
+          content="https://ballerina.io/images/ballerina-generic-social-media-image-2023.png"
+        />
+      </Head>
+      <Layout>
+        <Col sm={3} xxl={2} className="leftNav d-none d-sm-block">
+          <Link href="/learn/" passHref>
+            <div className="backToLanding">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="30"
+                height="30"
+                fill="#3ad1ca"
+                className="bi bi-box-arrow-left ms-0"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M6 12.5a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-9a.5.5 0 0 0-.5-.5h-8a.5.5 0 0 0-.5.5v2a.5.5 0 0 1-1 0v-2A1.5 1.5 0 0 1 6.5 2h8A1.5 1.5 0 0 1 16 3.5v9a1.5 1.5 0 0 1-1.5 1.5h-8A1.5 1.5 0 0 1 5 12.5v-2a.5.5 0 0 1 1 0v2z"
+                />
+                <path
+                  fillRule="evenodd"
+                  d="M.146 8.354a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L1.707 7.5H10.5a.5.5 0 0 1 0 1H1.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3z"
+                />
+              </svg>
+              <p className="m-0 p-0">Back to Learn</p>
+            </div>
+          </Link>
+        </Col>
+        <Col xs={12} sm={7} xxl={7} className="mdContent">
+          <Container>
+            <div className="topRow">
+              <Col xs={11}>
+                <h1>{frontmatter.title}</h1>
+              </Col>
+              <Col xs={1} className="gitIcon">
+                <a
+                  href={`${process.env.gitHubPath}swan-lake/ai-coding-assistants.md`}
+                  target="_blank"
+                  rel="noreferrer"
+                  title="Edit in GitHub"
+                >
+                  <Image
+                    src={`${prefix}/images/sm-icons/github.svg`}
+                    height={20}
+                    width={20}
+                    alt="Edit in GitHub"
+                  />
+                </a>
+              </Col>
+            </div>
+
+            <p className="intro">{frontmatter.intro}</p>
+
+            <MainContent content={content} handleToc={handleToc} />
+          </Container>
+        </Col>
+        <Col sm={2} xxl={3} className="pageToc d-none d-sm-block">
+          {showToc ? (
+            <>
+              <h6>On this page</h6>
+              <Toc source={content} />
+            </>
+          ) : null}
+        </Col>
+      </Layout>
+    </>
+  );
+}

--- a/swan-lake/ai-coding-assistants.md
+++ b/swan-lake/ai-coding-assistants.md
@@ -1,0 +1,74 @@
+---
+title: AI coding assistants
+description: The Ballerina agent skills give an AI coding assistant the context, live library data, and language tooling it needs to write real Ballerina.
+keywords: ballerina, ai coding assistant, agent skills, claude code, plugin, mcp, language server, ballerina central
+intro: The Ballerina agent skills give an AI coding assistant the context, live library data, and language tooling it needs to write, build, run, and test Ballerina. The coding skill works in any agent that supports skills, and a companion plugin adds library discovery, the language server, and automatic activation.
+---
+
+The Ballerina agent skills are open source and distributed in two forms:
+
+- A **coding skill** that works in any agent that supports agent skills.
+- A **plugin** that bundles the coding skill with library discovery over MCP, the Ballerina Language Server, and activation hooks.
+
+Both are maintained in the [`ballerina-platform/skills`](https://github.com/ballerina-platform/skills) repository under the Apache 2.0 license.
+
+## Prerequisites
+
+- [Ballerina](https://ballerina.io/downloads/) 2201.12.0 (Swan Lake Update 12) or later, with `bal` available on the `PATH`.
+- Node.js 18 or later, required by the bundled library-discovery server.
+
+## Install in Claude Code
+
+Follow the steps below to install the plugin.
+
+1. Register the marketplace and install the plugin.
+
+    ```
+    /plugin marketplace add ballerina-platform/skills
+    /plugin install ballerina@ballerina-skills
+    ```
+
+2. Restart the session to activate the language server, the `ballerina` skill, the library-discovery agent, and the activation hooks.
+
+    >**Info:** The MCP server ships pre-built, so no `npm install` or build step is required.
+
+The skill activates automatically when a request involves Ballerina. To invoke it directly, use the `/ballerina` command.
+
+```
+/ballerina <request>
+```
+
+## Use with other agents
+
+The coding skill is portable. Install it for agents such as Codex, Cursor, Gemini CLI, and GitHub Copilot with the Open Agent Skills CLI.
+
+```
+$ npx skills add ballerina-platform/skills
+```
+
+>**Tip:** Pass `--agent <name>` to target a specific agent.
+
+This channel installs the `ballerina` skill only. The language server, the library-discovery MCP server, and the activation hooks are Claude Code plugin features. On other agents, library discovery uses the `bal search` command.
+
+## What's included
+
+The coding skill works in any agent. The plugin provides the other three components.
+
+- **Coding skill.** The assistant's working knowledge of Ballerina: the language idioms, the project structure, and the build, run, and test workflow. It applies conventions such as typed records over `json`, named arguments, and `configurable` values for external inputs, and it resolves dependencies with `bal build` instead of hand-editing `Dependencies.toml`.
+- **Library discovery.** Instead of guessing a connector's API, the assistant queries [Ballerina Central](https://central.ballerina.io) and gets back a compact summary of the package: the organization and module, the client type, and the function signatures and record shapes.
+- **Language server.** The plugin registers the Ballerina Language Server for `.bal` files, so the assistant can hover for a type or signature, go to a definition or implementation, and find references and symbols.
+- **Activation hooks.** The hooks keep the assistant anchored to the skill and route library lookups to the discovery agent, so the support engages automatically when you work in Ballerina.
+
+## How it works
+
+**Coding skill.** `SKILL.md` is a short router that links to deeper files as they are needed: the full conventions, a langlib reference, and a troubleshooting index that maps a symptom to a single page. The assistant loads detail on demand rather than holding all of it at once.
+
+**Library discovery.** The `get_library` operation fetches a package's API documentation from Ballerina Central and rewrites it as a compact Ballerina-syntax summary of types, clients, functions, and services. The discovery agent narrows a search to the most suitable package, calls `get_library`, and keeps only the signatures the task needs.
+
+**Language server.** The language server provides navigation backed by the compiler, so the assistant can confirm an API against its source while writing code. Checking for errors is a separate step: `bal build` from the command line is the source of truth, not the language server.
+
+**Activation hooks.** One hook returns the assistant to the skill when you edit or run code, and another records when the skill activates.
+
+## Learn more
+
+The skill, the code rules, and the discovery server are open source. For the full documentation, issues, and contributions, see the [`ballerina-platform/skills`](https://github.com/ballerina-platform/skills) repository.


### PR DESCRIPTION
Adds a `/learn/ai-coding-assistants/` documentation page covering the Ballerina agent skills and the plugin that provides library discovery, the Ballerina Language Server, and activation hooks.

- New content: `swan-lake/ai-coding-assistants.md`
- New page: `pages/learn/ai-coding-assistants/index.js` (follows the existing dedicated-page pattern, e.g. the VS Code extension pages)
- Links the page from the References card on the Learn landing (`components/learn/boxes/Boxes.js`)

The page follows the house documentation style (numbered install steps, Info/Tip callouts, second-person voice). Rendered and verified locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a new AI coding assistants documentation page covering Ballerina agent skills, installation, supported platforms, library discovery, language-server integration, and activation hooks.

Updates the Learn landing page with a reference link and adds a dedicated page that renders the new Markdown content with navigation, metadata, and table-of-contents support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->