### PR TITLE
Point AI use-case sample links to upstream repository

### DIFF
--- a/components/ai/code/Code.js
+++ b/components/ai/code/Code.js
@@ -522,7 +522,7 @@ export default function UseCases(props) {
 
                                     <div className={styles.dVersion}>
                                         <span>Sample 2: Function Calling using OpenAI</span>
-                                        <a href='https://github.com/xlight05/ai-samples/blob/usecase-samples/function_calling/main.bal' className={styles.cDownload} target="_blank" rel="noreferrer">
+                                        <a href='https://github.com/ballerina-guides/ai-samples/blob/main/function_calling/main.bal' className={styles.cDownload} target="_blank" rel="noreferrer">
                                             <Image src={`${prefix}/images/sm-icons/github-grey.svg`} width={20} height={20} alt="View code on GitHub" />
                                             View code on GitHub
                                         </a>
@@ -592,7 +592,7 @@ export default function UseCases(props) {
                                     <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]}>{multimodel.frontmatter.description}</ReactMarkdown>
                                     <div className={styles.dVersion}>
                                         <span>Sample 1: Describe an image using OpenAI</span>
-                                        <a href='https://github.com/xlight05/ai-samples/blob/usecase-samples/describe_photo/main.bal' className={styles.cDownload} target="_blank" rel="noreferrer">
+                                        <a href='https://github.com/ballerina-guides/ai-samples/blob/main/describe_photo/main.bal' className={styles.cDownload} target="_blank" rel="noreferrer">
                                             <Image src={`${prefix}/images/sm-icons/github-grey.svg`} width={20} height={20} alt="View code on GitHub" />
                                             View code on GitHub
                                         </a>

--- a/components/ai/code/ai-bbe/why-is-ballerina-the-way-you-should-write-ai-applications.md
+++ b/components/ai/code/ai-bbe/why-is-ballerina-the-way-you-should-write-ai-applications.md
@@ -1,7 +1,7 @@
 ---
 title: 'Why is Ballerina the way you should write AI applications?'
 description: "Python remains the go-to for machine learning, data science, and analytics—but integrating AI into modern business applications is a different challenge. It’s now about invoking LLMs, prompt engineering, and embedding AI into workflows. Ballerina, a cloud-native language built for integration, offers powerful abstractions to connect with LLMs and seamlessly weave AI into your applications to deliver real value."
-url: 'https://github.com/xlight05/ai-samples/blob/usecase-samples/hr_agent_rag_app/main.bal'
+url: 'https://github.com/ballerina-guides/ai-samples/blob/main/hr_agent_rag_app/main.bal'
 ---
 ```
 service /agent on hrAgent {


### PR DESCRIPTION
## Purpose
Replace the three personal-fork sample links on `/use-cases/ai/` with `ballerina-guides/ai-samples` links on `main`: HR RAG, OpenAI function calling, and photo description.

Depends on https://github.com/ballerina-guides/ai-samples/pull/88. Merge and deploy this change only after that sample PR is merged so the new links resolve.

## Validation
- Confirmed all three `xlight05/ai-samples` links in the AI page sources are replaced.
- Verified the paths match the three sample files contributed in the dependent PR.
- `git diff --check` passed. The diff changes only three URLs across two files; no full website build was run.

## Checklist
No pages were added, removed, renamed, or restructured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates three AI sample links from `xlight05/ai-samples` to `ballerina-guides/ai-samples` for HR RAG, OpenAI function calling, and photo description samples.

The new paths align with the upstream sample files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->