### PR TITLE
Add the language security guarantees page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -541,6 +541,10 @@ const nextConfig = {
         destination: `/learn/development-tutorials/static-code-analysis/scan-rules`,
       },
       {
+        source: `/learn/language-security-guarantees`,
+        destination: `/learn/development-tutorials/static-code-analysis/language-security-guarantees`,
+      },
+      {
         source: `/${redirectBase}learn/consolidate-packages-tool`,
         destination: `/${redirectBase}learn/development-tutorials/additional-tools/consolidate-packages-tool`,
       },

--- a/swan-lake/development-tutorials/static-code-analysis/language-security-guarantees.md
+++ b/swan-lake/development-tutorials/static-code-analysis/language-security-guarantees.md
@@ -1,0 +1,211 @@
+---
+title: Language security guarantees
+description: Learn which classes of security weakness the Ballerina compiler prevents outright, and why the scan rule set targets what remains.
+keywords: ballerina, static code analysis, security, compiler, cwe, owasp, scan
+permalink: /learn/language-security-guarantees/
+active: language-security-guarantees
+---
+
+A static analysis rule set measures what a scanner looks for. It is not, on its own, a measure of how much is covered.
+
+Several weakness classes that dominate static analysis findings in other languages cannot be expressed in Ballerina at all. The compiler rejects them, so a scanner never reports them — there is nothing to report. This page shows what the language guarantees, demonstrates each guarantee with the compiler's own output, and states plainly where each one stops.
+
+Every example below was compiled with **Ballerina 2201.13.5 (Swan Lake Update 13)**. Each diagnostic shown is actual compiler output.
+
+## Null dereference
+
+Optional values have a distinct type in Ballerina, and the operations of the underlying type are not available on them.
+
+The following does not compile:
+
+```ballerina
+public function getName(map<string> data) returns string {
+    string? name = data["name"];
+    return name.trim();
+}
+```
+
+```
+ERROR [null.bal:(3:17,3:21)] undefined function 'trim' in type 'string?'
+```
+
+The map access yields `string?` — either a `string` or `()`. Calling a `string` method on it is not a warning to be triaged later; the program does not build.
+
+The nil case must be handled before the value can be used:
+
+```ballerina
+public function getName(map<string> data) returns string {
+    string? name = data["name"];
+    return name ?: "unknown";
+}
+```
+
+## Unchecked error conditions
+
+Errors are ordinary typed values, not exceptions thrown past the type system. A function that can fail returns a union that includes the error, and that union is not assignable to the success type.
+
+The following does not compile:
+
+```ballerina
+import ballerina/io;
+
+public function readConfig(string path) returns string {
+    string content = io:fileReadString(path);
+    return content;
+}
+```
+
+```
+ERROR [error.bal:(4:22,4:45)] incompatible types: expected 'string', found '(string|ballerina/io:1.8.1:Error)'
+```
+
+Ignoring the failure path is not possible, so there is no silently dropped error for a scanner to find. Use `check` to propagate the error to the caller:
+
+```ballerina
+import ballerina/io;
+
+public function readConfig(string path) returns string|io:Error {
+    string content = check io:fileReadString(path);
+    return content;
+}
+```
+
+Handling it locally with `if content is io:Error { ... }` is equally valid. What is not valid is ignoring it.
+
+## Data races
+
+The `isolated` qualifier is a compiler-checked assertion that a function accesses no shared mutable state. The compiler proves it rather than leaving it to review.
+
+The following does not compile:
+
+```ballerina
+int counter = 0;
+
+public isolated function increment() {
+    counter += 1;
+}
+```
+
+```
+ERROR [isolated.bal:(4:5,4:12)] invalid access of mutable storage in an 'isolated' function
+```
+
+Marking the variable `isolated` requires every access to sit inside a `lock`, and the compiler enforces the pairing:
+
+```ballerina
+isolated int counter = 0;
+
+public isolated function increment() {
+    lock {
+        counter += 1;
+    }
+}
+```
+
+## SQL injection
+
+`sql:ParameterizedQuery` is a template type, not a string. Values interpolated into it become bind parameters, and a query assembled by string concatenation has the wrong type.
+
+The following does not compile:
+
+```ballerina
+import ballerina/sql;
+
+public function buildQuery(string name) returns sql:ParameterizedQuery {
+    string raw = "SELECT * FROM users WHERE name = '" + name + "'";
+    return raw;
+}
+```
+
+```
+ERROR [sql.bal:(5:12,5:15)] incompatible types: expected 'ballerina/sql:1.19.0:ParameterizedQuery', found 'string'
+```
+
+The safe form is also the shorter and more natural one:
+
+```ballerina
+import ballerina/sql;
+
+public function buildQuery(string name) returns sql:ParameterizedQuery {
+    return `SELECT * FROM users WHERE name = ${name}`;
+}
+```
+
+`${name}` is sent to the database as a bind parameter. It is never spliced into the SQL text.
+
+## Mishandling of exceptional conditions
+
+The sections above cover most of the weaknesses grouped under this heading. Two more are worth showing.
+
+### Every path must return
+
+The following does not compile, even though all three values of the union are handled:
+
+```ballerina
+public type Status "active"|"inactive"|"pending";
+
+public function label(Status s) returns string {
+    match s {
+        "active" => { return "Active"; }
+        "inactive" => { return "Inactive"; }
+        "pending" => { return "Pending"; }
+    }
+}
+```
+
+```
+ERROR [match.bal:(9:1,9:2)] this function must return a result
+```
+
+A `match` statement requires a wildcard arm before the compiler treats the function as returning on every path. Type-narrowing `if`/`else` chains over a union, by contrast, are proven exhaustive and compile with no diagnostic:
+
+```ballerina
+public function describe(int|string v) returns string {
+    if v is int {
+        return "int";
+    } else if v is string {
+        return "string";
+    }
+}
+```
+
+### Patterns that can never match are reported
+
+```ballerina
+public type Status "active"|"inactive";
+
+public function label(Status s) returns string {
+    match s {
+        "active" => { return "Active"; }
+        "inactive" => { return "Inactive"; }
+        "archived" => { return "Archived"; }
+        _ => { return "?"; }
+    }
+}
+```
+
+```
+WARNING [match.bal:(7:9,7:19)] pattern will not be matched
+```
+
+A branch that can never execute — often a stale or misspelled case — is diagnosed.
+
+Ballerina also separates recoverable errors from panics. The scan rule [`ballerina:1`](/learn/scan-rules/#avoid-checkpanic) flags `checkpanic`, which turns a handled error into an abrupt termination.
+
+## Where these guarantees stop
+
+Each guarantee has a boundary, and knowing where it lies matters as much as the guarantee itself.
+
+| Guarantee           | Where it stops                                                                                                                                                                                                                                                                                         |
+|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Null dereference    | No exceptions. Optional types are enforced throughout the language.                                                                                                                                                                                                                                    |
+| Unchecked errors    | No exceptions. An error-typed value must be handled or propagated.                                                                                                                                                                                                                                     |
+| Data races          | Isolation is opt-in. Code that is not marked `isolated` is not proven concurrency-safe. The scan rules `ballerina:3` to `ballerina:6` exist to push public functions, methods, classes, and objects toward `isolated`, so the rules and the language feature work together.                            |
+| SQL injection       | Covers values, not identifiers. Table and column names cannot be bind parameters, so a dynamic identifier must be built another way, and `sql:queryConcat` composition and hand-built DDL fall outside the guarantee. The parameterised form is the default, and injection requires deliberate effort. |
+| Exhaustive handling | A `match` statement needs a wildcard arm. Full coverage of a singleton union is not treated as exhaustive on its own.                                                                                                                                                                                  |
+
+## What this means for the scan rule set
+
+Because these classes are closed at compile time, a Ballerina scanner has nothing to find in them. What remains for static analysis is the residue: configuration mistakes, and unsafe use of specific library APIs where a developer can still select the insecure option.
+
+That is what the [scan rules](/learn/scan-rules/) target, and it is why the rule set is smaller than that of a comparable tool for a language which must detect all of the above at scan time.

--- a/swan-lake/development-tutorials/static-code-analysis/scan-rules.md
+++ b/swan-lake/development-tutorials/static-code-analysis/scan-rules.md
@@ -13,6 +13,8 @@ adhere to best practices.
 
 ## Security standards mapping
 
+Several weakness classes are prevented by the language itself rather than by a rule, so they do not appear in the table below. See [Language security guarantees](/learn/language-security-guarantees/) for what the compiler enforces and where each guarantee stops.
+
 The table below maps the rules that have a known security weakness association to their [CWE](https://cwe.mitre.org/) identifiers and the corresponding [OWASP Top 10:2025](https://owasp.org/Top10/) categories.
 
 | Rule ID            | Rule                                                                                         | CWE                                                                                                                    | OWASP Top 10:2025                                                                                                                                |

--- a/swan-lake/development-tutorials/static-code-analysis/scan-tool.md
+++ b/swan-lake/development-tutorials/static-code-analysis/scan-tool.md
@@ -9,7 +9,7 @@ active: scan-tool
 The Ballerina scan tool is a static code analysis tool that performs analysis on Ballerina projects and identifies
 potential code smells, bugs, and vulnerabilities without executing them.
 
-> **Note:** Ballerina scan is an experimental feature that supports only a limited set of rules.
+> **Note:** Ballerina scan is an experimental feature that supports only a limited set of rules. The rule set is deliberately narrow: several weakness classes that other static analysis tools must detect at scan time cannot be expressed in Ballerina at all, because the compiler rejects them. See [Language security guarantees](/learn/language-security-guarantees/) for what the language prevents and where each guarantee stops.
 
 ## Install the tool
 

--- a/utils/learn-lm.json
+++ b/utils/learn-lm.json
@@ -905,6 +905,14 @@
                             "isDir": false,
                             "url": "/learn/scan-rules",
                             "id": "scan-rules"
+                        },
+                        {
+                            "dirName": "Language security guarantees",
+                            "level": 3,
+                            "position": 3,
+                            "isDir": false,
+                            "url": "/learn/language-security-guarantees",
+                            "id": "language-security-guarantees"
                         }
                     ]
                 },


