### PR TITLE
Keep the renamed FTP and SFTP caller example URLs working

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -535,6 +535,14 @@ const nextConfig = {
       {
         source: `/${redirectBase}learn/keystore-truststore`,
         destination: `/${redirectBase}learn/development-tutorials/deployment-guide/keystore-truststore`,
+      },
+      {
+        source: `/${redirectBase}learn/by-example/ftp-service-send-file`,
+        destination: `/${redirectBase}learn/by-example/ftp-caller`,
+      },
+      {
+        source: `/${redirectBase}learn/by-example/sftp-service-send-file`,
+        destination: `/${redirectBase}learn/by-example/sftp-caller`,
       }
     ];
   },


### PR DESCRIPTION
### Purpose

Two by-example pages are renamed in `ballerina-distribution` — `ftp-service-send-file` → `ftp-caller` and `sftp-service-send-file` → `sftp-caller` (a listener service does not send files; both samples exist to show the caller, so they are named "Caller object" like the HTTP sample). Their published URLs change with that, and the previous ones would otherwise 404, as `/learn/by-example/ftp-client-read/` does today from an earlier rename.

This adds a rewrite for each old URL so the existing links keep resolving to the renamed page.

### Related PRs

- ballerina-platform/ballerina-distribution#6419 (merged to `2201.13.x`)
- ballerina-platform/ballerina-distribution#6420 (`master`)

Once those are in, the pages themselves come from a run of `Create a PR for new Swan Lake BBE pages on demand`, which regenerates `swan-lake/by-example` and `_data/ballerina-by-example-nav.yml` — nothing in this PR touches the generated content.

### Notes

The entries go in `rewrites()`, matching how every other URL move in this config is handled; there is no `redirects()` block in the repo. If you would rather these be true 301s so search engines follow the rename, say so and I will move them into a `redirects()` block with `permanent: true`.

### Checklist

- [x] Linked to an issue or a related PR
- [x] Updated the changelog — n/a
- [x] Checked for conflicts with the base branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated URL rewrite rules for the renamed FTP and SFTP caller by-example pages. Existing links now redirect to the corresponding caller pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->