### PR TITLE
Fix broken observability doc link

### DIFF
--- a/components/microservices/code/microservices-bbe/msa-tracing.md
+++ b/components/microservices/code/microservices-bbe/msa-tracing.md
@@ -1,6 +1,6 @@
 ---
 title: Ballerina enables seamless monitoring of microservices
 description: Ballerina's tracing capabilities go beyond basic monitoring. With seamless integration with popular tracing frameworks like Jaeger and OpenTelemetry, developers can effortlessly instrument their microservices with tracing spans, enabling end-to-end tracing and analysis of complex transaction flows.
-url: https://ballerina.io/learn/observe-ballerina-programs/
+url: https://ballerina.io/learn/overview-of-ballerina-observability/
 image: 'images/screenshots-collage-final-image-transparent-v5.png'
 ---

--- a/swan-lake/by-example/counter-metrics/content.jsx
+++ b/swan-lake/by-example/counter-metrics/content.jsx
@@ -102,7 +102,7 @@ export function CounterMetrics({ codeSnippets }) {
 
       <p>
         For more information about configs and observing applications, see{" "}
-        <a href="/learn/observe-ballerina-programs/">
+        <a href="/learn/overview-of-ballerina-observability/">
           Observe Ballerina programs
         </a>
         .

--- a/swan-lake/by-example/gauge-metrics/content.jsx
+++ b/swan-lake/by-example/gauge-metrics/content.jsx
@@ -155,7 +155,7 @@ export function GaugeMetrics({ codeSnippets }) {
 
       <p>
         For more information about configs and observing applications, see{" "}
-        <a href="/learn/observe-ballerina-programs/">
+        <a href="/learn/overview-of-ballerina-observability/">
           Observe Ballerina programs
         </a>
         .

--- a/swan-lake/by-example/tracing/content.jsx
+++ b/swan-lake/by-example/tracing/content.jsx
@@ -102,7 +102,7 @@ export function Tracing({ codeSnippets }) {
         <p>
           <strong>Info:</strong> For more information about configs and
           observing applications, see{" "}
-          <a href="/learn/observe-ballerina-programs/">
+          <a href="/learn/overview-of-ballerina-observability/">
             Observe Ballerina programs
           </a>
           .


### PR DESCRIPTION
Replaces the stale /learn/observe-ballerina-programs/ link (404) with /learn/overview-of-ballerina-observability/ across the tracing, counter-metrics, and gauge-metrics by-example pages, plus the microservices tracing BBE metadata.

Fixes #9971

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated observability links across tracing, counter-metrics, gauge-metrics, and microservices tracing pages. The links now point to the available observability overview page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->