### PR DESCRIPTION
> **Depends on #10410.** This branch is based on `docs/scan-rules-cwe-owasp-mapping`, so the base of this PR is that branch rather than `master`. Merge #10410 first; this one then retargets `master` automatically.

## Purpose

The scan tool page opens by noting that the feature is experimental and "supports only a limited set of rules". Read on its own, that reads as immaturity, and it is the first thing anyone evaluating Ballerina's security tooling sees.

The rule set is narrow for a substantive reason: several weakness classes that other static analysis tools must detect at scan time cannot be expressed in Ballerina at all, because the compiler rejects them. A scanner never reports them because there is nothing to report. That reasoning was undocumented, so the rule count had no context.

This adds a page that demonstrates the claim, and links it from the two places where readers encounter the rule count.

## Changes

- **New page — Language security guarantees.** Covers null dereference, unchecked error conditions, data races, SQL injection, and mishandling of exceptional conditions. Each is presented as code that does not compile, followed by the compiler's actual diagnostic, then the form a developer writes instead.
- **A "Where these guarantees stop" section.** Isolation is opt-in, and SQL parameterisation covers values rather than identifiers. Stating the boundaries is what makes the rest of the page defensible when a reader tests the claims.
- **Navigation entry and redirect**, following the pattern of the two existing pages in the section.
- **Scan tool page** — the note about the limited rule set now explains why it is limited and links to the new page.
- **Scan rules page** — the security standards mapping section links out as well, since that is where readers count rules.

## Verification

Every example was compiled with **Ballerina 2201.13.5 (Swan Lake Update 13)**, and each diagnostic quoted on the page is actual compiler output rather than an illustration. The version is stated on the page so the examples can be re-verified against future releases.

`utils/learn-lm.json` was confirmed to still parse as JSON, and `next.config.js` to still load, since a malformed navigation config fails the site build rather than rendering incorrectly.

## Checklist

- [x] **Page addition**
  - [x] Add `permalink` to pages — `/learn/language-security-guarantees/`, with the matching navigation entry and redirect.
- [x] **Page removal** — not applicable
- [x] **Page rename** — not applicable
- [x] **Page restructure** — not applicable