### PR TITLE
Fix duplicated wrong responses in Health Tool CDS template generation section

### DIFF
--- a/swan-lake/integration-tools/health-tool.md
+++ b/swan-lake/integration-tools/health-tool.md
@@ -561,7 +561,7 @@ isolated function connectDecisionSystemForBookImagingCenter(cds:CdsRequest cdsRe
    ```
    $ bal run
    Compiling source
-           healthcare_samples/health.fhir.r4.uscore501.practitioner:1.0.0
+           wso2/cds_service:1.0.0
 
    Running executable
    ```
@@ -617,28 +617,47 @@ isolated function connectDecisionSystemForBookImagingCenter(cds:CdsRequest cdsRe
 
    ```json
    {
-     "resourceType": "Practitioner",
-     "identifier": [
-       {
-         "system": "http://hl7.org/fhir/sid/us-npi",
-         "use": "official",
-         "value": "1234567890"
-       }
-     ],
-     "meta": {
-       "lastUpdated": "2021-08-24T10:10:10Z",
-       "profile": [
-         "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
-       ]
-     },
-     "name": [
-       {
-         "given": ["John", "Jacob"],
-         "prefix": ["Dr."],
-         "use": "official",
-         "family": "Smith"
-       }
-     ],
-     "id": "1"
+       "cards": [
+           {
+               "summary": "Prior authorization",
+               "detail": "Obtain prior authorization to avoid claim denials and patient financial liability. Contact: For questions, reach out to the insurance provider or billing department.",
+               "indicator": "critical",
+               "source": {
+                   "label": "Static CDS Service Example",
+                   "url": "https://example.com",
+                   "icon": "https://example.com/img/icon-100px.png"
+               },
+               "suggestions": [
+                   {
+                       "label": "Kindly get pri-authorization"
+                   }
+               ],
+               "selectionBehavior": "at-most-one",
+               "links": [
+                   {
+                       "label": "Prior-auth",
+                       "url": "https://www.acmehealth.com/policies/lab-coverage",
+                       "type": "absolute"
+                   }
+               ]
+           },
+           {
+               "summary": "Alternative centers",
+               "detail": "Discuss alternative imaging centers with patients to enhance access and affordability. For assistance, reach out to the facility's scheduling department or insurance provider.",
+               "indicator": "info",
+               "source": {
+                   "label": "Static CDS Service Example",
+                   "url": "https://example.com",
+                   "icon": "https://example.com/img/icon-100px.png"
+               },
+               "suggestions": [
+                   {
+                       "label": "The selected imaging center is far away from your location. Please select nearby one. Suggested: Asiri labs : Col - 3"
+                   }
+               ],
+               "selectionBehavior": "any"
+           }
+       ],
+       "systemActions": []
    }
    ```


### PR DESCRIPTION
## Summary

Fixes #10192.

In the Health Tool documentation's "CDS template generation" section, two of the shown outputs were duplicated from the earlier "FHIR template generation" section instead of showing the actual CDS service outputs:

1. The "Run the service" compile output showed `healthcare_samples/health.fhir.r4.uscore501.practitioner:1.0.0` instead of the actual CDS service package.
2. The final response showed a FHIR `Practitioner` resource instead of the actual CDS `cards` response.

## Change

Replaced both with the correct outputs, as verified and provided by the issue reporter:

- Compile output now shows `wso2/cds_service:1.0.0`.
- The final response now shows the actual CDS `cards`/`systemActions` JSON response from running the example.

No other content on the page was changed.

## Test plan

- [x] Confirmed the old `"resourceType": "Practitioner"` block no longer appears anywhere in the file, and the correct `wso2/cds_service` text and `cards` JSON response are present exactly once, in the CDS template generation section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the Health Tool documentation to correct the CDS template generation examples. The compile output now uses `wso2/cds_service:1.0.0`, and the response now shows CDS `cards` and `systemActions` data instead of a FHIR `Practitioner` resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->