### PR TITLE
Changed String to string

### DIFF
--- a/swan-lake/development-tutorials/source-code-dependencies/organize-ballerina-code.md
+++ b/swan-lake/development-tutorials/source-code-dependencies/organize-ballerina-code.md
@@ -137,7 +137,7 @@ In a package, which has the default module containing the `main.bal` file and a 
 ```ballerina
 import hello_world.util;
 
-String formattedMsg = util:properCaseMessage("hello world!");
+string formattedMsg = util:properCaseMessage("hello world!");
 ```
 
 Since the `import-prefix` is not given, the module name `util` is used to refer to the symbols in the `hello_world.util` module. 


### PR DESCRIPTION
In the ballerina documentation, the type should be "string" in lowercase. However, this part of the documentation uses "String" with an uppercase S, which is incorrect and may cause errors when users are going through the documentation. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Corrected the Ballerina documentation example to use the valid lowercase `string` type, preventing user confusion and improving example accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->