### PR TITLE
Redirect the renamed FTP and SFTP BBE URLs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -563,6 +563,14 @@ const nextConfig = {
       {
         source: `/${redirectBase}learn/by-example/sftp-client-send-file`,
         destination: `/${redirectBase}learn/by-example/sftp-client-write-file`,
+      },
+      {
+        source: `/${redirectBase}learn/by-example/ftp-service-send-file`,
+        destination: `/${redirectBase}learn/by-example/ftp-caller`,
+      },
+      {
+        source: `/${redirectBase}learn/by-example/sftp-service-send-file`,
+        destination: `/${redirectBase}learn/by-example/sftp-caller`,
       }
     ];
   },

--- a/next.config.js
+++ b/next.config.js
@@ -547,6 +547,22 @@ const nextConfig = {
       {
         source: `/${redirectBase}learn/keystore-truststore`,
         destination: `/${redirectBase}learn/development-tutorials/deployment-guide/keystore-truststore`,
+      },
+      {
+        source: `/${redirectBase}learn/by-example/ftp-client-receive-file`,
+        destination: `/${redirectBase}learn/by-example/ftp-client-read-file`,
+      },
+      {
+        source: `/${redirectBase}learn/by-example/ftp-client-send-file`,
+        destination: `/${redirectBase}learn/by-example/ftp-client-write-file`,
+      },
+      {
+        source: `/${redirectBase}learn/by-example/sftp-client-receive-file`,
+        destination: `/${redirectBase}learn/by-example/sftp-client-read-file`,
+      },
+      {
+        source: `/${redirectBase}learn/by-example/sftp-client-send-file`,
+        destination: `/${redirectBase}learn/by-example/sftp-client-write-file`,
       }
     ];
   },


### PR DESCRIPTION
## Purpose

Companion to ballerina-platform/ballerina-distribution#6419 and
ballerina-platform/ballerina-distribution#6423, which rename the FTP and SFTP
client BBEs from send/receive to write/read so they match the SMB client group,
and rename the service send-file BBEs to the caller they demonstrate.

Six published URLs change, so this adds redirects for them:

| Old | New |
|---|---|
| `/learn/by-example/ftp-client-receive-file` | `/learn/by-example/ftp-client-read-file` |
| `/learn/by-example/ftp-client-send-file` | `/learn/by-example/ftp-client-write-file` |
| `/learn/by-example/sftp-client-receive-file` | `/learn/by-example/sftp-client-read-file` |
| `/learn/by-example/sftp-client-send-file` | `/learn/by-example/sftp-client-write-file` |
| `/learn/by-example/ftp-service-send-file` | `/learn/by-example/ftp-caller` |
| `/learn/by-example/sftp-service-send-file` | `/learn/by-example/sftp-caller` |

The last two restore what #10366 added and #10367 reverted, so all six renames
land together this time.

These are the first `by-example` entries in the redirects list. They follow the
`${redirectBase}` form used by the surrounding entries.

**Merge after** #10375, so the new URLs exist before the old ones start
redirecting to them.

`node --check next.config.js` passes.

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [x] **Page rename**
  - [x] Add front-matter `redirect_from`. — BBE pages are generated, so the
        redirects go in `next.config.js` rewrites instead.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds six redirects in `next.config.js` for renamed FTP and SFTP by-example pages. The redirects preserve access to the new read, write, and caller URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->