### PR TITLE
Update Nutcracker release fallback to v0.6.0

### DIFF
--- a/pages/nutcracker/index.js
+++ b/pages/nutcracker/index.js
@@ -30,18 +30,25 @@ import styles from '../../styles/Nutcracker.module.css';
 const REPO = 'ballerina-nutcracker/ballerina';
 
 // Static fallback used when the GitHub API cannot be reached at build time.
+// Refresh this at each release — it is what visitors see if the API is down or
+// rate-limited during a build. `size` matters: without it the download buttons
+// render with no file size, unlike the live path.
+const FALLBACK_TAG = 'v0.6.0';
 const FALLBACK_RELEASE = {
-  tag: 'v0.5.0',
-  name: 'v0.5.0',
-  publishedAt: '2026-05-19T14:26:43Z',
-  htmlUrl: `https://github.com/${REPO}/releases/tag/v0.5.0`,
+  tag: FALLBACK_TAG,
+  name: FALLBACK_TAG,
+  publishedAt: '2026-08-05T08:34:08Z',
+  htmlUrl: `https://github.com/${REPO}/releases/tag/${FALLBACK_TAG}`,
   assets: [
-    { name: 'ballerina-bal-darwin-arm64-0.5.0.zip', url: `https://github.com/${REPO}/releases/download/v0.5.0/ballerina-bal-darwin-arm64-0.5.0.zip` },
-    { name: 'ballerina-bal-darwin-amd64-0.5.0.zip', url: `https://github.com/${REPO}/releases/download/v0.5.0/ballerina-bal-darwin-amd64-0.5.0.zip` },
-    { name: 'ballerina-bal-linux-amd64-0.5.0.zip', url: `https://github.com/${REPO}/releases/download/v0.5.0/ballerina-bal-linux-amd64-0.5.0.zip` },
-    { name: 'ballerina-bal-linux-arm64-0.5.0.zip', url: `https://github.com/${REPO}/releases/download/v0.5.0/ballerina-bal-linux-arm64-0.5.0.zip` },
-    { name: 'ballerina-bal-windows-amd64-0.5.0.zip', url: `https://github.com/${REPO}/releases/download/v0.5.0/ballerina-bal-windows-amd64-0.5.0.zip` },
-  ],
+    ['darwin-amd64', 28501452],
+    ['darwin-arm64', 27875033],
+    ['linux-amd64', 28364579],
+    ['linux-arm64', 27501499],
+    ['windows-amd64', 28605559],
+  ].map(([platform, size]) => {
+    const name = `ballerina-nutcracker-${platform}-${FALLBACK_TAG.slice(1)}.zip`;
+    return { name, size, url: `https://github.com/${REPO}/releases/download/${FALLBACK_TAG}/${name}` };
+  }),
 };
 
 export default function Nutcracker({ release, ogImage }) {


### PR DESCRIPTION
### Purpose

The `/nutcracker` page fetches the latest release from the GitHub API at build time, with a static fallback used when that API is unreachable or rate-limited. The fallback still described **v0.5.0**.

### What changed

Bumped the fallback to **v0.6.0** (released 5 August 2026). Two things needed fixing beyond the version number:

- **Asset filenames changed between releases.** v0.5.0 shipped `ballerina-bal-*`; v0.6.0 ships `ballerina-nutcracker-*`. A plain version find-replace would have produced five download URLs that 404.
- **The fallback carried no `size`.** `fmtSize()` returns an empty string for a missing size, so a fallback render showed download buttons with no file size — silently different from the live API path.

The tag is now a constant and the assets are generated from a `[platform, size]` list, so the next bump is one string plus five numbers rather than ten places to keep in sync.

### Verification

The resulting object was diffed against the live GitHub API response and matches exactly — tag, `publishedAt`, `htmlUrl`, and all five assets (name, size, URL). Page renders and compiles (HTTP 200).

Note this only affects builds where the GitHub API call fails; normally `getStaticProps` fetches live, so the page shows v0.6 either way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the `/nutcracker` static release fallback from v0.5.0 to v0.6.0. The fallback now uses the v0.6.0 asset naming scheme, includes asset sizes, and generates assets from platform and size data. Release metadata matches the live GitHub API response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->