### PR TITLE
Clarify why package name changes from hyphen to underscore

### DIFF
--- a/swan-lake/integration/get-started.md
+++ b/swan-lake/integration/get-started.md
@@ -34,6 +34,8 @@ $ bal new country-service
 
 This command creates a new directory named `country-service` with the following content:
 
+>**Info:** Ballerina package names can only contain alphanumerics, underscores, and periods (no hyphens). So while the directory is named `country-service`, Ballerina automatically uses `country_service` as the actual package name internally. That's why you'll see `country_service` instead of `country-service` in later command outputs.
+
 ```
 country-service/
 ├── Ballerina.toml


### PR DESCRIPTION
Ballerina package names can only contain alphanumerics, underscores and periods but not hyphens. So running `bal new country-service` creates a directory named `country-service`, but the actual package name internally becomes `country_service`.

This wasn't explained anywhere in the guide, which caused confusion when I saw `country_service` appear in later command outputs (e.g. `bal run`) despite having created `country-service`. This PR adds a short info note explaining the conversion at the point where a beginner would first notice it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the getting-started documentation to clarify Ballerina package naming rules and explain how hyphens in directory names are converted to underscores in internal package names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->