### PR TITLE
Add pull-requests permission to workflow

### DIFF
--- a/.github/workflows/update_stdlib_specs.yml
+++ b/.github/workflows/update_stdlib_specs.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Purpose
>$subject
> Fixes #

## Checklist

- [ ] **Page addition**
  - [ ] Add `permalink` to pages.

- [ ] **Page removal**
  - [ ] Remove entry from corresponding left nav YAML file.
  - [ ] Add `redirect_from` on the alternative page.
  - [ ] If no alternative page, add redirection on the `redirections.js ` file.

- [ ] **Page rename**
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).

- [ ] **Page restrcuture**
  - [ ] Add `permalink` to pages.
  - [ ] Add front-matter `redirect_from`.
  - [ ] Add front-matter `redirect_to:` (if applicable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `.github/workflows/update_stdlib_specs.yml` to grant the workflow permission to write pull requests. This enables the workflow to create or update pull requests as part of its standard-library specification updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->