### PR TITLE
Add SMB and Zip packages to the Ballerina library specifications table

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -74,6 +74,8 @@ For previous draft language specifications of a Ballerina release, see the <a ta
 | `oauth2` | Swan Lake | <a target="_blank" href="/spec/oauth2/">Snapshot</a> | OAuth2 package of Ballerina language, which is used for authorization of listeners and clients (HTTP, gRPC, GraphQL, WebSocket, WebSub, etc.). |
 | `os` | Swan Lake | <a target="_blank" href="/spec/os/">Snapshot</a> | OS package of Ballerina language, which provides APIs to retrieve information about the operating system and its current users. |
 | `protobuf` | Swan Lake | <a target="_blank" href="/spec/protobuf/">Snapshot</a> | Protobuf package of Ballerina language, which provides APIs to represent a set of pre-defined protobuf types. |
+| `smb` | Swan Lake | <a target="_blank" href="/spec/smb/">Snapshot</a> | SMB package of Ballerina language, which provides SMB client/listener functionalities to read and write files on a remote SMB share and to watch a directory on it for file changes. |
 | `websub` | Swan Lake | <a target="_blank" href="/spec/websub/">Snapshot</a> | Websub package of Ballerina language, which provides WebSub subscriber service functionalities. |
 | `websubhub` | Swan Lake | <a target="_blank" href="/spec/websubhub/">Snapshot</a> | Websubhub package of Ballerina language, which provides WebSub hub and publisher related functionalities. |
 | `xlsx` | Swan Lake | <a target="_blank" href="/spec/xlsx/">Snapshot</a> | XLSX package of Ballerina language, which provides APIs to read and write Microsoft Excel files in the XLSX format with type-safe data binding to Ballerina records. |
+| `zip` | Swan Lake | <a target="_blank" href="/spec/zip/">Snapshot</a> | Zip package of Ballerina language, which provides APIs to create, read, and extract ZIP archives. |


### PR DESCRIPTION
## Purpose

The `smb` and `zip` module specifications are being added to this repository in #10384 (`spec/smb/spec.md`, `public/spec/smb/spec.md`) and #10385 (`spec/zip/spec.md`, `public/spec/zip/spec.md`), but neither is listed in the **Ballerina library specifications** table on the platform specifications page. Once those PRs land, the specs will be published at `/spec/smb/` and `/spec/zip/` but unreachable from `/learn/platform-specifications/`.

This PR adds the missing table rows so both specifications are discoverable alongside the other library specifications. Same change as #10381 did for `xlsx`.

## Changes

- Added an `smb` row to the Ballerina library specifications table in `spec/spec.md`, linking to `/spec/smb/`.
- Added a `zip` row to the same table, linking to `/spec/zip/`.

Rows are placed to preserve the table's ordering (`smb` after `protobuf`, `zip` after `xlsx`), and the descriptions follow the phrasing convention used by the surrounding rows.

> **Note:** The links resolve only after #10384 and #10385 are merged.