### PR TITLE
Add XLSX package to the Ballerina library specifications table

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -76,3 +76,4 @@ For previous draft language specifications of a Ballerina release, see the <a ta
 | `protobuf` | Swan Lake | <a target="_blank" href="/spec/protobuf/">Snapshot</a> | Protobuf package of Ballerina language, which provides APIs to represent a set of pre-defined protobuf types. |
 | `websub` | Swan Lake | <a target="_blank" href="/spec/websub/">Snapshot</a> | Websub package of Ballerina language, which provides WebSub subscriber service functionalities. |
 | `websubhub` | Swan Lake | <a target="_blank" href="/spec/websubhub/">Snapshot</a> | Websubhub package of Ballerina language, which provides WebSub hub and publisher related functionalities. |
+| `xlsx` | Swan Lake | <a target="_blank" href="/spec/xlsx/">Snapshot</a> | XLSX package of Ballerina language, which provides APIs to read and write Microsoft Excel files in the XLSX format with type-safe data binding to Ballerina records. |


### PR DESCRIPTION
## Purpose
The `xlsx` module specification was added to this repository in #10378 (`spec/xlsx/spec.md` and `public/spec/xlsx/spec.md`), but it was never listed in the **Ballerina library specifications** table on the platform specifications page. The spec is published at `/spec/xlsx/` but is currently unreachable from `/learn/platform-specifications/`.

This PR adds the missing table row so the XLSX specification is discoverable alongside the other library specifications.

## Changes
- Added an `xlsx` row to the Ballerina library specifications table in `spec/spec.md`, linking to `/spec/xlsx/`.

Placed after `websubhub` to preserve the table's ordering, and the description follows the phrasing convention used by the surrounding rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds the `xlsx` package to the Ballerina library specifications table. The entry links to `/spec/xlsx/` and describes its Excel read/write and type-safe record binding APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->